### PR TITLE
Feat: relationshipQueue に follow/block/unblock batch job を追加 (#1605)

### DIFF
--- a/internal/core/transfer/import_csv.go
+++ b/internal/core/transfer/import_csv.go
@@ -21,6 +21,12 @@ import (
 // 側 (ImportFollowingProcessorService.ts:75) は `parts.slice(2)` で parse する
 // バグがあり 2-fields export と整合しないが、mk-go は `parts[1:]` から parse して
 // 実 export format と一致させる。
+//
+// 設計判断 (#1605): upstream は行ごとに relationshipQueue へ follow job を
+// enqueue するが、mk-go は同期 loop を維持する。完了通知に載せる
+// Applied/Skipped 集計が per-pair 非同期化では「enqueue 数」しか数えられず
+// 不正確になるため (#1563 review)。queue surface (TaskTypeFollow /
+// EnqueueFollowBulk) は用意済みなので、集計を再設計する場合はそちらへ移行する。
 func (i *Importer) importFollowing(user *model.User, body []byte) (*ImportResult, error) {
 	if i.deps.Following == nil {
 		return nil, fmt.Errorf("following service not configured")
@@ -74,6 +80,8 @@ func parseFollowingCSVLine(line string) (string, FollowOptions) {
 }
 
 // importBlocking parses `acct` lines and applies a block per entry.
+// 同期 loop を維持する理由は importFollowing の設計判断 (#1605) と同じ
+// (upstream は createBlockJob で per-pair enqueue)。
 func (i *Importer) importBlocking(user *model.User, body []byte) (*ImportResult, error) {
 	if i.deps.Blocking == nil {
 		return nil, fmt.Errorf("blocking service not configured")

--- a/internal/queue/processors/block.go
+++ b/internal/queue/processors/block.go
@@ -1,0 +1,59 @@
+package processors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/shiroha-a/mk/internal/core/blocking"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
+)
+
+// Blocker is the narrow subset of core/blocking.Service the block processor
+// needs (テスト差し替えのため interface で受け取る)。
+type Blocker interface {
+	Block(blockerID, blockeeID string) (*model.Blocking, error)
+}
+
+// BlockProcessor handles per-pair Block queue jobs. Misskey TS の
+// relationshipQueue 'block' job (RelationshipProcessorService.processBlock)
+// と同じ役割 (#1605)。
+type BlockProcessor struct {
+	blocker Blocker
+}
+
+// NewBlockProcessor wires the processor with the blocking service.
+func NewBlockProcessor(blocker Blocker) *BlockProcessor {
+	return &BlockProcessor{blocker: blocker}
+}
+
+// Handle implements driver.HandlerFunc.
+func (p *BlockProcessor) Handle(_ context.Context, t driver.Task) error {
+	payload, err := queue.DecodeBlockPayload(t.Payload())
+	if err != nil {
+		return fmt.Errorf("decode block payload: %w: %w", err, driver.SkipRetry)
+	}
+	if payload.BlockerID == "" || payload.BlockeeID == "" {
+		return fmt.Errorf("block: blockerId and blockeeId are required: %w", driver.SkipRetry)
+	}
+	if p.blocker == nil {
+		return fmt.Errorf("block: service not wired: %w", driver.SkipRetry)
+	}
+	_, err = p.blocker.Block(payload.BlockerID, payload.BlockeeID)
+	switch {
+	case err == nil:
+		return nil
+	// 既に block 済は望む終状態に到達済みとして成功扱い - 冪等吸収。
+	case errors.Is(err, blocking.ErrAlreadyBlocking):
+		return nil
+	// 自己 block / 対象不在は retry しても解消しない恒久エラー。
+	case errors.Is(err, blocking.ErrSelfBlock),
+		errors.Is(err, blocking.ErrBlockeeNotFound):
+		return fmt.Errorf("block %s->%s: %w: %w",
+			payload.BlockerID, payload.BlockeeID, err, driver.SkipRetry)
+	default:
+		return err
+	}
+}

--- a/internal/queue/processors/block_test.go
+++ b/internal/queue/processors/block_test.go
@@ -1,0 +1,93 @@
+package processors_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mk/internal/core/blocking"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
+	"github.com/shiroha-a/mk/internal/queue/processors"
+)
+
+type fakeBlocker struct {
+	calls [][2]string
+	err   error
+}
+
+func (f *fakeBlocker) Block(blockerID, blockeeID string) (*model.Blocking, error) {
+	f.calls = append(f.calls, [2]string{blockerID, blockeeID})
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &model.Blocking{}, nil
+}
+
+func TestBlockProcessor_Success(t *testing.T) {
+	fb := &fakeBlocker{}
+	p := processors.NewBlockProcessor(fb)
+	task := queue.NewBlockTask(queue.BlockPayload{BlockerID: "localA", BlockeeID: "rA"})
+	require.NoError(t, p.Handle(context.Background(), task))
+	require.Len(t, fb.calls, 1)
+	assert.Equal(t, [2]string{"localA", "rA"}, fb.calls[0])
+}
+
+// 既に block 済は望む終状態なので成功扱い。
+func TestBlockProcessor_AlreadyBlocking_Success(t *testing.T) {
+	fb := &fakeBlocker{err: blocking.ErrAlreadyBlocking}
+	p := processors.NewBlockProcessor(fb)
+	task := queue.NewBlockTask(queue.BlockPayload{BlockerID: "a", BlockeeID: "b"})
+	assert.NoError(t, p.Handle(context.Background(), task))
+}
+
+// 自己 block / 対象不在は retry 不能の恒久エラー。
+func TestBlockProcessor_PermanentErrors_SkipRetry(t *testing.T) {
+	for _, sentinel := range []error{blocking.ErrSelfBlock, blocking.ErrBlockeeNotFound} {
+		fb := &fakeBlocker{err: sentinel}
+		p := processors.NewBlockProcessor(fb)
+		task := queue.NewBlockTask(queue.BlockPayload{BlockerID: "a", BlockeeID: "b"})
+		err := p.Handle(context.Background(), task)
+		require.Error(t, err, sentinel.Error())
+		assert.True(t, errors.Is(err, driver.SkipRetry), sentinel.Error())
+	}
+}
+
+func TestBlockProcessor_GenericError_Retries(t *testing.T) {
+	fb := &fakeBlocker{err: errors.New("network down")}
+	p := processors.NewBlockProcessor(fb)
+	task := queue.NewBlockTask(queue.BlockPayload{BlockerID: "a", BlockeeID: "b"})
+	err := p.Handle(context.Background(), task)
+	assert.Error(t, err)
+	assert.False(t, errors.Is(err, driver.SkipRetry), "transient error は retry させる")
+}
+
+func TestBlockProcessor_MissingFields_SkipsRetry(t *testing.T) {
+	fb := &fakeBlocker{}
+	p := processors.NewBlockProcessor(fb)
+	task := queue.NewBlockTask(queue.BlockPayload{BlockeeID: "rA"})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, driver.SkipRetry))
+	assert.Empty(t, fb.calls)
+}
+
+func TestBlockProcessor_NoBlocker_SkipsRetry(t *testing.T) {
+	p := processors.NewBlockProcessor(nil)
+	task := queue.NewBlockTask(queue.BlockPayload{BlockerID: "a", BlockeeID: "b"})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, driver.SkipRetry))
+}
+
+func TestBlockProcessor_BadPayload_SkipsRetry(t *testing.T) {
+	p := processors.NewBlockProcessor(&fakeBlocker{})
+	task := driver.RawTask{TypeName: queue.TaskTypeBlock, Body: []byte("not json")}
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, driver.SkipRetry))
+}

--- a/internal/queue/processors/follow.go
+++ b/internal/queue/processors/follow.go
@@ -1,0 +1,65 @@
+package processors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/shiroha-a/mk/internal/core/following"
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
+)
+
+// Follower is the narrow subset of core/following.Service the processor
+// needs. core/following は queue を import しないため直接参照しても循環
+// しない (processors/transfer.go と同じ前例) が、テスト差し替えのため
+// interface で受け取る。
+type Follower interface {
+	Follow(followerID, followeeID string, opts following.FollowOptions) (*following.FollowResult, error)
+}
+
+// FollowProcessor handles per-pair Follow queue jobs. Misskey TS の
+// relationshipQueue 'follow' job (RelationshipProcessorService.processFollow)
+// と同じ役割 (#1605)。
+type FollowProcessor struct {
+	follower Follower
+}
+
+// NewFollowProcessor wires the processor with the follow service.
+func NewFollowProcessor(follower Follower) *FollowProcessor {
+	return &FollowProcessor{follower: follower}
+}
+
+// Handle implements driver.HandlerFunc.
+func (p *FollowProcessor) Handle(_ context.Context, t driver.Task) error {
+	payload, err := queue.DecodeFollowPayload(t.Payload())
+	if err != nil {
+		return fmt.Errorf("decode follow payload: %w: %w", err, driver.SkipRetry)
+	}
+	if payload.FollowerID == "" || payload.FolloweeID == "" {
+		return fmt.Errorf("follow: followerId and followeeId are required: %w", driver.SkipRetry)
+	}
+	if p.follower == nil {
+		return fmt.Errorf("follow: service not wired: %w", driver.SkipRetry)
+	}
+	_, err = p.follower.Follow(payload.FollowerID, payload.FolloweeID,
+		following.FollowOptions{WithReplies: payload.WithReplies})
+	switch {
+	case err == nil:
+		return nil
+	// 既に follow 済 / follow request 送信済は望む終状態に到達済みとして
+	// 成功扱い - 冪等吸収。
+	case errors.Is(err, following.ErrAlreadyFollowing),
+		errors.Is(err, following.ErrAlreadyRequested):
+		return nil
+	// block 関係 / 自己 follow / 対象不在は retry しても解消しない恒久
+	// エラーなので即終了する (本家は job fail のまま放置される)。
+	case errors.Is(err, following.ErrBlocked),
+		errors.Is(err, following.ErrSelfFollow),
+		errors.Is(err, following.ErrFolloweeNotFound):
+		return fmt.Errorf("follow %s->%s: %w: %w",
+			payload.FollowerID, payload.FolloweeID, err, driver.SkipRetry)
+	default:
+		return err
+	}
+}

--- a/internal/queue/processors/follow_test.go
+++ b/internal/queue/processors/follow_test.go
@@ -1,0 +1,103 @@
+package processors_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mk/internal/core/following"
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
+	"github.com/shiroha-a/mk/internal/queue/processors"
+)
+
+type followCall struct {
+	followerID, followeeID string
+	opts                   following.FollowOptions
+}
+
+type fakeFollower struct {
+	calls []followCall
+	err   error
+}
+
+func (f *fakeFollower) Follow(followerID, followeeID string, opts following.FollowOptions) (*following.FollowResult, error) {
+	f.calls = append(f.calls, followCall{followerID, followeeID, opts})
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &following.FollowResult{}, nil
+}
+
+func TestFollowProcessor_Success(t *testing.T) {
+	ff := &fakeFollower{}
+	p := processors.NewFollowProcessor(ff)
+	task := queue.NewFollowTask(queue.FollowPayload{
+		FollowerID: "localA", FolloweeID: "rA", WithReplies: true,
+	})
+	require.NoError(t, p.Handle(context.Background(), task))
+	require.Len(t, ff.calls, 1)
+	assert.Equal(t, "localA", ff.calls[0].followerID)
+	assert.Equal(t, "rA", ff.calls[0].followeeID)
+	assert.True(t, ff.calls[0].opts.WithReplies, "payload の withReplies を FollowOptions に引き継ぐ")
+}
+
+// 既に follow 済 / follow request 送信済は望む終状態なので成功扱い。
+func TestFollowProcessor_AlreadyFollowing_Success(t *testing.T) {
+	for _, sentinel := range []error{following.ErrAlreadyFollowing, following.ErrAlreadyRequested} {
+		ff := &fakeFollower{err: sentinel}
+		p := processors.NewFollowProcessor(ff)
+		task := queue.NewFollowTask(queue.FollowPayload{FollowerID: "a", FolloweeID: "b"})
+		assert.NoError(t, p.Handle(context.Background(), task), sentinel.Error())
+	}
+}
+
+// block 関係 / 自己 follow / 対象不在は retry 不能の恒久エラー。
+func TestFollowProcessor_PermanentErrors_SkipRetry(t *testing.T) {
+	for _, sentinel := range []error{following.ErrBlocked, following.ErrSelfFollow, following.ErrFolloweeNotFound} {
+		ff := &fakeFollower{err: sentinel}
+		p := processors.NewFollowProcessor(ff)
+		task := queue.NewFollowTask(queue.FollowPayload{FollowerID: "a", FolloweeID: "b"})
+		err := p.Handle(context.Background(), task)
+		require.Error(t, err, sentinel.Error())
+		assert.True(t, errors.Is(err, driver.SkipRetry), sentinel.Error())
+	}
+}
+
+func TestFollowProcessor_GenericError_Retries(t *testing.T) {
+	ff := &fakeFollower{err: errors.New("network down")}
+	p := processors.NewFollowProcessor(ff)
+	task := queue.NewFollowTask(queue.FollowPayload{FollowerID: "a", FolloweeID: "b"})
+	err := p.Handle(context.Background(), task)
+	assert.Error(t, err)
+	assert.False(t, errors.Is(err, driver.SkipRetry), "transient error は retry させる")
+}
+
+func TestFollowProcessor_MissingFields_SkipsRetry(t *testing.T) {
+	ff := &fakeFollower{}
+	p := processors.NewFollowProcessor(ff)
+	task := queue.NewFollowTask(queue.FollowPayload{FolloweeID: "rA"})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, driver.SkipRetry))
+	assert.Empty(t, ff.calls)
+}
+
+func TestFollowProcessor_NoFollower_SkipsRetry(t *testing.T) {
+	p := processors.NewFollowProcessor(nil)
+	task := queue.NewFollowTask(queue.FollowPayload{FollowerID: "a", FolloweeID: "b"})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, driver.SkipRetry))
+}
+
+func TestFollowProcessor_BadPayload_SkipsRetry(t *testing.T) {
+	p := processors.NewFollowProcessor(&fakeFollower{})
+	task := driver.RawTask{TypeName: queue.TaskTypeFollow, Body: []byte("not json")}
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, driver.SkipRetry))
+}

--- a/internal/queue/processors/unblock.go
+++ b/internal/queue/processors/unblock.go
@@ -1,0 +1,57 @@
+package processors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/shiroha-a/mk/internal/core/blocking"
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
+)
+
+// Unblocker is the narrow subset of core/blocking.Service the unblock
+// processor needs (テスト差し替えのため interface で受け取る)。
+type Unblocker interface {
+	Unblock(blockerID, blockeeID string) error
+}
+
+// UnblockProcessor handles per-pair Unblock queue jobs. Misskey TS の
+// relationshipQueue 'unblock' job (RelationshipProcessorService.processUnblock)
+// と同じ役割 (#1605)。
+type UnblockProcessor struct {
+	unblocker Unblocker
+}
+
+// NewUnblockProcessor wires the processor with the blocking service.
+func NewUnblockProcessor(unblocker Unblocker) *UnblockProcessor {
+	return &UnblockProcessor{unblocker: unblocker}
+}
+
+// Handle implements driver.HandlerFunc.
+func (p *UnblockProcessor) Handle(_ context.Context, t driver.Task) error {
+	payload, err := queue.DecodeUnblockPayload(t.Payload())
+	if err != nil {
+		return fmt.Errorf("decode unblock payload: %w: %w", err, driver.SkipRetry)
+	}
+	if payload.BlockerID == "" || payload.BlockeeID == "" {
+		return fmt.Errorf("unblock: blockerId and blockeeId are required: %w", driver.SkipRetry)
+	}
+	if p.unblocker == nil {
+		return fmt.Errorf("unblock: service not wired: %w", driver.SkipRetry)
+	}
+	err = p.unblocker.Unblock(payload.BlockerID, payload.BlockeeID)
+	switch {
+	case err == nil:
+		return nil
+	// 既に解消済 (row 無し) は望む終状態に到達済みとして成功扱い - 冪等吸収。
+	case errors.Is(err, blocking.ErrNotBlocking):
+		return nil
+	// 自己 unblock は retry しても解消しない恒久エラー。
+	case errors.Is(err, blocking.ErrSelfBlock):
+		return fmt.Errorf("unblock %s->%s: %w: %w",
+			payload.BlockerID, payload.BlockeeID, err, driver.SkipRetry)
+	default:
+		return err
+	}
+}

--- a/internal/queue/processors/unblock_test.go
+++ b/internal/queue/processors/unblock_test.go
@@ -1,0 +1,87 @@
+package processors_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mk/internal/core/blocking"
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
+	"github.com/shiroha-a/mk/internal/queue/processors"
+)
+
+type fakeUnblocker struct {
+	calls [][2]string
+	err   error
+}
+
+func (f *fakeUnblocker) Unblock(blockerID, blockeeID string) error {
+	f.calls = append(f.calls, [2]string{blockerID, blockeeID})
+	return f.err
+}
+
+func TestUnblockProcessor_Success(t *testing.T) {
+	fu := &fakeUnblocker{}
+	p := processors.NewUnblockProcessor(fu)
+	task := queue.NewUnblockTask(queue.UnblockPayload{BlockerID: "localA", BlockeeID: "rA"})
+	require.NoError(t, p.Handle(context.Background(), task))
+	require.Len(t, fu.calls, 1)
+	assert.Equal(t, [2]string{"localA", "rA"}, fu.calls[0])
+}
+
+// 既に解消済 (row 無し) は望む終状態なので成功扱い。
+func TestUnblockProcessor_NotBlocking_Success(t *testing.T) {
+	fu := &fakeUnblocker{err: blocking.ErrNotBlocking}
+	p := processors.NewUnblockProcessor(fu)
+	task := queue.NewUnblockTask(queue.UnblockPayload{BlockerID: "a", BlockeeID: "b"})
+	assert.NoError(t, p.Handle(context.Background(), task))
+}
+
+// 自己 unblock は retry 不能の恒久エラー。
+func TestUnblockProcessor_SelfBlock_SkipRetry(t *testing.T) {
+	fu := &fakeUnblocker{err: blocking.ErrSelfBlock}
+	p := processors.NewUnblockProcessor(fu)
+	task := queue.NewUnblockTask(queue.UnblockPayload{BlockerID: "a", BlockeeID: "b"})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, driver.SkipRetry))
+}
+
+func TestUnblockProcessor_GenericError_Retries(t *testing.T) {
+	fu := &fakeUnblocker{err: errors.New("network down")}
+	p := processors.NewUnblockProcessor(fu)
+	task := queue.NewUnblockTask(queue.UnblockPayload{BlockerID: "a", BlockeeID: "b"})
+	err := p.Handle(context.Background(), task)
+	assert.Error(t, err)
+	assert.False(t, errors.Is(err, driver.SkipRetry), "transient error は retry させる")
+}
+
+func TestUnblockProcessor_MissingFields_SkipsRetry(t *testing.T) {
+	fu := &fakeUnblocker{}
+	p := processors.NewUnblockProcessor(fu)
+	task := queue.NewUnblockTask(queue.UnblockPayload{BlockeeID: "rA"})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, driver.SkipRetry))
+	assert.Empty(t, fu.calls)
+}
+
+func TestUnblockProcessor_NoUnblocker_SkipsRetry(t *testing.T) {
+	p := processors.NewUnblockProcessor(nil)
+	task := queue.NewUnblockTask(queue.UnblockPayload{BlockerID: "a", BlockeeID: "b"})
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, driver.SkipRetry))
+}
+
+func TestUnblockProcessor_BadPayload_SkipsRetry(t *testing.T) {
+	p := processors.NewUnblockProcessor(&fakeUnblocker{})
+	task := driver.RawTask{TypeName: queue.TaskTypeUnblock, Body: []byte("not json")}
+	err := p.Handle(context.Background(), task)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, driver.SkipRetry))
+}

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -12,6 +12,7 @@ package queue
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -435,12 +436,89 @@ func (c *Client) EnqueueDeleteAccount(payload DeleteAccountPayload) error {
 // AP delivery 失敗を吸収できる程度に設定。
 func (c *Client) EnqueueUnfollow(payload UnfollowPayload) error {
 	body := mustMarshal(payload)
+	return c.enqueueRelationship(TaskTypeUnfollow, body)
+}
+
+// EnqueueFollow schedules a single Follow job for the given pair.
+// Misskey TS の relationshipQueue 'follow' job 相当 (#1605)。retry /
+// uniqueness の方針は EnqueueUnfollow と同じ。
+func (c *Client) EnqueueFollow(payload FollowPayload) error {
+	body := mustMarshal(payload)
+	return c.enqueueRelationship(TaskTypeFollow, body)
+}
+
+// EnqueueBlock schedules a single Block job for the given pair (#1605)。
+func (c *Client) EnqueueBlock(payload BlockPayload) error {
+	body := mustMarshal(payload)
+	return c.enqueueRelationship(TaskTypeBlock, body)
+}
+
+// EnqueueUnblock schedules a single Unblock job for the given pair (#1605)。
+func (c *Client) EnqueueUnblock(payload UnblockPayload) error {
+	body := mustMarshal(payload)
+	return c.enqueueRelationship(TaskTypeUnblock, body)
+}
+
+// enqueueRelationship is the shared enqueue path for the per-pair
+// relationship jobs (follow / unfollow / block / unblock)。
+func (c *Client) enqueueRelationship(taskType string, body []byte) error {
 	base := []driver.EnqueueOption{
 		driver.WithQueue(QueueName),
 		driver.WithMaxRetry(3),
 	}
 	base = append(base, c.retentionOpts(QueueName)...)
-	return c.inner.Enqueue(context.Background(), TaskTypeUnfollow, body, base...)
+	return c.inner.Enqueue(context.Background(), taskType, body, base...)
+}
+
+// EnqueueFollowBulk schedules one Follow job per payload. 本家
+// QueueService.createFollowJob の addBulk 相当 (#1605)。driver に bulk
+// API は無いため逐次 enqueue し、失敗した payload 分のエラーを
+// errors.Join で集約して返す (成功分は enqueue 済のまま)。worker 側が
+// 冪等吸収するため、エラー時に batch 全体を再実行しても安全。
+func (c *Client) EnqueueFollowBulk(payloads []FollowPayload) error {
+	var errs []error
+	for _, p := range payloads {
+		if err := c.EnqueueFollow(p); err != nil {
+			errs = append(errs, fmt.Errorf("follow %s->%s: %w", p.FollowerID, p.FolloweeID, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// EnqueueUnfollowBulk schedules one Unfollow job per payload. 本家
+// QueueService.createUnfollowJob の addBulk 相当 (#1605)。
+func (c *Client) EnqueueUnfollowBulk(payloads []UnfollowPayload) error {
+	var errs []error
+	for _, p := range payloads {
+		if err := c.EnqueueUnfollow(p); err != nil {
+			errs = append(errs, fmt.Errorf("unfollow %s->%s: %w", p.FollowerID, p.FolloweeID, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// EnqueueBlockBulk schedules one Block job per payload. 本家
+// QueueService.createBlockJob の addBulk 相当 (#1605)。
+func (c *Client) EnqueueBlockBulk(payloads []BlockPayload) error {
+	var errs []error
+	for _, p := range payloads {
+		if err := c.EnqueueBlock(p); err != nil {
+			errs = append(errs, fmt.Errorf("block %s->%s: %w", p.BlockerID, p.BlockeeID, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// EnqueueUnblockBulk schedules one Unblock job per payload. 本家
+// QueueService.createUnblockJob の addBulk 相当 (#1605)。
+func (c *Client) EnqueueUnblockBulk(payloads []UnblockPayload) error {
+	var errs []error
+	for _, p := range payloads {
+		if err := c.EnqueueUnblock(p); err != nil {
+			errs = append(errs, fmt.Errorf("unblock %s->%s: %w", p.BlockerID, p.BlockeeID, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // Close releases the underlying client connection.

--- a/internal/queue/relationship_test.go
+++ b/internal/queue/relationship_test.go
@@ -1,0 +1,246 @@
+package queue_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/shiroha-a/mk/internal/queue/driver"
+)
+
+// recordedTask is one Enqueue call captured by recordingQueueClient.
+type recordedTask struct {
+	taskType string
+	payload  []byte
+}
+
+// recordingQueueClient is a driver.Client fake that records Enqueue calls
+// in-memory. relationship 系 client API は redis を要しないため、driver
+// 非依存 (= asynq にも mkq にも縛られない) の fake で検証する。
+type recordingQueueClient struct {
+	enqueued []recordedTask
+	// failWhen returns an error for payloads it wants to reject.
+	failWhen func(taskType string, payload []byte) error
+}
+
+func (c *recordingQueueClient) Enqueue(_ context.Context, taskType string, payload []byte, _ ...driver.EnqueueOption) error {
+	if c.failWhen != nil {
+		if err := c.failWhen(taskType, payload); err != nil {
+			return err
+		}
+	}
+	c.enqueued = append(c.enqueued, recordedTask{taskType: taskType, payload: payload})
+	return nil
+}
+
+func (c *recordingQueueClient) Close() error { return nil }
+
+// recordingDriver satisfies driver.Driver with only Client populated; the
+// queue.Client under test touches Client and Inspector only.
+type recordingDriver struct{ client *recordingQueueClient }
+
+func (d *recordingDriver) Client() driver.Client       { return d.client }
+func (d *recordingDriver) Server() driver.Server       { return nil }
+func (d *recordingDriver) Inspector() driver.Inspector { return nil }
+func (d *recordingDriver) Scheduler() driver.Scheduler { return nil }
+func (d *recordingDriver) Close() error                { return nil }
+func (d *recordingDriver) WorkerCount(string) int      { return 0 }
+func (d *recordingDriver) Resize(string, int) error    { return driver.ErrResizeNotSupported }
+
+func newRecordingClient(failWhen func(string, []byte) error) (*queue.Client, *recordingQueueClient) {
+	rc := &recordingQueueClient{failWhen: failWhen}
+	return queue.NewClient(&recordingDriver{client: rc}), rc
+}
+
+func TestNewFollowTask_RoundTrip(t *testing.T) {
+	payload := queue.FollowPayload{FollowerID: "localA", FolloweeID: "rA", WithReplies: true}
+	task := queue.NewFollowTask(payload)
+	require.Equal(t, queue.TaskTypeFollow, task.Type())
+	got, err := queue.DecodeFollowPayload(task.Payload())
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+}
+
+func TestDecodeFollowPayload_MalformedReturnsError(t *testing.T) {
+	_, err := queue.DecodeFollowPayload([]byte(`not-json`))
+	require.Error(t, err)
+}
+
+func TestNewBlockTask_RoundTrip(t *testing.T) {
+	payload := queue.BlockPayload{BlockerID: "localA", BlockeeID: "rA"}
+	task := queue.NewBlockTask(payload)
+	require.Equal(t, queue.TaskTypeBlock, task.Type())
+	got, err := queue.DecodeBlockPayload(task.Payload())
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+}
+
+func TestDecodeBlockPayload_MalformedReturnsError(t *testing.T) {
+	_, err := queue.DecodeBlockPayload([]byte(`not-json`))
+	require.Error(t, err)
+}
+
+func TestNewUnblockTask_RoundTrip(t *testing.T) {
+	payload := queue.UnblockPayload{BlockerID: "localA", BlockeeID: "rA"}
+	task := queue.NewUnblockTask(payload)
+	require.Equal(t, queue.TaskTypeUnblock, task.Type())
+	got, err := queue.DecodeUnblockPayload(task.Payload())
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+}
+
+func TestDecodeUnblockPayload_MalformedReturnsError(t *testing.T) {
+	_, err := queue.DecodeUnblockPayload([]byte(`not-json`))
+	require.Error(t, err)
+}
+
+func TestClient_EnqueueFollow_TaskTypeAndPayload(t *testing.T) {
+	c, rc := newRecordingClient(nil)
+	require.NoError(t, c.EnqueueFollow(queue.FollowPayload{
+		FollowerID: "localA", FolloweeID: "rA", WithReplies: true,
+	}))
+	require.Len(t, rc.enqueued, 1)
+	assert.Equal(t, queue.TaskTypeFollow, rc.enqueued[0].taskType)
+	got, err := queue.DecodeFollowPayload(rc.enqueued[0].payload)
+	require.NoError(t, err)
+	assert.Equal(t, "localA", got.FollowerID)
+	assert.Equal(t, "rA", got.FolloweeID)
+	assert.True(t, got.WithReplies)
+}
+
+func TestClient_EnqueueBlockAndUnblock_TaskTypes(t *testing.T) {
+	c, rc := newRecordingClient(nil)
+	require.NoError(t, c.EnqueueBlock(queue.BlockPayload{BlockerID: "a", BlockeeID: "b"}))
+	require.NoError(t, c.EnqueueUnblock(queue.UnblockPayload{BlockerID: "a", BlockeeID: "b"}))
+	require.Len(t, rc.enqueued, 2)
+	assert.Equal(t, queue.TaskTypeBlock, rc.enqueued[0].taskType)
+	assert.Equal(t, queue.TaskTypeUnblock, rc.enqueued[1].taskType)
+}
+
+func TestClient_EnqueueFollowBulk_EnqueuesAll(t *testing.T) {
+	c, rc := newRecordingClient(nil)
+	require.NoError(t, c.EnqueueFollowBulk([]queue.FollowPayload{
+		{FollowerID: "a", FolloweeID: "x"},
+		{FollowerID: "b", FolloweeID: "y"},
+		{FollowerID: "c", FolloweeID: "z"},
+	}))
+	require.Len(t, rc.enqueued, 3)
+	for _, e := range rc.enqueued {
+		assert.Equal(t, queue.TaskTypeFollow, e.taskType)
+	}
+}
+
+// 途中の payload が enqueue 失敗しても残りは enqueue され、失敗分が
+// errors.Join で集約されて返ること (本家 addBulk 相当の best-effort)。
+func TestClient_EnqueueFollowBulk_PartialFailureJoinsErrors(t *testing.T) {
+	c, rc := newRecordingClient(func(_ string, payload []byte) error {
+		p, err := queue.DecodeFollowPayload(payload)
+		require.NoError(t, err)
+		if p.FollowerID == "b" {
+			return assert.AnError
+		}
+		return nil
+	})
+	err := c.EnqueueFollowBulk([]queue.FollowPayload{
+		{FollowerID: "a", FolloweeID: "x"},
+		{FollowerID: "b", FolloweeID: "y"},
+		{FollowerID: "c", FolloweeID: "z"},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, assert.AnError)
+	assert.Contains(t, err.Error(), "b->y", "失敗ペアを特定できるエラーメッセージ")
+	require.Len(t, rc.enqueued, 2, "失敗以外の payload は enqueue 済")
+}
+
+func TestClient_EnqueueUnfollowBulk_EnqueuesAll(t *testing.T) {
+	c, rc := newRecordingClient(nil)
+	require.NoError(t, c.EnqueueUnfollowBulk([]queue.UnfollowPayload{
+		{FollowerID: "a", FolloweeID: "x"},
+		{FollowerID: "b", FolloweeID: "y"},
+	}))
+	require.Len(t, rc.enqueued, 2)
+	for _, e := range rc.enqueued {
+		assert.Equal(t, queue.TaskTypeUnfollow, e.taskType)
+	}
+}
+
+func TestClient_EnqueueBlockBulk_EnqueuesAll(t *testing.T) {
+	c, rc := newRecordingClient(nil)
+	require.NoError(t, c.EnqueueBlockBulk([]queue.BlockPayload{
+		{BlockerID: "a", BlockeeID: "x"},
+		{BlockerID: "b", BlockeeID: "y"},
+	}))
+	require.Len(t, rc.enqueued, 2)
+	for _, e := range rc.enqueued {
+		assert.Equal(t, queue.TaskTypeBlock, e.taskType)
+	}
+}
+
+func TestClient_EnqueueUnblockBulk_EnqueuesAll(t *testing.T) {
+	c, rc := newRecordingClient(nil)
+	require.NoError(t, c.EnqueueUnblockBulk([]queue.UnblockPayload{
+		{BlockerID: "a", BlockeeID: "x"},
+		{BlockerID: "b", BlockeeID: "y"},
+	}))
+	require.Len(t, rc.enqueued, 2)
+	for _, e := range rc.enqueued {
+		assert.Equal(t, queue.TaskTypeUnblock, e.taskType)
+	}
+}
+
+func TestClient_EnqueueBlockBulk_PartialFailureJoinsErrors(t *testing.T) {
+	c, rc := newRecordingClient(func(_ string, payload []byte) error {
+		p, err := queue.DecodeBlockPayload(payload)
+		require.NoError(t, err)
+		if p.BlockerID == "a" {
+			return assert.AnError
+		}
+		return nil
+	})
+	err := c.EnqueueBlockBulk([]queue.BlockPayload{
+		{BlockerID: "a", BlockeeID: "x"},
+		{BlockerID: "b", BlockeeID: "y"},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, assert.AnError)
+	require.Len(t, rc.enqueued, 1)
+}
+
+func TestClient_EnqueueUnfollowBulk_PartialFailureJoinsErrors(t *testing.T) {
+	c, rc := newRecordingClient(func(_ string, payload []byte) error {
+		p, err := queue.DecodeUnfollowPayload(payload)
+		require.NoError(t, err)
+		if p.FollowerID == "a" {
+			return assert.AnError
+		}
+		return nil
+	})
+	err := c.EnqueueUnfollowBulk([]queue.UnfollowPayload{
+		{FollowerID: "a", FolloweeID: "x"},
+		{FollowerID: "b", FolloweeID: "y"},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, assert.AnError)
+	require.Len(t, rc.enqueued, 1)
+}
+
+func TestClient_EnqueueUnblockBulk_PartialFailureJoinsErrors(t *testing.T) {
+	c, rc := newRecordingClient(func(_ string, payload []byte) error {
+		p, err := queue.DecodeUnblockPayload(payload)
+		require.NoError(t, err)
+		if p.BlockerID == "a" {
+			return assert.AnError
+		}
+		return nil
+	})
+	err := c.EnqueueUnblockBulk([]queue.UnblockPayload{
+		{BlockerID: "a", BlockeeID: "x"},
+		{BlockerID: "b", BlockeeID: "y"},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, assert.AnError)
+	require.Len(t, rc.enqueued, 1)
+}

--- a/internal/queue/tasks.go
+++ b/internal/queue/tasks.go
@@ -350,6 +350,89 @@ func DecodeUnfollowPayload(body []byte) (UnfollowPayload, error) {
 	return p, nil
 }
 
+// TaskTypeFollow is the task type for the per-pair Follow queue job.
+// Misskey TS の relationshipQueue の `follow` job 名と一致 (#1605)。
+// import / AccountMove のような大量関係操作を per-pair で retry 可能に
+// する非同期 surface (本家 RelationshipProcessorService.processFollow)。
+const TaskTypeFollow = "relationship:follow"
+
+// FollowPayload identifies the (follower, followee) pair to attach.
+// 本家 TS の RelationshipJobData {from, to, silent, requestId, withReplies}
+// に相当。silent / requestId は mk-go の core/following.Follow が未対応の
+// ため payload に含めない (UnfollowPayload と同方針、core 対応時に追加)。
+type FollowPayload struct {
+	FollowerID  string `json:"followerId"`
+	FolloweeID  string `json:"followeeId"`
+	WithReplies bool   `json:"withReplies,omitempty"`
+}
+
+// NewFollowTask serializes a FollowPayload into a driver.Task.
+func NewFollowTask(payload FollowPayload) driver.Task {
+	body, _ := json.Marshal(payload)
+	return driver.RawTask{TypeName: TaskTypeFollow, Body: body}
+}
+
+// DecodeFollowPayload extracts a FollowPayload from a task body.
+func DecodeFollowPayload(body []byte) (FollowPayload, error) {
+	var p FollowPayload
+	if err := json.Unmarshal(body, &p); err != nil {
+		return FollowPayload{}, err
+	}
+	return p, nil
+}
+
+// TaskTypeBlock is the task type for the per-pair Block queue job.
+// Misskey TS の relationshipQueue の `block` job 名と一致 (#1605)。
+const TaskTypeBlock = "relationship:block"
+
+// BlockPayload identifies the (blocker, blockee) pair to attach.
+// 本家 TS の RelationshipJobData {from, to, silent} に相当。silent は
+// mk-go の core/blocking.Block が未対応のため含めない。
+type BlockPayload struct {
+	BlockerID string `json:"blockerId"`
+	BlockeeID string `json:"blockeeId"`
+}
+
+// NewBlockTask serializes a BlockPayload into a driver.Task.
+func NewBlockTask(payload BlockPayload) driver.Task {
+	body, _ := json.Marshal(payload)
+	return driver.RawTask{TypeName: TaskTypeBlock, Body: body}
+}
+
+// DecodeBlockPayload extracts a BlockPayload from a task body.
+func DecodeBlockPayload(body []byte) (BlockPayload, error) {
+	var p BlockPayload
+	if err := json.Unmarshal(body, &p); err != nil {
+		return BlockPayload{}, err
+	}
+	return p, nil
+}
+
+// TaskTypeUnblock is the task type for the per-pair Unblock queue job.
+// Misskey TS の relationshipQueue の `unblock` job 名と一致 (#1605)。
+const TaskTypeUnblock = "relationship:unblock"
+
+// UnblockPayload identifies the (blocker, blockee) pair to detach.
+type UnblockPayload struct {
+	BlockerID string `json:"blockerId"`
+	BlockeeID string `json:"blockeeId"`
+}
+
+// NewUnblockTask serializes an UnblockPayload into a driver.Task.
+func NewUnblockTask(payload UnblockPayload) driver.Task {
+	body, _ := json.Marshal(payload)
+	return driver.RawTask{TypeName: TaskTypeUnblock, Body: body}
+}
+
+// DecodeUnblockPayload extracts an UnblockPayload from a task body.
+func DecodeUnblockPayload(body []byte) (UnblockPayload, error) {
+	var p UnblockPayload
+	if err := json.Unmarshal(body, &p); err != nil {
+		return UnblockPayload{}, err
+	}
+	return p, nil
+}
+
 // PostScheduledNotePayload identifies a draft scheduled for future publish.
 // upstream `PostScheduledNoteJobData { noteDraftId }` と shape 一致 (#1040)。
 type PostScheduledNotePayload struct {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -682,6 +682,18 @@ func (s *Server) setupRoutes() {
 	// 配送を行う。Misskey TS の relationshipQueue 'unfollow' job 相当。
 	unfollowProcessor := processors.NewUnfollowProcessor(followingService)
 	s.queueServer.Handle(queue.TaskTypeUnfollow, unfollowProcessor.Handle)
+
+	// Per-pair Follow / Block / Unblock job (#1605): 本家
+	// RelationshipProcessorService の processFollow / processBlock /
+	// processUnblock 相当。大量関係操作 (将来の AccountMove フォロワー移行
+	// 等) の非同期バックプレッシャ surface。import は完了通知の
+	// Applied/Skipped 集計を保つため同期適用を維持する (core/transfer)。
+	followProcessor := processors.NewFollowProcessor(followingService)
+	s.queueServer.Handle(queue.TaskTypeFollow, followProcessor.Handle)
+	blockProcessor := processors.NewBlockProcessor(blockingService)
+	s.queueServer.Handle(queue.TaskTypeBlock, blockProcessor.Handle)
+	unblockProcessor := processors.NewUnblockProcessor(blockingService)
+	s.queueServer.Handle(queue.TaskTypeUnblock, unblockProcessor.Handle)
 	if bufMeta, err := metaRepo.Fetch(); err == nil && bufMeta.EnableReactionsBuffering {
 		go func() {
 			ticker := time.NewTicker(30 * time.Second)


### PR DESCRIPTION
## Summary

mk-go の relationship queue は `relationship:unfollow` のみ (#587) で、本家 `RelationshipProcessorService` の processFollow / processBlock / processUnblock + `QueueService.createFollowJob` / `createBlockJob` / `createUnblockJob` (addBulk) に相当する非同期バックプレッシャ surface が無かった (#1563 項目6 の follow-up)。follow / block / unblock の batch job + processor + addBulk 相当の bulk enqueue API を追加する。

## 主な変更点

### queue surface (`internal/queue/tasks.go` / `queue.go`)

- `TaskTypeFollow` (`relationship:follow`) / `TaskTypeBlock` (`relationship:block`) / `TaskTypeUnblock` (`relationship:unblock`) + payload / `New*Task` / `Decode*Payload` を既存 `relationship:unfollow` と同形式で追加。
- `FollowPayload` は `{followerId, followeeId, withReplies}`。本家 `RelationshipJobData` の `silent` / `requestId` は mk-go の `core/following.Follow` が未対応のため payload に含めない (`UnfollowPayload` と同方針、core 対応時に追加)。
- `EnqueueFollow` / `EnqueueBlock` / `EnqueueUnblock` を追加 (`EnqueueUnfollow` と同じ deliver queue / MaxRetry 3 / Unique なし。共通の `enqueueRelationship` に集約)。
- 本家 addBulk 相当の `EnqueueFollowBulk` / `EnqueueUnfollowBulk` / `EnqueueBlockBulk` / `EnqueueUnblockBulk`。driver に bulk API は無いため逐次 enqueue し、失敗分を `errors.Join` で集約して返す (worker 側の冪等吸収により batch 全体の再実行が安全)。

### processors (`internal/queue/processors/{follow,block,unblock}.go`)

本家 `RelationshipProcessorService` の各 process* に対応し、router に配線:

- 冪等吸収 (成功扱い): follow=`ErrAlreadyFollowing`/`ErrAlreadyRequested`、block=`ErrAlreadyBlocking`、unblock=`ErrNotBlocking` (望む終状態に到達済み)。
- 恒久エラー (`driver.SkipRetry`): follow=`ErrBlocked`/`ErrSelfFollow`/`ErrFolloweeNotFound`、block=`ErrSelfBlock`/`ErrBlockeeNotFound`、unblock=`ErrSelfBlock`。retry しても解消しないため即終了。
- その他のエラーは retry。
- core/following・core/blocking は queue を import しないため canonical sentinel を `errors.Is` で直接照合 (processors/transfer.go の先行例に準拠。既存 unfollow.go の文字列照合は変更せず)。

### import 経路の設計判断 (issue の注意事項への対応)

本家は import-following / import-blocking で per-line に follow/block job を enqueue するが、mk-go の import は完了通知に Applied/Skipped count を載せるため、per-pair 非同期化すると「Applied = enqueue 数」となり follow 失敗 (block 済等) を数えられず count が不正確になる regression がある (#1563 review)。よって **import は同期 loop を維持**し、`import_csv.go` に設計判断コメントを明記した。AccountMove のフォロワー移行 (本家 createFollowJob 経路) は mk-go 未実装機能のため、実装時に本 surface を使う。

## テスト

- queue 層は asynq 非依存の fake driver (`recordingDriver`) で検証: payload round-trip / malformed / taskType / Bulk 全量 enqueue / 部分失敗の errors.Join 集約 (4 種すべて)。
- processors 3 種: success (withReplies 引き継ぎ含む) / 冪等吸収 / SkipRetry / retry / payload 不正 / field 欠落 / service 未配線の全分岐。
- カバレッジ: `internal/queue` 93.2% / `internal/queue/processors` 92.0% (新規関数はすべて 100%)。
- `make fmt` / `make lint` / 全パッケージテスト pass。
- 実行方法: `go test ./internal/queue/... -run 'Follow|Block|Unblock'`

## Closes

Closes #1605

## その他

- 本家の `createDelayedUnfollowJob` (delay 付き unfollow、suspend 経路用) は mk-go に suspend 時 unfollow 経路自体が無いため未追加。経路実装時に `driver.WithProcessIn` で対応可能。
- 新 processor の現時点の producer は無し (surface の提供が本 issue の目的)。AccountMove フォロワー移行 / UserList proxy follow 等の未実装機能が実装される際にここへ enqueue する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)