### PR TITLE
Fix: drive/* parity の MEDIUM/LOW 差分 15 件をまとめて解消 (#1564)

### DIFF
--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strings"
 	"unicode/utf8"
 
@@ -109,77 +110,56 @@ func (h *Handler) emojiLookup() entity.EmojiLookup {
 	return h.emojiRepo
 }
 
-// packDriveFileFull packs a drive file and, when repositories are wired,
-// embeds the owning folder/user as nested objects. Matches Misskey's
-// packDriveFileSchema which exposes both `folder` and `user`.
-//
-// 注: 戻り値は upstream の `pack(file, { detail: true, withUser: true })`
-// 相当 (= owner ID と user 込み) で drive/files/show のような detail 経路
-// で使う。それ以外の経路は対応する helper を使うこと:
-//
-//   - `drive/files/create` (= self single, `pack(file, { self: true })`):
-//     `packDriveFileSelfSingle` (#812)
-//   - `drive/files/find` / `find-by-hash` (= self list,
-//     `packMany(files, { self: true })`):
-//     `packDriveFileSelfList` (#818)
-//
-// 本関数を上記 self 経路で直接 c.JSON に渡すと shape drift する。
-func (h *Handler) packDriveFileFull(f *model.DriveFile) entity.DriveFileEntity {
-	// list loop (FilesList / FilesFind / Stream) からも呼ばれ、1ファイル
-	// 当たり最大2 DB read (O(N) queries)が発生する。1ページ上限が10-100
-	// 程度なので実害は小さいが、大量ファイルを返す admin list 等では
-	// batch化の余地あり (follow-up issueで検討)。
-	var folder *model.DriveFolder
-	if h.folderRepo != nil && f.FolderID != nil {
-		if fo, err := h.folderRepo.FindByID(*f.FolderID); err == nil {
-			folder = fo
-		}
-	}
-	var user *model.User
-	if h.userRepo != nil && f.UserID != nil {
-		if u, err := h.userRepo.FindByID(*f.UserID); err == nil {
-			user = u
-		}
-	}
-	return entity.PackDriveFileWithRelations(f, h.idGen, folder, user)
-}
+// upstream paramDef の maxLength 定数 (#1564)。ajv の maxLength は UTF-16
+// code unit 基準だが mk-go は rune 数で近似する (多バイト文字を過剰に弾か
+// ない側。サロゲートペア絵文字は upstream より長く受理される既知の差)。
+const (
+	// maxDriveCommentLength は drive/files/{create,update,upload-from-url}
+	// の comment maxLength (= upstream DB_MAX_IMAGE_COMMENT_LENGTH)。
+	maxDriveCommentLength = 512
+	// maxDriveFolderNameLength は drive/folders/{create,update} の name
+	// maxLength。core 側 ValidateFileName の 200 (file name) とは別の値。
+	maxDriveFolderNameLength = 200
+)
+
+// driveTypePatternRe は drive/files・drive/stream の `type` param に対する
+// upstream paramDef pattern `^[a-zA-Z\/\-*]+$` の移植 (#1564 review)。
+// 数字を含む MIME (video/mp4 等) も upstream はこの pattern で reject する。
+// SQL LIKE の metacharacter (% _) もここで弾かれるため repo 層の LIKE に
+// wildcard が混入しない。
+var driveTypePatternRe = regexp.MustCompile(`^[a-zA-Z/\-*]+$`)
 
 // packDriveFileSelfSingle packs a drive file for the "self single" path used
-// by drive/files/create.
+// by drive/files/create (and the urlUploadFinished payload in url_upload.go).
 //
 // upstream Misskey TS は `pack(file, { self: true })` (= withUser=false /
 // detail=false) を呼び、`folder=null` / `user=null` / `userId=null` を
-// 返す (DriveFileEntityService.ts:191-222)。mk-go は packDriveFileFull が
-// 常に folder / user を resolve するため、helper で post-fixup して shape
-// を整合させる (#812 / #818)。
+// 返す (DriveFileEntityService.ts:191-222)。PackDriveFile は Folder / User
+// を fetch しない (= nil) ので、userId の null 化だけ足す (#812 / #1564
+// review で full pack→null 潰しの無駄 fetch を解消)。
 //
-// drive/files/find / find-by-hash の self list path とは異なり userId も
-// **null にする** 点に注意 (= pack は detail=false で userId を返さない、
-// packNullable とは別経路)。
-func (h *Handler) packDriveFileSelfSingle(f *model.DriveFile) entity.DriveFileEntity {
-	e := h.packDriveFileFull(f)
-	e.Folder = nil
+// self list path とは異なり userId も **null にする** 点に注意 (= pack は
+// detail=false で userId を返さない、packNullable とは別経路)。
+func packDriveFileSelfSingle(f *model.DriveFile, idGen id.Generator) entity.DriveFileEntity {
+	e := entity.PackDriveFile(f, idGen)
 	e.UserID = nil
-	e.User = nil
 	return e
 }
 
 // packDriveFileSelfList packs a drive file for the "self list" path used by
-// drive/files/find と drive/files/find-by-hash.
+// drive/files, drive/files/find, drive/files/find-by-hash, drive/stream.
 //
 // upstream Misskey TS は `packMany(files, { self: true })` 経由で
 // `packNullable` を呼び、`folder=null` / `user=null` / `userId=owner ID`
 // を返す (DriveFileEntityService.ts:225-261, withUser/detail デフォルト
-// false)。mk-go は packDriveFileFull が常に folder / user を resolve する
-// ため、helper で post-fixup して shape を整合させる (#818)。
+// false)。PackDriveFile がそのままこの shape (Folder/User nil, UserID 維持)
+// を返す (#818 / #1564 review で full pack→null 潰しの per-file 2 query を
+// 解消。limit=100 の list で最大 200 query 削減)。
 //
-// drive/files/create の self single path (#812) とは異なり userId は
-// **owner ID を維持** する点に注意 (= packNullable は userId を常時返す)。
+// self single path (#812) とは異なり userId は **owner ID を維持** する
+// (= packNullable は userId を常時返す)。
 func (h *Handler) packDriveFileSelfList(f *model.DriveFile) entity.DriveFileEntity {
-	e := h.packDriveFileFull(f)
-	e.Folder = nil
-	e.User = nil
-	return e
+	return entity.PackDriveFile(f, h.idGen)
 }
 
 // readMultipartFile extracts the uploaded file's bytes and original filename.
@@ -211,17 +191,38 @@ func (h *Handler) FilesCreate(c echo.Context) error {
 	in := coredrive.UploadInput{
 		User:           user,
 		Body:           body,
-		Name:           filename,
 		RequestIP:      requestIPFromContext(c),
 		RequestHeaders: requestHeadersForDrive(c),
 	}
-	if v := c.FormValue("name"); v != "" {
-		in.Name = v
+	// upstream create.ts:98-108 の name 決定: ps.name ?? file.name を trim し、
+	// 空 / 'blob' は null 化、それ以外は validateFileName 失敗で
+	// INVALID_FILE_NAME (#1564)。null 時 upstream は DriveService.addFile が
+	// `file.name || 'untitled'` + 拡張子補正で保存するが、mk-go は拡張子補正
+	// (correctFilename) 未実装のため 'untitled' 固定で fallback する。
+	// multipart form の name 欄は「明示的な空文字」と「未指定」を区別する
+	// (upstream `ps.name ?? file.name` は '' を nullish 扱いしないため、
+	// 明示 '' は trim 後 null → 'untitled' になる) (#1564 review)。
+	name := filename
+	if form, ferr := c.MultipartForm(); ferr == nil && form != nil {
+		if vs, ok := form.Value["name"]; ok && len(vs) > 0 {
+			name = vs[0]
+		}
 	}
+	name = strings.TrimSpace(name)
+	if name == "" || name == "blob" {
+		name = "untitled"
+	} else if !coredrive.ValidateFileName(name) {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_FILE_NAME", "Invalid file name.", "f449b209-0c60-4e51-84d5-29486263bfd4"))
+	}
+	in.Name = name
 	if v := c.FormValue("folderId"); v != "" {
 		in.FolderID = &v
 	}
 	if v := c.FormValue("comment"); v != "" {
+		// upstream paramDef は comment maxLength=512 (#1564)。
+		if utf8.RuneCountInString(v) > maxDriveCommentLength {
+			return apierr.JSONInvalidParam(c)
+		}
 		in.Comment = &v
 	}
 	if c.FormValue("isSensitive") == "true" {
@@ -256,7 +257,7 @@ func (h *Handler) FilesCreate(c echo.Context) error {
 	// self single path 経路 (#812)。helper が folder / userId / user を
 	// 一律 null 化する (旧 inline 版は folder の nil 化を見落としていて
 	// folderId 指定 upload で drift していたが、helper 化で同時に解消)。
-	return c.JSON(http.StatusOK, h.packDriveFileSelfSingle(f))
+	return c.JSON(http.StatusOK, packDriveFileSelfSingle(f, h.idGen))
 }
 
 // FileIDRequest is the body for show/delete and similar single-file ops.
@@ -265,17 +266,57 @@ type FileIDRequest struct {
 }
 
 // FilesShow handles POST /api/drive/files/show.
+//
+// upstream paramDef は anyOf で {fileId} または {url} を受け、url 指定時は
+// url / webpublicUrl / thumbnailUrl の OR 一致で検索する (#1564)。
 func (h *Handler) FilesShow(c echo.Context) error {
 	user := middleware.GetUser(c)
-	var req FileIDRequest
-	if err := c.Bind(&req); err != nil || req.FileID == "" {
+	// fileId / url は「キー存在」で anyOf を判定する (upstream の required は
+	// presence のみで、`{"url":""}` は lookup に進んで 404 NO_SUCH_FILE になる)
+	// (#1564 review)。fileId は format misskey:id なので空文字は INVALID_PARAM。
+	var req struct {
+		FileID *string `json:"fileId"`
+		URL    *string `json:"url"`
+	}
+	if err := c.Bind(&req); err != nil || (req.FileID == nil && req.URL == nil) {
 		return apierr.JSONInvalidParam(c)
 	}
-	f, err := h.svc.Show(user, req.FileID)
+	var f *model.DriveFile
+	var err error
+	if req.FileID != nil {
+		if *req.FileID == "" {
+			return apierr.JSONInvalidParam(c)
+		}
+		f, err = h.svc.Show(user, *req.FileID)
+	} else {
+		f, err = h.svc.ShowByURL(user, *req.URL)
+	}
 	if err != nil {
 		return mapFileError(c, err, fileEndpointShow)
 	}
-	return c.JSON(http.StatusOK, h.packDriveFileFull(f))
+	return c.JSON(http.StatusOK, h.packDriveFileShow(f))
+}
+
+// packDriveFileShow is the drive/files/show pack: upstream は pack(file,
+// {detail:true, withUser:true, self:true}) で、埋め込み folder を detail mode
+// (foldersCount / filesCount / parent 付き)、user を UserLite で pack する
+// (#1564)。folder / user は各 1 回だけ fetch する (full pack 経由の二重
+// fetch を解消、#1564 review)。
+func (h *Handler) packDriveFileShow(f *model.DriveFile) entity.DriveFileEntity {
+	e := entity.PackDriveFile(f, h.idGen)
+	if h.folderRepo != nil && f.FolderID != nil {
+		if fo, err := h.folderRepo.FindByID(*f.FolderID); err == nil {
+			d := h.packDriveFolderDetail(fo)
+			e.Folder = &d
+		}
+	}
+	if h.userRepo != nil && f.UserID != nil {
+		if u, err := h.userRepo.FindByID(*f.UserID); err == nil {
+			lite := entity.PackUserLite(u)
+			e.User = &lite
+		}
+	}
+	return e
 }
 
 // FilesUpdateRequest is the body for drive/files/update.
@@ -301,6 +342,10 @@ func (h *Handler) FilesUpdate(c echo.Context) error {
 		IsSensitive: req.IsSensitive,
 	}
 	if req.Comment != nil {
+		// upstream update.ts paramDef は comment maxLength=512 (#1564)。
+		if utf8.RuneCountInString(*req.Comment) > maxDriveCommentLength {
+			return apierr.JSONInvalidParam(c)
+		}
 		c2 := req.Comment
 		in.Comment = &c2
 	}
@@ -319,7 +364,7 @@ func (h *Handler) FilesUpdate(c echo.Context) error {
 	// upstream は updateFile 後 `pack(file.id, { self: true })` を返す
 	// (= self single shape、DriveService.ts)。本実装も #812 の create と
 	// 同じ self single helper を使う (folder / userId / user 全 null)。
-	return c.JSON(http.StatusOK, h.packDriveFileSelfSingle(f))
+	return c.JSON(http.StatusOK, packDriveFileSelfSingle(f, h.idGen))
 }
 
 // FilesDelete handles POST /api/drive/files/delete.
@@ -347,12 +392,19 @@ func (h *Handler) FilesFindByHash(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.MD5 == "" {
 		return apierr.JSONInvalidParam(c)
 	}
-	f, err := h.svc.FindByHash(user, req.MD5)
+	files, err := h.svc.FindByHash(user, req.MD5)
 	if err != nil {
-		return mapFileError(c, err, fileEndpointFindByHash)
+		// FindByHash は #1564 以降 not-found を空 slice で返すため、ここに
+		// 来るのは repo error のみ (= upstream も 500 相当)。
+		return apierr.JSONInternalError(c)
 	}
-	// upstream `packMany(files, { self: true })` 経路 (#818)。
-	return c.JSON(http.StatusOK, []entity.DriveFileEntity{h.packDriveFileSelfList(f)})
+	// upstream は findBy({md5, userId}) の一致全件を `packMany(files,
+	// { self: true })` で返す (#818 / #1564 で最新 1 件 → 全件に修正)。
+	out := make([]entity.DriveFileEntity, 0, len(files))
+	for _, f := range files {
+		out = append(out, h.packDriveFileSelfList(f))
+	}
+	return c.JSON(http.StatusOK, out)
 }
 
 // FoldersCreateRequest is the body for drive/folders/create.
@@ -366,6 +418,10 @@ func (h *Handler) FoldersCreate(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req FoldersCreateRequest
 	if err := c.Bind(&req); err != nil {
+		return apierr.JSONInvalidParam(c)
+	}
+	// upstream folders/create paramDef は name maxLength=200 (#1564)。
+	if utf8.RuneCountInString(req.Name) > maxDriveFolderNameLength {
 		return apierr.JSONInvalidParam(c)
 	}
 	if req.Name == "" {
@@ -410,6 +466,16 @@ func (h *Handler) FoldersShow(c echo.Context) error {
 // parent は nil。これは production runtime には影響しない (= router で
 // 必ず wired される)。
 func (h *Handler) packDriveFolderDetail(f *model.DriveFolder) entity.DriveFolderEntity {
+	return h.packDriveFolderDetailGuarded(f, map[string]struct{}{})
+}
+
+// packDriveFolderDetailGuarded is the recursion body of packDriveFolderDetail.
+// visited は parent 連鎖の循環 data guard (#1564 review): 旧 mk-go は folder
+// 循環を作れてしまっていた (folders/update の RECURSIVE_NESTING 検証は #1564
+// で追加) ため、既存の循環 data で parent 再帰が無限 loop → stack overflow
+// でプロセスごと落ちるのを防ぐ。既出 folder に当たったら連鎖を打ち切る。
+func (h *Handler) packDriveFolderDetailGuarded(f *model.DriveFolder, visited map[string]struct{}) entity.DriveFolderEntity {
+	visited[f.ID] = struct{}{}
 	e := entity.PackDriveFolder(f, h.idGen)
 	foldersCount := 0
 	filesCount := 0
@@ -433,8 +499,10 @@ func (h *Handler) packDriveFolderDetail(f *model.DriveFolder) entity.DriveFolder
 	e.FoldersCount = &foldersCount
 	e.FilesCount = &filesCount
 	if f.ParentID != nil && h.folderRepo != nil {
-		if parent, err := h.folderRepo.FindByID(*f.ParentID); err == nil {
-			parentPacked := h.packDriveFolderDetail(parent)
+		if _, seen := visited[*f.ParentID]; seen {
+			slog.Warn("packDriveFolderDetail: folder parent cycle detected, truncating", "folderID", f.ID, "parentID", *f.ParentID)
+		} else if parent, err := h.folderRepo.FindByID(*f.ParentID); err == nil {
+			parentPacked := h.packDriveFolderDetailGuarded(parent, visited)
 			e.Parent = &parentPacked
 		} else {
 			// parent FindByID error は recursion 切断の原因。同上で Warn。
@@ -457,6 +525,10 @@ func (h *Handler) FoldersUpdate(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req FoldersUpdateRequest
 	if err := c.Bind(&req); err != nil || req.FolderID == "" {
+		return apierr.JSONInvalidParam(c)
+	}
+	// upstream folders/update paramDef は name maxLength=200 (#1564)。
+	if req.Name != nil && utf8.RuneCountInString(*req.Name) > maxDriveFolderNameLength {
 		return apierr.JSONInvalidParam(c)
 	}
 	in := coredrive.UpdateFolderInput{Name: req.Name}
@@ -498,7 +570,6 @@ const (
 	fileEndpointShow fileEndpoint = iota
 	fileEndpointUpdate
 	fileEndpointDelete
-	fileEndpointFindByHash
 )
 
 func mapFileError(c echo.Context, err error, ep fileEndpoint) error {
@@ -506,7 +577,7 @@ func mapFileError(c echo.Context, err error, ep fileEndpoint) error {
 	case errors.Is(err, coredrive.ErrFileNotFound):
 		var id string
 		switch ep {
-		case fileEndpointShow, fileEndpointFindByHash:
+		case fileEndpointShow:
 			id = "067bc436-2718-4795-b0fb-ecbe43949e31"
 		case fileEndpointUpdate:
 			id = "e7778c7e-3af9-49cd-9690-6dbc3e6c972d"
@@ -532,13 +603,14 @@ func mapFileError(c echo.Context, err error, ep fileEndpoint) error {
 			id = "01a53b27-82fc-445b-a0c1-b558465a8ed2"
 		case fileEndpointDelete:
 			id = "5eb8d909-2540-4970-90b8-dd6f86088121"
-		case fileEndpointFindByHash:
-			// find-by-hash は ACCESS_DENIED を golden 未定義。汎用 id を使う。
-			id = "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"
 		default:
 			panic(fmt.Sprintf("mapFileError: unknown fileEndpoint %d", ep))
 		}
 		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", id))
+	case errors.Is(err, coredrive.ErrInvalidFileName):
+		// upstream drive/files/update の invalidFileName (#1564)。create は
+		// handler 内で別 UUID (f449b209-...) を直接返すためここには来ない。
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_FILE_NAME", "Invalid file name.", "395e7156-f9f0-475e-af89-53c3c23080c2"))
 	case errors.Is(err, coredrive.ErrCannotUnmarkSensitive):
 		// upstream drive/files/update の restrictedByRole は i/update と別 UUID
 		// (7f59dccb-...)。endpoint 単位で frontend が i18n 引きするので、
@@ -594,6 +666,10 @@ func mapFolderError(c echo.Context, err error, ep folderEndpoint) error {
 		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
 	case errors.Is(err, coredrive.ErrFolderNotEmpty):
 		return c.JSON(http.StatusBadRequest, apierr.Error("HAS_CHILD_FILES_OR_FOLDERS", "Folder is not empty.", "b0fc8a17-963c-405d-bfbc-859a487295e1"))
+	case errors.Is(err, coredrive.ErrRecursiveNesting):
+		// upstream folders/update の recursiveNesting (#1564)。id はダッシュ
+		// 無しの upstream 原文 (i/2fa の typo UUID と同じく矯正しない)。
+		return c.JSON(http.StatusBadRequest, apierr.Error("RECURSIVE_NESTING", "It can not be structured like nesting folders recursively.", "dbeb024837894013aed44279f9199740"))
 	}
 	return apierr.JSONInternalError(c)
 }
@@ -624,8 +700,17 @@ func (h *Handler) FilesList(c echo.Context) error {
 		UntilDate *int64  `json:"untilDate"`
 		FolderID  *string `json:"folderId"`
 		Type      string  `json:"type"`
+		Sort      string  `json:"sort"`
 	}
 	if err := c.Bind(&req); err != nil {
+		return apierr.JSONInvalidParam(c)
+	}
+	// upstream paramDef の sort は enum、type は pattern (#1564)。違反は
+	// ajv が INVALID_PARAM で弾くので同じく reject する。
+	if !isValidDriveSort(req.Sort) {
+		return apierr.JSONInvalidParam(c)
+	}
+	if req.Type != "" && !driveTypePatternRe.MatchString(req.Type) {
 		return apierr.JSONInvalidParam(c)
 	}
 	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
@@ -634,15 +719,27 @@ func (h *Handler) FilesList(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1173)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
-	files, err := h.fileRepo.ListByUser(user.ID, req.FolderID, untilID, sinceID, req.Limit)
+	files, err := h.fileRepo.ListByUser(user.ID, req.FolderID, false, req.Type, req.Sort, untilID, sinceID, req.Limit)
 	if err != nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
+	// upstream files.ts は packMany(files, {detail:false, self:true}) =
+	// folder/user null, userId は owner ID (#1564)。
 	out := make([]entity.DriveFileEntity, 0, len(files))
 	for _, f := range files {
-		out = append(out, h.packDriveFileFull(f))
+		out = append(out, h.packDriveFileSelfList(f))
 	}
 	return c.JSON(http.StatusOK, out)
+}
+
+// isValidDriveSort reports whether v matches upstream drive/files.ts
+// `sort: enum ['+createdAt','-createdAt','+name','-name','+size','-size', null]`.
+func isValidDriveSort(v string) bool {
+	switch v {
+	case "", "+createdAt", "-createdAt", "+name", "-name", "+size", "-size":
+		return true
+	}
+	return false
 }
 
 // FilesFind handles POST /api/drive/files/find — search by name.
@@ -718,14 +815,19 @@ func (h *Handler) FilesAttachedNotes(c echo.Context) error {
 		return apierr.JSONInvalidParam(c)
 	}
 	// upstream Misskey TS の attached-notes.ts と同じ semantics: viewer 所有
-	// file のみ許可 (#1470 IDOR fix)。upstream 専用 UUID
-	// `c118ece3-2e4b-4296-99d1-51756e32d232` を使い、汎用 NoSuchFile
+	// file のみ許可 (#1470 IDOR fix)。moderator は upstream と同じく任意
+	// user の file を照会できる (#1564、userId filter を外す)。upstream 専用
+	// UUID `c118ece3-2e4b-4296-99d1-51756e32d232` を使い、汎用 NoSuchFile
 	// (UUIDNoSuchFile) と区別する。
 	if h.fileRepo == nil {
 		return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_FILE", "No such file.", "c118ece3-2e4b-4296-99d1-51756e32d232"))
 	}
+	// owner 判定を先に行い、moderator role lookup は非 owner のときだけ払う
+	// (lazy 評価、#1564 review)。moderator 判定は core 側の RoleChecker
+	// (svc.IsModerator) に一本化し、wiring を二重化しない。
 	f, err := h.fileRepo.FindByID(req.FileID)
-	if err != nil || f.UserID == nil || *f.UserID != viewer.ID {
+	viewerIsOwner := err == nil && f.UserID != nil && *f.UserID == viewer.ID
+	if err != nil || (!viewerIsOwner && !h.svc.IsModerator(viewer.ID)) {
 		return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_FILE", "No such file.", "c118ece3-2e4b-4296-99d1-51756e32d232"))
 	}
 	// fileIds配列にfileIDを含むノートを検索 (PostgreSQL配列演算子)
@@ -738,6 +840,15 @@ func (h *Handler) FilesAttachedNotes(c echo.Context) error {
 	notes, err := h.noteRepo.ListByFileID(req.FileID, sinceID, untilID, req.Limit)
 	if err != nil {
 		return c.JSON(http.StatusOK, []any{})
+	}
+	// moderator が他人 file を照会する経路 (#1564) では note が viewer 自身の
+	// ものとは限らないため、可視性 filter を通す (followingRepo=nil の
+	// fail-closed: followers note は author 本人以外に出さない)。TS は
+	// pack 側の hide で本文を null 化するが、mk-go は drop で安全側に倒す。
+	// owner 経路は従来どおり filter 不要 (notes/create の checkFileIDs により
+	// 必然的に viewer 自身の note のみ)。
+	if !viewerIsOwner {
+		notes = notesfilter.FilterVisible(viewer, notes, nil)
 	}
 	notes = notesfilter.ApplyHardMute(h.userRepo, viewer, notes)
 	out := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
@@ -768,7 +879,7 @@ func (h *Handler) FilesUploadFromURL(c echo.Context) error {
 	// upstream paramDef は comment maxLength=512。ajv の maxLength は文字数
 	// (code unit) 基準なので byte 長ではなく rune 数で判定する (多バイト文字を
 	// 過剰に弾かないため)。超過は INVALID_PARAM。
-	if req.Comment != nil && utf8.RuneCountInString(*req.Comment) > 512 {
+	if req.Comment != nil && utf8.RuneCountInString(*req.Comment) > maxDriveCommentLength {
 		return apierr.JSONInvalidParam(c)
 	}
 	// uploader 未配線 (= 単体テスト等) は upstream と同じ空レスポンスで返す。
@@ -839,19 +950,25 @@ func (h *Handler) Stream(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
+	// upstream stream.ts paramDef の type pattern (#1564)。
+	if req.Type != "" && !driveTypePatternRe.MatchString(req.Type) {
+		return apierr.JSONInvalidParam(c)
+	}
 	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	if h.fileRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1173)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
-	files, err := h.fileRepo.ListByUser(user.ID, nil, untilID, sinceID, req.Limit)
+	// upstream stream.ts は folder 条件を付けず全 folder 横断 (#1564)。
+	files, err := h.fileRepo.ListByUser(user.ID, nil, true, req.Type, "", untilID, sinceID, req.Limit)
 	if err != nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
+	// upstream stream.ts も packMany(files, {detail:false, self:true}) (#1564)。
 	out := make([]entity.DriveFileEntity, 0, len(files))
 	for _, f := range files {
-		out = append(out, h.packDriveFileFull(f))
+		out = append(out, h.packDriveFileSelfList(f))
 	}
 	return c.JSON(http.StatusOK, out)
 }
@@ -880,13 +997,11 @@ func (h *Handler) FoldersList(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
-	out := make([]map[string]any, 0, len(folders))
+	// upstream folders.ts は pack(folder) を返すため createdAt を含む
+	// (#1564 で手組み 3 field map から修正)。
+	out := make([]entity.DriveFolderEntity, 0, len(folders))
 	for _, f := range folders {
-		out = append(out, map[string]any{
-			"id":       f.ID,
-			"name":     f.Name,
-			"parentId": f.ParentID,
-		})
+		out = append(out, entity.PackDriveFolder(f, h.idGen))
 	}
 	return c.JSON(http.StatusOK, out)
 }
@@ -908,13 +1023,11 @@ func (h *Handler) FoldersFind(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
-	out := make([]map[string]any, 0, len(folders))
+	// upstream folders/find.ts も pack(folder) を返すため createdAt を含む
+	// (#1564)。
+	out := make([]entity.DriveFolderEntity, 0, len(folders))
 	for _, f := range folders {
-		out = append(out, map[string]any{
-			"id":       f.ID,
-			"name":     f.Name,
-			"parentId": f.ParentID,
-		})
+		out = append(out, entity.PackDriveFolder(f, h.idGen))
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/drive/handler_parity_test.go
+++ b/internal/api/drive/handler_parity_test.go
@@ -1,0 +1,421 @@
+package drive
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// #1564 parity sweep の handler 層テスト群。
+
+// --- FilesCreate: name pipeline ---
+
+func TestFilesCreate_NameTrimmed(t *testing.T) {
+	h, _, _ := newHandler(t)
+	c, rec := newMultipartReq(t, "raw.txt", "hello", map[string]string{"name": "  photo.jpg  "})
+	setUser(c, "u1")
+	require.NoError(t, h.FilesCreate(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Equal(t, "photo.jpg", out["name"], "前後空白は trim される")
+}
+
+func TestFilesCreate_BlobNameFallsBackToUntitled(t *testing.T) {
+	// upstream は 'blob' を null 化し addFile が 'untitled'(+拡張子) で保存
+	// する。mk-go は拡張子補正未実装のため 'untitled' 固定 (#1564)。
+	h, _, _ := newHandler(t)
+	c, rec := newMultipartReq(t, "blob", "hello", nil)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesCreate(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Equal(t, "untitled", out["name"])
+}
+
+func TestFilesCreate_InvalidName(t *testing.T) {
+	h, _, _ := newHandler(t)
+	for _, bad := range []string{"a/b.png", `a\b.png`, "a..png", strings.Repeat("x", 201)} {
+		c, rec := newMultipartReq(t, "raw.txt", "hello", map[string]string{"name": bad})
+		setUser(c, "u1")
+		require.NoError(t, h.FilesCreate(c))
+		assert.Equal(t, http.StatusBadRequest, rec.Code, bad)
+		assert.Contains(t, rec.Body.String(), "INVALID_FILE_NAME", bad)
+		// upstream create.ts 固有 UUID (update とは別)。
+		assert.Contains(t, rec.Body.String(), "f449b209-0c60-4e51-84d5-29486263bfd4", bad)
+	}
+}
+
+func TestFilesCreate_CommentTooLong(t *testing.T) {
+	h, _, _ := newHandler(t)
+	c, rec := newMultipartReq(t, "a.txt", "hello", map[string]string{"comment": strings.Repeat("あ", 513)})
+	setUser(c, "u1")
+	require.NoError(t, h.FilesCreate(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_PARAM")
+}
+
+func TestFilesCreate_Comment512OK(t *testing.T) {
+	h, _, _ := newHandler(t)
+	c, rec := newMultipartReq(t, "a.txt", "hello", map[string]string{"comment": strings.Repeat("あ", 512)})
+	setUser(c, "u1")
+	require.NoError(t, h.FilesCreate(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// --- FilesUpdate ---
+
+func TestFilesUpdate_InvalidName(t *testing.T) {
+	h, fileRepo, _ := newHandler(t)
+	uid := "u1"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &uid, Name: "old"}
+	c, rec := newJSONReq(t, `{"fileId":"f1","name":"a/b.png"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesUpdate(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_FILE_NAME")
+	// upstream update.ts 固有 UUID (create とは別)。
+	assert.Contains(t, rec.Body.String(), "395e7156-f9f0-475e-af89-53c3c23080c2")
+}
+
+func TestFilesUpdate_CommentTooLong(t *testing.T) {
+	h, fileRepo, _ := newHandler(t)
+	uid := "u1"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &uid}
+	body, _ := json.Marshal(map[string]any{"fileId": "f1", "comment": strings.Repeat("あ", 513)})
+	c, rec := newJSONReq(t, string(body))
+	setUser(c, "u1")
+	require.NoError(t, h.FilesUpdate(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_PARAM")
+}
+
+// --- FilesShow: url anyOf + detail folder ---
+
+func TestFilesShow_ByURL(t *testing.T) {
+	h, fileRepo, _ := newHandlerWithRepos(t)
+	uid := "u1"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &uid, URL: "https://example.com/files/x"}
+	c, rec := newJSONReq(t, `{"url":"https://example.com/files/x"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesShow(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Equal(t, "f1", out["id"])
+}
+
+func TestFilesShow_NeitherFileIDNorURL(t *testing.T) {
+	// upstream paramDef は anyOf {fileId}|{url} 必須 (#1564)。
+	h, _, _ := newHandlerWithRepos(t)
+	c, rec := newJSONReq(t, `{}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesShow(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestFilesShow_FolderIsDetailPacked(t *testing.T) {
+	// upstream pack(file, {detail:true}) は埋め込み folder を detail mode で
+	// pack するため foldersCount / filesCount を含む (#1564)。
+	h, fileRepo, folderRepo := newHandlerWithRepos(t)
+	uid := "u1"
+	folderRepo.Folders["fo1"] = &model.DriveFolder{ID: "fo1", Name: "docs", UserID: &uid}
+	fid := "fo1"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &uid, FolderID: &fid}
+	c, rec := newJSONReq(t, `{"fileId":"f1"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesShow(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out struct {
+		Folder map[string]any `json:"folder"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.NotNil(t, out.Folder)
+	assert.Contains(t, out.Folder, "foldersCount")
+	assert.Contains(t, out.Folder, "filesCount")
+}
+
+// --- FilesFindByHash: 全件 ---
+
+func TestFilesFindByHash_ReturnsAllMatches(t *testing.T) {
+	h, fileRepo, _ := newHandler(t)
+	uid := "u1"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &uid, MD5: "h"}
+	fileRepo.Files["f2"] = &model.DriveFile{ID: "f2", UserID: &uid, MD5: "h"}
+	c, rec := newJSONReq(t, `{"md5":"h"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesFindByHash(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 2, "md5 一致の全件を返す (#1564)")
+}
+
+// --- FilesList: sort / type / self pack ---
+
+func TestFilesList_InvalidSortRejected(t *testing.T) {
+	h, _, _ := newHandlerWithRepos(t)
+	c, rec := newJSONReq(t, `{"sort":"+bogus"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesList(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestFilesList_TypeFilterAndSort(t *testing.T) {
+	h, fileRepo, _ := newHandlerWithRepos(t)
+	uid := "u1"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &uid, Type: "image/png", Size: 10}
+	fileRepo.Files["f2"] = &model.DriveFile{ID: "f2", UserID: &uid, Type: "image/jpeg", Size: 30}
+	fileRepo.Files["f3"] = &model.DriveFile{ID: "f3", UserID: &uid, Type: "video/webm", Size: 20}
+
+	// type prefix filter ("image/*")
+	c, rec := newJSONReq(t, `{"type":"image/*","sort":"+size"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesList(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 2, "video は除外")
+	assert.Equal(t, "f2", out[0]["id"], "+size は size DESC")
+	assert.Equal(t, "f1", out[1]["id"])
+
+	// type exact match (upstream pattern は数字を許さないため digit-less MIME)
+	c, rec = newJSONReq(t, `{"type":"video/webm"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesList(c))
+	out = nil
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	assert.Equal(t, "f3", out[0]["id"])
+}
+
+func TestFilesList_InvalidTypePatternRejected(t *testing.T) {
+	// upstream paramDef の type pattern は ^[a-zA-Z\/\-*]+$ (#1564 review)。
+	// 数字を含む MIME (video/mp4) も % 等の記号も upstream は INVALID_PARAM
+	// で弾く。LIKE wildcard (% _) がここで止まるため repo 層に混入しない。
+	h, _, _ := newHandlerWithRepos(t)
+	for _, bad := range []string{"video/mp4", "%/*", "ima_e/*", "image/%"} {
+		c, rec := newJSONReq(t, `{"type":"`+bad+`"}`)
+		setUser(c, "u1")
+		require.NoError(t, h.FilesList(c))
+		assert.Equal(t, http.StatusBadRequest, rec.Code, bad)
+	}
+	// Stream も同じ pattern 検証
+	c, rec := newJSONReq(t, `{"type":"%/*"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.Stream(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestFilesShow_EmptyURLIs404(t *testing.T) {
+	// upstream の anyOf required は「キー存在」のみ検証するため
+	// {"url":""} は lookup に進み 404 NO_SUCH_FILE になる (#1564 review)。
+	h, _, _ := newHandlerWithRepos(t)
+	c, rec := newJSONReq(t, `{"url":""}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesShow(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_FILE")
+
+	// fileId は format misskey:id なので空文字は INVALID_PARAM。
+	c, rec = newJSONReq(t, `{"fileId":""}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesShow(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestFilesCreate_ExplicitEmptyNameFallsBackToUntitled(t *testing.T) {
+	// multipart で name="" を明示送信した場合、upstream は ''→null→'untitled'
+	// (filename への fallback はしない) (#1564 review)。
+	h, _, _ := newHandler(t)
+	c, rec := newMultipartReq(t, "photo.jpg", "hello", map[string]string{"name": ""})
+	setUser(c, "u1")
+	require.NoError(t, h.FilesCreate(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Equal(t, "untitled", out["name"])
+}
+
+func TestFoldersShow_CyclicDataDoesNotHang(t *testing.T) {
+	// 旧 mk-go で作れてしまった循環 folder data (#1564 で作成自体は禁止) を
+	// detail pack が visited guard で打ち切ること。guard が無いと無限再帰で
+	// stack overflow → プロセスクラッシュする (#1564 review)。
+	h, _, folderRepo := newHandlerWithRepos(t)
+	uid := "u1"
+	aID := "cyc-a"
+	bID := "cyc-b"
+	folderRepo.Folders[aID] = &model.DriveFolder{ID: aID, Name: "a", UserID: &uid, ParentID: &bID}
+	folderRepo.Folders[bID] = &model.DriveFolder{ID: bID, Name: "b", UserID: &uid, ParentID: &aID}
+	c, rec := newJSONReq(t, `{"folderId":"cyc-a"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FoldersShow(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	// a → parent b までは pack され、b の parent (= a, 既出) で打ち切られる。
+	parent, ok := out["parent"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, bID, parent["id"])
+	assert.Nil(t, parent["parent"], "循環は既出 folder で打ち切る")
+}
+
+func TestFilesList_SelfPackNullsFolderAndUser(t *testing.T) {
+	// upstream files.ts は packMany({detail:false, self:true}) なので
+	// folder/user は null、userId は owner ID (#1564)。
+	h, fileRepo, folderRepo := newHandlerWithRepos(t)
+	uid := "u1"
+	folderRepo.Folders["fo1"] = &model.DriveFolder{ID: "fo1", UserID: &uid}
+	fid := "fo1"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &uid, FolderID: &fid}
+	c, rec := newJSONReq(t, `{"folderId":"fo1"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesList(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	assert.Nil(t, out[0]["folder"], "self list は folder null")
+	assert.Nil(t, out[0]["user"], "self list は user null")
+	assert.Equal(t, "u1", out[0]["userId"], "userId は owner ID を維持")
+}
+
+// --- Stream: 全 folder 横断 + type ---
+
+func TestStream_IncludesSubfolderFiles(t *testing.T) {
+	// upstream stream.ts は folder 条件を付けないため、サブフォルダ内の
+	// ファイルも返る (#1564 で root 限定の過剰絞り込みを解消)。
+	h, fileRepo, folderRepo := newHandlerWithRepos(t)
+	uid := "u1"
+	folderRepo.Folders["fo1"] = &model.DriveFolder{ID: "fo1", UserID: &uid}
+	fid := "fo1"
+	fileRepo.Files["root1"] = &model.DriveFile{ID: "root1", UserID: &uid, Type: "image/png"}
+	fileRepo.Files["sub1"] = &model.DriveFile{ID: "sub1", UserID: &uid, FolderID: &fid, Type: "image/png"}
+	fileRepo.Files["sub2"] = &model.DriveFile{ID: "sub2", UserID: &uid, FolderID: &fid, Type: "video/mp4"}
+
+	c, rec := newJSONReq(t, `{}`)
+	setUser(c, "u1")
+	require.NoError(t, h.Stream(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 3, "root + サブフォルダの全ファイル")
+	assert.Nil(t, out[0]["folder"], "self list pack")
+
+	// type filter も効く
+	c, rec = newJSONReq(t, `{"type":"image/*"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.Stream(c))
+	out = nil
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 2)
+}
+
+// --- FoldersList / FoldersFind: createdAt ---
+
+func TestFoldersList_IncludesCreatedAt(t *testing.T) {
+	h, _, folderRepo := newHandlerWithRepos(t)
+	uid := "u1"
+	// aidx 形式 id なら createdAt が復元できる
+	fo := &model.DriveFolder{ID: h.idGen.Generate(time.Now()), Name: "docs", UserID: &uid}
+	folderRepo.Folders[fo.ID] = fo
+	c, rec := newJSONReq(t, `{}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FoldersList(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	assert.NotEmpty(t, out[0]["createdAt"], "upstream pack(folder) は createdAt を含む (#1564)")
+	assert.Equal(t, "docs", out[0]["name"])
+}
+
+func TestFoldersFind_IncludesCreatedAt(t *testing.T) {
+	h, _, folderRepo := newHandlerWithRepos(t)
+	uid := "u1"
+	fo := &model.DriveFolder{ID: h.idGen.Generate(time.Now()), Name: "docs", UserID: &uid}
+	folderRepo.Folders[fo.ID] = fo
+	c, rec := newJSONReq(t, `{"name":"docs"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FoldersFind(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	assert.NotEmpty(t, out[0]["createdAt"])
+}
+
+// --- Folders name maxLength ---
+
+func TestFoldersCreate_NameTooLong(t *testing.T) {
+	h, _, _ := newHandler(t)
+	body, _ := json.Marshal(map[string]any{"name": strings.Repeat("あ", 201)})
+	c, rec := newJSONReq(t, string(body))
+	setUser(c, "u1")
+	require.NoError(t, h.FoldersCreate(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestFoldersUpdate_NameTooLong(t *testing.T) {
+	h, _, folderRepo := newHandler(t)
+	uid := "u1"
+	folderRepo.Folders["fo1"] = &model.DriveFolder{ID: "fo1", UserID: &uid}
+	body, _ := json.Marshal(map[string]any{"folderId": "fo1", "name": strings.Repeat("あ", 201)})
+	c, rec := newJSONReq(t, string(body))
+	setUser(c, "u1")
+	require.NoError(t, h.FoldersUpdate(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- FoldersUpdate: RECURSIVE_NESTING mapping ---
+
+func TestFoldersUpdate_RecursiveNesting(t *testing.T) {
+	h, _, folderRepo := newHandler(t)
+	uid := "u1"
+	folderRepo.Folders["fo1"] = &model.DriveFolder{ID: "fo1", UserID: &uid}
+	c, rec := newJSONReq(t, `{"folderId":"fo1","parentId":"fo1"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FoldersUpdate(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "RECURSIVE_NESTING")
+	// upstream はダッシュ無し id 文字列をそのまま使う。
+	assert.Contains(t, rec.Body.String(), "dbeb024837894013aed44279f9199740")
+}
+
+// --- FilesAttachedNotes: moderator bypass ---
+
+// fakeRoleChecker は coredrive.RoleChecker の test double (moderator 判定のみ)。
+type fakeRoleChecker struct{ mods map[string]bool }
+
+func (f *fakeRoleChecker) IsModerator(userID string) bool        { return f.mods[userID] }
+func (f *fakeRoleChecker) GetUserPolicies(string) map[string]any { return nil }
+
+func TestFilesAttachedNotes_ModeratorCanQueryOthersFile(t *testing.T) {
+	// upstream attached-notes.ts は moderator のとき userId filter を外す
+	// (#1564)。非 moderator の他人 file は従来どおり NO_SUCH_FILE (#1470)。
+	// moderator 判定は core 側 RoleChecker (svc.IsModerator) に一本化。
+	h, fileRepo, _ := newHandlerWithRepos(t)
+	h.svc.SetRoleChecker(&fakeRoleChecker{mods: map[string]bool{"mod1": true}})
+	other := "u2"
+	fileRepo.Files["f-other"] = &model.DriveFile{ID: "f-other", UserID: &other}
+
+	c, rec := newJSONReq(t, `{"fileId":"f-other"}`)
+	setUser(c, "mod1")
+	require.NoError(t, h.FilesAttachedNotes(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// 非 moderator は引き続き拒否
+	c, rec = newJSONReq(t, `{"fileId":"f-other"}`)
+	setUser(c, "u3")
+	require.NoError(t, h.FilesAttachedNotes(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_FILE")
+}

--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -483,11 +483,13 @@ func TestFilesFindByHash_InvalidParam(t *testing.T) {
 }
 
 func TestFilesFindByHash_NotFound(t *testing.T) {
+	// upstream find-by-hash は不一致でも 404 ではなく空配列 200 (#1564)。
 	h, _, _ := newHandler(t)
 	c, rec := newJSONReq(t, `{"md5":"ghost"}`)
 	setUser(c, "u1")
 	require.NoError(t, h.FilesFindByHash(c))
-	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.JSONEq(t, `[]`, rec.Body.String())
 }
 
 // --- FoldersCreate ---

--- a/internal/api/drive/url_upload.go
+++ b/internal/api/drive/url_upload.go
@@ -9,7 +9,6 @@ import (
 	"path"
 
 	coredrive "github.com/shiroha-a/mk/internal/core/drive"
-	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/safehttp"
@@ -98,9 +97,12 @@ func (u *URLUploader) Process(ctx context.Context, in URLUploadInput) {
 	if u.publisher == nil || in.User == nil {
 		return
 	}
+	// upstream は pack(file, {self:true}) の single pack を payload に使う
+	// (= drive/files/create の応答と同 shape)。helper を共有して shape drift
+	// を防ぐ (#1564 review)。
 	u.publisher.PublishMainEvent(in.User.ID, "urlUploadFinished", map[string]any{
 		"marker": in.Marker,
-		"file":   entity.PackDriveFile(df, u.idGen),
+		"file":   packDriveFileSelfSingle(df, u.idGen),
 	})
 }
 

--- a/internal/api/drive/url_upload_test.go
+++ b/internal/api/drive/url_upload_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	coredrive "github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
@@ -107,6 +108,13 @@ func TestURLUploader_Process_Success(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, &marker, body["marker"])
 	require.NotNil(t, body["file"])
+	// upstream の pack(file, {self:true}) single pack は userId も null
+	// (#1564)。folder / user は PackDriveFile が元々 nil。
+	file, ok := body["file"].(entity.DriveFileEntity)
+	require.True(t, ok)
+	assert.Nil(t, file.UserID, "urlUploadFinished payload の userId は null")
+	assert.Nil(t, file.Folder)
+	assert.Nil(t, file.User)
 }
 
 func TestURLUploader_Process_FetchErrorNoPublish(t *testing.T) {

--- a/internal/core/drive/drive_service.go
+++ b/internal/core/drive/drive_service.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -57,7 +58,27 @@ var (
 	// mk-go では LRU 退去ロジックが未実装のため remote user は本 gate を
 	// skip して従来どおり受け入れる (cleanup logic は future work)。
 	ErrNoFreeSpace = errors.New("no free space")
+	// ErrInvalidFileName is returned when a file rename fails
+	// ValidateFileName. Handler maps this to upstream's INVALID_FILE_NAME
+	// (drive/files/update は 395e7156-..., create は f449b209-...) (#1564)。
+	ErrInvalidFileName = errors.New("invalid file name")
+	// ErrRecursiveNesting is returned when drive/folders/update would make a
+	// folder its own ancestor (self-parent or ancestor cycle)。upstream
+	// folders/update の recursiveNesting (#1564)。
+	ErrRecursiveNesting = errors.New("recursive folder nesting")
 )
+
+// ValidateFileName mirrors upstream DriveFileEntityService.validateFileName:
+// the trimmed name must be non-empty, at most 200 characters, and must not
+// contain a backslash, a slash, or "..". 長さは JS の String.length (UTF-16)
+// に対し rune 数で近似する (upload-from-url の comment 512 判定と同方針)。
+func ValidateFileName(name string) bool {
+	return strings.TrimSpace(name) != "" &&
+		utf8.RuneCountInString(name) <= 200 &&
+		!strings.Contains(name, "\\") &&
+		!strings.Contains(name, "/") &&
+		!strings.Contains(name, "..")
+}
 
 // StreamingPublisher receives drive file life-cycle events so that
 // WebSocket subscribers (the "drive" channel) can be pushed in real time.
@@ -65,6 +86,16 @@ var (
 // stream)。eventTypeは"fileCreated"/"fileUpdated"/"fileDeleted"。
 type StreamingPublisher interface {
 	PublishDriveEvent(userID, eventType string, file *model.DriveFile)
+}
+
+// FolderStreamingPublisher receives drive folder life-cycle events for the
+// "drive" WebSocket channel. upstream の publishDriveStream(userID,
+// 'folderCreated'|'folderUpdated', folderObj) / ('folderDeleted', folder.id)
+// に対応する (#1564)。body は packed folder (created/updated) または folder
+// id 文字列 (deleted)。StreamingPublisher (file 専用、*model.DriveFile 固定)
+// とは payload 型が異なるため別 interface にする。実装は internal/stream。
+type FolderStreamingPublisher interface {
+	PublishDriveFolderEvent(userID, eventType string, body any)
 }
 
 // MainStreamPublisher emits real-time events to a single target user's `main`
@@ -115,6 +146,23 @@ type Service struct {
 	// Optional moderator bypass for Show. Nil keeps the default "owner-only"
 	// guard.
 	roleChecker RoleChecker
+	// folderPublisher emits folderCreated/folderUpdated/folderDeleted to the
+	// drive channel (#1564)。nil disables folder events.
+	folderPublisher FolderStreamingPublisher
+}
+
+// SetFolderStreamingPublisher attaches the drive-channel publisher for folder
+// life-cycle events (#1564)。Optional — nil disables emit.
+func (s *Service) SetFolderStreamingPublisher(p FolderStreamingPublisher) {
+	s.folderPublisher = p
+}
+
+// publishFolderEvent is the best-effort wrapper for folder events.
+func (s *Service) publishFolderEvent(userID, eventType string, body any) {
+	if s.folderPublisher == nil || userID == "" {
+		return
+	}
+	s.folderPublisher.PublishDriveFolderEvent(userID, eventType, body)
 }
 
 // SetRoleChecker wires a moderator role lookup so Show allows moderators to
@@ -515,12 +563,42 @@ func (s *Service) Show(user *model.User, id string) (*model.DriveFile, error) {
 	if err != nil {
 		return nil, ErrFileNotFound
 	}
-	owner := f.UserID != nil && *f.UserID == user.ID
-	moderator := s.roleChecker != nil && s.roleChecker.IsModerator(user.ID)
-	if !owner && !moderator {
-		return nil, ErrAccessDenied
+	return s.authorizeFileRead(user, f)
+}
+
+// ShowByURL is the url-keyed variant of Show used by drive/files/show's
+// anyOf {url} param (#1564)。url / webpublicUrl / thumbnailUrl のいずれか一致
+// で検索し、permission は Show と同じ owner or moderator。
+func (s *Service) ShowByURL(user *model.User, url string) (*model.DriveFile, error) {
+	if user == nil {
+		return nil, errors.New("user is required")
 	}
-	return f, nil
+	f, err := s.fileRepo.FindByAnyURL(url)
+	if err != nil {
+		return nil, ErrFileNotFound
+	}
+	return s.authorizeFileRead(user, f)
+}
+
+// authorizeFileRead is the shared read guard for Show / ShowByURL: the owner
+// always may read; otherwise a moderator may (lazy 評価で owner 経路は role
+// lookup を払わない)。read 認可規則を 1 箇所に集約して fileId / url 経路の
+// drift を防ぐ (#1564 review)。
+func (s *Service) authorizeFileRead(user *model.User, f *model.DriveFile) (*model.DriveFile, error) {
+	if f.UserID != nil && *f.UserID == user.ID {
+		return f, nil
+	}
+	if s.IsModerator(user.ID) {
+		return f, nil
+	}
+	return nil, ErrAccessDenied
+}
+
+// IsModerator reports whether the user holds a moderator role via the wired
+// RoleChecker (false when none is wired). handler 層 (attached-notes の
+// moderator bypass、#1564) が参照する。
+func (s *Service) IsModerator(userID string) bool {
+	return s.roleChecker != nil && s.roleChecker.IsModerator(userID)
 }
 
 // findOwnedFile is the strict owner-only equivalent of Show, used by write
@@ -540,16 +618,14 @@ func (s *Service) findOwnedFile(user *model.User, id string) (*model.DriveFile, 
 	return f, nil
 }
 
-// FindByHash returns the user's most recent file with the given md5 hash.
-func (s *Service) FindByHash(user *model.User, md5 string) (*model.DriveFile, error) {
+// FindByHash returns every file of the user with the given md5 hash.
+// upstream drive/files/find-by-hash は findBy({md5, userId}) で一致全件を
+// 配列で返す (#1564 で最新 1 件 → 全件に修正)。一致 0 件は空 slice。
+func (s *Service) FindByHash(user *model.User, md5 string) ([]*model.DriveFile, error) {
 	if user == nil {
 		return nil, errors.New("user is required")
 	}
-	f, err := s.fileRepo.FindByMD5(user.ID, md5)
-	if err != nil {
-		return nil, ErrFileNotFound
-	}
-	return f, nil
+	return s.fileRepo.FindAllByMD5(user.ID, md5)
 }
 
 // UpdateInput holds the editable fields of a drive file.
@@ -570,6 +646,11 @@ func (s *Service) Update(user *model.User, id string, in UpdateInput) (*model.Dr
 	}
 	fields := map[string]any{}
 	if in.Name != nil {
+		// upstream DriveService.updateFile は values.name に validateFileName
+		// を実行し、失敗時 InvalidFileNameError を投げる (#1564)。
+		if !ValidateFileName(*in.Name) {
+			return nil, ErrInvalidFileName
+		}
 		fields["name"] = *in.Name
 	}
 	if in.Comment != nil {
@@ -676,6 +757,9 @@ func (s *Service) CreateFolder(user *model.User, name string, parentID *string) 
 	if err := s.folderRepo.Create(f); err != nil {
 		return nil, err
 	}
+	// upstream folders/create は publishDriveStream(me.id, 'folderCreated',
+	// folderObj) を発火する (#1564)。body は packed folder。
+	s.publishFolderEvent(user.ID, "folderCreated", entity.PackDriveFolder(f, s.idGen))
 	return f, nil
 }
 
@@ -712,6 +796,11 @@ func (s *Service) UpdateFolder(user *model.User, id string, in UpdateFolderInput
 	}
 	if in.ParentID != nil {
 		if *in.ParentID != nil {
+			// upstream folders/update: parentId === folder.id は即
+			// recursiveNesting (#1564)。
+			if **in.ParentID == f.ID {
+				return nil, ErrRecursiveNesting
+			}
 			parent, err := s.folderRepo.FindByID(**in.ParentID)
 			if err != nil {
 				// folders/update では parent が未存在のときに upstream は
@@ -722,13 +811,56 @@ func (s *Service) UpdateFolder(user *model.User, id string, in UpdateFolderInput
 			if parent.UserID == nil || *parent.UserID != user.ID {
 				return nil, ErrAccessDenied
 			}
+			// upstream checkCircle: 新 parent の祖先 chain に folder 自身が
+			// いたら循環 (#1564)。mk-go は過去に循環を作れてしまっていたため、
+			// 既存の循環 data でも無限 loop しないよう visited set で打ち切る。
+			if ok, err := s.folderAncestorContains(parent.ParentID, f.ID); err != nil {
+				return nil, err
+			} else if ok {
+				return nil, ErrRecursiveNesting
+			}
 		}
 		fields["parentId"] = *in.ParentID
 	}
 	if err := s.folderRepo.Update(f.ID, fields); err != nil {
 		return nil, err
 	}
-	return s.folderRepo.FindByID(f.ID)
+	updated, err := s.folderRepo.FindByID(f.ID)
+	if err != nil {
+		return nil, err
+	}
+	// upstream folders/update は publishDriveStream(me.id, 'folderUpdated',
+	// folderObj) を発火する (#1564)。
+	s.publishFolderEvent(user.ID, "folderUpdated", entity.PackDriveFolder(updated, s.idGen))
+	return updated, nil
+}
+
+// folderAncestorContains walks the parent chain starting at startParentID and
+// reports whether targetID appears in it (upstream folders/update の
+// checkCircle 相当)。walk 中の FindByID 失敗は「循環なし」に潰さず error と
+// して伝播する: 一時的な DB 障害で循環チェックを skip して循環 parentId を
+// commit してしまうと、read 経路の parent 再帰が壊れる (upstream の
+// findOneByOrFail も request ごと失敗させる)。なお DeleteFolder は子持ち
+// folder を消せないため dangling parentId は通常発生しない。
+func (s *Service) folderAncestorContains(startParentID *string, targetID string) (bool, error) {
+	visited := map[string]struct{}{}
+	cur := startParentID
+	for cur != nil {
+		if *cur == targetID {
+			return true, nil
+		}
+		// 既存の循環 data に当たっても無限 loop しない。
+		if _, seen := visited[*cur]; seen {
+			return false, nil
+		}
+		visited[*cur] = struct{}{}
+		anc, err := s.folderRepo.FindByID(*cur)
+		if err != nil {
+			return false, fmt.Errorf("walk folder ancestors: %w", err)
+		}
+		cur = anc.ParentID
+	}
+	return false, nil
 }
 
 // DeleteFolder removes an empty folder owned by user.
@@ -744,7 +876,13 @@ func (s *Service) DeleteFolder(user *model.User, id string) error {
 	if hasChildren {
 		return ErrFolderNotEmpty
 	}
-	return s.folderRepo.Delete(f)
+	if err := s.folderRepo.Delete(f); err != nil {
+		return err
+	}
+	// upstream folders/delete は publishDriveStream(me.id, 'folderDeleted',
+	// folder.id) を発火する (#1564)。body は packed folder ではなく id 文字列。
+	s.publishFolderEvent(user.ID, "folderDeleted", f.ID)
+	return nil
 }
 
 // randReader is the source of randomness for newAccessKey. Tests override

--- a/internal/core/drive/drive_service_parity_test.go
+++ b/internal/core/drive/drive_service_parity_test.go
@@ -1,0 +1,204 @@
+package drive_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	drive "github.com/shiroha-a/mk/internal/core/drive"
+	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// #1564 parity sweep のサービス層テスト群。
+
+// --- ValidateFileName ---
+
+func TestValidateFileName(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"plain", "photo.jpg", true},
+		{"japanese", "写真.png", true},
+		{"boundary 200 runes", strings.Repeat("あ", 200), true},
+		{"201 runes", strings.Repeat("あ", 201), false},
+		{"empty", "", false},
+		{"spaces only", "   ", false},
+		{"backslash", `a\b.png`, false},
+		{"slash", "a/b.png", false},
+		{"dotdot", "a..png", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, drive.ValidateFileName(tc.input))
+		})
+	}
+}
+
+func TestUpdate_InvalidFileName(t *testing.T) {
+	// upstream DriveService.updateFile は validateFileName 失敗で
+	// InvalidFileNameError を投げる (#1564)。
+	svc, fileRepo, _ := newSvc(t)
+	uid := "u1"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &uid, Name: "old"}
+	bad := "a/b"
+	_, err := svc.Update(&model.User{ID: "u1"}, "f1", drive.UpdateInput{Name: &bad})
+	require.ErrorIs(t, err, drive.ErrInvalidFileName)
+	assert.Equal(t, "old", fileRepo.Files["f1"].Name, "検証失敗時は書き換えない")
+}
+
+// --- ShowByURL ---
+
+func TestShowByURL_OwnerMatchesAllURLColumns(t *testing.T) {
+	svc, fileRepo, _ := newSvc(t)
+	uid := "u1"
+	web := "https://example.com/files/web"
+	thumb := "https://example.com/files/thumb"
+	fileRepo.Files["f1"] = &model.DriveFile{
+		ID: "f1", UserID: &uid,
+		URL:          "https://example.com/files/orig",
+		WebpublicURL: &web,
+		ThumbnailURL: &thumb,
+	}
+	for _, u := range []string{"https://example.com/files/orig", web, thumb} {
+		got, err := svc.ShowByURL(&model.User{ID: "u1"}, u)
+		require.NoError(t, err, u)
+		assert.Equal(t, "f1", got.ID)
+	}
+}
+
+func TestShowByURL_NotFound(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	_, err := svc.ShowByURL(&model.User{ID: "u1"}, "https://example.com/none")
+	require.ErrorIs(t, err, drive.ErrFileNotFound)
+}
+
+func TestShowByURL_OtherOwnerDenied_ModeratorAllowed(t *testing.T) {
+	svc, fileRepo, _ := newSvc(t)
+	other := "u2"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &other, URL: "https://example.com/files/x"}
+	_, err := svc.ShowByURL(&model.User{ID: "u1"}, "https://example.com/files/x")
+	require.ErrorIs(t, err, drive.ErrAccessDenied)
+
+	svc.SetRoleChecker(&fakeMod{moderators: map[string]bool{"u1": true}})
+	got, err := svc.ShowByURL(&model.User{ID: "u1"}, "https://example.com/files/x")
+	require.NoError(t, err)
+	assert.Equal(t, "f1", got.ID)
+}
+
+// --- UpdateFolder recursive nesting ---
+
+func TestUpdateFolder_SelfParent_RecursiveNesting(t *testing.T) {
+	svc, _, folderRepo := newSvc(t)
+	uid := "u1"
+	folderRepo.Folders["a"] = &model.DriveFolder{ID: "a", UserID: &uid}
+	pid := "a"
+	pp := &pid
+	_, err := svc.UpdateFolder(&model.User{ID: "u1"}, "a", drive.UpdateFolderInput{ParentID: &pp})
+	require.ErrorIs(t, err, drive.ErrRecursiveNesting)
+}
+
+func TestUpdateFolder_AncestorCycle_RecursiveNesting(t *testing.T) {
+	// a の下に b、b の下に c がある状態で a の親を c にすると循環。
+	svc, _, folderRepo := newSvc(t)
+	uid := "u1"
+	aID := "a"
+	bID := "b"
+	folderRepo.Folders["a"] = &model.DriveFolder{ID: "a", UserID: &uid}
+	folderRepo.Folders["b"] = &model.DriveFolder{ID: "b", UserID: &uid, ParentID: &aID}
+	folderRepo.Folders["c"] = &model.DriveFolder{ID: "c", UserID: &uid, ParentID: &bID}
+	cid := "c"
+	cp := &cid
+	_, err := svc.UpdateFolder(&model.User{ID: "u1"}, "a", drive.UpdateFolderInput{ParentID: &cp})
+	require.ErrorIs(t, err, drive.ErrRecursiveNesting)
+}
+
+func TestUpdateFolder_ValidReparent_OK(t *testing.T) {
+	svc, _, folderRepo := newSvc(t)
+	uid := "u1"
+	folderRepo.Folders["a"] = &model.DriveFolder{ID: "a", UserID: &uid}
+	folderRepo.Folders["b"] = &model.DriveFolder{ID: "b", UserID: &uid}
+	bid := "b"
+	bp := &bid
+	got, err := svc.UpdateFolder(&model.User{ID: "u1"}, "a", drive.UpdateFolderInput{ParentID: &bp})
+	require.NoError(t, err)
+	require.NotNil(t, got.ParentID)
+	assert.Equal(t, "b", *got.ParentID)
+}
+
+func TestUpdateFolder_ExistingCycleData_NoInfiniteLoop(t *testing.T) {
+	// 旧 mk-go は循環を作れてしまっていたため、既に x⇄y の循環がある DB
+	// でも祖先 walk が無限 loop しないこと (visited set guard、#1564)。
+	svc, _, folderRepo := newSvc(t)
+	uid := "u1"
+	xID := "x"
+	yID := "y"
+	folderRepo.Folders["x"] = &model.DriveFolder{ID: "x", UserID: &uid, ParentID: &yID}
+	folderRepo.Folders["y"] = &model.DriveFolder{ID: "y", UserID: &uid, ParentID: &xID}
+	folderRepo.Folders["a"] = &model.DriveFolder{ID: "a", UserID: &uid}
+	xp := &xID
+	// a は循環 chain (x→y→x) の外なので walk は visited guard で打ち切られ、
+	// 循環なし扱いで更新が通る。
+	got, err := svc.UpdateFolder(&model.User{ID: "u1"}, "a", drive.UpdateFolderInput{ParentID: &xp})
+	require.NoError(t, err)
+	require.NotNil(t, got.ParentID)
+	assert.Equal(t, "x", *got.ParentID)
+}
+
+// --- Folder stream events ---
+
+type folderEvent struct {
+	userID    string
+	eventType string
+	body      any
+}
+
+type fakeFolderPublisher struct{ events []folderEvent }
+
+func (f *fakeFolderPublisher) PublishDriveFolderEvent(userID, eventType string, body any) {
+	f.events = append(f.events, folderEvent{userID, eventType, body})
+}
+
+func TestFolderLifecycle_PublishesDriveStreamEvents(t *testing.T) {
+	// upstream folders/{create,update,delete} は publishDriveStream で
+	// folderCreated/folderUpdated (packed folder) / folderDeleted (id) を
+	// 発火する (#1564)。
+	svc, _, _ := newSvc(t)
+	pub := &fakeFolderPublisher{}
+	svc.SetFolderStreamingPublisher(pub)
+
+	f, err := svc.CreateFolder(&model.User{ID: "u1"}, "docs", nil)
+	require.NoError(t, err)
+	newName := "renamed"
+	_, err = svc.UpdateFolder(&model.User{ID: "u1"}, f.ID, drive.UpdateFolderInput{Name: &newName})
+	require.NoError(t, err)
+	require.NoError(t, svc.DeleteFolder(&model.User{ID: "u1"}, f.ID))
+
+	require.Len(t, pub.events, 3)
+	assert.Equal(t, "folderCreated", pub.events[0].eventType)
+	created, ok := pub.events[0].body.(entity.DriveFolderEntity)
+	require.True(t, ok, "created body は packed folder")
+	assert.Equal(t, f.ID, created.ID)
+	assert.NotEmpty(t, created.CreatedAt)
+
+	assert.Equal(t, "folderUpdated", pub.events[1].eventType)
+	updated, ok := pub.events[1].body.(entity.DriveFolderEntity)
+	require.True(t, ok)
+	assert.Equal(t, "renamed", updated.Name)
+
+	assert.Equal(t, "folderDeleted", pub.events[2].eventType)
+	assert.Equal(t, f.ID, pub.events[2].body, "deleted body は folder id 文字列")
+	for _, ev := range pub.events {
+		assert.Equal(t, "u1", ev.userID)
+	}
+}
+
+func TestFolderLifecycle_NoPublisherIsNoop(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	f, err := svc.CreateFolder(&model.User{ID: "u1"}, "docs", nil)
+	require.NoError(t, err)
+	require.NoError(t, svc.DeleteFolder(&model.User{ID: "u1"}, f.ID))
+}

--- a/internal/core/drive/drive_service_test.go
+++ b/internal/core/drive/drive_service_test.go
@@ -252,18 +252,25 @@ func TestFindByHash_NilUser(t *testing.T) {
 }
 
 func TestFindByHash_NotFound(t *testing.T) {
+	// upstream find-by-hash は不一致でもエラーにせず空配列を返す (#1564)。
 	svc, _, _ := newSvc(t)
-	_, err := svc.FindByHash(&model.User{ID: "u1"}, "ghost")
-	require.ErrorIs(t, err, drive.ErrFileNotFound)
+	got, err := svc.FindByHash(&model.User{ID: "u1"}, "ghost")
+	require.NoError(t, err)
+	assert.Empty(t, got)
 }
 
 func TestFindByHash_Found(t *testing.T) {
+	// 同一 md5 の複数 file を全件返す (upstream findBy({md5,userId})、#1564)。
 	svc, fileRepo, _ := newSvc(t)
 	uid := "u1"
 	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &uid, MD5: "abc"}
+	fileRepo.Files["f2"] = &model.DriveFile{ID: "f2", UserID: &uid, MD5: "abc"}
+	fileRepo.Files["f3"] = &model.DriveFile{ID: "f3", UserID: &uid, MD5: "other"}
 	got, err := svc.FindByHash(&model.User{ID: "u1"}, "abc")
 	require.NoError(t, err)
-	assert.Equal(t, "f1", got.ID)
+	require.Len(t, got, 2)
+	assert.Equal(t, "f1", got[0].ID)
+	assert.Equal(t, "f2", got[1].ID)
 }
 
 // --- Update ---

--- a/internal/core/transfer/drive_reader_test.go
+++ b/internal/core/transfer/drive_reader_test.go
@@ -70,8 +70,14 @@ func (f *fakeDriveFileRepo) Update(_ string, _ map[string]any) error {
 	return nil
 }
 func (f *fakeDriveFileRepo) Delete(_ *model.DriveFile) error { return nil }
-func (f *fakeDriveFileRepo) ListByUser(_ string, _ *string, _, _ string, _ int) ([]*model.DriveFile, error) {
+func (f *fakeDriveFileRepo) ListByUser(_ string, _ *string, _ bool, _, _, _, _ string, _ int) ([]*model.DriveFile, error) {
 	return nil, nil
+}
+func (f *fakeDriveFileRepo) FindAllByMD5(_, _ string) ([]*model.DriveFile, error) {
+	return nil, nil
+}
+func (f *fakeDriveFileRepo) FindByAnyURL(_ string) (*model.DriveFile, error) {
+	return nil, errors.New("not found")
 }
 func (f *fakeDriveFileRepo) FindByName(_, _ string, _ *string) ([]*model.DriveFile, error) {
 	return nil, nil

--- a/internal/entity/drive.go
+++ b/internal/entity/drive.go
@@ -38,8 +38,8 @@ type DriveFileEntity struct {
 	UserID       *string             `json:"userId"`
 	// Folder は upstream が detail packing で常に出す (= null or DriveFolder)。
 	// 旧実装は omitempty で省略していたが drop-in shape drift だったため #812
-	// で外した。caller (= packDriveFileFull) で pre-fetch してセットし、未設定
-	// なら nil → JSON `null` として出す。
+	// で外した。caller (detail 経路) で pre-fetch してセットし、未設定なら
+	// nil → JSON `null` として出す。
 	Folder *DriveFolderEntity `json:"folder"`
 	// User も upstream の detail packing で常に出す (= null or UserLite)。
 	// 同じく #812 で omitempty を外した。

--- a/internal/repository/drive_file.go
+++ b/internal/repository/drive_file.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"strings"
+
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/gorm"
 )
@@ -11,7 +13,16 @@ type DriveFileRepository interface {
 	FindByID(id string) (*model.DriveFile, error)
 	FindByIDs(ids []string) ([]*model.DriveFile, error)
 	FindByMD5(userID, md5 string) (*model.DriveFile, error)
+	// FindAllByMD5 returns every file of the user with the given md5 hash.
+	// upstream drive/files/find-by-hash は findBy({md5, userId}) で一致
+	// 全件を返すため、最新 1 件の FindByMD5 (upload dedup 用) と別に持つ
+	// (#1564)。
+	FindAllByMD5(userID, md5 string) ([]*model.DriveFile, error)
 	FindByAccessKey(accessKey string) (*model.DriveFile, error)
+	// FindByAnyURL looks up a DriveFile whose url / webpublicUrl /
+	// thumbnailUrl matches. upstream drive/files/show の url 指定検索
+	// (anyOf param) で使う (#1564)。
+	FindByAnyURL(url string) (*model.DriveFile, error)
 	// FindByAnyAccessKey looks up a DriveFile whose primary / thumbnail /
 	// webpublic access key matches. Used by `/files/:accessKey` to resolve
 	// storedInternal=true rows that the configured storage backend (S3)
@@ -22,7 +33,15 @@ type DriveFileRepository interface {
 	FindByURI(uri string) (*model.DriveFile, error)
 	Update(id string, fields map[string]any) error
 	Delete(f *model.DriveFile) error
-	ListByUser(userID string, folderID *string, untilID, sinceID string, limit int) ([]*model.DriveFile, error)
+	// ListByUser returns the user's drive files (#1564 で filter/sort 対応):
+	//   - folderID: anyFolder=false のとき nil は root (folderId IS NULL)
+	//   - anyFolder: true で folder 条件を付けない (upstream drive/stream は
+	//     全 folder 横断で返す)
+	//   - fileType: MIME filter。"image/*" 形式は prefix match、それ以外は
+	//     完全一致 (upstream drive/files.ts と同 semantics)。空は無条件
+	//   - sort: "+createdAt"|"-createdAt"|"+name"|"-name"|"+size"|"-size"|""
+	//     (空は sinceID/untilID 由来の id 順。createdAt は id 列で代理)
+	ListByUser(userID string, folderID *string, anyFolder bool, fileType, sort, untilID, sinceID string, limit int) ([]*model.DriveFile, error)
 	// ListForAdmin returns drive files across all users with optional
 	// userID / origin / host / type filters. When userID is non-empty,
 	// origin / host are ignored (upstream Misskey の semantics と一致)。
@@ -116,6 +135,36 @@ func (r *driveFileRepository) FindByMD5(userID, md5 string) (*model.DriveFile, e
 	return &f, nil
 }
 
+// FindAllByMD5 returns every file of the user with the given md5 hash,
+// oldest first (id ASC). upstream find-by-hash の findBy({md5, userId}) は
+// order 未指定だが、決定的な応答のため id 昇順に固定する。
+func (r *driveFileRepository) FindAllByMD5(userID, md5 string) ([]*model.DriveFile, error) {
+	var files []*model.DriveFile
+	if err := r.db.
+		Where("\"userId\" = ? AND md5 = ?", userID, md5).
+		Order("id ASC").
+		Find(&files).Error; err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+// FindByAnyURL resolves a file by matching url, webpublicUrl, or
+// thumbnailUrl (upstream drive/files/show の url anyOf 検索、#1564)。
+func (r *driveFileRepository) FindByAnyURL(url string) (*model.DriveFile, error) {
+	if url == "" {
+		return nil, gorm.ErrRecordNotFound
+	}
+	var f model.DriveFile
+	if err := r.db.Where(
+		`"url" = ? OR "webpublicUrl" = ? OR "thumbnailUrl" = ?`,
+		url, url, url,
+	).First(&f).Error; err != nil {
+		return nil, err
+	}
+	return &f, nil
+}
+
 func (r *driveFileRepository) FindByURI(uri string) (*model.DriveFile, error) {
 	if uri == "" {
 		return nil, gorm.ErrRecordNotFound
@@ -177,15 +226,26 @@ func (r *driveFileRepository) Delete(f *model.DriveFile) error {
 	return r.db.Delete(f).Error
 }
 
-// ListByUser returns the user's drive files. folderID=nil means root files
-// (folderId IS NULL); otherwise restricts to that folder.
-func (r *driveFileRepository) ListByUser(userID string, folderID *string, untilID, sinceID string, limit int) ([]*model.DriveFile, error) {
+// ListByUser returns the user's drive files filtered/sorted per the
+// interface doc (#1564).
+func (r *driveFileRepository) ListByUser(userID string, folderID *string, anyFolder bool, fileType, sort, untilID, sinceID string, limit int) ([]*model.DriveFile, error) {
 	var rows []*model.DriveFile
 	q := r.db.Where("\"userId\" = ?", userID)
-	if folderID == nil {
-		q = q.Where("\"folderId\" IS NULL")
-	} else {
-		q = q.Where("\"folderId\" = ?", *folderID)
+	if !anyFolder {
+		if folderID == nil {
+			q = q.Where("\"folderId\" IS NULL")
+		} else {
+			q = q.Where("\"folderId\" = ?", *folderID)
+		}
+	}
+	if fileType != "" {
+		// upstream files.ts: `/*` 終端は `type.replace('/*','/') + '%'` の
+		// prefix LIKE、それ以外は完全一致。
+		if strings.HasSuffix(fileType, "/*") {
+			q = q.Where(`"type" LIKE ?`, strings.TrimSuffix(fileType, "*")+"%")
+		} else {
+			q = q.Where(`"type" = ?`, fileType)
+		}
 	}
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)
@@ -193,7 +253,27 @@ func (r *driveFileRepository) ListByUser(userID string, folderID *string, untilI
 	if sinceID != "" {
 		q = q.Where("id > ?", sinceID)
 	}
-	if err := q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit).Find(&rows).Error; err != nil {
+	// upstream files.ts は sort 指定時に makePaginationQuery の orderBy を
+	// 上書きする (cursor の WHERE 条件はそのまま残る)。createdAt は id 列で
+	// 代理 (= aidx は時系列順)。
+	order := ""
+	switch sort {
+	case "+createdAt":
+		order = "id DESC"
+	case "-createdAt":
+		order = "id ASC"
+	case "+name":
+		order = "name DESC"
+	case "-name":
+		order = "name ASC"
+	case "+size":
+		order = "size DESC"
+	case "-size":
+		order = "size ASC"
+	default:
+		order = paginationOrder(sinceID, untilID, "id")
+	}
+	if err := q.Order(order).Limit(limit).Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil

--- a/internal/repository/drive_file_test.go
+++ b/internal/repository/drive_file_test.go
@@ -93,23 +93,138 @@ func TestDriveFileRepository_ListByUser(t *testing.T) {
 	defer cleanupDriveFile(t, root.ID)
 	defer cleanupDriveFile(t, infolder.ID)
 
-	rows, err := repo.ListByUser(user.ID, nil, "", "", 10)
+	rows, err := repo.ListByUser(user.ID, nil, false, "", "", "", "", 10)
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	assert.Equal(t, "f_lst_1", rows[0].ID)
 
-	rows, err = repo.ListByUser(user.ID, &folderID, "", "", 10)
+	rows, err = repo.ListByUser(user.ID, &folderID, false, "", "", "", "", 10)
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
 	assert.Equal(t, "f_lst_2", rows[0].ID)
 
 	// untilID/sinceIDの分岐を踏む (root のみ)
-	rows, err = repo.ListByUser(user.ID, nil, "z", "", 10)
+	rows, err = repo.ListByUser(user.ID, nil, false, "", "", "z", "", 10)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
-	rows, err = repo.ListByUser(user.ID, nil, "", "a", 10)
+	rows, err = repo.ListByUser(user.ID, nil, false, "", "", "", "a", 10)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
+}
+
+func TestDriveFileRepository_ListByUser_TypeSortAnyFolder(t *testing.T) {
+	// #1564: type filter (完全一致 / "/*" prefix)、sort、anyFolder の分岐。
+	repo := NewDriveFileRepository(testDB)
+	user := insertTestUser(t, "u_df_ts", "dfts")
+	defer cleanupUser(t, user.ID)
+
+	folderRepo := NewDriveFolderRepository(testDB)
+	uid := user.ID
+	folder := &model.DriveFolder{ID: "fold_ts", Name: "F", UserID: &uid}
+	require.NoError(t, folderRepo.Create(folder))
+	defer testDB.Exec(`DELETE FROM "drive_folder" WHERE id = ?`, folder.ID)
+	folderID := folder.ID
+
+	png := newTestDriveFile("f_ts_1", user.ID, "t1", nil)
+	png.Type = "image/png"
+	png.Name = "bbb.png"
+	png.Size = 10
+	jpg := newTestDriveFile("f_ts_2", user.ID, "t2", &folderID)
+	jpg.Type = "image/jpeg"
+	jpg.Name = "aaa.jpg"
+	jpg.Size = 30
+	mp4 := newTestDriveFile("f_ts_3", user.ID, "t3", nil)
+	mp4.Type = "video/mp4"
+	mp4.Name = "ccc.mp4"
+	mp4.Size = 20
+	for _, f := range []*model.DriveFile{png, jpg, mp4} {
+		require.NoError(t, repo.Create(f))
+		defer cleanupDriveFile(t, f.ID)
+	}
+
+	// anyFolder=true は folder 条件なし (サブフォルダの jpg も入る)
+	rows, err := repo.ListByUser(user.ID, nil, true, "", "", "", "", 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 3)
+
+	// type prefix ("image/*") + anyFolder
+	rows, err = repo.ListByUser(user.ID, nil, true, "image/*", "", "", "", 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+
+	// type 完全一致
+	rows, err = repo.ListByUser(user.ID, nil, true, "video/mp4", "", "", "", 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, mp4.ID, rows[0].ID)
+
+	// sort 各種 (anyFolder で全件対象)
+	for _, tc := range []struct {
+		sort  string
+		first string
+	}{
+		{"+createdAt", mp4.ID}, // id DESC
+		{"-createdAt", png.ID}, // id ASC
+		{"+name", mp4.ID},      // name DESC (ccc)
+		{"-name", jpg.ID},      // name ASC (aaa)
+		{"+size", jpg.ID},      // size DESC (30)
+		{"-size", png.ID},      // size ASC (10)
+	} {
+		rows, err = repo.ListByUser(user.ID, nil, true, "", tc.sort, "", "", 10)
+		require.NoError(t, err, tc.sort)
+		require.Len(t, rows, 3, tc.sort)
+		assert.Equal(t, tc.first, rows[0].ID, tc.sort)
+	}
+}
+
+func TestDriveFileRepository_FindAllByMD5(t *testing.T) {
+	// #1564: find-by-hash の一致全件 (id ASC)。
+	repo := NewDriveFileRepository(testDB)
+	user := insertTestUser(t, "u_df_am", "dfam")
+	defer cleanupUser(t, user.ID)
+
+	f1 := newTestDriveFile("f_am_1", user.ID, "samehash", nil)
+	f2 := newTestDriveFile("f_am_2", user.ID, "samehash", nil)
+	f3 := newTestDriveFile("f_am_3", user.ID, "otherhash", nil)
+	for _, f := range []*model.DriveFile{f1, f2, f3} {
+		require.NoError(t, repo.Create(f))
+		defer cleanupDriveFile(t, f.ID)
+	}
+
+	got, err := repo.FindAllByMD5(user.ID, "samehash")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "f_am_1", got[0].ID)
+	assert.Equal(t, "f_am_2", got[1].ID)
+
+	got, err = repo.FindAllByMD5(user.ID, "ghost")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestDriveFileRepository_FindByAnyURL(t *testing.T) {
+	// #1564: drive/files/show の url anyOf 検索 (url/webpublicUrl/thumbnailUrl)。
+	repo := NewDriveFileRepository(testDB)
+	user := insertTestUser(t, "u_df_au", "dfau")
+	defer cleanupUser(t, user.ID)
+
+	web := "http://example.com/files/f_au_web"
+	thumb := "http://example.com/files/f_au_thumb"
+	f := newTestDriveFile("f_au", user.ID, "aumd5", nil)
+	f.WebpublicURL = &web
+	f.ThumbnailURL = &thumb
+	require.NoError(t, repo.Create(f))
+	defer cleanupDriveFile(t, f.ID)
+
+	for _, u := range []string{f.URL, web, thumb} {
+		got, err := repo.FindByAnyURL(u)
+		require.NoError(t, err, u)
+		assert.Equal(t, f.ID, got.ID)
+	}
+	_, err := repo.FindByAnyURL("")
+	assert.Error(t, err)
+	_, err = repo.FindByAnyURL("http://example.com/none")
+	assert.Error(t, err)
 }
 
 func TestDriveFileRepository_FindByAnyAccessKey(t *testing.T) {
@@ -154,7 +269,7 @@ func TestDriveFileRepository_QueryErrors(t *testing.T) {
 	assert.Error(t, err)
 	err = repo.Update("a", map[string]any{"name": "b"})
 	assert.Error(t, err)
-	_, err = repo.ListByUser("a", nil, "", "", 10)
+	_, err = repo.ListByUser("a", nil, false, "", "", "", "", 10)
 	assert.Error(t, err)
 }
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1863,6 +1863,9 @@ func (s *Server) setupRoutes() {
 	notificationService.SetMainStreamPublisher(mainStreamPublisher)
 	notificationService.SetPacker(notificationPublisher)
 	driveService.SetStreamingPublisher(drivePublisher)
+	// folder の folderCreated/folderUpdated/folderDeleted も同じ drive channel
+	// publisher で配信する (#1564)。
+	driveService.SetFolderStreamingPublisher(drivePublisher)
 	driveService.SetMainStreamPublisher(mainStreamPublisher)
 	// /drive/files/upload-from-url: SSRF-safe client で URL を download し、
 	// drive へ保存後 urlUploadFinished を main stream に流す (#1217)。download は

--- a/internal/stream/note_publisher.go
+++ b/internal/stream/note_publisher.go
@@ -368,8 +368,34 @@ func (p *DrivePublisher) PublishDriveEvent(userID, eventType string, file *model
 	}
 }
 
-// 静的アサーション: DrivePublisher が core/drive.StreamingPublisher を満たす。
-var _ coredrive.StreamingPublisher = (*DrivePublisher)(nil)
+// PublishDriveFolderEvent wraps a folder life-cycle payload (packed folder
+// for folderCreated/folderUpdated, the folder id string for folderDeleted)
+// in the `{type, body}` envelope and publishes to drive:<userID> (#1564)。
+func (p *DrivePublisher) PublishDriveFolderEvent(userID, eventType string, body any) {
+	if p.pub == nil || userID == "" || eventType == "" || body == nil {
+		return
+	}
+	envelope := map[string]any{
+		"type": eventType,
+		"body": body,
+	}
+	raw, err := json.Marshal(envelope)
+	if err != nil {
+		slog.Warn("drive publisher: folder event marshal failed", "err", err)
+		return
+	}
+	topic := "drive:" + userID
+	if err := p.pub.Publish(context.Background(), topic, json.RawMessage(raw)); err != nil {
+		slog.Warn("drive publisher: folder event publish failed", "topic", topic, "err", err)
+	}
+}
+
+// 静的アサーション: DrivePublisher が core/drive.StreamingPublisher と
+// FolderStreamingPublisher を満たす。
+var (
+	_ coredrive.StreamingPublisher       = (*DrivePublisher)(nil)
+	_ coredrive.FolderStreamingPublisher = (*DrivePublisher)(nil)
+)
 
 // 静的アサーション: NotificationPublisher が core/notification.StreamingPublisher
 // と core/notification.Packer の両方を満たす。interface signature が

--- a/internal/stream/note_publisher_test.go
+++ b/internal/stream/note_publisher_test.go
@@ -641,6 +641,53 @@ func TestDrivePublisher_PublishErrorIsLogged(t *testing.T) {
 // 静的アサーションは note_publisher.go に置いてある。
 func TestDrivePublisher_ImplementsServiceInterface(t *testing.T) {
 	var _ coredrive.StreamingPublisher = (*DrivePublisher)(nil)
+	var _ coredrive.FolderStreamingPublisher = (*DrivePublisher)(nil)
+}
+
+// --- DrivePublisher folder events (#1564) -----------------------------------
+
+func TestDrivePublisher_PublishesFolderEvent(t *testing.T) {
+	pub := &stubPublisher{}
+	dp := NewDrivePublisher(pub)
+	dp.PublishDriveFolderEvent("alice", "folderCreated", map[string]any{"id": "fo1", "name": "docs"})
+	require.Len(t, pub.topics, 1)
+	assert.Equal(t, "drive:alice", pub.topics[0])
+	raw := pub.payloads[0].(json.RawMessage)
+	assert.Contains(t, string(raw), `"type":"folderCreated"`)
+	assert.Contains(t, string(raw), `"docs"`)
+}
+
+func TestDrivePublisher_FolderDeletedBodyIsID(t *testing.T) {
+	// folderDeleted の body は packed folder ではなく id 文字列。
+	pub := &stubPublisher{}
+	dp := NewDrivePublisher(pub)
+	dp.PublishDriveFolderEvent("alice", "folderDeleted", "fo1")
+	require.Len(t, pub.topics, 1)
+	assert.Contains(t, string(pub.payloads[0].(json.RawMessage)), `"body":"fo1"`)
+}
+
+func TestDrivePublisher_FolderEventEmptyArgsAreNoOps(t *testing.T) {
+	pub := &stubPublisher{}
+	dp := NewDrivePublisher(pub)
+	dp.PublishDriveFolderEvent("", "folderCreated", "fo1")
+	dp.PublishDriveFolderEvent("alice", "", "fo1")
+	dp.PublishDriveFolderEvent("alice", "folderCreated", nil)
+	assert.Empty(t, pub.topics)
+	NewDrivePublisher(nil).PublishDriveFolderEvent("alice", "folderCreated", "fo1")
+}
+
+func TestDrivePublisher_FolderEventMarshalErrorIsLogged(t *testing.T) {
+	pub := &stubPublisher{}
+	dp := NewDrivePublisher(pub)
+	// chan は json.Marshal 不能なので marshal error 経路を踏む
+	dp.PublishDriveFolderEvent("alice", "folderCreated", make(chan int))
+	assert.Empty(t, pub.topics)
+}
+
+func TestDrivePublisher_FolderEventPublishErrorIsLogged(t *testing.T) {
+	pub := &stubPublisher{err: errors.New("redis down")}
+	dp := NewDrivePublisher(pub)
+	dp.PublishDriveFolderEvent("alice", "folderCreated", "fo1")
 }
 
 func TestDrivePublisher_MarshalErrorIsLogged(t *testing.T) {

--- a/internal/testutil/mock_drive.go
+++ b/internal/testutil/mock_drive.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	sortpkg "sort"
 	"strings"
 
 	"github.com/shiroha-a/mk/internal/model"
@@ -71,6 +72,30 @@ func (m *MockDriveFileRepository) FindByMD5(userID, md5 string) (*model.DriveFil
 		return nil, ErrNotFound
 	}
 	return match, nil
+}
+
+// FindAllByMD5 returns every md5-matching file of the user, id ASC
+// (production 実装と同じ決定的順序)。
+func (m *MockDriveFileRepository) FindAllByMD5(userID, md5 string) ([]*model.DriveFile, error) {
+	var result []*model.DriveFile
+	for _, f := range m.Files {
+		if f.UserID != nil && *f.UserID == userID && f.MD5 == md5 {
+			result = append(result, f)
+		}
+	}
+	sortpkg.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })
+	return result, nil
+}
+
+func (m *MockDriveFileRepository) FindByAnyURL(url string) (*model.DriveFile, error) {
+	for _, f := range m.Files {
+		if f.URL == url ||
+			(f.WebpublicURL != nil && *f.WebpublicURL == url) ||
+			(f.ThumbnailURL != nil && *f.ThumbnailURL == url) {
+			return f, nil
+		}
+	}
+	return nil, ErrNotFound
 }
 
 func (m *MockDriveFileRepository) FindByURI(uri string) (*model.DriveFile, error) {
@@ -170,18 +195,29 @@ func (m *MockDriveFileRepository) Delete(f *model.DriveFile) error {
 	return nil
 }
 
-func (m *MockDriveFileRepository) ListByUser(userID string, folderID *string, untilID, sinceID string, limit int) ([]*model.DriveFile, error) {
+func (m *MockDriveFileRepository) ListByUser(userID string, folderID *string, anyFolder bool, fileType, sort, untilID, sinceID string, limit int) ([]*model.DriveFile, error) {
 	var rows []*model.DriveFile
 	for _, f := range m.Files {
 		if f.UserID == nil || *f.UserID != userID {
 			continue
 		}
-		if folderID == nil {
-			if f.FolderID != nil {
-				continue
+		if !anyFolder {
+			if folderID == nil {
+				if f.FolderID != nil {
+					continue
+				}
+			} else {
+				if f.FolderID == nil || *f.FolderID != *folderID {
+					continue
+				}
 			}
-		} else {
-			if f.FolderID == nil || *f.FolderID != *folderID {
+		}
+		if fileType != "" {
+			if strings.HasSuffix(fileType, "/*") {
+				if !strings.HasPrefix(f.Type, strings.TrimSuffix(fileType, "*")) {
+					continue
+				}
+			} else if f.Type != fileType {
 				continue
 			}
 		}
@@ -193,13 +229,24 @@ func (m *MockDriveFileRepository) ListByUser(userID string, folderID *string, un
 		}
 		rows = append(rows, f)
 	}
-	for i := 0; i < len(rows); i++ {
-		for j := i + 1; j < len(rows); j++ {
-			if rows[i].ID < rows[j].ID {
-				rows[i], rows[j] = rows[j], rows[i]
-			}
+	sortpkg.Slice(rows, func(i, j int) bool {
+		switch sort {
+		case "-createdAt":
+			return rows[i].ID < rows[j].ID
+		case "+name":
+			return rows[i].Name > rows[j].Name
+		case "-name":
+			return rows[i].Name < rows[j].Name
+		case "+size":
+			return rows[i].Size > rows[j].Size
+		case "-size":
+			return rows[i].Size < rows[j].Size
+		default:
+			// "+createdAt" と未指定はともに id DESC (sinceID 指定時の ASC は
+			// mock では省略 — 既存テストは untilID / 無指定のみ)。
+			return rows[i].ID > rows[j].ID
 		}
-	}
+	})
 	if limit > 0 && len(rows) > limit {
 		rows = rows[:limit]
 	}


### PR DESCRIPTION
## Summary

互換性監査 issue #1564 で確定した drive/* の未対応差分 (10 MEDIUM / 6 LOW) のうち 15 件を解消する。残り 1 件 ([M] read:drive / write:drive の kind scope enforcement) は **#1607 (PR #1614) で実装済み**を確認したため本 PR の対象外。

## 主な変更点

### MEDIUM

- **files/create・files/update — INVALID_FILE_NAME 検証**: `coredrive.ValidateFileName` (upstream `validateFileName`: trim>0 / 200 字以下 / `\` `/` `..` 禁止) を新設。update は core の `Service.Update` で検証 (upstream `DriveService.updateFile` と同配置、id `395e7156-...`)、create は endpoint 層で name trim → 空/`'blob'`→null (mk-go は `'untitled'` fallback) → 検証失敗で id `f449b209-...` (upstream `create.ts` と同配置)。
- **files/show — url 検索 (anyOf)**: `{fileId}` または `{url}` を受け、url 指定時は `url` / `webpublicUrl` / `thumbnailUrl` の OR 一致 (`FindByAnyURL` 新設)。permission は fileId 経路と共通の owner-or-moderator guard。
- **files/find-by-hash — 一致全件返却**: `FindAllByMD5` 新設で md5 一致の全件を配列返却 (旧: 最新 1 件のみ)。不一致は upstream 同様 404 でなく空配列。
- **folders/update — RECURSIVE_NESTING**: 自己親 + 新 parent の祖先 walk (upstream `checkCircle`) で循環を検出し `RECURSIVE_NESTING` (upstream のダッシュ無し id `dbeb0248...` を原文採用)。旧 mk-go は循環を作れてしまっていたため、既存循環 data でも無限 loop しない visited set 付き。
- **folders / folders/find — createdAt 復元**: 手組み 3 field map から `entity.PackDriveFolder` に変更。
- **folders/{create,update,delete} — drive stream 配信**: `FolderStreamingPublisher` を core/drive に新設し、`folderCreated` / `folderUpdated` (packed folder)・`folderDeleted` (folder id) を upstream `publishDriveStream` 相当で配信。`stream.DrivePublisher` が実装。
- **files — type filter + sort**: `ListByUser` を filter/sort 対応に拡張 (`/*` 終端は prefix LIKE / それ以外完全一致、sort は +/-createdAt|name|size)。sort は enum、type は upstream paramDef pattern `^[a-zA-Z\/\-*]+$` で検証 (数字を含む MIME も upstream 同様 INVALID_PARAM。SQL LIKE wildcard の混入もここで遮断)。
- **stream — type filter + 全 folder 横断化**: 旧実装は root (folderId IS NULL) に過剰絞り込みでサブフォルダのファイルが出なかった。upstream 同様 folder 条件なしに修正。

### LOW

- **files / stream の self pack 化**: upstream `packMany({detail:false, self:true})` に合わせ folder/user は null、userId は owner ID。
- **files/show の埋め込み folder detail 化**: foldersCount / filesCount / parent (再帰) を含む。
- **comment maxLength 512 / folder name maxLength 200**: create/update 系で rune 数検証 (パッケージ定数化)。
- **attached-notes の moderator 照会**: upstream 同様 moderator は他人 file を照会可。非 owner viewer には `notesfilter.FilterVisible` を適用 (TS は pack-level hide、mk-go は drop で安全側 — 意図的 divergence として明記)。
- **urlUploadFinished payload**: upstream の single self pack に合わせ userId を null 化 (files/create 応答と helper を共有)。

### 敵対的レビュー (7 angle 並列) → 修正 10 件

#1511 の教訓に従い実装後にレビューを実施し、以下を修正済み:

- **[重要] `packDriveFolderDetail` の循環 data 無限再帰**: 旧 mk-go が作れてしまった循環 folder で parent 再帰が stack overflow → プロセスクラッシュする経路 (本 PR で files/show にも拡大していた)。visited guard で打ち切り + テスト追加。
- **[重要] `folderAncestorContains` の DB error 握り潰し**: 瞬断で循環チェックが skip され循環が commit されうる → error 伝播に変更 (upstream `findOneByOrFail` と同方向)。
- **self pack の無駄 fetch 解消**: full pack → null 潰しで list 1 ページ最大 200 query を浪費していた → ゼロクエリの `PackDriveFile` 直結。show の folder 二重 fetch も解消、dead code (`packDriveFileFull`、find-by-hash の不達 error branch) 削除。
- **edge parity**: multipart で `name=""` 明示送信 → `'untitled'` (filename への fallback をしない)、`{"url":""}` → 404 NO_SUCH_FILE (presence 判定)。
- **構造整理**: Show/ShowByURL の認可 guard 共通化 (lazy moderator 評価)、moderator 判定の wiring を core RoleChecker に一本化、maxLength 定数化。

## 意図的 divergence (明記)

- maxLength は ajv の UTF-16 code unit に対し rune 数で近似 (サロゲートペア絵文字は upstream より長く受理。既存 upload-from-url と同方針)。
- name null 時の `'untitled'` は upstream の拡張子補正 (`correctFilename`) 未実装のため拡張子なし。
- attached-notes moderator 経路は hide-in-place でなく visibility drop。

## Follow-up 候補

- `FindByAnyURL` (url/webpublicUrl/thumbnailUrl) は index 未追加のため大規模インスタンスでは seq scan になる。migration 追加は本 PR の scope 外として別 issue 化を推奨。

## テスト

- repository: ListByUser の type (exact / prefix) / sort 6 種 / anyFolder、FindAllByMD5、FindByAnyURL の統合テスト。
- core/drive: ValidateFileName table、Update 名前検証、ShowByURL (3 URL 列 / 権限 / moderator)、RECURSIVE_NESTING (自己親 / 祖先循環 / 既存循環 data の無限 loop 防止)、folder event 3 種の payload 検証。
- api/drive: 各 handler の新分岐 19 テスト (INVALID_FILE_NAME 両 UUID / blob / 明示空 name / 512 / 200 / url show / 空 url 404 / find-by-hash 複数 / sort・type / pattern reject / stream サブフォルダ / self pack shape / folders createdAt / RECURSIVE_NESTING mapping / moderator 照会 / 循環 data ハング防止)。
- カバレッジ: api/drive 91.4% / core/drive 98.5% / repository 90.5% / stream 90.5%。
- `make fmt` / `make lint` / `make errorid-check` (id・status・kind gate) / 全パッケージテスト pass (flake なし)。
- 実行方法: `go test ./internal/api/drive/ ./internal/core/drive/ ./internal/repository/ ./internal/stream/`

## Closes

Closes #1564

🤖 Generated with [Claude Code](https://claude.com/claude-code)