### PR TITLE
Perf: drive_file の url/webpublicUrl/thumbnailUrl に index を追加 (#1625)

### DIFF
--- a/internal/repository/drive_file.go
+++ b/internal/repository/drive_file.go
@@ -21,7 +21,8 @@ type DriveFileRepository interface {
 	FindByAccessKey(accessKey string) (*model.DriveFile, error)
 	// FindByAnyURL looks up a DriveFile whose url / webpublicUrl /
 	// thumbnailUrl matches. upstream drive/files/show の url 指定検索
-	// (anyOf param) で使う (#1564)。
+	// (anyOf param) で使う (#1564)。3 列の index は migration
+	// 000059-000061 で追加済み (#1625、BitmapOr で結合される)。
 	FindByAnyURL(url string) (*model.DriveFile, error)
 	// FindByAnyAccessKey looks up a DriveFile whose primary / thumbnail /
 	// webpublic access key matches. Used by `/files/:accessKey` to resolve
@@ -151,6 +152,8 @@ func (r *driveFileRepository) FindAllByMD5(userID, md5 string) ([]*model.DriveFi
 
 // FindByAnyURL resolves a file by matching url, webpublicUrl, or
 // thumbnailUrl (upstream drive/files/show の url anyOf 検索、#1564)。
+// OR 3 条件は migration 000059-000061 (#1625) の各列 index を BitmapOr で
+// 束ねて解決される (seq scan 回避)。
 func (r *driveFileRepository) FindByAnyURL(url string) (*model.DriveFile, error) {
 	if url == "" {
 		return nil, gorm.ErrRecordNotFound

--- a/internal/repository/drive_file_test.go
+++ b/internal/repository/drive_file_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/shiroha-a/mk/internal/model"
@@ -225,6 +226,58 @@ func TestDriveFileRepository_FindByAnyURL(t *testing.T) {
 	assert.Error(t, err)
 	_, err = repo.FindByAnyURL("http://example.com/none")
 	assert.Error(t, err)
+}
+
+// TestDriveFileRepository_URLIndexes verifies that the #1625 url-column
+// indexes (migration 000059-000061) are created and actually usable for the
+// FindByAnyURL OR-equality query. testutil.ApplyMigrations は migration の
+// エラーを swallow するため、これらが落ちても CI は沈黙し drive_file 肥大に
+// 比例して静かに性能退行する。000054/000055 の GIN index guard
+// (TestNoteRepository_MentionsFileIdsGINIndexes) と同じ regression guard。
+func TestDriveFileRepository_URLIndexes(t *testing.T) {
+	// 1. index が存在すること (CONCURRENTLY migration が適用されたことの確認
+	//    も兼ねる)。nullable 列の 2 本は部分 index (WHERE IS NOT NULL) で
+	//    あることも固定する。
+	for _, tc := range []struct {
+		index   string
+		partial bool
+	}{
+		{"IDX_drive_file_url", false},
+		{"IDX_drive_file_webpublicUrl", true},
+		{"IDX_drive_file_thumbnailUrl", true},
+	} {
+		var indexdef string
+		err := testDB.Raw(
+			`SELECT indexdef FROM pg_indexes WHERE tablename = 'drive_file' AND indexname = ?`, tc.index,
+		).Scan(&indexdef).Error
+		require.NoError(t, err)
+		require.NotEmpty(t, indexdef, "index %s must exist (migration applied)", tc.index)
+		if tc.partial {
+			assert.Contains(t, indexdef, "IS NOT NULL", "%s must be a partial index", tc.index)
+		}
+	}
+
+	// 2. planner が各列の equality に index を選べること。小さな test テーブル
+	//    では planner が seq scan を選ぶため、同一接続上で enable_seqscan=off
+	//    を効かせて index 経路を強制し、plan に index 名が現れることを確認する
+	//    (index が無ければ強制しても seq scan のまま)。SET LOCAL は transaction
+	//    スコープなので Begin/Rollback で閉じる。
+	checkPlanUsesIndex := func(query, arg, indexName string) {
+		tx := testDB.Begin()
+		defer tx.Rollback()
+		require.NoError(t, tx.Exec(`SET LOCAL enable_seqscan = off`).Error)
+		var lines []string
+		require.NoError(t, tx.Raw(`EXPLAIN `+query, arg).Scan(&lines).Error)
+		plan := strings.Join(lines, "\n")
+		assert.Contains(t, plan, indexName,
+			"equality query should use %s under enable_seqscan=off; plan was:\n%s", indexName, plan)
+	}
+	checkPlanUsesIndex(
+		`SELECT * FROM "drive_file" WHERE "url" = ?`, "http://example.com/x", "IDX_drive_file_url")
+	checkPlanUsesIndex(
+		`SELECT * FROM "drive_file" WHERE "webpublicUrl" = ?`, "http://example.com/x", "IDX_drive_file_webpublicUrl")
+	checkPlanUsesIndex(
+		`SELECT * FROM "drive_file" WHERE "thumbnailUrl" = ?`, "http://example.com/x", "IDX_drive_file_thumbnailUrl")
 }
 
 func TestDriveFileRepository_FindByAnyAccessKey(t *testing.T) {

--- a/migration/000059_drive_file_url_index.down.sql
+++ b/migration/000059_drive_file_url_index.down.sql
@@ -1,0 +1,3 @@
+-- CONCURRENTLY で作った index は CONCURRENTLY で drop して write block を避ける
+-- (DROP INDEX CONCURRENTLY も transaction 外・単一文でのみ実行可能)。
+DROP INDEX CONCURRENTLY IF EXISTS "IDX_drive_file_url";

--- a/migration/000059_drive_file_url_index.up.sql
+++ b/migration/000059_drive_file_url_index.up.sql
@@ -1,0 +1,28 @@
+-- #1625 (#1564 follow-up): drive/files/show の url anyOf 検索
+-- (DriveFileRepository.FindByAnyURL) は
+--   "url" = ? OR "webpublicUrl" = ? OR "thumbnailUrl" = ?
+-- で引くが、3 列とも index が無く行数比例の全行走査になっていた (GORM First
+-- の ORDER BY id LIMIT 1 が付くため実 plan は pkey 順の Index Scan + Filter
+-- だが、ヒットするまで O(全行) なのは seq scan と同じ)。drive_file はローカル
+-- アップロード + リモートメディアキャッシュで数百万行に達するため、3 列
+-- それぞれに index を張り PostgreSQL の BitmapOr で結合させる。
+--
+-- 本家 Misskey TS の MiDriveFile にはこの 3 列の index は存在しない (本家の
+-- files/show url 検索も seq scan)。mk-go では 000040 (IDX_drive_file_uri) と
+-- 同じく実 query 経路の保護を優先して独自に追加する。
+--
+-- url 列は NOT NULL のため部分 index にしない (000060/000061 の nullable 列
+-- とは異なる)。大規模テーブルへの index 追加なので CONCURRENTLY で書き込みを
+-- block せずに構築する。CONCURRENTLY は単一文でしか実行できないため、3 index
+-- を 000059/000060/000061 の 3 migration に分割している。
+-- 失敗時の回復手順 (INVALID index の DROP + migrate dirty 解除) は 000054 の
+-- コメントを参照 (対象 index 名は読み替える)。
+--
+-- 注意: url は varchar(1024) のため、octet_length > 約 2688 bytes の多バイト
+-- URL 行が既存 DB にあると btree の index row 上限 (約 2704 bytes) で build が
+-- 失敗する。mk-go 生成データでは発生しない (サーバー生成 URL は短い ASCII、
+-- リモート添付は url = uri で 000040 の uri index が既に同じ制約を課している)
+-- が、drop-in で TS 時代から引き継いだ DB に適用する際は事前に
+--   SELECT count(*) FROM drive_file WHERE octet_length("url") > 2688;
+-- が 0 であることを確認すると保険になる。
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_drive_file_url" ON "drive_file" ("url");

--- a/migration/000060_drive_file_webpublicurl_index.down.sql
+++ b/migration/000060_drive_file_webpublicurl_index.down.sql
@@ -1,0 +1,2 @@
+-- CONCURRENTLY で作った index は CONCURRENTLY で drop して write block を避ける。
+DROP INDEX CONCURRENTLY IF EXISTS "IDX_drive_file_webpublicUrl";

--- a/migration/000060_drive_file_webpublicurl_index.up.sql
+++ b/migration/000060_drive_file_webpublicurl_index.up.sql
@@ -1,0 +1,6 @@
+-- #1625: FindByAnyURL 用 index の 2/3 (経緯・CONCURRENTLY 採用理由・3 分割の
+-- 事情は 000059 のコメント参照)。webpublicUrl はリモートキャッシュや webpublic
+-- 未生成の file で NULL になり、実 query は "webpublicUrl" = ? のみで NULL を
+-- 引かないため、部分 index (WHERE IS NOT NULL) で NULL 行を除外して index を
+-- 小さく保つ (000040 drive_file uri と同方針)。
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_drive_file_webpublicUrl" ON "drive_file" ("webpublicUrl") WHERE "webpublicUrl" IS NOT NULL;

--- a/migration/000061_drive_file_thumbnailurl_index.down.sql
+++ b/migration/000061_drive_file_thumbnailurl_index.down.sql
@@ -1,0 +1,2 @@
+-- CONCURRENTLY で作った index は CONCURRENTLY で drop して write block を避ける。
+DROP INDEX CONCURRENTLY IF EXISTS "IDX_drive_file_thumbnailUrl";

--- a/migration/000061_drive_file_thumbnailurl_index.up.sql
+++ b/migration/000061_drive_file_thumbnailurl_index.up.sql
@@ -1,0 +1,4 @@
+-- #1625: FindByAnyURL 用 index の 3/3 (経緯・CONCURRENTLY 採用理由・3 分割の
+-- 事情は 000059 のコメント参照)。thumbnailUrl も nullable で実 query は
+-- "thumbnailUrl" = ? のみのため、000060 と同じく部分 index にする。
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_drive_file_thumbnailUrl" ON "drive_file" ("thumbnailUrl") WHERE "thumbnailUrl" IS NOT NULL;


### PR DESCRIPTION
## Summary

#1564 (PR #1624) で実装した`drive/files/show`のurl anyOf検索 (`DriveFileRepository.FindByAnyURL`) は`"url" = ? OR "webpublicUrl" = ? OR "thumbnailUrl" = ?`で引くが、3列ともindexが無く行数比例の全行走査になっていた (GORM `First()`の`ORDER BY id LIMIT 1`が付くため実planはpkey順Index Scan+Filterだが、ヒットするまでO(全行))。drive_fileは数百万行に達するため、3列それぞれにindexを追加してBitmapOrで解決させる。

本家Misskey TSの`MiDriveFile`を確認した結果、url/webpublicUrl/thumbnailUrlにindexは存在しない (本家のfiles/show url検索もseq scan)。揃える対象が無いため、000040 (`IDX_drive_file_uri`) と同じく「本家に無いがmk-goのquery経路上必須」のmk-go独自indexとして追加し、migrationコメントに根拠を明記した。

## 主な変更点

- `migration/000059_drive_file_url_index.{up,down}.sql` — `IDX_drive_file_url` (urlはNOT NULLのため全行index)
- `migration/000060_drive_file_webpublicurl_index.{up,down}.sql` — `IDX_drive_file_webpublicUrl` (部分index `WHERE IS NOT NULL`)
- `migration/000061_drive_file_thumbnailurl_index.{up,down}.sql` — `IDX_drive_file_thumbnailUrl` (同上)
- `internal/repository/drive_file.go` — `FindByAnyURL`コメントにindex前提を追記 (実装変更なし)
- `internal/repository/drive_file_test.go` — index regression guardテスト追加 (後述)

設計上の注意点:

- drive_fileは大規模テーブルのため、既存方針 (000045/000054/000055/000057) どおり`CREATE INDEX CONCURRENTLY`で書き込みをblockせず構築する。CONCURRENTLYは単一文でしか実行できないため1 index=1 migrationで3分割。downは`DROP INDEX CONCURRENTLY IF EXISTS` (data lossなし)。失敗時のINVALID index回復手順は000054のコメントを参照させた。
- 部分index (`WHERE IS NOT NULL`) は実queryが`= ?`のみでNULLを引かないため適用可能 (`=`はstrict operatorなのでgeneric planでも述語証明が成立することを実証済み)。
- urlはvarchar(1024)のため、drop-inでTS時代から引き継いだDBに`octet_length("url") > 2688`の多バイトURL行があるとbtreeのindex row上限でbuildが失敗し得る。mk-go生成データでは発生しない (リモート添付は`url = uri`で000040のuri indexが既に同じ制約を課している) が、事前チェックSQLを000059のコメントに記載した。

## 敵対的レビュー

migration運用/DB性能の2方向でレビューを実施し、以下を修正:

- **index regression guardテスト追加** (`TestDriveFileRepository_URLIndexes`): `testutil.ApplyMigrations`はmigrationエラーをswallowするため、indexが欠落してもCIが沈黙する。000054/000055の`TestNoteRepository_MentionsFileIdsGINIndexes`と同パターンで、pg_indexesでの存在+部分述語の確認と`enable_seqscan=off`下のEXPLAIN planへのindex名出現を固定。
- 000059コメントの「seq scan」表現を実planに即した記述へ修正、octet_length事前チェックの注意書きを追記。

レビューで問題なしを実証確認: `ORDER BY id LIMIT 1`付き実query形状でのBitmapOr選択 (50万行、custom/generic plan両方)、書き込み増幅+24µs/行 (無視できる規模)、既存queryへのplan退行なし、drop-in互換 (TS製DBへ純additive、index名衝突なし)。

## テスト

- 使い捨てPostgreSQL 16で`make migrate-up` → 3 index作成+部分述語確認 (version 61 clean) → 50k行投入+ANALYZE → EXPLAINで**BitmapOr (3 index scan)** 確認 → `-steps 3`でdown (version 58 clean) → 実データありで再up → `indisvalid=t`×3
- `TestDriveFileRepository_URLIndexes` (新規regression guard) pass
- `make fmt` / `make lint` / `make test` 全133パッケージpass

実行方法: `go test ./internal/repository/... -run TestDriveFileRepository_URLIndexes -count=1`

## Closes

Closes #1625

## その他

- 本番適用時はCONCURRENTLY buildのためmigrate-upの所要時間がdrive_file行数に比例して伸びるが、書き込みはblockしない。
- レビューで000040のコメント「TS側にuri indexは無い」が現行TSとずれている (現TSは`uri`に`@Index`あり) ことが見つかったが、本PRのスコープ外のため未修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)