### PR TITLE
Fix reversi: ready状態のlost update raceを修正

### DIFF
--- a/internal/api/reversi/handler_test.go
+++ b/internal/api/reversi/handler_test.go
@@ -53,6 +53,31 @@ func (m *mockReversiRepo) Update(g *model.ReversiGame) error {
 	return nil
 }
 
+func (m *mockReversiRepo) UpdateReadyState(gameID string, user1 bool, ready bool) (*model.ReversiGame, error) {
+	g, ok := m.games[gameID]
+	if !ok || g.IsStarted || g.IsEnded {
+		return nil, nil
+	}
+	if user1 {
+		g.User1Ready = ready
+	} else {
+		g.User2Ready = ready
+	}
+	return g, nil
+}
+
+func (m *mockReversiRepo) MarkStarted(g *model.ReversiGame) (bool, error) {
+	stored, ok := m.games[g.ID]
+	if !ok || stored.IsStarted {
+		return false, nil
+	}
+	stored.Black = g.Black
+	stored.IsStarted = true
+	stored.StartedAt = g.StartedAt
+	stored.CRC32 = g.CRC32
+	return true, nil
+}
+
 func (m *mockReversiRepo) ListByUser(userID string, limit int) ([]*model.ReversiGame, error) {
 	var result []*model.ReversiGame
 	for _, g := range m.games {

--- a/internal/core/federation/reversi_inbox_test.go
+++ b/internal/core/federation/reversi_inbox_test.go
@@ -74,6 +74,36 @@ func (r *fedFakeReversiRepo) Update(g *model.ReversiGame) error {
 	return nil
 }
 
+func (r *fedFakeReversiRepo) UpdateReadyState(gameID string, user1 bool, ready bool) (*model.ReversiGame, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	g, ok := r.games[gameID]
+	if !ok || g.IsStarted || g.IsEnded {
+		return nil, nil
+	}
+	if user1 {
+		g.User1Ready = ready
+	} else {
+		g.User2Ready = ready
+	}
+	clone := *g
+	return &clone, nil
+}
+
+func (r *fedFakeReversiRepo) MarkStarted(g *model.ReversiGame) (bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	stored, ok := r.games[g.ID]
+	if !ok || stored.IsStarted {
+		return false, nil
+	}
+	stored.Black = g.Black
+	stored.IsStarted = true
+	stored.StartedAt = g.StartedAt
+	stored.CRC32 = g.CRC32
+	return true, nil
+}
+
 func (r *fedFakeReversiRepo) ListByUser(userID string, _ int) ([]*model.ReversiGame, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/core/reversi/service.go
+++ b/internal/core/reversi/service.go
@@ -360,13 +360,24 @@ func (s *Service) UpdateReady(ctx context.Context, gameID, userID string, ready 
 	if !isPlayer(game, userID) {
 		return ErrNotPlayer
 	}
-	if game.User1ID == userID {
-		game.User1Ready = ready
-	} else {
-		game.User2Ready = ready
-	}
-	if err := s.repo.Update(game); err != nil {
+	// ローカルWS経由のreadyと連合inbox経由の相手readyが並行して走ると、
+	// Get→full-row Saveのread-modify-writeでは相手のready=trueをstale値で
+	// 上書きするlost updateが起きる (#1626)。自分のカラムだけをguard付き
+	// 単一UPDATEで書き、読み直した最新行で以降の判定を行う。
+	game, err = s.repo.UpdateReadyState(gameID, game.User1ID == userID, ready)
+	if err != nil {
 		return err
+	}
+	if game == nil {
+		// guard不成立: pre-checkとUPDATEの間にstarted/ended/削除へ遷移した
+		fresh, ferr := s.Get(ctx, gameID)
+		if ferr != nil {
+			return ferr
+		}
+		if fresh.IsEnded {
+			return ErrAlreadyEnded
+		}
+		return ErrAlreadyStarted
 	}
 	s.publish(gameID, "changeReadyStates", map[string]any{
 		"user1": game.User1Ready,
@@ -492,8 +503,15 @@ func (s *Service) StartGame(ctx context.Context, game *model.ReversiGame) error 
 		game.CRC32 = &crc
 	}
 
-	if err := s.repo.Update(game); err != nil {
+	// 並行UpdateReadyの両者がboth-readyを観測すると、StartGameに二重到達
+	// する (#1626)。isStarted=falseをguardにしたatomic claimで先勝ちを決め、
+	// 負けた側はtimer設定もstarted publishもせず静かに成功扱いにする。
+	claimed, err := s.repo.MarkStarted(game)
+	if err != nil {
 		return err
+	}
+	if !claimed {
+		return nil
 	}
 	// 初期ターンタイマー: logsCount=0 (まだ一手も置かれていない)
 	s.setTurnTimer(ctx, game.ID, 0, game.TimeLimitForEachTurn)

--- a/internal/core/reversi/service_concurrency_test.go
+++ b/internal/core/reversi/service_concurrency_test.go
@@ -1,0 +1,148 @@
+package reversi
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/require"
+)
+
+// TestService_UpdateReady_ConcurrentBothReady_StartsExactlyOnce is the
+// regression test for #1626: when both players' ready updates run
+// concurrently (local WebSocket handler vs federation inbox goroutine),
+// neither update may be lost and the game must start with exactly one
+// `started` event.
+//
+// 修正前のUpdateReadyはGet→full-row Saveのread-modify-writeだったため、
+// 並行実行でstale stateが相手のready=trueを上書きし(lost update)、
+// 両者readyが揃わずstartedが発火しないことがあった。-raceと反復実行で
+// その退行を検出する。
+func TestService_UpdateReady_ConcurrentBothReady_StartsExactlyOnce(t *testing.T) {
+	ctx := context.Background()
+	for i := 0; i < 100; i++ {
+		game, repo, pub, svc := newPendingGame(t)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		errs := make([]error, 2)
+		go func() {
+			defer wg.Done()
+			errs[0] = svc.UpdateReady(ctx, game.ID, "alice", true)
+		}()
+		go func() {
+			defer wg.Done()
+			errs[1] = svc.UpdateReady(ctx, game.ID, "bob", true)
+		}()
+		wg.Wait()
+		require.NoError(t, errs[0], "iteration %d", i)
+		require.NoError(t, errs[1], "iteration %d", i)
+
+		got, err := repo.FindByID(game.ID)
+		require.NoError(t, err)
+		require.True(t, got.User1Ready, "iteration %d: user1Ready must not be lost", i)
+		require.True(t, got.User2Ready, "iteration %d: user2Ready must not be lost", i)
+		require.True(t, got.IsStarted, "iteration %d: both-ready must start the game", i)
+
+		started := 0
+		for _, kind := range pub.types() {
+			if kind == "started" {
+				started++
+			}
+		}
+		require.Equal(t, 1, started, "iteration %d: started must be published exactly once", i)
+	}
+}
+
+// readyGuardFailRepo simulates losing the UpdateReadyState guard race:
+// pre-checkは通ったがUPDATE時点でstarted/ended/削除へ遷移していたケースを
+// 決定論的に再現する。
+type readyGuardFailRepo struct {
+	*fakeRepo
+	mutate func(r *fakeRepo)
+}
+
+func (r *readyGuardFailRepo) UpdateReadyState(_ string, _ bool, _ bool) (*model.ReversiGame, error) {
+	if r.mutate != nil {
+		r.mutate(r.fakeRepo)
+	}
+	return nil, nil
+}
+
+// TestService_UpdateReady_GuardFailMapsToStateError verifies the (nil, nil)
+// guard result is mapped to the precise state error via re-fetch (#1626).
+func TestService_UpdateReady_GuardFailMapsToStateError(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("game started concurrently", func(t *testing.T) {
+		game, repo, _, _ := newPendingGame(t)
+		wrapped := &readyGuardFailRepo{fakeRepo: repo, mutate: func(r *fakeRepo) {
+			r.mu.Lock()
+			defer r.mu.Unlock()
+			r.games[game.ID].IsStarted = true
+		}}
+		svc := NewService(wrapped, &capturePublisher{}, nil)
+		err := svc.UpdateReady(ctx, game.ID, "alice", true)
+		require.ErrorIs(t, err, ErrAlreadyStarted)
+	})
+
+	t.Run("game ended concurrently", func(t *testing.T) {
+		game, repo, _, _ := newPendingGame(t)
+		wrapped := &readyGuardFailRepo{fakeRepo: repo, mutate: func(r *fakeRepo) {
+			r.mu.Lock()
+			defer r.mu.Unlock()
+			r.games[game.ID].IsEnded = true
+		}}
+		svc := NewService(wrapped, &capturePublisher{}, nil)
+		err := svc.UpdateReady(ctx, game.ID, "alice", true)
+		require.ErrorIs(t, err, ErrAlreadyEnded)
+	})
+
+	t.Run("game deleted concurrently", func(t *testing.T) {
+		game, repo, _, _ := newPendingGame(t)
+		wrapped := &readyGuardFailRepo{fakeRepo: repo, mutate: func(r *fakeRepo) {
+			r.mu.Lock()
+			defer r.mu.Unlock()
+			delete(r.games, game.ID)
+		}}
+		svc := NewService(wrapped, &capturePublisher{}, nil)
+		err := svc.UpdateReady(ctx, game.ID, "alice", true)
+		require.ErrorIs(t, err, ErrGameNotFound)
+	})
+}
+
+func TestService_UpdateReady_RepoErrorPropagates(t *testing.T) {
+	game, repo, _, svc := newPendingGame(t)
+	repo.updateErr = errors.New("boom")
+	require.Error(t, svc.UpdateReady(context.Background(), game.ID, "alice", true))
+}
+
+func TestService_StartGame_MarkStartedErrorPropagates(t *testing.T) {
+	game, repo, _, svc := newPendingGame(t)
+	repo.updateErr = errors.New("boom")
+	require.Error(t, svc.StartGame(context.Background(), game))
+}
+
+// TestService_StartGame_ClaimLostIsSilentNoop verifies that a StartGame call
+// losing the started claim neither errors nor double-publishes (#1626).
+func TestService_StartGame_ClaimLostIsSilentNoop(t *testing.T) {
+	ctx := context.Background()
+	game, _, pub, svc := newPendingGame(t)
+
+	require.NoError(t, svc.StartGame(ctx, game))
+
+	// 並行goroutineが持つstale copy (IsStarted=false) からの二重到達を模す
+	stale := *game
+	stale.IsStarted = false
+	require.NoError(t, svc.StartGame(ctx, &stale))
+
+	started := 0
+	for _, kind := range pub.types() {
+		if kind == "started" {
+			started++
+		}
+	}
+	require.Equal(t, 1, started, "claim loser must not publish a second started event")
+}

--- a/internal/core/reversi/service_wire_test.go
+++ b/internal/core/reversi/service_wire_test.go
@@ -61,6 +61,47 @@ func (r *fakeRepo) Update(g *model.ReversiGame) error {
 	return nil
 }
 
+func (r *fakeRepo) UpdateReadyState(gameID string, user1 bool, ready bool) (*model.ReversiGame, error) {
+	r.mu.Lock()
+	if r.updateErr != nil {
+		r.mu.Unlock()
+		return nil, r.updateErr
+	}
+	g, ok := r.games[gameID]
+	if !ok || g.IsStarted || g.IsEnded {
+		r.mu.Unlock()
+		return nil, nil
+	}
+	// 実DB実装と同じく自分のカラムだけを書き換える (#1626)
+	if user1 {
+		g.User1Ready = ready
+	} else {
+		g.User2Ready = ready
+	}
+	r.mu.Unlock()
+	// 実DB実装ではUPDATEとre-readが別ステートメントなので、両goroutineが
+	// both-readyを観測してStartGameへ二重到達し得る。fakeも同じ二段構成に
+	// して、MarkStartedのclaim排他をserviceテストで踏めるようにする。
+	return r.FindByID(gameID)
+}
+
+func (r *fakeRepo) MarkStarted(g *model.ReversiGame) (bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.updateErr != nil {
+		return false, r.updateErr
+	}
+	stored, ok := r.games[g.ID]
+	if !ok || stored.IsStarted {
+		return false, nil
+	}
+	stored.Black = g.Black
+	stored.IsStarted = true
+	stored.StartedAt = g.StartedAt
+	stored.CRC32 = g.CRC32
+	return true, nil
+}
+
 func (r *fakeRepo) ListByUser(userID string, limit int) ([]*model.ReversiGame, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/repository/reversi.go
+++ b/internal/repository/reversi.go
@@ -10,6 +10,19 @@ type ReversiRepository interface {
 	Create(game *model.ReversiGame) error
 	FindByID(id string) (*model.ReversiGame, error)
 	Update(game *model.ReversiGame) error
+	// UpdateReadyState atomically sets one player's ready flag with a
+	// pre-start guard and returns the freshly reloaded row. Returns
+	// (nil, nil) when the guard fails (game already started/ended or the
+	// row is gone). ローカルWSと連合inboxの並行readyがfull-row Saveで互いの
+	// フラグを上書きするlost update (#1626) を防ぐため、自分のカラムだけを
+	// 単一UPDATEで書く。
+	UpdateReadyState(gameID string, user1 bool, ready bool) (*model.ReversiGame, error)
+	// MarkStarted atomically claims the not-started -> started transition,
+	// persisting the start fields (black / isStarted / startedAt / crc32)
+	// only when the row is not yet started. Returns whether this caller won
+	// the claim. 並行UpdateReadyの両者がboth-readyを観測してStartGameに
+	// 二重到達したとき、startedイベントを一度だけ発火させるための排他 (#1626)。
+	MarkStarted(game *model.ReversiGame) (bool, error)
 	ListByUser(userID string, limit int) ([]*model.ReversiGame, error)
 	// ListByUserCursor returns user's games (User1 or User2) with keyset
 	// pagination via sinceID / untilID。limit は上限 (0 → 10)。id DESC 順。
@@ -68,6 +81,43 @@ func (r *reversiRepository) FindByFederationID(federationID string) (*model.Reve
 
 func (r *reversiRepository) Update(game *model.ReversiGame) error {
 	return r.db.Save(game).Error
+}
+
+func (r *reversiRepository) UpdateReadyState(gameID string, user1 bool, ready bool) (*model.ReversiGame, error) {
+	column := "user2Ready"
+	if user1 {
+		column = "user1Ready"
+	}
+	// started/ended後のready変更は無視する (本家gameReadyと同じセマンティクス)。
+	// guardをUPDATE自体に含めることで、pre-checkとの間のTOCTOUも閉じる。
+	res := r.db.Model(&model.ReversiGame{}).
+		Where(`"id" = ? AND "isStarted" = false AND "isEnded" = false`, gameID).
+		UpdateColumn(column, ready)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	if res.RowsAffected == 0 {
+		return nil, nil
+	}
+	// 書き込み後に読み直すことで、相手側の並行更新がcommit済みなら必ず観測
+	// できる。両者の更新がどう交錯しても、少なくとも後にre-readした側は
+	// both-ready=trueを見る。
+	return r.FindByID(gameID)
+}
+
+func (r *reversiRepository) MarkStarted(game *model.ReversiGame) (bool, error) {
+	res := r.db.Model(&model.ReversiGame{}).
+		Where(`"id" = ? AND "isStarted" = false`, game.ID).
+		Updates(map[string]any{
+			"black":     game.Black,
+			"isStarted": true,
+			"startedAt": game.StartedAt,
+			"crc32":     game.CRC32,
+		})
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected > 0, nil
 }
 
 func (r *reversiRepository) ListByUser(userID string, limit int) ([]*model.ReversiGame, error) {

--- a/internal/repository/reversi_test.go
+++ b/internal/repository/reversi_test.go
@@ -1,7 +1,10 @@
 package repository
 
 import (
+	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/model"
@@ -38,6 +41,143 @@ func TestReversiRepository_DeleteOutdatedGames(t *testing.T) {
 	assert.NoError(t, err, "開始済みは残る")
 	_, err = repo.FindByID("zzz_new_unstarted")
 	assert.NoError(t, err, "新しい game は残る")
+}
+
+// TestReversiRepository_UpdateReadyState_Guards verifies the atomic ready
+// update and its pre-start guard semantics (#1626).
+func TestReversiRepository_UpdateReadyState_Guards(t *testing.T) {
+	repo := NewReversiRepository(testDB)
+	u1 := insertTestUser(t, "u_revg_1", "reversigrd1")
+	defer cleanupUser(t, u1.ID)
+	u2 := insertTestUser(t, "u_revg_2", "reversigrd2")
+	defer cleanupUser(t, u2.ID)
+
+	game := &model.ReversiGame{
+		ID: "rev_grd_1", User1ID: u1.ID, User2ID: u2.ID,
+		Map: pq.StringArray{"--------"}, BW: "random", TimeLimitForEachTurn: 90, Logs: datatypes.JSON("[]"),
+	}
+	require.NoError(t, repo.Create(game))
+	defer testDB.Exec(`DELETE FROM "reversi_game" WHERE id = ?`, game.ID)
+
+	// 正常系: 自分のカラムだけ更新され、最新行が返る
+	got, err := repo.UpdateReadyState(game.ID, true, true)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.True(t, got.User1Ready)
+	assert.False(t, got.User2Ready)
+
+	got, err = repo.UpdateReadyState(game.ID, false, true)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.True(t, got.User1Ready, "user2側の更新でuser1Readyが失われてはならない")
+	assert.True(t, got.User2Ready)
+
+	// started後のready変更はguardで無視され(nil, nil)が返る
+	require.NoError(t, testDB.Exec(`UPDATE "reversi_game" SET "isStarted" = true WHERE id = ?`, game.ID).Error)
+	got, err = repo.UpdateReadyState(game.ID, true, false)
+	require.NoError(t, err)
+	assert.Nil(t, got, "started後のready変更はguardで弾かれる")
+
+	// 存在しない行も(nil, nil)
+	got, err = repo.UpdateReadyState("rev_grd_ghost", true, true)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+// TestReversiRepository_UpdateReadyState_ConcurrentNoLostUpdate is the
+// regression test for #1626: concurrent per-player ready updates must not
+// clobber each other. full-row Saveに退行するとここが高確率で落ちる。
+func TestReversiRepository_UpdateReadyState_ConcurrentNoLostUpdate(t *testing.T) {
+	repo := NewReversiRepository(testDB)
+	u1 := insertTestUser(t, "u_revc_1", "reversicon1")
+	defer cleanupUser(t, u1.ID)
+	u2 := insertTestUser(t, "u_revc_2", "reversicon2")
+	defer cleanupUser(t, u2.ID)
+
+	for i := 0; i < 20; i++ {
+		gameID := fmt.Sprintf("rev_con_%02d", i)
+		game := &model.ReversiGame{
+			ID: gameID, User1ID: u1.ID, User2ID: u2.ID,
+			Map: pq.StringArray{"--------"}, BW: "random", TimeLimitForEachTurn: 90, Logs: datatypes.JSON("[]"),
+		}
+		require.NoError(t, repo.Create(game))
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		errs := make([]error, 2)
+		go func() {
+			defer wg.Done()
+			_, errs[0] = repo.UpdateReadyState(gameID, true, true)
+		}()
+		go func() {
+			defer wg.Done()
+			_, errs[1] = repo.UpdateReadyState(gameID, false, true)
+		}()
+		wg.Wait()
+		require.NoError(t, errs[0])
+		require.NoError(t, errs[1])
+
+		got, err := repo.FindByID(gameID)
+		require.NoError(t, err)
+		assert.True(t, got.User1Ready, "iteration %d: user1Ready must survive concurrent update", i)
+		assert.True(t, got.User2Ready, "iteration %d: user2Ready must survive concurrent update", i)
+		require.NoError(t, repo.Delete(gameID))
+	}
+}
+
+// TestReversiRepository_MarkStarted_SingleWinner verifies the started claim is
+// won by exactly one concurrent caller (#1626).
+func TestReversiRepository_MarkStarted_SingleWinner(t *testing.T) {
+	repo := NewReversiRepository(testDB)
+	u1 := insertTestUser(t, "u_revm_1", "reversimrk1")
+	defer cleanupUser(t, u1.ID)
+	u2 := insertTestUser(t, "u_revm_2", "reversimrk2")
+	defer cleanupUser(t, u2.ID)
+
+	for i := 0; i < 10; i++ {
+		gameID := fmt.Sprintf("rev_mrk_%02d", i)
+		game := &model.ReversiGame{
+			ID: gameID, User1ID: u1.ID, User2ID: u2.ID,
+			Map: pq.StringArray{"--------"}, BW: "random", TimeLimitForEachTurn: 90, Logs: datatypes.JSON("[]"),
+		}
+		require.NoError(t, repo.Create(game))
+
+		black := 1
+		now := time.Now()
+		crc := "12345"
+		claim := &model.ReversiGame{ID: gameID, Black: &black, StartedAt: &now, CRC32: &crc}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		wins := make([]bool, 2)
+		errs := make([]error, 2)
+		for j := 0; j < 2; j++ {
+			go func(j int) {
+				defer wg.Done()
+				wins[j], errs[j] = repo.MarkStarted(claim)
+			}(j)
+		}
+		wg.Wait()
+		require.NoError(t, errs[0])
+		require.NoError(t, errs[1])
+		winners := 0
+		for _, w := range wins {
+			if w {
+				winners++
+			}
+		}
+		assert.Equal(t, 1, winners, "iteration %d: exactly one caller must win the start claim", i)
+
+		got, err := repo.FindByID(gameID)
+		require.NoError(t, err)
+		assert.True(t, got.IsStarted)
+		require.NotNil(t, got.Black)
+		assert.Equal(t, 1, *got.Black)
+		require.NotNil(t, got.CRC32)
+		assert.Equal(t, "12345", *got.CRC32)
+		assert.NotNil(t, got.StartedAt)
+		require.NoError(t, repo.Delete(gameID))
+	}
 }
 
 func TestReversiRepository_CRUD(t *testing.T) {

--- a/internal/stream/channels/reversi_game_test.go
+++ b/internal/stream/channels/reversi_game_test.go
@@ -34,6 +34,30 @@ func (r *channelFakeRepo) Update(g *model.ReversiGame) error {
 	r.games[g.ID] = g
 	return nil
 }
+func (r *channelFakeRepo) UpdateReadyState(gameID string, user1 bool, ready bool) (*model.ReversiGame, error) {
+	g, ok := r.games[gameID]
+	if !ok || g.IsStarted || g.IsEnded {
+		return nil, nil
+	}
+	if user1 {
+		g.User1Ready = ready
+	} else {
+		g.User2Ready = ready
+	}
+	clone := *g
+	return &clone, nil
+}
+func (r *channelFakeRepo) MarkStarted(g *model.ReversiGame) (bool, error) {
+	stored, ok := r.games[g.ID]
+	if !ok || stored.IsStarted {
+		return false, nil
+	}
+	stored.Black = g.Black
+	stored.IsStarted = true
+	stored.StartedAt = g.StartedAt
+	stored.CRC32 = g.CRC32
+	return true, nil
+}
 func (r *channelFakeRepo) ListByUser(_ string, _ int) ([]*model.ReversiGame, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Summary

`TestReversi_ReadyPropagatesAndStarts`が約1/2の確率でtimeoutするflake (#1626) の原因を調査し、test起因ではなく連合reversiのready更新経路の実バグ(lost update race)であることを特定して修正した。

## 原因

`Service.UpdateReady`がGet→full-row Save(`db.Save`)のread-modify-writeになっており、同一サーバー上で「ローカルWS経由のready」と「連合inbox経由の相手のready」が並行して走ると、両goroutineがstale stateを読み、相手の`ready=true`をfalseで上書きしていた。失敗時のstreamに届く`{user1:false,user2:true}` → `{user1:true,user2:false}`はこのlost updateの痕跡そのもの。

## 主な変更点

- **`internal/repository/reversi.go`**
  - `UpdateReadyState`を追加: 自分のカラム(`user1Ready`/`user2Ready`)だけを`isStarted=false AND isEnded=false` guard付き単一UPDATEで書き、最新行をre-readして返す。lost updateが構造的に起きなくなり、両更新のcommit後は少なくとも後にre-readした側がboth-readyを観測する
  - `MarkStarted`を追加: `isStarted=false`をguardにしたatomic claimでstarted遷移の先勝ちを決める
- **`internal/core/reversi/service.go`**
  - `UpdateReady`: full-row Saveを`UpdateReadyState`に置換。guard不成立時はre-fetchして`ErrAlreadyStarted`/`ErrAlreadyEnded`/`ErrGameNotFound`に正確にマップ
  - `StartGame`: full-row Saveを`MarkStarted`に置換。lost update解消で顕在化する「両goroutineがboth-readyを観測してStartGame二重到達」に対し、claim負け側はtimer設定も`started` publishもせずsilent no-op(イベント二重発火防止)
- **各テストfake×4**: interface追従(実装と同じ「UPDATE→別ステップre-read」のatomicセマンティクスを再現)
- started後のready変更をguardで無視する挙動は本家`ReversiService.gameReady`(`if (game.isStarted) return`)と同じセマンティクス

## テスト

- 修正前: `go test ./test/e2e_federation/ -run TestReversi_ReadyPropagatesAndStarts -count=5`で失敗を再現(issue記載どおり)
- 修正後: 同`-count=10`で全pass
- 回帰テスト追加:
  - `TestReversiRepository_UpdateReadyState_ConcurrentNoLostUpdate`(実DB、20反復並行更新)
  - `TestReversiRepository_MarkStarted_SingleWinner`(実DB、並行claimの勝者がちょうど1)
  - `TestReversiRepository_UpdateReadyState_Guards`(guardセマンティクス)
  - `TestService_UpdateReady_ConcurrentBothReady_StartsExactlyOnce`(100反復、-race、started発火ちょうど1回)
  - guard失敗→各エラーへのマップ / claim負けsilent no-op / repoエラー伝播
- カバレッジ: `internal/repository` 90.5% / `internal/core/reversi` 92.3%(`UpdateReady` 100%)
- `make fmt` / `make lint` / `go test ./... -count=1`全pass

## Closes

Closes #1626

🤖 Generated with [Claude Code](https://claude.com/claude-code)