### PR TITLE
Fix: following/* + clips/* parity の MEDIUM/LOW 差分をまとめて解消

### DIFF
--- a/internal/api/clips/favorites.go
+++ b/internal/api/clips/favorites.go
@@ -16,6 +16,9 @@ type ClipFavoriteRepository interface {
 	Delete(userID, clipID string) error
 	ListByUser(userID string) ([]*model.ClipFavorite, error)
 	Exists(userID, clipID string) (bool, error)
+	// CountByClip returns the favorite count used by the clip response's
+	// favoritedCount field (#1562).
+	CountByClip(clipID string) (int64, error)
 }
 
 // SetFavoriteRepo attaches a ClipFavoriteRepository for favorite endpoints.
@@ -35,13 +38,19 @@ func (h *Handler) Favorite(c echo.Context) error {
 	if h.favoriteRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
-	// クリップの存在確認
+	// クリップの存在確認 (private clip の他人は Show が ErrClipNotFound を
+	// 返すので upstream favorite.ts と同じく NO_SUCH_CLIP に落ちる)
 	if _, err := h.svc.Show(user.ID, req.ClipID); err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CLIP", "No such clip.", "4c2aaeae-80d8-4250-9606-26cb1fdb77a5"))
 	}
-	already, _ := h.favoriteRepo.Exists(user.ID, req.ClipID)
+	already, err := h.favoriteRepo.Exists(user.ID, req.ClipID)
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
 	if already {
-		return c.NoContent(http.StatusNoContent)
+		// upstream favorite.ts は重複 favorite を silent 成功させず
+		// ALREADY_FAVORITED を返す (#1562)。
+		return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_FAVORITED", "The clip has already been favorited.", "92658936-c625-4273-8326-2d790129256e"))
 	}
 	fav := &model.ClipFavorite{
 		ID:     h.idGen.Generate(time.Now()),
@@ -66,6 +75,23 @@ func (h *Handler) Unfavorite(c echo.Context) error {
 	if h.favoriteRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
+	// upstream unfavorite.ts は clip の生存在 (visibility 検査なし) と
+	// favorite row の存在を順に検査する (#1562)。visibility を見ないのは、
+	// favorite 後に非公開化された clip でも解除できる必要があるため。
+	exists, err := h.svc.Exists(req.ClipID)
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
+	if !exists {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CLIP", "No such clip.", "2603966e-b865-426c-94a7-af4a01241dc1"))
+	}
+	favorited, err := h.favoriteRepo.Exists(user.ID, req.ClipID)
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
+	if !favorited {
+		return c.JSON(http.StatusBadRequest, apierr.Error("NOT_FAVORITED", "You have not favorited the clip.", "90c3a9e8-b321-4dae-bf57-2bf79bbcc187"))
+	}
 	if err := h.favoriteRepo.Delete(user.ID, req.ClipID); err != nil {
 		return apierr.JSONInternalError(c)
 	}
@@ -88,7 +114,7 @@ func (h *Handler) MyFavorites(c echo.Context) error {
 		if err != nil {
 			continue
 		}
-		out = append(out, h.clipToMap(cl))
+		out = append(out, h.clipToMap(cl, user))
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/clips/favorites_test.go
+++ b/internal/api/clips/favorites_test.go
@@ -63,8 +63,11 @@ func TestClipFavorite_AlreadyFavorited(t *testing.T) {
 	h, clipRepo, favRepo := newStubHandler(t)
 	clipRepo.Clips["cl1"] = &model.Clip{ID: "cl1", UserID: "u1", Name: "test", IsPublic: true}
 	favRepo.Favorites["u1:cl1"] = &model.ClipFavorite{ID: "f1", UserID: "u1", ClipID: "cl1"}
+	// upstream favorite.ts は重複 favorite を ALREADY_FAVORITED 400 で拒否する (#1562)
 	rec := postStubWithBody(t, h.Favorite, `{"clipId":"cl1"}`, "u1")
-	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "ALREADY_FAVORITED")
+	assert.Contains(t, rec.Body.String(), "92658936-c625-4273-8326-2d790129256e")
 }
 
 func TestClipFavorite_NilRepo(t *testing.T) {
@@ -75,12 +78,42 @@ func TestClipFavorite_NilRepo(t *testing.T) {
 }
 
 func TestClipUnfavorite_Success(t *testing.T) {
-	h, _, favRepo := newStubHandler(t)
+	h, clipRepo, favRepo := newStubHandler(t)
+	clipRepo.Clips["cl1"] = &model.Clip{ID: "cl1", UserID: "u1", Name: "test", IsPublic: true}
 	favRepo.Favorites["u1:cl1"] = &model.ClipFavorite{ID: "f1", UserID: "u1", ClipID: "cl1"}
 	rec := postStubWithBody(t, h.Unfavorite, `{"clipId":"cl1"}`, "u1")
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 	exists, _ := favRepo.Exists("u1", "cl1")
 	assert.False(t, exists)
+}
+
+// upstream unfavorite.ts は clip 不在を NO_SUCH_CLIP、未 favorite を
+// NOT_FAVORITED で拒否する (#1562)。
+func TestClipUnfavorite_NoSuchClip(t *testing.T) {
+	h, _, _ := newStubHandler(t)
+	rec := postStubWithBody(t, h.Unfavorite, `{"clipId":"ghost"}`, "u1")
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_CLIP")
+	assert.Contains(t, rec.Body.String(), "2603966e-b865-426c-94a7-af4a01241dc1")
+}
+
+func TestClipUnfavorite_NotFavorited(t *testing.T) {
+	h, clipRepo, _ := newStubHandler(t)
+	clipRepo.Clips["cl1"] = &model.Clip{ID: "cl1", UserID: "u1", Name: "test", IsPublic: true}
+	rec := postStubWithBody(t, h.Unfavorite, `{"clipId":"cl1"}`, "u1")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NOT_FAVORITED")
+	assert.Contains(t, rec.Body.String(), "90c3a9e8-b321-4dae-bf57-2bf79bbcc187")
+}
+
+// favorite 済の非公開化 clip も unfavorite できる (upstream は visibility を
+// 見ない、#1562)。
+func TestClipUnfavorite_PrivateClipStillRemovable(t *testing.T) {
+	h, clipRepo, favRepo := newStubHandler(t)
+	clipRepo.Clips["cl1"] = &model.Clip{ID: "cl1", UserID: "owner", Name: "test", IsPublic: false}
+	favRepo.Favorites["u1:cl1"] = &model.ClipFavorite{ID: "f1", UserID: "u1", ClipID: "cl1"}
+	rec := postStubWithBody(t, h.Unfavorite, `{"clipId":"cl1"}`, "u1")
+	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
 func TestClipUnfavorite_MissingClipID(t *testing.T) {

--- a/internal/api/clips/handler.go
+++ b/internal/api/clips/handler.go
@@ -36,6 +36,43 @@ type Handler struct {
 	// で 404 NO_SUCH_NOTE を返し、visibility 未検証の note を絶対に clip に
 	// 永続化しない (#1455 favorites/create と同形)。
 	queryService *corenote.QueryService
+	// mutingRepo / blockingRepo は clips/notes の muted-user / blocked-user
+	// filter (#1562、upstream generateMutedUserQueryForNotes 等) に使う。
+	// 未配線時は該当次元の filter を skip する。
+	mutingRepo   repository.MutingRepository
+	blockingRepo repository.BlockingRepository
+	// metaRepo は clips/notes の blocked-host filter (#1562、upstream
+	// generateBlockedHostQueryForNote) で meta.blockedHosts を引く。
+	metaRepo repository.MetaRepository
+}
+
+// SetMuteBlockRepos wires the muting / blocking repositories used by the
+// clips/notes muted-user / blocked-user filters (#1562).
+func (h *Handler) SetMuteBlockRepos(m repository.MutingRepository, b repository.BlockingRepository) {
+	h.mutingRepo = m
+	h.blockingRepo = b
+}
+
+// SetMetaRepo wires a MetaRepository used by the clips/notes blocked-host
+// filter (#1562).
+func (h *Handler) SetMetaRepo(r repository.MetaRepository) {
+	h.metaRepo = r
+}
+
+// blockedHosts returns meta.blockedHosts, or nil when the meta repo is not
+// wired. Fetch error は fail-closed にするため caller へ返す (#1544 と同方針)。
+func (h *Handler) blockedHosts() ([]string, error) {
+	if h.metaRepo == nil {
+		return nil, nil
+	}
+	meta, err := h.metaRepo.Fetch()
+	if err != nil {
+		return nil, err
+	}
+	if meta == nil {
+		return nil, nil
+	}
+	return meta.BlockedHosts, nil
 }
 
 // SetUserRepo wires a UserRepository so clips/notes filters out notes that
@@ -106,11 +143,42 @@ type CreateRequest struct {
 	IsPublic    bool    `json:"isPublic"`
 }
 
+// upstream paramDef の長さ制約 (clips/create.ts / update.ts)。ajv は UTF-16
+// code unit 長だが、mk-go では他 endpoint と同じく rune 数で近似する (#1624 と
+// 同方針。サロゲートペアを含む文字列は upstream より長く受理される)。
+const (
+	clipNameMaxLength        = 100
+	clipDescriptionMaxLength = 2048
+)
+
+// validateClipParams checks name (1..100) / description (≤2048) length and
+// normalizes an empty description to null (upstream `ps.description || null`)。
+// name が nil の場合 (update の未指定) は検査しない。
+func validateClipParams(name *string, description **string) bool {
+	if name != nil {
+		if n := len([]rune(*name)); n < 1 || n > clipNameMaxLength {
+			return false
+		}
+	}
+	if description != nil && *description != nil {
+		if *(*description) == "" {
+			// 空文字は null に正規化して保存する (#1562)
+			*description = nil
+		} else if len([]rune(**description)) > clipDescriptionMaxLength {
+			return false
+		}
+	}
+	return true
+}
+
 // Create handles POST /api/clips/create.
 func (h *Handler) Create(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req CreateRequest
 	if err := c.Bind(&req); err != nil || req.Name == "" {
+		return apierr.JSONInvalidParam(c)
+	}
+	if !validateClipParams(&req.Name, &req.Description) {
 		return apierr.JSONInvalidParam(c)
 	}
 	cl, err := h.svc.Create(coreclip.CreateInput{
@@ -125,7 +193,7 @@ func (h *Handler) Create(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, h.clipToMap(cl))
+	return c.JSON(http.StatusOK, h.clipToMap(cl, user))
 }
 
 // ShowRequest is the request body for clips/show.
@@ -144,14 +212,14 @@ func (h *Handler) Show(c echo.Context) error {
 	if user != nil {
 		requesterID = user.ID
 	}
+	// 非公開 clip を他人/匿名が見た場合も service が ErrClipNotFound を返す
+	// ので、missing と同一の NO_SUCH_CLIP 404 になり存在が秘匿される (#1562、
+	// upstream show.ts と同じ enumeration oracle 封じ)。
 	cl, err := h.svc.Show(requesterID, req.ClipID)
 	if err != nil {
-		if errors.Is(err, coreclip.ErrAccessDenied) {
-			return apierr.JSONAccessDenied(c)
-		}
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CLIP", "No such clip.", "c3c5fe33-d62c-44d2-9ea5-d997703f5c20"))
 	}
-	return c.JSON(http.StatusOK, h.clipToMap(cl))
+	return c.JSON(http.StatusOK, h.clipToMap(cl, user))
 }
 
 // UpdateRequest is the request body for clips/update.
@@ -169,27 +237,30 @@ func (h *Handler) Update(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.ClipID == "" {
 		return apierr.JSONInvalidParam(c)
 	}
+	// upstream update.ts は `ps.description || null` を常に ClipService に渡す
+	// ため、description 未指定 (undefined) でも NULL にクリアされる。mk-go も
+	// 常に Description を更新対象にする (#1562)。
+	desc := req.Description
 	in := coreclip.UpdateInput{
-		Name:     req.Name,
-		IsPublic: req.IsPublic,
+		Name:        req.Name,
+		Description: &desc,
+		IsPublic:    req.IsPublic,
 	}
-	if req.Description != nil {
-		desc := req.Description
-		in.Description = &desc
+	// name 長 / description 長の検証と空 description の null 正規化 (#1562)
+	if !validateClipParams(req.Name, in.Description) {
+		return apierr.JSONInvalidParam(c)
 	}
 	cl, err := h.svc.Update(user.ID, req.ClipID, in)
 	if err != nil {
 		switch {
 		case errors.Is(err, coreclip.ErrClipNotFound):
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CLIP", "No such clip.", "b4d92d70-b216-46fa-9a3f-a8c811699257"))
-		case errors.Is(err, coreclip.ErrAccessDenied):
-			return apierr.JSONAccessDenied(c)
 		case errors.Is(err, coreclip.ErrClipNameRequired):
 			return apierr.JSONInvalidParam(c)
 		}
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, h.clipToMap(cl))
+	return c.JSON(http.StatusOK, h.clipToMap(cl, user))
 }
 
 // DeleteRequest is the request body for clips/delete.
@@ -208,8 +279,6 @@ func (h *Handler) Delete(c echo.Context) error {
 		switch {
 		case errors.Is(err, coreclip.ErrClipNotFound):
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CLIP", "No such clip.", "70ca08ba-6865-4630-b6fb-8494759aa754"))
-		case errors.Is(err, coreclip.ErrAccessDenied):
-			return apierr.JSONAccessDenied(c)
 		}
 		return apierr.JSONInternalError(c)
 	}
@@ -245,7 +314,7 @@ func (h *Handler) List(c echo.Context) error {
 	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, cl := range rows {
-		out = append(out, h.clipToMap(cl))
+		out = append(out, h.clipToMap(cl, user))
 	}
 	return c.JSON(http.StatusOK, out)
 }
@@ -278,8 +347,6 @@ func (h *Handler) AddNote(c echo.Context) error {
 		switch {
 		case errors.Is(err, coreclip.ErrClipNotFound):
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CLIP", "No such clip.", "d6e76cc0-a1b5-4c7c-a287-73fa9c716dcf"))
-		case errors.Is(err, coreclip.ErrAccessDenied):
-			return apierr.JSONAccessDenied(c)
 		case errors.Is(err, coreclip.ErrNoteNotFound):
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "fc8c0b49-c7a3-4664-a0a6-b418d386bb8b"))
 		case errors.Is(err, coreclip.ErrAlreadyClipped):
@@ -309,8 +376,6 @@ func (h *Handler) RemoveNote(c echo.Context) error {
 		switch {
 		case errors.Is(err, coreclip.ErrClipNotFound):
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CLIP", "No such clip.", "b80525c6-97f7-49d7-a42d-ebccd49cfd52"))
-		case errors.Is(err, coreclip.ErrAccessDenied):
-			return apierr.JSONAccessDenied(c)
 		case errors.Is(err, coreclip.ErrNotClipped):
 			return notClipped(c)
 		}
@@ -321,13 +386,18 @@ func (h *Handler) RemoveNote(c echo.Context) error {
 
 // NotesRequest is the request body for clips/notes.
 type NotesRequest struct {
-	ClipID    string `json:"clipId"`
-	UntilID   string `json:"untilId"`
-	SinceID   string `json:"sinceId"`
-	SinceDate *int64 `json:"sinceDate"`
-	UntilDate *int64 `json:"untilDate"`
-	Limit     int    `json:"limit"`
+	ClipID    string  `json:"clipId"`
+	UntilID   string  `json:"untilId"`
+	SinceID   string  `json:"sinceId"`
+	SinceDate *int64  `json:"sinceDate"`
+	UntilDate *int64  `json:"untilDate"`
+	Limit     int     `json:"limit"`
+	Search    *string `json:"search"`
 }
+
+// clipNotesSearchMaxLength は upstream clips/notes paramDef の search
+// maxLength。minLength は 1 (空文字は 400)。
+const clipNotesSearchMaxLength = 100
 
 // Notes handles POST /api/clips/notes.
 func (h *Handler) Notes(c echo.Context) error {
@@ -336,6 +406,15 @@ func (h *Handler) Notes(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.ClipID == "" {
 		return apierr.JSONInvalidParam(c)
 	}
+	// search は nullable (null = 未指定)。指定時は 1..100 を強制 (upstream
+	// paramDef minLength 1 / maxLength 100、#1562)。
+	search := ""
+	if req.Search != nil {
+		if n := len([]rune(*req.Search)); n < 1 || n > clipNotesSearchMaxLength {
+			return apierr.JSONInvalidParam(c)
+		}
+		search = *req.Search
+	}
 	requesterID := ""
 	if user != nil {
 		requesterID = user.ID
@@ -343,18 +422,32 @@ func (h *Handler) Notes(c echo.Context) error {
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
 	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
-	notes, err := h.svc.Notes(requesterID, req.ClipID, untilID, sinceID, req.Limit)
+	notes, err := h.svc.Notes(requesterID, req.ClipID, untilID, sinceID, req.Limit, search)
 	if err != nil {
-		switch {
-		case errors.Is(err, coreclip.ErrClipNotFound):
+		// 非公開 clip の他人/匿名閲覧は missing と同じ ErrClipNotFound →
+		// NO_SUCH_CLIP 404 (存在秘匿、#1562)。
+		if errors.Is(err, coreclip.ErrClipNotFound) {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CLIP", "No such clip.", "1d7645e6-2b6d-4635-b0fe-fe22b0e72e00"))
-		case errors.Is(err, coreclip.ErrAccessDenied):
-			return apierr.JSONAccessDenied(c)
 		}
 		return apierr.JSONInternalError(c)
 	}
 	// visibility は clip service の ListByClipVisible で push down 済み (#1418
-	// review)。ここでは hardMutedWords filter のみ適用する。
+	// review)。muted-user / blocked-user / blocked-host / hardMutedWords を
+	// post-fetch で適用する (#1562。antennas / roles の #1544 と同形のため
+	// LIMIT 後適用 = ページ過少充填はあり得る)。channel mute は upstream
+	// clips/notes が適用しないため渡さない。upstream が併せ持つ
+	// muted-instances と renote 入れ子変種 (renote の reply/renote author) は
+	// #1544 と同じく未対応の follow-up。
+	mbSets, err := notesfilter.LoadMuteBlockSets(user, h.mutingRepo, h.blockingRepo, nil)
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
+	notes = notesfilter.ApplyMuteBlockChannel(notes, mbSets)
+	blockedHosts, err := h.blockedHosts()
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
+	notes = notesfilter.ApplyBlockedHosts(notes, blockedHosts)
 	notes = notesfilter.ApplyHardMute(h.userRepo, user, notes)
 	entities := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(entities, user)
@@ -370,12 +463,39 @@ func (h *Handler) Notes(c echo.Context) error {
 // entity.PackClip. owner (clip の所有ユーザー) を userRepo から解決して user
 // field を埋める。misskey_dart の Clip.fromJson は createdAt / user /
 // favoritedCount を非null必須とするため、旧 ad-hoc map では落ちていた (#1245)。
-func (h *Handler) clipToMap(cl *model.Clip) map[string]any {
+// viewer は favoritedCount / isFavorited / notesCount の出し分けに使う (#1562)。
+func (h *Handler) clipToMap(cl *model.Clip, viewer *model.User) map[string]any {
 	var owner *model.User
 	if h.userRepo != nil {
 		owner, _ = h.userRepo.FindByID(cl.UserID)
 	}
-	return entity.PackClip(cl, h.idGen, owner)
+	return entity.PackClip(cl, h.idGen, owner, h.clipExtras(cl, viewer))
+}
+
+// clipExtras resolves the viewer-dependent clip fields (#1562)。upstream
+// ClipEntityService.pack 同様 favoritedCount は実カウント、isFavorited は
+// 認証 viewer のみ、notesCount は owner 閲覧時のみ出す。favoriteRepo 未配線
+// や lookup 失敗時は count 0 / isFavorited false に degrade する。
+func (h *Handler) clipExtras(cl *model.Clip, viewer *model.User) entity.ClipExtras {
+	extras := entity.ClipExtras{
+		ShowNotesCount: viewer != nil && viewer.ID == cl.UserID,
+	}
+	if viewer != nil {
+		fav := false
+		extras.IsFavorited = &fav
+	}
+	if h.favoriteRepo == nil {
+		return extras
+	}
+	if n, err := h.favoriteRepo.CountByClip(cl.ID); err == nil {
+		extras.FavoritedCount = n
+	}
+	if viewer != nil {
+		if ok, err := h.favoriteRepo.Exists(viewer.ID, cl.ID); err == nil {
+			extras.IsFavorited = &ok
+		}
+	}
+	return extras
 }
 
 func notClipped(c echo.Context) error {

--- a/internal/api/clips/handler_test.go
+++ b/internal/api/clips/handler_test.go
@@ -151,13 +151,16 @@ func TestShow_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
-func TestShow_AccessDenied(t *testing.T) {
+// 非公開 clip の他人閲覧は missing と同じ NO_SUCH_CLIP 404 (存在秘匿、#1562)
+func TestShow_PrivateHiddenFromOthers(t *testing.T) {
 	h, repo, _, _ := newHandler(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "owner"}
 	c, rec := newReq(t, `{"clipId":"c1"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Show(c))
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_CLIP")
+	assert.Contains(t, rec.Body.String(), "c3c5fe33-d62c-44d2-9ea5-d997703f5c20")
 }
 
 func TestShow_AnonymousOnPublic(t *testing.T) {
@@ -172,12 +175,13 @@ func TestShow_AnonymousOnPublic(t *testing.T) {
 // middleware bypass や guest viewer 路を追加した時に regression するため、
 // 未認証 viewer (= viewer == nil) が private clip を叩いた時の 403 reject を
 // handler 層 negative test で固定する。
-func TestShow_AnonymousAccessDenied(t *testing.T) {
+func TestShow_AnonymousPrivateHidden(t *testing.T) {
 	h, repo, _, _ := newHandler(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice", IsPublic: false}
 	c, rec := newReq(t, `{"clipId":"c1"}`)
 	require.NoError(t, h.Show(c))
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_CLIP")
 }
 
 // --- Update ----------------------------------------------------------------
@@ -207,13 +211,16 @@ func TestUpdate_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
-func TestUpdate_AccessDenied(t *testing.T) {
+// 非 owner mutation は upstream と同じく missing と区別不能な 404 NO_SUCH_CLIP
+// を返す (#1562、存在 enumeration oracle 封じ)。
+func TestUpdate_NonOwnerHidden(t *testing.T) {
 	h, repo, _, _ := newHandler(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "owner"}
 	c, rec := newReq(t, `{"clipId":"c1","name":"x"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Update(c))
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_CLIP")
 }
 
 func TestUpdate_NameEmpty(t *testing.T) {
@@ -274,13 +281,14 @@ func TestDelete_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
-func TestDelete_AccessDenied(t *testing.T) {
+func TestDelete_NonOwnerHidden(t *testing.T) {
 	h, repo, _, _ := newHandler(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "owner"}
 	c, rec := newReq(t, `{"clipId":"c1"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Delete(c))
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_CLIP")
 }
 
 // failingDeleteRepo causes Delete to fail.
@@ -433,16 +441,17 @@ func TestAddNote_ClipNotFound(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "NO_SUCH_CLIP")
 }
 
-func TestAddNote_AccessDenied(t *testing.T) {
+func TestAddNote_NonOwnerHidden(t *testing.T) {
 	h, repo, _, notes := newHandler(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "owner"}
-	// visibility gate (#1456) を通過させた上で、owner 不一致で ACCESS_DENIED
-	// に到達することを担保する seed。
+	// visibility gate (#1456) を通過させた上で、owner 不一致が 404 NO_SUCH_CLIP
+	// に落ちることを担保する seed (#1562)。
 	notes.Notes["n1"] = &model.Note{ID: "n1", Visibility: model.NoteVisibilityPublic}
 	c, rec := newReq(t, `{"clipId":"c1","noteId":"n1"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.AddNote(c))
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_CLIP")
 }
 
 func TestAddNote_NoteNotFound(t *testing.T) {
@@ -627,13 +636,14 @@ func TestRemoveNote_ClipNotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
-func TestRemoveNote_AccessDenied(t *testing.T) {
+func TestRemoveNote_NonOwnerHidden(t *testing.T) {
 	h, repo, _, _ := newHandler(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "owner"}
 	c, rec := newReq(t, `{"clipId":"c1","noteId":"n1"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.RemoveNote(c))
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_CLIP")
 }
 
 func TestRemoveNote_NotClipped(t *testing.T) {
@@ -699,13 +709,15 @@ func TestNotes_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
-func TestNotes_AccessDenied(t *testing.T) {
+func TestNotes_PrivateHiddenFromOthers(t *testing.T) {
 	h, repo, _, _ := newHandler(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "owner"}
 	c, rec := newReq(t, `{"clipId":"c1"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Notes(c))
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_CLIP")
+	assert.Contains(t, rec.Body.String(), "1d7645e6-2b6d-4635-b0fe-fe22b0e72e00")
 }
 
 func TestNotes_AnonymousOnPublic(t *testing.T) {
@@ -756,7 +768,7 @@ type listFailNoteRepo struct {
 	*testutil.MockClipNoteRepository
 }
 
-func (r *listFailNoteRepo) ListByClipVisible(_, _, _, _ string, _ int) ([]*model.ClipNote, error) {
+func (r *listFailNoteRepo) ListByClipVisible(_, _, _, _ string, _ int, _ []string) ([]*model.ClipNote, error) {
 	return nil, errors.New("boom")
 }
 

--- a/internal/api/clips/parity_1562_test.go
+++ b/internal/api/clips/parity_1562_test.go
@@ -1,0 +1,342 @@
+package clips
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- #1562: name / description 長さ検証と '' → null 正規化 ---
+
+func TestCreate_NameTooLongRejected(t *testing.T) {
+	h, _, _, _ := newHandler(t)
+	name := strings.Repeat("a", clipNameMaxLength+1)
+	c, rec := newReq(t, fmt.Sprintf(`{"name":%q}`, name))
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestCreate_NameAtMaxLengthAccepted(t *testing.T) {
+	h, _, _, _ := newHandler(t)
+	name := strings.Repeat("a", clipNameMaxLength)
+	c, rec := newReq(t, fmt.Sprintf(`{"name":%q}`, name))
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestCreate_DescriptionTooLongRejected(t *testing.T) {
+	h, _, _, _ := newHandler(t)
+	desc := strings.Repeat("d", clipDescriptionMaxLength+1)
+	c, rec := newReq(t, fmt.Sprintf(`{"name":"x","description":%q}`, desc))
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestCreate_EmptyDescriptionNormalizedToNull(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	c, rec := newReq(t, `{"name":"x","description":""}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	for _, cl := range repo.Clips {
+		assert.Nil(t, cl.Description, "empty description must be stored as NULL (upstream `ps.description || null`)")
+	}
+}
+
+func TestUpdate_NameTooLongRejected(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice", Name: "old"}
+	name := strings.Repeat("あ", clipNameMaxLength+1) // rune 数で判定する
+	c, rec := newReq(t, fmt.Sprintf(`{"clipId":"c1","name":%q}`, name))
+	setUser(c, "alice")
+	require.NoError(t, h.Update(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestUpdate_EmptyDescriptionNormalizedToNull(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	desc := "before"
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice", Name: "old", Description: &desc}
+	c, rec := newReq(t, `{"clipId":"c1","description":""}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Update(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Nil(t, repo.Clips["c1"].Description)
+}
+
+// --- #1562: favoritedCount / isFavorited / notesCount の出し分け ---
+
+func newHandlerWithFavorites(t *testing.T) (*Handler, *testutil.MockClipRepository, *testutil.MockClipFavoriteRepository) {
+	t.Helper()
+	h, repo, _, _ := newHandler(t)
+	favRepo := testutil.NewMockClipFavoriteRepository()
+	h.SetFavoriteRepo(favRepo)
+	return h, repo, favRepo
+}
+
+func TestShow_OwnerSeesCountsAndFavorited(t *testing.T) {
+	h, repo, favRepo := newHandlerWithFavorites(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice", IsPublic: true, NotesCount: 7}
+	favRepo.Favorites["alice:c1"] = &model.ClipFavorite{ID: "f1", UserID: "alice", ClipID: "c1"}
+	favRepo.Favorites["bob:c1"] = &model.ClipFavorite{ID: "f2", UserID: "bob", ClipID: "c1"}
+
+	c, rec := newReq(t, `{"clipId":"c1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Show(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, `"favoritedCount":2`)
+	assert.Contains(t, body, `"isFavorited":true`)
+	assert.Contains(t, body, `"notesCount":7`)
+}
+
+func TestShow_NonOwnerHidesNotesCount(t *testing.T) {
+	h, repo, _ := newHandlerWithFavorites(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice", IsPublic: true, NotesCount: 7}
+
+	c, rec := newReq(t, `{"clipId":"c1"}`)
+	setUser(c, "bob")
+	require.NoError(t, h.Show(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.NotContains(t, body, "notesCount", "notesCount must be omitted for non-owner viewers (#1562)")
+	assert.Contains(t, body, `"isFavorited":false`)
+	assert.Contains(t, body, `"favoritedCount":0`)
+}
+
+func TestShow_AnonymousOmitsIsFavorited(t *testing.T) {
+	h, repo, _ := newHandlerWithFavorites(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice", IsPublic: true}
+
+	c, rec := newReq(t, `{"clipId":"c1"}`)
+	require.NoError(t, h.Show(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "isFavorited", "isFavorited must be omitted for anonymous viewers (#1562)")
+}
+
+// --- #1562: clips/notes search param ---
+
+func TestNotes_SearchValidation(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice", IsPublic: true}
+
+	// 空文字は minLength 1 違反
+	c, rec := newReq(t, `{"clipId":"c1","search":""}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Notes(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// 101 rune は maxLength 100 違反
+	c, rec = newReq(t, fmt.Sprintf(`{"clipId":"c1","search":%q}`, strings.Repeat("x", clipNotesSearchMaxLength+1)))
+	setUser(c, "alice")
+	require.NoError(t, h.Notes(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestNotes_SearchFiltersByTextAndCW(t *testing.T) {
+	h, repo, noteRepo, notes := newHandler(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice", IsPublic: true}
+	hitText := "golang rocks"
+	missText := "unrelated"
+	hitCW := "warning golang"
+	notes.Notes["n1"] = &model.Note{ID: "n1", Text: &hitText, Visibility: model.NoteVisibilityPublic}
+	notes.Notes["n2"] = &model.Note{ID: "n2", Text: &missText, Visibility: model.NoteVisibilityPublic}
+	notes.Notes["n3"] = &model.Note{ID: "n3", CW: &hitCW, Visibility: model.NoteVisibilityPublic}
+	noteRepo.Entries["cn1"] = &model.ClipNote{ID: "cn1", ClipID: "c1", NoteID: "n1"}
+	noteRepo.Entries["cn2"] = &model.ClipNote{ID: "cn2", ClipID: "c1", NoteID: "n2"}
+	noteRepo.Entries["cn3"] = &model.ClipNote{ID: "cn3", ClipID: "c1", NoteID: "n3"}
+
+	c, rec := newReq(t, `{"clipId":"c1","search":"golang"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Notes(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.Contains(t, body, `"id":"n1"`, "text hit must be returned")
+	assert.Contains(t, body, `"id":"n3"`, "cw hit must be returned")
+	assert.NotContains(t, body, `"id":"n2"`, "non-matching note must be filtered")
+}
+
+// --- #1562: clips/notes muted/blocked-user + blocked-host filter ---
+
+func TestNotes_MutedAndBlockedUsersFiltered(t *testing.T) {
+	h, repo, noteRepo, notes := newHandler(t)
+	mutingRepo := testutil.NewMockMutingRepository()
+	blockingRepo := testutil.NewMockBlockingRepository()
+	h.SetMuteBlockRepos(mutingRepo, blockingRepo)
+
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice", IsPublic: true}
+	notes.Notes["n1"] = &model.Note{ID: "n1", UserID: "muted", Visibility: model.NoteVisibilityPublic}
+	notes.Notes["n2"] = &model.Note{ID: "n2", UserID: "blocker", Visibility: model.NoteVisibilityPublic}
+	notes.Notes["n3"] = &model.Note{ID: "n3", UserID: "ok", Visibility: model.NoteVisibilityPublic}
+	noteRepo.Entries["cn1"] = &model.ClipNote{ID: "cn1", ClipID: "c1", NoteID: "n1"}
+	noteRepo.Entries["cn2"] = &model.ClipNote{ID: "cn2", ClipID: "c1", NoteID: "n2"}
+	noteRepo.Entries["cn3"] = &model.ClipNote{ID: "cn3", ClipID: "c1", NoteID: "n3"}
+	// viewer が muted を mute、blocker が viewer を block
+	mutingRepo.Mutings["m1"] = &model.Muting{ID: "m1", MuterID: "viewer", MuteeID: "muted"}
+	blockingRepo.Blockings["b1"] = &model.Blocking{ID: "b1", BlockerID: "blocker", BlockeeID: "viewer"}
+
+	c, rec := newReq(t, `{"clipId":"c1"}`)
+	setUser(c, "viewer")
+	require.NoError(t, h.Notes(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.NotContains(t, body, `"id":"n1"`, "muted author must be filtered")
+	assert.NotContains(t, body, `"id":"n2"`, "blocking author must be filtered")
+	assert.Contains(t, body, `"id":"n3"`)
+}
+
+func TestNotes_BlockedHostFiltered(t *testing.T) {
+	h, repo, noteRepo, notes := newHandler(t)
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "x", BlockedHosts: []string{"blocked.example"}}
+	h.SetMetaRepo(metaRepo)
+
+	host := "blocked.example"
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice", IsPublic: true}
+	notes.Notes["n1"] = &model.Note{ID: "n1", UserHost: &host, Visibility: model.NoteVisibilityPublic}
+	notes.Notes["n2"] = &model.Note{ID: "n2", Visibility: model.NoteVisibilityPublic}
+	noteRepo.Entries["cn1"] = &model.ClipNote{ID: "cn1", ClipID: "c1", NoteID: "n1"}
+	noteRepo.Entries["cn2"] = &model.ClipNote{ID: "cn2", ClipID: "c1", NoteID: "n2"}
+
+	c, rec := newReq(t, `{"clipId":"c1"}`)
+	setUser(c, "viewer")
+	require.NoError(t, h.Notes(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.NotContains(t, body, `"id":"n1"`, "blocked-host author must be filtered")
+	assert.Contains(t, body, `"id":"n2"`)
+}
+
+// 匿名 viewer でも blocked-host filter は適用される (admin 政策なので viewer
+// 非依存、upstream notes.ts も me なしで適用する)。
+func TestNotes_BlockedHostFilteredForAnonymous(t *testing.T) {
+	h, repo, noteRepo, notes := newHandler(t)
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "x", BlockedHosts: []string{"blocked.example"}}
+	h.SetMetaRepo(metaRepo)
+
+	host := "blocked.example"
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice", IsPublic: true}
+	notes.Notes["n1"] = &model.Note{ID: "n1", UserHost: &host, Visibility: model.NoteVisibilityPublic}
+	noteRepo.Entries["cn1"] = &model.ClipNote{ID: "cn1", ClipID: "c1", NoteID: "n1"}
+
+	c, rec := newReq(t, `{"clipId":"c1"}`)
+	require.NoError(t, h.Notes(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), `"id":"n1"`)
+}
+
+// --- #1562: error branch coverage ---
+
+// failingFavRepo wraps the mock to force errors on selected methods.
+type failingFavRepo struct {
+	*testutil.MockClipFavoriteRepository
+	existsErr error
+	countErr  error
+	deleteErr error
+}
+
+func (f *failingFavRepo) Exists(userID, clipID string) (bool, error) {
+	if f.existsErr != nil {
+		return false, f.existsErr
+	}
+	return f.MockClipFavoriteRepository.Exists(userID, clipID)
+}
+
+func (f *failingFavRepo) CountByClip(clipID string) (int64, error) {
+	if f.countErr != nil {
+		return 0, f.countErr
+	}
+	return f.MockClipFavoriteRepository.CountByClip(clipID)
+}
+
+func (f *failingFavRepo) Delete(userID, clipID string) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	return f.MockClipFavoriteRepository.Delete(userID, clipID)
+}
+
+func TestClipFavorite_ExistsErrorIs500(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	fail := &failingFavRepo{MockClipFavoriteRepository: testutil.NewMockClipFavoriteRepository(), existsErr: assert.AnError}
+	h.SetFavoriteRepo(fail)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "u1", IsPublic: true}
+	c, rec := newReq(t, `{"clipId":"c1"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.Favorite(c))
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestClipUnfavorite_FavoriteExistsErrorIs500(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	fail := &failingFavRepo{MockClipFavoriteRepository: testutil.NewMockClipFavoriteRepository(), existsErr: assert.AnError}
+	h.SetFavoriteRepo(fail)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "u1", IsPublic: true}
+	c, rec := newReq(t, `{"clipId":"c1"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.Unfavorite(c))
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestClipUnfavorite_DeleteErrorIs500(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	mock := testutil.NewMockClipFavoriteRepository()
+	mock.Favorites["u1:c1"] = &model.ClipFavorite{ID: "f1", UserID: "u1", ClipID: "c1"}
+	fail := &failingFavRepo{MockClipFavoriteRepository: mock, deleteErr: assert.AnError}
+	h.SetFavoriteRepo(fail)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "u1", IsPublic: true}
+	c, rec := newReq(t, `{"clipId":"c1"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.Unfavorite(c))
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// clipExtras は count / exists の lookup error を degrade して 0 / false に
+// 落とす (200 を維持、#1562)。
+func TestShow_FavoriteLookupErrorDegrades(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	fail := &failingFavRepo{MockClipFavoriteRepository: testutil.NewMockClipFavoriteRepository(), existsErr: assert.AnError, countErr: assert.AnError}
+	h.SetFavoriteRepo(fail)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice", IsPublic: true}
+	c, rec := newReq(t, `{"clipId":"c1"}`)
+	setUser(c, "bob")
+	require.NoError(t, h.Show(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"favoritedCount":0`)
+	assert.Contains(t, rec.Body.String(), `"isFavorited":false`)
+}
+
+// metaRepo.Fetch error は fail-closed で 500 (#1544 と同方針)。
+func TestNotes_MetaFetchErrorIs500(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	h.SetMetaRepo(testutil.NewMockMetaRepository()) // Meta 未設定 → Fetch error
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice", IsPublic: true}
+	c, rec := newReq(t, `{"clipId":"c1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Notes(c))
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// upstream update.ts は `ps.description || null` を常に渡すため、description
+// 未指定 (undefined) でも NULL にクリアされる (#1562)。
+func TestUpdate_OmittedDescriptionClearedToNull(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	desc := "before"
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice", Name: "old", Description: &desc}
+	c, rec := newReq(t, `{"clipId":"c1","name":"new"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Update(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Nil(t, repo.Clips["c1"].Description, "omitted description must clear to NULL (upstream `ps.description || null`)")
+	assert.Equal(t, "new", repo.Clips["c1"].Name)
+}

--- a/internal/api/following/handler.go
+++ b/internal/api/following/handler.go
@@ -70,6 +70,10 @@ func (h *Handler) Create(c echo.Context) error {
 			return c.JSON(http.StatusBadRequest, apierr.Error("FOLLOWEE_IS_YOURSELF", "Followee is yourself.", "26fbe7bb-a331-4857-af17-205b426669a9"))
 		case errors.Is(err, corefollowing.ErrAlreadyFollowing), errors.Is(err, corefollowing.ErrAlreadyRequested):
 			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_FOLLOWING", "You are already following that user.", "35387507-38c7-4cb9-9197-300b93783fa0"))
+		case errors.Is(err, corefollowing.ErrBlocking):
+			// follower が followee を block している方向は BLOCKED ではなく
+			// BLOCKING (upstream create.ts の blocking エラー、#1562)。
+			return c.JSON(http.StatusBadRequest, apierr.Error("BLOCKING", "You are blocking that user.", "4e2206ec-aa4f-4960-b865-6c23ac38e2d9"))
 		case errors.Is(err, corefollowing.ErrBlocked):
 			// upstream Misskey TS の following/create は BLOCKED を 400 で
 			// 返す (kind: 'client')。旧 mk-go は 403 で返していたが drop-in
@@ -158,6 +162,10 @@ func (h *Handler) RejectRequest(c echo.Context) error {
 }
 
 // CancelRequest handles POST /api/following/requests/cancel.
+//
+// upstream requests/cancel.ts は followee を getUser で先に解決して
+// NO_SUCH_USER を返し、request 不在は FOLLOW_REQUEST_NOT_FOUND (service 内部
+// error とは別の公開 id) に変換し、成功時は packed followee を返す (#1562)。
 func (h *Handler) CancelRequest(c echo.Context) error {
 	me := middleware.GetUser(c)
 
@@ -166,13 +174,18 @@ func (h *Handler) CancelRequest(c echo.Context) error {
 		return apierr.JSONInvalidParam(c)
 	}
 
+	bundle, err := h.userService.ShowByID(req.UserID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "4e68c551-fc4c-4e46-bb41-7d4a37bf9dab"))
+	}
+
 	if err := h.followingService.CancelRequest(me.ID, req.UserID); err != nil {
 		if errors.Is(err, corefollowing.ErrRequestNotFound) {
-			return c.JSON(http.StatusNotFound, apierr.Error("NO_FOLLOW_REQUEST", "No such follow request.", "17447091-ea95-43eb-a7d4-c78cb2853c20"))
+			return c.JSON(http.StatusNotFound, apierr.Error("FOLLOW_REQUEST_NOT_FOUND", "Follow request not found.", "089b125b-d338-482a-9a09-e2622ac9f8d4"))
 		}
 		return apierr.JSONInternalError(c)
 	}
-	return c.NoContent(http.StatusNoContent)
+	return c.JSON(http.StatusOK, entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen))
 }
 
 // ListRequestsResponseItem represents a single received follow request.

--- a/internal/api/following/handler_test.go
+++ b/internal/api/following/handler_test.go
@@ -261,6 +261,22 @@ func TestCreate_Blocked(t *testing.T) {
 	// upstream Misskey TS と同じ 400 BLOCKED (= drop-in 互換、#872)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 	assert.Contains(t, rec.Body.String(), `"code":"BLOCKED"`)
+	assert.Contains(t, rec.Body.String(), "c4ab57cc-4e41-45e9-bfd9-584f61e35ce0")
+}
+
+// follower 自身が followee を block している方向は BLOCKED ではなく BLOCKING
+// (upstream create.ts の blocking エラー、#1562)。
+func TestCreate_Blocking(t *testing.T) {
+	h, repo := newTestHandler(t)
+	alice := addUser(repo, "alice", false)
+	addUser(repo, "bob", false)
+	// alice -> bob を follow しようとして alice が bob をブロックしている状況
+	h.followingService.SetBlockingChecker(&stubBlockedChecker{blockerID: "alice", blockeeID: "bob"})
+
+	rec := postJSON(h.Create, `{"userId": "bob"}`, alice)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"code":"BLOCKING"`)
+	assert.Contains(t, rec.Body.String(), "4e2206ec-aa4f-4960-b865-6c23ac38e2d9")
 }
 
 func TestCreate_InvalidParam(t *testing.T) {
@@ -396,15 +412,34 @@ func TestCancelRequest_Success(t *testing.T) {
 	postJSON(h.Create, `{"userId": "bob"}`, alice)
 
 	rec := postJSON(h.CancelRequest, `{"userId": "bob"}`, alice)
-	assert.Equal(t, http.StatusNoContent, rec.Code)
+	// upstream requests/cancel.ts は packed followee (UserLite) を 200 で返す (#1562)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "bob", body["id"])
 }
 
 func TestCancelRequest_NotFound(t *testing.T) {
 	h, repo := newTestHandler(t)
 	alice := addUser(repo, "alice", false)
+	addUser(repo, "bob", true)
 
+	// request を送っていない → upstream の公開エラー FOLLOW_REQUEST_NOT_FOUND
+	// (service 内部 id 流用の旧 NO_FOLLOW_REQUEST から変更、#1562)
 	rec := postJSON(h.CancelRequest, `{"userId": "bob"}`, alice)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "FOLLOW_REQUEST_NOT_FOUND")
+	assert.Contains(t, rec.Body.String(), "089b125b-d338-482a-9a09-e2622ac9f8d4")
+}
+
+func TestCancelRequest_NoSuchUser(t *testing.T) {
+	h, repo := newTestHandler(t)
+	alice := addUser(repo, "alice", false)
+
+	rec := postJSON(h.CancelRequest, `{"userId": "ghost"}`, alice)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_USER")
+	assert.Contains(t, rec.Body.String(), "4e68c551-fc4c-4e46-bb41-7d4a37bf9dab")
 }
 
 func TestCancelRequest_InvalidParam(t *testing.T) {

--- a/internal/api/following/relation.go
+++ b/internal/api/following/relation.go
@@ -7,6 +7,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	corefollowing "github.com/shiroha-a/mk/internal/core/following"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
@@ -23,13 +24,23 @@ func (h *Handler) Invalidate(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return apierr.JSONInvalidParam(c)
 	}
+	// upstream invalidate.ts は self check → getUser → Following row 検査の
+	// 順で FOLLOWER_IS_YOURSELF / NO_SUCH_USER / NOT_FOLLOWING を返し、成功時
+	// は packed follower (= 外された相手) を返す (#1562)。
+	if req.UserID == me.ID {
+		return c.JSON(http.StatusBadRequest, apierr.Error("FOLLOWER_IS_YOURSELF", "Follower is yourself.", "07dc03b9-03da-422d-885b-438313707662"))
+	}
+	bundle, err := h.userService.ShowByID(req.UserID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "b77e6ae6-a3e5-40da-9cc8-c240115479cc"))
+	}
 	if err := h.followingService.Unfollow(req.UserID, me.ID); err != nil {
 		if errors.Is(err, corefollowing.ErrNotFollowing) {
-			return c.JSON(http.StatusBadRequest, apierr.Error("NOT_FOLLOWING", "You are not followed by that user.", "918faac3-074f-41ae-9c43-ed5d2946770d"))
+			return c.JSON(http.StatusBadRequest, apierr.Error("NOT_FOLLOWING", "The other use is not following you.", "918faac3-074f-41ae-9c43-ed5d2946770d"))
 		}
 		return apierr.JSONInternalError(c)
 	}
-	return c.NoContent(http.StatusNoContent)
+	return c.JSON(http.StatusOK, entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen))
 }
 
 // UpdateFollow handles POST /api/following/update.
@@ -51,6 +62,20 @@ func (h *Handler) UpdateFollow(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return apierr.JSONInvalidParam(c)
 	}
+	// upstream update.ts は self check → getUser → Following row 検査の順で
+	// FOLLOWEE_IS_YOURSELF / NO_SUCH_USER / NOT_FOLLOWING を返し、成功時は
+	// packed follower (= 自分) を返す (#1562)。
+	if req.UserID == me.ID {
+		return c.JSON(http.StatusBadRequest, apierr.Error("FOLLOWEE_IS_YOURSELF", "Followee is yourself.", "4c4cbaf9-962a-463b-8418-a5e365dbf2eb"))
+	}
+	if _, err := h.userService.ShowByID(req.UserID); err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "14318698-f67e-492a-99da-5353a5ac52be"))
+	}
+	if following, err := h.followingService.IsFollowing(me.ID, req.UserID); err != nil {
+		return apierr.JSONInternalError(c)
+	} else if !following {
+		return c.JSON(http.StatusBadRequest, apierr.Error("NOT_FOLLOWING", "You are not following that user.", "b8dc75cf-1cb5-46c9-b14b-5f1ffbd782c9"))
+	}
 	fields := map[string]any{}
 	if req.Notify != nil {
 		fields["notify"] = normalizeNotify(*req.Notify)
@@ -61,7 +86,11 @@ func (h *Handler) UpdateFollow(c echo.Context) error {
 	if err := h.followingService.UpdateRelation(me.ID, req.UserID, fields); err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	return c.NoContent(http.StatusNoContent)
+	meBundle, err := h.userService.ShowByID(me.ID)
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
+	return c.JSON(http.StatusOK, entity.PackUserDetailed(meBundle.User, meBundle.Profile, h.idGen))
 }
 
 // normalizeNotify converts the upstream `notify` enum ("normal" / "none") to

--- a/internal/api/following/relation_test.go
+++ b/internal/api/following/relation_test.go
@@ -1,6 +1,7 @@
 package following
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -35,7 +36,11 @@ func TestInvalidate_Success(t *testing.T) {
 	_, _ = h.followingService.Follow(follower.ID, admin.ID, corefollowing.FollowOptions{})
 
 	rec := postJSON(h.Invalidate, `{"userId":"follower"}`, admin)
-	assert.Equal(t, http.StatusNoContent, rec.Code)
+	// upstream invalidate.ts は packed follower (UserLite) を 200 で返す (#1562)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "follower", body["id"])
 }
 
 func TestInvalidate_NotFollowing(t *testing.T) {
@@ -50,9 +55,65 @@ func TestInvalidate_NotFollowing(t *testing.T) {
 }
 
 func TestUpdateFollow_Success(t *testing.T) {
-	h, _ := newTestHandler(t)
-	assert.Equal(t, http.StatusNoContent,
-		postJSON(h.UpdateFollow, `{"userId":"u2","notify":"normal","withReplies":true}`, &model.User{ID: "u1"}).Code)
+	h, repo, fRepo, _ := newTestHandlerWithRepos(t)
+	alice := addUser(repo, "alice", false)
+	bob := addUser(repo, "bob", false)
+	fRepo.Followings["f1"] = &model.Following{ID: "f1", FollowerID: alice.ID, FolloweeID: bob.ID}
+	rec := postJSON(h.UpdateFollow, `{"userId":"bob","notify":"normal","withReplies":true}`, alice)
+	// upstream update.ts は packed follower (= 自分) を 200 で返す (#1562)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, alice.ID, body["id"])
+}
+
+// upstream update.ts は self / 不在 user / 未フォローをそれぞれ
+// FOLLOWEE_IS_YOURSELF / NO_SUCH_USER / NOT_FOLLOWING で拒否する (#1562)。
+func TestUpdateFollow_SelfRejected(t *testing.T) {
+	h, repo := newTestHandler(t)
+	alice := addUser(repo, "alice", false)
+	rec := postJSON(h.UpdateFollow, `{"userId":"alice"}`, alice)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "FOLLOWEE_IS_YOURSELF")
+	assert.Contains(t, rec.Body.String(), "4c4cbaf9-962a-463b-8418-a5e365dbf2eb")
+}
+
+func TestUpdateFollow_NoSuchUser(t *testing.T) {
+	h, repo := newTestHandler(t)
+	alice := addUser(repo, "alice", false)
+	rec := postJSON(h.UpdateFollow, `{"userId":"ghost"}`, alice)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_USER")
+	assert.Contains(t, rec.Body.String(), "14318698-f67e-492a-99da-5353a5ac52be")
+}
+
+func TestUpdateFollow_NotFollowing(t *testing.T) {
+	h, repo := newTestHandler(t)
+	alice := addUser(repo, "alice", false)
+	addUser(repo, "bob", false)
+	rec := postJSON(h.UpdateFollow, `{"userId":"bob"}`, alice)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NOT_FOLLOWING")
+	assert.Contains(t, rec.Body.String(), "b8dc75cf-1cb5-46c9-b14b-5f1ffbd782c9")
+}
+
+// invalidate も self / 不在 user を upstream と同じエラーで拒否する (#1562)。
+func TestInvalidate_SelfRejected(t *testing.T) {
+	h, repo := newTestHandler(t)
+	admin := addUser(repo, "admin", false)
+	rec := postJSON(h.Invalidate, `{"userId":"admin"}`, admin)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "FOLLOWER_IS_YOURSELF")
+	assert.Contains(t, rec.Body.String(), "07dc03b9-03da-422d-885b-438313707662")
+}
+
+func TestInvalidate_NoSuchUser(t *testing.T) {
+	h, repo := newTestHandler(t)
+	admin := addUser(repo, "admin", false)
+	rec := postJSON(h.Invalidate, `{"userId":"ghost"}`, admin)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_USER")
+	assert.Contains(t, rec.Body.String(), "b77e6ae6-a3e5-40da-9cc8-c240115479cc")
 }
 
 func TestUpdateFollowAll_WithFields(t *testing.T) {
@@ -78,7 +139,7 @@ func TestUpdateFollow_NotifyNone_NormalizedToNull(t *testing.T) {
 	}
 
 	rec := postJSON(h.UpdateFollow, `{"userId":"bob","notify":"none"}`, alice)
-	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, http.StatusOK, rec.Code)
 	// notify="none" → DB の Notify 列が nil (= SQL NULL) になる
 	assert.Nil(t, fRepo.Followings["f1"].Notify, "notify=none must normalize to nil for following/list notification=true filter")
 }
@@ -95,7 +156,7 @@ func TestUpdateFollow_NotifyNormal_StoredAsString(t *testing.T) {
 	}
 
 	rec := postJSON(h.UpdateFollow, `{"userId":"bob","notify":"normal"}`, alice)
-	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, http.StatusOK, rec.Code)
 	require.NotNil(t, fRepo.Followings["f1"].Notify)
 	assert.Equal(t, "normal", *fRepo.Followings["f1"].Notify)
 }

--- a/internal/api/users/content_lists.go
+++ b/internal/api/users/content_lists.go
@@ -60,7 +60,24 @@ func (h *Handler) Clips(c echo.Context) error {
 	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, cl := range rows {
-		out = append(out, entity.PackClip(cl, h.idGen, owner))
+		// favoritedCount は常時実カウント、isFavorited は認証 viewer のみ、
+		// notesCount は owner 閲覧時のみ (#1562、upstream ClipEntityService.pack)。
+		extras := entity.ClipExtras{ShowNotesCount: isSelf}
+		if viewer != nil {
+			fav := false
+			extras.IsFavorited = &fav
+		}
+		if h.clipFavoriteRepo != nil {
+			if n, err := h.clipFavoriteRepo.CountByClip(cl.ID); err == nil {
+				extras.FavoritedCount = n
+			}
+			if viewer != nil {
+				if ok, err := h.clipFavoriteRepo.Exists(viewer.ID, cl.ID); err == nil {
+					extras.IsFavorited = &ok
+				}
+			}
+		}
+		out = append(out, entity.PackClip(cl, h.idGen, owner, extras))
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -51,6 +51,7 @@ type Handler struct {
 	userListFavoriteRepo UserListFavoriteRepository
 	userListRepo         repository.UserListRepository
 	clipRepo             repository.ClipRepository
+	clipFavoriteRepo     repository.ClipFavoriteRepository
 	flashRepo            repository.FlashRepository
 	galleryRepo          repository.GalleryRepository
 	pageRepo             repository.PageRepository
@@ -153,6 +154,10 @@ func (h *Handler) SetPiningRepo(r repository.UserNotePiningRepository) {
 
 // SetClipRepo attaches a ClipRepository for users/clips.
 func (h *Handler) SetClipRepo(r repository.ClipRepository) { h.clipRepo = r }
+
+// SetClipFavoriteRepo attaches a ClipFavoriteRepository so users/clips can
+// resolve favoritedCount / isFavorited (#1562).
+func (h *Handler) SetClipFavoriteRepo(r repository.ClipFavoriteRepository) { h.clipFavoriteRepo = r }
 
 // SetFlashRepo attaches a FlashRepository for users/flashs.
 func (h *Handler) SetFlashRepo(r repository.FlashRepository) { h.flashRepo = r }

--- a/internal/api/users/parity_1562_clips_test.go
+++ b/internal/api/users/parity_1562_clips_test.go
@@ -1,0 +1,54 @@
+package users
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// users/clips の favoritedCount / isFavorited / notesCount 出し分け (#1562)。
+func TestClips_FavoritedCountAndIsFavorited(t *testing.T) {
+	h, _ := newTestHandler(t)
+	repo := testutil.NewMockClipRepository()
+	require.NoError(t, repo.Create(&model.Clip{ID: "c1", UserID: "owner", Name: "pub", IsPublic: true, NotesCount: 4}))
+	h.SetClipRepo(repo)
+	favRepo := testutil.NewMockClipFavoriteRepository()
+	favRepo.Favorites["viewer:c1"] = &model.ClipFavorite{ID: "f1", UserID: "viewer", ClipID: "c1"}
+	favRepo.Favorites["other:c1"] = &model.ClipFavorite{ID: "f2", UserID: "other", ClipID: "c1"}
+	h.SetClipFavoriteRepo(favRepo)
+
+	// 認証 viewer (非 owner): favoritedCount 実数 + isFavorited true、notesCount 省略
+	rec := postStub(h.Clips, `{"userId":"owner"}`, &model.User{ID: "viewer"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.EqualValues(t, 2, rows[0]["favoritedCount"])
+	assert.Equal(t, true, rows[0]["isFavorited"])
+	_, hasNotesCount := rows[0]["notesCount"]
+	assert.False(t, hasNotesCount, "notesCount must be omitted for non-owner viewers")
+
+	// owner 閲覧: notesCount が出る
+	rec = postStub(h.Clips, `{"userId":"owner"}`, &model.User{ID: "owner"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	rows = nil
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.EqualValues(t, 4, rows[0]["notesCount"])
+	assert.Equal(t, false, rows[0]["isFavorited"])
+
+	// 匿名: isFavorited 自体が出ない
+	rec = postStub(h.Clips, `{"userId":"owner"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	rows = nil
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	_, hasIsFavorited := rows[0]["isFavorited"]
+	assert.False(t, hasIsFavorited, "isFavorited must be omitted for anonymous viewers")
+	assert.EqualValues(t, 2, rows[0]["favoritedCount"])
+}

--- a/internal/core/clip/clip_service.go
+++ b/internal/core/clip/clip_service.go
@@ -5,11 +5,13 @@ package clip
 
 import (
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
+	"gorm.io/gorm"
 )
 
 // Errors returned by Service.
@@ -18,9 +20,6 @@ var (
 	ErrClipNotFound = errors.New("clip not found")
 	// ErrClipNameRequired is returned when name is empty on Create / Update.
 	ErrClipNameRequired = errors.New("clip name is required")
-	// ErrAccessDenied is returned when a user attempts to mutate a clip they
-	// do not own. Public clips are still readable by anyone.
-	ErrAccessDenied = errors.New("not the owner of this clip")
 	// ErrNoteNotFound is returned when the target note for AddNote does not
 	// exist.
 	ErrNoteNotFound = errors.New("note not found")
@@ -126,16 +125,33 @@ func (s *Service) Create(in CreateInput) (*model.Clip, error) {
 }
 
 // Show returns a clip by id. requesterID は閲覧者で、空文字なら anonymous
-// 扱い。private clip は所有者だけがアクセスできる。
+// 扱い。private clip は所有者だけがアクセスでき、他人/匿名には missing と
+// 同じ ErrClipNotFound を返して存在を秘匿する (#1562、upstream show.ts は
+// !isPublic && 非所有者を noSuchClip にする。ErrAccessDenied だと 403/404 の
+// 差で非公開 clip の存在 enumeration oracle になる)。
 func (s *Service) Show(requesterID, clipID string) (*model.Clip, error) {
 	c, err := s.repo.FindByID(clipID)
 	if err != nil {
 		return nil, ErrClipNotFound
 	}
 	if !c.IsPublic && c.UserID != requesterID {
-		return nil, ErrAccessDenied
+		return nil, ErrClipNotFound
 	}
 	return c, nil
+}
+
+// Exists reports whether a clip row exists, regardless of visibility. clips/
+// unfavorite の存在チェック用 (#1562、upstream unfavorite.ts は findOneBy({id})
+// のみで visibility を見ない — favorite 後に非公開化された clip も解除可能に
+// するため)。not-found 以外の driver error は caller へ返す (fail-closed)。
+func (s *Service) Exists(clipID string) (bool, error) {
+	if _, err := s.repo.FindByID(clipID); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 // UpdateInput holds the editable fields of a clip.
@@ -145,14 +161,16 @@ type UpdateInput struct {
 	IsPublic    *bool
 }
 
-// Update applies the non-nil fields to a clip owned by ownerID.
+// Update applies the non-nil fields to a clip owned by ownerID. 非 owner は
+// upstream ClipService.update の findOneBy({id, userId}) と同じく missing と
+// 区別不能な ErrClipNotFound (#1562、存在 enumeration oracle 封じ)。
 func (s *Service) Update(ownerID, clipID string, in UpdateInput) (*model.Clip, error) {
 	c, err := s.repo.FindByID(clipID)
 	if err != nil {
 		return nil, ErrClipNotFound
 	}
 	if c.UserID != ownerID {
-		return nil, ErrAccessDenied
+		return nil, ErrClipNotFound
 	}
 	fields := map[string]any{}
 	if in.Name != nil {
@@ -174,13 +192,14 @@ func (s *Service) Update(ownerID, clipID string, in UpdateInput) (*model.Clip, e
 }
 
 // Delete removes a clip owned by ownerID. clip_note は CASCADE で削除される。
+// 非 owner は Update と同じく ErrClipNotFound (#1562)。
 func (s *Service) Delete(ownerID, clipID string) error {
 	c, err := s.repo.FindByID(clipID)
 	if err != nil {
 		return ErrClipNotFound
 	}
 	if c.UserID != ownerID {
-		return ErrAccessDenied
+		return ErrClipNotFound
 	}
 	return s.repo.Delete(c)
 }
@@ -191,14 +210,15 @@ func (s *Service) ListByUser(userID, sinceID, untilID string, limit, offset int)
 	return s.repo.ListByUser(userID, sinceID, untilID, limit, offset)
 }
 
-// AddNote attaches a note to the clip. ownerID 以外は AccessDenied。
+// AddNote attaches a note to the clip. 非 owner は upstream add-note.ts の
+// findOneBy({id, userId}) と同じく ErrClipNotFound (#1562)。
 func (s *Service) AddNote(ownerID, clipID, noteID string) error {
 	c, err := s.repo.FindByID(clipID)
 	if err != nil {
 		return ErrClipNotFound
 	}
 	if c.UserID != ownerID {
-		return ErrAccessDenied
+		return ErrClipNotFound
 	}
 	if _, err := s.notes.FindByID(noteID); err != nil {
 		return ErrNoteNotFound
@@ -234,14 +254,14 @@ func (s *Service) AddNote(ownerID, clipID, noteID string) error {
 	return nil
 }
 
-// RemoveNote detaches a note from the clip. ownerID 以外は AccessDenied。
+// RemoveNote detaches a note from the clip. 非 owner は ErrClipNotFound (#1562)。
 func (s *Service) RemoveNote(ownerID, clipID, noteID string) error {
 	c, err := s.repo.FindByID(clipID)
 	if err != nil {
 		return ErrClipNotFound
 	}
 	if c.UserID != ownerID {
-		return ErrAccessDenied
+		return ErrClipNotFound
 	}
 	cn, err := s.noteRepo.FindByPair(clipID, noteID)
 	if err != nil {
@@ -255,19 +275,26 @@ func (s *Service) RemoveNote(ownerID, clipID, noteID string) error {
 }
 
 // Notes returns the notes attached to the clip newest first. requesterID は
-// 閲覧者で、private clip は owner だけがアクセスできる (Show と同じ規則)。
-func (s *Service) Notes(requesterID, clipID, untilID, sinceID string, limit int) ([]*model.Note, error) {
+// 閲覧者で、private clip は owner 以外には missing と同じ ErrClipNotFound を
+// 返して存在を秘匿する (Show と同じ規則、#1562)。search は空白区切り各語を
+// note.text / note.cw に ILIKE AND で適用する (upstream notes.ts:103-110)。
+func (s *Service) Notes(requesterID, clipID, untilID, sinceID string, limit int, search string) ([]*model.Note, error) {
 	c, err := s.repo.FindByID(clipID)
 	if err != nil {
 		return nil, ErrClipNotFound
 	}
 	if !c.IsPublic && c.UserID != requesterID {
-		return nil, ErrAccessDenied
+		return nil, ErrClipNotFound
 	}
+	// upstream は search.trim().split(' ')。連続空白が生む空語は ILIKE '%%'
+	// となり text/cw が NULL でない note には全一致なので、空語を落とす
+	// strings.Fields でほぼ等価になる (tab 等の whitespace も区切る点と、
+	// text/cw 両方 NULL の note の扱いのみ微差、実用上の影響なし)。
+	searchWords := strings.Fields(search)
 	// visibility は repository 側で LIMIT 前に push down する (#1418 review)。
 	// clip は author 混在のため post-fetch filter だと per-note の follow 判定
 	// N+1 + ページ過少充填になる。
-	rows, err := s.noteRepo.ListByClipVisible(clipID, requesterID, untilID, sinceID, limit)
+	rows, err := s.noteRepo.ListByClipVisible(clipID, requesterID, untilID, sinceID, limit, searchWords)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/clip/clip_service_test.go
+++ b/internal/core/clip/clip_service_test.go
@@ -110,11 +110,12 @@ func TestShow_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, clip.ErrClipNotFound)
 }
 
-func TestShow_PrivateAccessDenied(t *testing.T) {
+func TestShow_PrivateHiddenFromOthers(t *testing.T) {
 	svc, repo, _, _ := newSvc(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "u1", IsPublic: false}
+	// 非公開 clip の他人閲覧は missing と区別不能な ErrClipNotFound (#1562)
 	_, err := svc.Show("u2", "c1")
-	assert.ErrorIs(t, err, clip.ErrAccessDenied)
+	assert.ErrorIs(t, err, clip.ErrClipNotFound)
 }
 
 func TestShow_PublicReadableByAnyone(t *testing.T) {
@@ -149,11 +150,13 @@ func TestUpdate_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, clip.ErrClipNotFound)
 }
 
-func TestUpdate_AccessDenied(t *testing.T) {
+func TestUpdate_NonOwnerHidden(t *testing.T) {
 	svc, repo, _, _ := newSvc(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "owner"}
+	// 非 owner mutation は upstream findOneBy({id, userId}) と同じく
+	// missing と区別不能な ErrClipNotFound (#1562)
 	_, err := svc.Update("u1", "c1", clip.UpdateInput{})
-	assert.ErrorIs(t, err, clip.ErrAccessDenied)
+	assert.ErrorIs(t, err, clip.ErrClipNotFound)
 }
 
 func TestUpdate_NameEmpty(t *testing.T) {
@@ -188,11 +191,11 @@ func TestDelete_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, clip.ErrClipNotFound)
 }
 
-func TestDelete_AccessDenied(t *testing.T) {
+func TestDelete_NonOwnerHidden(t *testing.T) {
 	svc, repo, _, _ := newSvc(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "owner"}
 	err := svc.Delete("u1", "c1")
-	assert.ErrorIs(t, err, clip.ErrAccessDenied)
+	assert.ErrorIs(t, err, clip.ErrClipNotFound)
 }
 
 // --- ListByUser ------------------------------------------------------------
@@ -224,11 +227,11 @@ func TestAddNote_ClipNotFound(t *testing.T) {
 	assert.ErrorIs(t, err, clip.ErrClipNotFound)
 }
 
-func TestAddNote_AccessDenied(t *testing.T) {
+func TestAddNote_NonOwnerHidden(t *testing.T) {
 	svc, repo, _, _ := newSvc(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "owner"}
 	err := svc.AddNote("u1", "c1", "n1")
-	assert.ErrorIs(t, err, clip.ErrAccessDenied)
+	assert.ErrorIs(t, err, clip.ErrClipNotFound)
 }
 
 func TestAddNote_NoteNotFound(t *testing.T) {
@@ -283,11 +286,11 @@ func TestRemoveNote_ClipNotFound(t *testing.T) {
 	assert.ErrorIs(t, err, clip.ErrClipNotFound)
 }
 
-func TestRemoveNote_AccessDenied(t *testing.T) {
+func TestRemoveNote_NonOwnerHidden(t *testing.T) {
 	svc, repo, _, _ := newSvc(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "owner"}
 	err := svc.RemoveNote("u1", "c1", "n1")
-	assert.ErrorIs(t, err, clip.ErrAccessDenied)
+	assert.ErrorIs(t, err, clip.ErrClipNotFound)
 }
 
 func TestRemoveNote_NotClipped(t *testing.T) {
@@ -326,22 +329,22 @@ func TestNotes_HappyPath(t *testing.T) {
 	require.NoError(t, svc.AddNote("u1", "c1", "n1"))
 	require.NoError(t, svc.AddNote("u1", "c1", "n2"))
 
-	rows, err := svc.Notes("u1", "c1", "", "", 10)
+	rows, err := svc.Notes("u1", "c1", "", "", 10, "")
 	require.NoError(t, err)
 	assert.Len(t, rows, 2)
 }
 
 func TestNotes_NotFound(t *testing.T) {
 	svc, _, _, _ := newSvc(t)
-	_, err := svc.Notes("u1", "missing", "", "", 10)
+	_, err := svc.Notes("u1", "missing", "", "", 10, "")
 	assert.ErrorIs(t, err, clip.ErrClipNotFound)
 }
 
-func TestNotes_PrivateAccessDenied(t *testing.T) {
+func TestNotes_PrivateHiddenFromOthers(t *testing.T) {
 	svc, repo, _, _ := newSvc(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "u1", IsPublic: false}
-	_, err := svc.Notes("u2", "c1", "", "", 10)
-	assert.ErrorIs(t, err, clip.ErrAccessDenied)
+	_, err := svc.Notes("u2", "c1", "", "", 10, "")
+	assert.ErrorIs(t, err, clip.ErrClipNotFound)
 }
 
 func TestNotes_PublicReadableByAnyone(t *testing.T) {
@@ -349,7 +352,7 @@ func TestNotes_PublicReadableByAnyone(t *testing.T) {
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "u1", IsPublic: true}
 	notes.Notes["n1"] = &model.Note{ID: "n1", Visibility: model.NoteVisibilityPublic}
 	require.NoError(t, svc.AddNote("u1", "c1", "n1"))
-	rows, err := svc.Notes("u2", "c1", "", "", 10)
+	rows, err := svc.Notes("u2", "c1", "", "", 10, "")
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 }
@@ -357,7 +360,7 @@ func TestNotes_PublicReadableByAnyone(t *testing.T) {
 func TestNotes_EmptyClipReturnsNil(t *testing.T) {
 	svc, repo, _, _ := newSvc(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "u1"}
-	rows, err := svc.Notes("u1", "c1", "", "", 10)
+	rows, err := svc.Notes("u1", "c1", "", "", 10, "")
 	require.NoError(t, err)
 	assert.Empty(t, rows)
 }
@@ -368,7 +371,7 @@ type listFailRepo struct {
 	*testutil.MockClipNoteRepository
 }
 
-func (r *listFailRepo) ListByClipVisible(_, _, _, _ string, _ int) ([]*model.ClipNote, error) {
+func (r *listFailRepo) ListByClipVisible(_, _, _, _ string, _ int, _ []string) ([]*model.ClipNote, error) {
 	return nil, errors.New("boom")
 }
 
@@ -378,7 +381,7 @@ func TestNotes_RepoError(t *testing.T) {
 	noteRepo := &listFailRepo{MockClipNoteRepository: testutil.NewMockClipNoteRepository()}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := clip.NewService(repo, noteRepo, testutil.NewMockNoteRepository(), idGen)
-	_, err := svc.Notes("u1", "c1", "", "", 10)
+	_, err := svc.Notes("u1", "c1", "", "", 10, "")
 	assert.Error(t, err)
 }
 

--- a/internal/core/clip/parity_1562_test.go
+++ b/internal/core/clip/parity_1562_test.go
@@ -1,0 +1,54 @@
+package clip_test
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- #1562: Notes search ---
+
+func TestNotes_SearchWordsFilter(t *testing.T) {
+	svc, repo, noteRepo, notes := newSvc(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "u1", IsPublic: true}
+	hit := "misskey reversi notes"
+	miss := "nothing here"
+	notes.Notes["n1"] = &model.Note{ID: "n1", Text: &hit, Visibility: model.NoteVisibilityPublic}
+	notes.Notes["n2"] = &model.Note{ID: "n2", Text: &miss, Visibility: model.NoteVisibilityPublic}
+	noteRepo.Entries["cn1"] = &model.ClipNote{ID: "cn1", ClipID: "c1", NoteID: "n1"}
+	noteRepo.Entries["cn2"] = &model.ClipNote{ID: "cn2", ClipID: "c1", NoteID: "n2"}
+
+	// 空白区切りの 2 語は AND (両方含む note のみ)
+	rows, err := svc.Notes("u1", "c1", "", "", 10, "misskey reversi")
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "n1", rows[0].ID)
+
+	// 片方の語しか持たない場合は AND を満たさない
+	rows, err = svc.Notes("u1", "c1", "", "", 10, "misskey nothing")
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+
+	// 連続空白は upstream split(' ') の空要素 ('%%') と同じく無視される
+	rows, err = svc.Notes("u1", "c1", "", "", 10, "misskey  reversi")
+	require.NoError(t, err)
+	assert.Len(t, rows, 1)
+}
+
+// --- #1562: Exists (unfavorite の生存在チェック) ---
+
+func TestExists(t *testing.T) {
+	svc, repo, _, _ := newSvc(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "u1", IsPublic: false}
+
+	// private でも raw 存在は true (visibility 非依存)
+	ok, err := svc.Exists("c1")
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = svc.Exists("missing")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}

--- a/internal/core/following/following_service.go
+++ b/internal/core/following/following_service.go
@@ -27,8 +27,11 @@ var (
 	ErrRequestNotFound = errors.New("follow request not found")
 	// ErrAlreadyRequested is returned when a follow request already exists.
 	ErrAlreadyRequested = errors.New("already requested")
-	// ErrBlocked is returned when either party blocks the other.
+	// ErrBlocked is returned when the followee has blocked the follower.
 	ErrBlocked = errors.New("blocking relationship prevents this operation")
+	// ErrBlocking is returned when the follower is blocking the followee.
+	// upstream following/create は方向で BLOCKING / BLOCKED を区別する (#1562)。
+	ErrBlocking = errors.New("you are blocking that user")
 )
 
 // BlockingChecker reports whether one user has blocked another. パッケージ間の
@@ -235,14 +238,18 @@ func (s *Service) Follow(followerID, followeeID string, opts FollowOptions) (*Fo
 		return nil, ErrAlreadyFollowing
 	}
 
-	// ブロック関係があるとフォロー不可 (双方向で確認)
+	// ブロック関係があるとフォロー不可 (双方向で確認)。upstream
+	// UserFollowingService.follow は blocking (follower→followee) を先に
+	// 検査して 'blocking'、次に blocked (followee→follower) を 'blocked' と
+	// 方向別に投げ、create.ts が BLOCKING / BLOCKED に map する (#1562)。
+	// 相互ブロック時に BLOCKING が優先される順序も upstream に合わせる。
 	if s.blockingChecker != nil {
-		if blocked, err := s.blockingChecker.IsBlocked(followeeID, followerID); err != nil {
+		if blocking, err := s.blockingChecker.IsBlocked(followerID, followeeID); err != nil {
 			return nil, err
-		} else if blocked {
-			return nil, ErrBlocked
+		} else if blocking {
+			return nil, ErrBlocking
 		}
-		if blocked, err := s.blockingChecker.IsBlocked(followerID, followeeID); err != nil {
+		if blocked, err := s.blockingChecker.IsBlocked(followeeID, followerID); err != nil {
 			return nil, err
 		} else if blocked {
 			return nil, ErrBlocked
@@ -582,6 +589,13 @@ func (s *Service) ListFollowingForList(followerID, sinceID, untilID string, noti
 // Returns nil if the relation does not exist (no-op).
 func (s *Service) UpdateRelation(followerID, followeeID string, fields map[string]any) error {
 	return s.followingRepo.UpdateRelation(followerID, followeeID, fields)
+}
+
+// IsFollowing reports whether follower currently follows followee. Used by
+// following/update to emit NOT_FOLLOWING before applying a no-op update
+// (#1562、upstream update.ts は Following row 不在で notFollowing を返す)。
+func (s *Service) IsFollowing(followerID, followeeID string) (bool, error) {
+	return s.followingRepo.Exists(followerID, followeeID)
 }
 
 // UpdateAllByFollower applies partial updates to every Following row whose

--- a/internal/core/following/following_service_test.go
+++ b/internal/core/following/following_service_test.go
@@ -969,14 +969,30 @@ func TestFollow_BlockedByFollowee(t *testing.T) {
 	require.ErrorIs(t, err, following.ErrBlocked)
 }
 
-func TestFollow_BlockedFollowee(t *testing.T) {
+// follower (bob) が followee (alice) を block している方向は ErrBlocking
+// (upstream の 'blocking' に対応、#1562)。
+func TestFollow_BlockingFollowee(t *testing.T) {
 	svc, ur, _, _ := newSvc(t)
 	addUser(t, ur, "alice", false)
 	addUser(t, ur, "bob", false)
 	svc.SetBlockingChecker(&stubBlockingChecker{blockedPairs: map[string]bool{"bob->alice": true}})
 
 	_, err := svc.Follow("bob", "alice", following.FollowOptions{})
-	require.ErrorIs(t, err, following.ErrBlocked)
+	require.ErrorIs(t, err, following.ErrBlocking)
+}
+
+// 相互 block 時は upstream と同じく blocking 判定が先勝ちする (#1562)。
+func TestFollow_MutualBlockPrefersBlocking(t *testing.T) {
+	svc, ur, _, _ := newSvc(t)
+	addUser(t, ur, "alice", false)
+	addUser(t, ur, "bob", false)
+	svc.SetBlockingChecker(&stubBlockingChecker{blockedPairs: map[string]bool{
+		"bob->alice": true,
+		"alice->bob": true,
+	}})
+
+	_, err := svc.Follow("bob", "alice", following.FollowOptions{})
+	require.ErrorIs(t, err, following.ErrBlocking)
 }
 
 func TestFollow_BlockingCheckerReverseError(t *testing.T) {

--- a/internal/core/following/parity_1562_test.go
+++ b/internal/core/following/parity_1562_test.go
@@ -1,0 +1,31 @@
+package following_test
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/core/following"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// IsFollowing は following/update の NOT_FOLLOWING 判定に使う (#1562)。
+func TestIsFollowing(t *testing.T) {
+	svc, ur, _, _ := newSvc(t)
+	addUser(t, ur, "alice", false)
+	addUser(t, ur, "bob", false)
+
+	ok, err := svc.IsFollowing("alice", "bob")
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	_, err = svc.Follow("alice", "bob", following.FollowOptions{})
+	require.NoError(t, err)
+
+	ok, err = svc.IsFollowing("alice", "bob")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	// 逆方向は false のまま
+	ok, err = svc.IsFollowing("bob", "alice")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}

--- a/internal/core/notesfilter/blockedhost.go
+++ b/internal/core/notesfilter/blockedhost.go
@@ -1,0 +1,52 @@
+package notesfilter
+
+import (
+	"strings"
+
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// ApplyBlockedHosts drops notes whose author, reply author, or renote author
+// belongs to an admin-blocked instance, mirroring upstream
+// QueryService.generateBlockedHostQueryForNote (#1562)。
+//
+// upstream は meta.blockedHosts を [x, %.x] に展開して NOT ILIKE ALL で突合
+// する = exact 一致または subdomain 一致で除外。local user (host IS NULL) は
+// 常に通す。blockedHosts が空なら no-op。
+func ApplyBlockedHosts(notes []*model.Note, blockedHosts []string) []*model.Note {
+	if len(notes) == 0 || len(blockedHosts) == 0 {
+		return notes
+	}
+	out := make([]*model.Note, 0, len(notes))
+	for _, n := range notes {
+		if n == nil {
+			continue
+		}
+		if hostBlocked(n.UserHost, blockedHosts) ||
+			hostBlocked(n.ReplyUserHost, blockedHosts) ||
+			hostBlocked(n.RenoteUserHost, blockedHosts) {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
+// hostBlocked reports whether host matches any blocked entry exactly or as a
+// subdomain (`%.entry` 相当)。ILIKE 突合なので case-insensitive。
+func hostBlocked(host *string, blockedHosts []string) bool {
+	if host == nil || *host == "" {
+		return false
+	}
+	h := strings.ToLower(*host)
+	for _, b := range blockedHosts {
+		b = strings.ToLower(b)
+		if b == "" {
+			continue
+		}
+		if h == b || strings.HasSuffix(h, "."+b) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/core/notesfilter/blockedhost_test.go
+++ b/internal/core/notesfilter/blockedhost_test.go
@@ -1,0 +1,68 @@
+package notesfilter
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestApplyBlockedHosts_EmptyListIsNoop(t *testing.T) {
+	notes := []*model.Note{{ID: "n1", UserHost: strPtr("blocked.example")}}
+	assert.Len(t, ApplyBlockedHosts(notes, nil), 1)
+	assert.Len(t, ApplyBlockedHosts(notes, []string{}), 1)
+}
+
+func TestApplyBlockedHosts_DropsAuthorHost(t *testing.T) {
+	notes := []*model.Note{
+		{ID: "n1", UserHost: strPtr("blocked.example")},
+		{ID: "n2", UserHost: strPtr("ok.example")},
+		{ID: "n3"}, // local note (host nil) は常に通す
+	}
+	out := ApplyBlockedHosts(notes, []string{"blocked.example"})
+	assert.Len(t, out, 2)
+	assert.Equal(t, "n2", out[0].ID)
+	assert.Equal(t, "n3", out[1].ID)
+}
+
+func TestApplyBlockedHosts_SubdomainMatch(t *testing.T) {
+	// upstream は [x, %.x] の ILIKE 突合 = subdomain も block 対象
+	notes := []*model.Note{
+		{ID: "n1", UserHost: strPtr("sub.blocked.example")},
+		{ID: "n2", UserHost: strPtr("notblocked.example")},
+	}
+	out := ApplyBlockedHosts(notes, []string{"blocked.example"})
+	assert.Len(t, out, 1)
+	assert.Equal(t, "n2", out[0].ID, "suffix一致は `.` 境界でのみ成立する (notblocked.example は残る)")
+}
+
+func TestApplyBlockedHosts_CaseInsensitive(t *testing.T) {
+	notes := []*model.Note{{ID: "n1", UserHost: strPtr("Blocked.Example")}}
+	assert.Empty(t, ApplyBlockedHosts(notes, []string{"blocked.example"}))
+}
+
+func TestApplyBlockedHosts_ReplyAndRenoteAuthors(t *testing.T) {
+	notes := []*model.Note{
+		{ID: "n1", ReplyUserHost: strPtr("blocked.example")},
+		{ID: "n2", RenoteUserHost: strPtr("blocked.example")},
+		{ID: "n3", UserHost: strPtr("ok.example")},
+	}
+	out := ApplyBlockedHosts(notes, []string{"blocked.example"})
+	assert.Len(t, out, 1)
+	assert.Equal(t, "n3", out[0].ID)
+}
+
+func TestApplyBlockedHosts_NilNoteSkipped(t *testing.T) {
+	notes := []*model.Note{nil, {ID: "n1"}}
+	out := ApplyBlockedHosts(notes, []string{"blocked.example"})
+	assert.Len(t, out, 1)
+}
+
+func TestApplyBlockedHosts_EmptyBlockedEntryIgnored(t *testing.T) {
+	// 空文字 entry が全 host を block しないこと
+	notes := []*model.Note{{ID: "n1", UserHost: strPtr("ok.example")}}
+	out := ApplyBlockedHosts(notes, []string{""})
+	assert.Len(t, out, 1)
+}

--- a/internal/entity/clip.go
+++ b/internal/entity/clip.go
@@ -5,6 +5,21 @@ import (
 	"github.com/shiroha-a/mk/internal/model"
 )
 
+// ClipExtras carries the viewer-dependent fields of the clip shape (#1562).
+// upstream ClipEntityService.pack は favoritedCount を実カウント、isFavorited
+// を me 有時のみ、notesCount を owner 閲覧時のみ出力する
+// (ClipEntityService.ts:54-56)。
+type ClipExtras struct {
+	// FavoritedCount is the number of clip_favorite rows for this clip.
+	FavoritedCount int64
+	// IsFavorited reports whether the viewer favorited this clip. nil なら
+	// フィールド自体を省略する (匿名 viewer、upstream は undefined)。
+	IsFavorited *bool
+	// ShowNotesCount controls whether notesCount is emitted. upstream は
+	// viewer == owner のときのみ出力する。
+	ShowNotesCount bool
+}
+
 // PackClip converts a model.Clip into the Misskey-compatible clip shape.
 //
 // misskey_dart の Clip.fromJson は createdAt (String) / userId (String) /
@@ -13,10 +28,7 @@ import (
 // を埋めるために caller が渡す (nil なら user は省略するが、misskey_dart 互換の
 // ため呼び出し側は必ず owner を解決して渡すこと)。createdAt は clip ID (aidx)
 // から復元する。
-//
-// favoritedCount は mk-go が clip favorite を追跡しないため 0 固定 (upstream は
-// clip_favorite の count)。
-func PackClip(cl *model.Clip, idGen id.Generator, owner *model.User) map[string]any {
+func PackClip(cl *model.Clip, idGen id.Generator, owner *model.User, extras ClipExtras) map[string]any {
 	if cl == nil {
 		return nil
 	}
@@ -33,9 +45,16 @@ func PackClip(cl *model.Clip, idGen id.Generator, owner *model.User) map[string]
 		"name":           cl.Name,
 		"description":    cl.Description,
 		"isPublic":       cl.IsPublic,
-		"notesCount":     cl.NotesCount,
 		"lastClippedAt":  lastClippedAt,
-		"favoritedCount": 0,
+		"favoritedCount": extras.FavoritedCount,
+	}
+	// notesCount は owner 閲覧時のみ (upstream は他人には undefined を返し
+	// note 件数を露出しない、#1562)。
+	if extras.ShowNotesCount {
+		out["notesCount"] = cl.NotesCount
+	}
+	if extras.IsFavorited != nil {
+		out["isFavorited"] = *extras.IsFavorited
 	}
 	if idGen != nil {
 		if t, err := idGen.ParseTime(cl.ID); err == nil {

--- a/internal/entity/clip_test.go
+++ b/internal/entity/clip_test.go
@@ -16,7 +16,8 @@ func TestPackClip_Basic(t *testing.T) {
 	lastClipped := time.Date(2026, 4, 10, 1, 2, 3, 0, time.UTC)
 	cl := &model.Clip{ID: clipID, UserID: "u1", Name: "favs", Description: &desc, IsPublic: true, NotesCount: 5, LastClippedAt: &lastClipped}
 
-	out := PackClip(cl, idGen, owner)
+	fav := true
+	out := PackClip(cl, idGen, owner, ClipExtras{FavoritedCount: 3, IsFavorited: &fav, ShowNotesCount: true})
 	assert.Equal(t, clipID, out["id"])
 	assert.Equal(t, "u1", out["userId"])
 	assert.Equal(t, "favs", out["name"])
@@ -29,20 +30,36 @@ func TestPackClip_Basic(t *testing.T) {
 	createdAt, ok := out["createdAt"].(string)
 	assert.True(t, ok, "createdAt must be a non-null string")
 	assert.NotEmpty(t, createdAt)
-	assert.Equal(t, 0, out["favoritedCount"])
+	// viewer 依存 field は ClipExtras から透過する (#1562)
+	assert.Equal(t, int64(3), out["favoritedCount"])
+	assert.Equal(t, true, out["isFavorited"])
 	user, ok := out["user"].(UserLite)
 	assert.True(t, ok, "user must be present")
 	assert.Equal(t, "u1", user.ID)
 }
 
+// 非 owner 閲覧では notesCount を出さず、匿名では isFavorited も出さない
+// (upstream ClipEntityService.pack の undefined と同じ省略、#1562)。
+func TestPackClip_ViewerDependentFieldsHidden(t *testing.T) {
+	idGen := newTestIDGen(t)
+	cl := &model.Clip{ID: idGen.Generate(time.Now()), UserID: "u1", Name: "favs", IsPublic: true, NotesCount: 5}
+
+	out := PackClip(cl, idGen, &model.User{ID: "u1"}, ClipExtras{})
+	_, hasNotesCount := out["notesCount"]
+	assert.False(t, hasNotesCount, "notesCount must be omitted for non-owner viewers")
+	_, hasIsFavorited := out["isFavorited"]
+	assert.False(t, hasIsFavorited, "isFavorited must be omitted for anonymous viewers")
+	assert.Equal(t, int64(0), out["favoritedCount"], "favoritedCount stays non-null for misskey_dart")
+}
+
 func TestPackClip_NilOwnerOmitsUser(t *testing.T) {
 	idGen := newTestIDGen(t)
 	cl := &model.Clip{ID: idGen.Generate(time.Now()), UserID: "u1", Name: "x"}
-	out := PackClip(cl, idGen, nil)
+	out := PackClip(cl, idGen, nil, ClipExtras{})
 	_, hasUser := out["user"]
 	assert.False(t, hasUser)
 }
 
 func TestPackClip_NilInput(t *testing.T) {
-	assert.Nil(t, PackClip(nil, nil, nil))
+	assert.Nil(t, PackClip(nil, nil, nil, ClipExtras{}))
 }

--- a/internal/entitycompat/runtime_test.go
+++ b/internal/entitycompat/runtime_test.go
@@ -344,7 +344,7 @@ func TestClipShapeL2(t *testing.T) {
 	owner := &model.User{ID: "u_owner", Username: "owner"}
 	desc := "my clip"
 	cl := &model.Clip{ID: idGen.Generate(time.Now()), UserID: "u_owner", Name: "clip", Description: &desc, IsPublic: true}
-	out := entity.PackClip(cl, idGen, owner)
+	out := entity.PackClip(cl, idGen, owner, entity.ClipExtras{})
 	assertNoGatedDrift(t, "Clip", out, schema)
 }
 

--- a/internal/queue/processors/follow.go
+++ b/internal/queue/processors/follow.go
@@ -55,6 +55,7 @@ func (p *FollowProcessor) Handle(_ context.Context, t driver.Task) error {
 	// block 関係 / 自己 follow / 対象不在は retry しても解消しない恒久
 	// エラーなので即終了する (本家は job fail のまま放置される)。
 	case errors.Is(err, following.ErrBlocked),
+		errors.Is(err, following.ErrBlocking),
 		errors.Is(err, following.ErrSelfFollow),
 		errors.Is(err, following.ErrFolloweeNotFound):
 		return fmt.Errorf("follow %s->%s: %w: %w",

--- a/internal/repository/clip_favorite.go
+++ b/internal/repository/clip_favorite.go
@@ -11,6 +11,9 @@ type ClipFavoriteRepository interface {
 	Delete(userID, clipID string) error
 	ListByUser(userID string) ([]*model.ClipFavorite, error)
 	Exists(userID, clipID string) (bool, error)
+	// CountByClip returns the number of favorites for a clip. clip 応答の
+	// favoritedCount 実カウント用 (#1562、upstream clipFavoritesRepository.countBy)。
+	CountByClip(clipID string) (int64, error)
 }
 
 type clipFavoriteRepository struct {
@@ -44,4 +47,11 @@ func (r *clipFavoriteRepository) Exists(userID, clipID string) (bool, error) {
 	err := r.db.Model(&model.ClipFavorite{}).
 		Where(`"userId" = ? AND "clipId" = ?`, userID, clipID).Count(&count).Error
 	return count > 0, err
+}
+
+func (r *clipFavoriteRepository) CountByClip(clipID string) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.ClipFavorite{}).
+		Where(`"clipId" = ?`, clipID).Count(&count).Error
+	return count, err
 }

--- a/internal/repository/clip_note.go
+++ b/internal/repository/clip_note.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"strings"
+
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/gorm"
 )
@@ -16,7 +18,10 @@ type ClipNoteRepository interface {
 	// excluded before LIMIT. viewerID 空文字は匿名 (public/home のみ)。clips/notes
 	// で post-fetch filter によるページ過少充填と per-note の follow 判定 N+1 を
 	// 避けるため (#1418 review)。export 経路は全件必要なので ListByClip を使う。
-	ListByClipVisible(clipID, viewerID, untilID, sinceID string, limit int) ([]*model.ClipNote, error)
+	// searchWords は各語を note.text / note.cw への ILIKE 部分一致 (OR) として
+	// AND 結合する (#1562、upstream clips/notes の search param 相当)。空 slice
+	// は無条件。
+	ListByClipVisible(clipID, viewerID, untilID, sinceID string, limit int, searchWords []string) ([]*model.ClipNote, error)
 	// CountByClip returns the number of notes in the given clip. Used by
 	// noteEachClipsLimit policy gate (#1029 PR-1 follow-up).
 	CountByClip(clipID string) (int64, error)
@@ -62,15 +67,15 @@ func (r *clipNoteRepository) CountByClip(clipID string) (int64, error) {
 // the clip_note id. Order flips to ASC when only sinceID is supplied,
 // matching paginationOrder (upstream QueryService.makePaginationQuery parity).
 func (r *clipNoteRepository) ListByClip(clipID string, untilID, sinceID string, limit int) ([]*model.ClipNote, error) {
-	return r.listByClip(clipID, "", false, untilID, sinceID, limit)
+	return r.listByClip(clipID, "", false, untilID, sinceID, limit, nil)
 }
 
 // ListByClipVisible is ListByClip with the visibility push-down enabled.
-func (r *clipNoteRepository) ListByClipVisible(clipID, viewerID, untilID, sinceID string, limit int) ([]*model.ClipNote, error) {
-	return r.listByClip(clipID, viewerID, true, untilID, sinceID, limit)
+func (r *clipNoteRepository) ListByClipVisible(clipID, viewerID, untilID, sinceID string, limit int, searchWords []string) ([]*model.ClipNote, error) {
+	return r.listByClip(clipID, viewerID, true, untilID, sinceID, limit, searchWords)
 }
 
-func (r *clipNoteRepository) listByClip(clipID, viewerID string, filterVisibility bool, untilID, sinceID string, limit int) ([]*model.ClipNote, error) {
+func (r *clipNoteRepository) listByClip(clipID, viewerID string, filterVisibility bool, untilID, sinceID string, limit int, searchWords []string) ([]*model.ClipNote, error) {
 	if limit <= 0 {
 		limit = 30
 	}
@@ -83,6 +88,23 @@ func (r *clipNoteRepository) listByClip(clipID, viewerID string, filterVisibilit
 		// visibility を LIMIT 前に絞る。条件は core/note.CanSeeNote と一致 (#1454)。
 		q = applyViewerVisibilityExists(q, `"clip_note"."noteId"`, viewerID)
 	}
+	// search 各語を text / cw への ILIKE 部分一致 (語内 OR、語間 AND) で絞る
+	// (#1562、upstream clips/notes.ts:103-110)。LIMIT 前に適用しないと
+	// ページ過少充填になるため visibility と同じく push down する。同一 note
+	// 行への相関なので、語ごとに EXISTS を重ねず単一 EXISTS 内で AND する
+	// (subplan が語数分走るのを避ける)。
+	if len(searchWords) > 0 {
+		var cond strings.Builder
+		args := make([]any, 0, len(searchWords)*2)
+		cond.WriteString(`EXISTS (SELECT 1 FROM "note" sn WHERE sn."id" = "clip_note"."noteId"`)
+		for _, word := range searchWords {
+			like := "%" + escapeLike(word) + "%"
+			cond.WriteString(` AND (sn."text" ILIKE ? OR sn."cw" ILIKE ?)`)
+			args = append(args, like, like)
+		}
+		cond.WriteString(`)`)
+		q = q.Where(cond.String(), args...)
+	}
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)
 	}
@@ -94,4 +116,14 @@ func (r *clipNoteRepository) listByClip(clipID, viewerID string, filterVisibilit
 		return nil, err
 	}
 	return rows, nil
+}
+
+// escapeLike escapes LIKE/ILIKE metacharacters so user input matches
+// literally (upstream sqlLikeEscape 相当)。PostgreSQL の既定 escape 文字は
+// backslash なので \ 自身もエスケープする。
+func escapeLike(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
 }

--- a/internal/repository/clip_note_test.go
+++ b/internal/repository/clip_note_test.go
@@ -154,22 +154,22 @@ func TestClipNoteRepository_ListByClipVisible(t *testing.T) {
 	assert.Equal(t, []string{"n_cnv_fol", "n_cnv_pub", "n_cnv_spec"}, noteIDsOf(rows))
 
 	// 匿名 viewer は public のみ。
-	rows, err = repo.ListByClipVisible(c.ID, "", "", "", 50)
+	rows, err = repo.ListByClipVisible(c.ID, "", "", "", 50, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_cnv_pub"}, noteIDsOf(rows))
 
 	// follower は public + followers。
-	rows, err = repo.ListByClipVisible(c.ID, follower.ID, "", "", 50)
+	rows, err = repo.ListByClipVisible(c.ID, follower.ID, "", "", 50, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_cnv_fol", "n_cnv_pub"}, noteIDsOf(rows))
 
 	// specified 対象 viewer は public + specified。
-	rows, err = repo.ListByClipVisible(c.ID, allowed.ID, "", "", 50)
+	rows, err = repo.ListByClipVisible(c.ID, allowed.ID, "", "", 50, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_cnv_pub", "n_cnv_spec"}, noteIDsOf(rows))
 
 	// author 本人は全 visibility を閲覧可。
-	rows, err = repo.ListByClipVisible(c.ID, author.ID, "", "", 50)
+	rows, err = repo.ListByClipVisible(c.ID, author.ID, "", "", 50, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_cnv_fol", "n_cnv_pub", "n_cnv_spec"}, noteIDsOf(rows))
 }

--- a/internal/repository/parity_1562_test.go
+++ b/internal/repository/parity_1562_test.go
@@ -1,0 +1,103 @@
+package repository
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+)
+
+// TestClipNoteRepository_SearchWords は clips/notes の search push-down
+// (#1562) を検証する。text / cw への ILIKE 部分一致 (語内 OR、語間 AND) と
+// LIKE メタ文字 (%) の literal 扱いを実 SQL で確認する。
+func TestClipNoteRepository_SearchWords(t *testing.T) {
+	clipRepo := NewClipRepository(testDB)
+	repo := NewClipNoteRepository(testDB)
+	noteRepo := NewNoteRepository(testDB)
+
+	author := insertTestUser(t, "u_cns_a", "cnsauthor")
+	t.Cleanup(func() { cleanupUser(t, author.ID) })
+
+	c := newTestClip("clp_cns", author.ID, "search")
+	require.NoError(t, clipRepo.Create(c))
+	defer cleanupClip(t, c.ID)
+
+	mkNote := func(id string, text, cw *string) {
+		n := &model.Note{ID: id, UserID: author.ID, Visibility: model.NoteVisibilityPublic,
+			Text: text, CW: cw, Reactions: datatypes.JSON([]byte("{}"))}
+		require.NoError(t, noteRepo.Create(n))
+		t.Cleanup(func() { cleanupNote(t, id) })
+		cn := &model.ClipNote{ID: "cns_" + id, ClipID: c.ID, NoteID: id}
+		require.NoError(t, repo.Create(cn))
+		t.Cleanup(func() { testDB.Exec(`DELETE FROM "clip_note" WHERE id = ?`, cn.ID) })
+	}
+	s := func(v string) *string { return &v }
+	mkNote("n_cns_1", s("Golang ROCKS here"), nil)
+	mkNote("n_cns_2", s("unrelated text"), nil)
+	mkNote("n_cns_3", nil, s("cw mentions golang"))
+	mkNote("n_cns_4", s("100% literal percent"), nil)
+
+	ids := func(rows []*model.ClipNote) []string {
+		out := make([]string, 0, len(rows))
+		for _, r := range rows {
+			out = append(out, r.NoteID)
+		}
+		sort.Strings(out)
+		return out
+	}
+
+	// ILIKE は case-insensitive、text / cw のどちらかに当たれば良い
+	rows, err := repo.ListByClipVisible(c.ID, "", "", "", 50, []string{"golang"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_cns_1", "n_cns_3"}, ids(rows))
+
+	// 複数語は AND
+	rows, err = repo.ListByClipVisible(c.ID, "", "", "", 50, []string{"golang", "rocks"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_cns_1"}, ids(rows))
+
+	// LIKE メタ文字はエスケープされ literal 一致になる ("100%" は n_cns_4 のみ)
+	rows, err = repo.ListByClipVisible(c.ID, "", "", "", 50, []string{"100%"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"n_cns_4"}, ids(rows))
+
+	// "_" も literal ("100_" は wildcard 解釈なら n_cns_4 に当たるが、escape
+	// 済みなので 0 件)
+	rows, err = repo.ListByClipVisible(c.ID, "", "", "", 50, []string{"100_"})
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+// TestClipFavoriteRepository_CountByClip は favoritedCount 実カウント (#1562)
+// の repository 実装を検証する。
+func TestClipFavoriteRepository_CountByClip(t *testing.T) {
+	clipRepo := NewClipRepository(testDB)
+	repo := NewClipFavoriteRepository(testDB)
+
+	owner := insertTestUser(t, "u_cfc_o", "cfcowner")
+	t.Cleanup(func() { cleanupUser(t, owner.ID) })
+	fan1 := insertTestUser(t, "u_cfc_1", "cfcfan1")
+	t.Cleanup(func() { cleanupUser(t, fan1.ID) })
+	fan2 := insertTestUser(t, "u_cfc_2", "cfcfan2")
+	t.Cleanup(func() { cleanupUser(t, fan2.ID) })
+
+	c := newTestClip("clp_cfc", owner.ID, "counted")
+	require.NoError(t, clipRepo.Create(c))
+	defer cleanupClip(t, c.ID)
+
+	n, err := repo.CountByClip(c.ID)
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, n)
+
+	require.NoError(t, repo.Create(&model.ClipFavorite{ID: "cf_cfc_1", UserID: fan1.ID, ClipID: c.ID}))
+	t.Cleanup(func() { testDB.Exec(`DELETE FROM "clip_favorite" WHERE id = ?`, "cf_cfc_1") })
+	require.NoError(t, repo.Create(&model.ClipFavorite{ID: "cf_cfc_2", UserID: fan2.ID, ClipID: c.ID}))
+	t.Cleanup(func() { testDB.Exec(`DELETE FROM "clip_favorite" WHERE id = ?`, "cf_cfc_2") })
+
+	n, err = repo.CountByClip(c.ID)
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, n)
+}

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -309,6 +309,27 @@ func RequireScope(kind string) echo.MiddlewareFunc {
 	}
 }
 
+// RequireNotMoved rejects requests from accounts that have completed an
+// account migration (movedToUri set), mirroring upstream prohibitMoved
+// endpoints (ApiCallService.ts:368-377、#1562)。RequireAuth の後段に配線する
+// こと (GetUser が nil の場合は素通しし、認可は RequireAuth 側に任せる)。
+func RequireNotMoved() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			user := GetUser(c)
+			if user != nil && user.MovedToURI != nil && *user.MovedToURI != "" {
+				return c.JSON(http.StatusForbidden, apierr.ErrorWithKind(
+					"YOUR_ACCOUNT_MOVED",
+					"You have moved your account.",
+					"56f20ec9-fd06-4fa5-841b-edd6d7d4fa31",
+					apierr.KindPermission,
+				))
+			}
+			return next(c)
+		}
+	}
+}
+
 // RoleChecker abstracts role checking to avoid circular dependency with core/role.
 type RoleChecker interface {
 	IsAdministrator(userID string) bool

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -900,3 +900,71 @@ func TestAuthenticate_NativeTokenIsNotApp(t *testing.T) {
 	})
 	require.NoError(t, handler(c))
 }
+
+// --- RequireNotMoved (#1562 prohibitMoved) ---
+
+func newMovedCtx(user *model.User) (echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	rec := httptest.NewRecorder()
+	c := e.NewContext(httptest.NewRequest(http.MethodPost, "/", nil), rec)
+	if user != nil {
+		c.Set(string(UserContextKey), user)
+	}
+	return c, rec
+}
+
+func TestRequireNotMoved_NormalUserPasses(t *testing.T) {
+	c, rec := newMovedCtx(&model.User{ID: "u1"})
+	called := false
+	h := RequireNotMoved()(func(c echo.Context) error {
+		called = true
+		return c.NoContent(http.StatusOK)
+	})
+	require.NoError(t, h(c))
+	assert.True(t, called)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestRequireNotMoved_MovedUserRejected(t *testing.T) {
+	moved := "https://other.example/users/xyz"
+	c, rec := newMovedCtx(&model.User{ID: "u1", MovedToURI: &moved})
+	called := false
+	h := RequireNotMoved()(func(c echo.Context) error {
+		called = true
+		return c.NoContent(http.StatusOK)
+	})
+	require.NoError(t, h(c))
+	assert.False(t, called, "moved account must not reach the handler")
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "YOUR_ACCOUNT_MOVED")
+	assert.Contains(t, rec.Body.String(), "56f20ec9-fd06-4fa5-841b-edd6d7d4fa31")
+	assert.Contains(t, rec.Body.String(), `"kind":"permission"`)
+}
+
+func TestRequireNotMoved_EmptyMovedURIPasses(t *testing.T) {
+	// movedToUri が空文字の行 (NULL でなく '' で入った過去データ) は moved
+	// 扱いしない。
+	empty := ""
+	c, rec := newMovedCtx(&model.User{ID: "u1", MovedToURI: &empty})
+	called := false
+	h := RequireNotMoved()(func(c echo.Context) error {
+		called = true
+		return c.NoContent(http.StatusOK)
+	})
+	require.NoError(t, h(c))
+	assert.True(t, called)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestRequireNotMoved_AnonymousPasses(t *testing.T) {
+	// user 未設定 (anonymous) は素通しし、認可は RequireAuth に任せる。
+	c, rec := newMovedCtx(nil)
+	called := false
+	h := RequireNotMoved()(func(c echo.Context) error {
+		called = true
+		return c.NoContent(http.StatusOK)
+	})
+	require.NoError(t, h(c))
+	assert.True(t, called)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1266,6 +1266,7 @@ func (s *Server) setupRoutes() {
 	usersHandler.SetEmojiRepo(emojiRepo)
 	usersHandler.SetReactionReader(reactionCountWriter)
 	usersHandler.SetClipRepo(clipRepo)
+	usersHandler.SetClipFavoriteRepo(clipFavoriteRepo) // #1562: users/clips の favoritedCount / isFavorited
 	usersHandler.SetFlashRepo(flashRepo)
 	usersHandler.SetGalleryRepo(repository.NewGalleryRepository(s.db))
 	usersHandler.SetPageRepo(pageRepo)
@@ -1722,14 +1723,16 @@ func (s *Server) setupRoutes() {
 	clipsHandler.SetReactionReader(reactionCountWriter)
 	clipsHandler.SetNoteFieldResolver(noteFieldResolver)
 	clipsHandler.SetUserRepo(userRepo)
-	clipsHandler.SetQueryService(noteQueryService) // #1456: AddNote の visibility gate
-	api.POST("/clips/create", clipsHandler.Create, middleware.RequireAuth(), middleware.RequireScope("write:account"))
+	clipsHandler.SetQueryService(noteQueryService)           // #1456: AddNote の visibility gate
+	clipsHandler.SetMuteBlockRepos(mutingRepo, blockingRepo) // #1562: Notes の muted/blocked-user filter
+	clipsHandler.SetMetaRepo(metaRepo)                       // #1562: Notes の blocked-host filter
+	api.POST("/clips/create", clipsHandler.Create, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:account"))
 	api.POST("/clips/show", clipsHandler.Show, middleware.RequireScope("read:account"))
-	api.POST("/clips/update", clipsHandler.Update, middleware.RequireAuth(), middleware.RequireScope("write:account"))
+	api.POST("/clips/update", clipsHandler.Update, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:account"))
 	api.POST("/clips/delete", clipsHandler.Delete, middleware.RequireAuth(), middleware.RequireScope("write:account"))
 	api.POST("/clips/list", clipsHandler.List, middleware.RequireAuth(), middleware.RequireScope("read:account"))
-	api.POST("/clips/add-note", clipsHandler.AddNote, middleware.RequireAuth(), middleware.RequireScope("write:account"))
-	api.POST("/clips/remove-note", clipsHandler.RemoveNote, middleware.RequireAuth(), middleware.RequireScope("write:account"))
+	api.POST("/clips/add-note", clipsHandler.AddNote, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:account"))
+	api.POST("/clips/remove-note", clipsHandler.RemoveNote, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:account"))
 	api.POST("/clips/notes", clipsHandler.Notes, middleware.RequireScope("read:account"))
 
 	// Pages endpoints (Phase 4.5)
@@ -1952,7 +1955,7 @@ func (s *Server) setupRoutes() {
 	// Following endpoints
 	followingHandler := following.NewHandler(followingService, userService)
 	followingHandler.SetIDGen(idGen)
-	api.POST("/following/create", followingHandler.Create, middleware.RequireAuth(), middleware.RequireScope("write:following"))
+	api.POST("/following/create", followingHandler.Create, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:following"))
 	api.POST("/following/delete", followingHandler.Delete, middleware.RequireAuth(), middleware.RequireScope("write:following"))
 	api.POST("/following/list", followingHandler.List, middleware.RequireAuth(), middleware.RequireScope("read:following"))
 	api.POST("/following/requests/list", followingHandler.ListRequests, middleware.RequireAuth(), middleware.RequireScope("read:following"))
@@ -1972,8 +1975,8 @@ func (s *Server) setupRoutes() {
 	api.POST("/channels/my-favorites", channelsHandler.MyFavorites, middleware.RequireAuth(), middleware.RequireScope("read:channels"))
 	api.POST("/channels/mute/list", channelsHandler.MuteList, middleware.RequireAuth(), middleware.RequireScope("read:channels"))
 	// clips 残り
-	api.POST("/clips/favorite", clipsHandler.Favorite, middleware.RequireAuth(), middleware.RequireScope("write:clip-favorite"))
-	api.POST("/clips/unfavorite", clipsHandler.Unfavorite, middleware.RequireAuth(), middleware.RequireScope("write:clip-favorite"))
+	api.POST("/clips/favorite", clipsHandler.Favorite, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:clip-favorite"))
+	api.POST("/clips/unfavorite", clipsHandler.Unfavorite, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:clip-favorite"))
 	api.POST("/clips/my-favorites", clipsHandler.MyFavorites, middleware.RequireAuth(), middleware.RequireScope("read:clip-favorite"))
 	// federation の残ルートは上で登録済 (federationHandler 初期化直後)
 

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -3465,22 +3465,54 @@ func (m *MockClipNoteRepository) CountByClip(clipID string) (int64, error) {
 }
 
 func (m *MockClipNoteRepository) ListByClip(clipID string, untilID, sinceID string, limit int) ([]*model.ClipNote, error) {
-	return m.listByClip(clipID, "", false, untilID, sinceID, limit)
+	return m.listByClip(clipID, "", false, untilID, sinceID, limit, nil)
+}
+
+// noteMatchesSearchWords mirrors the real repo's clips/notes search predicate:
+// every word must hit note.text OR note.cw (substring, case-insensitive)。
+// 空 slice / note 不在 (search 無条件) は true。
+func noteMatchesSearchWords(n *model.Note, searchWords []string) bool {
+	if len(searchWords) == 0 {
+		return true
+	}
+	if n == nil {
+		return false
+	}
+	text := ""
+	if n.Text != nil {
+		text = strings.ToLower(*n.Text)
+	}
+	cw := ""
+	if n.CW != nil {
+		cw = strings.ToLower(*n.CW)
+	}
+	for _, w := range searchWords {
+		w = strings.ToLower(w)
+		if !strings.Contains(text, w) && !strings.Contains(cw, w) {
+			return false
+		}
+	}
+	return true
 }
 
 // ListByClipVisible mirrors the real repo's visibility push-down: clip entries
 // whose note the viewer cannot see are dropped before the limit slice.
-func (m *MockClipNoteRepository) ListByClipVisible(clipID, viewerID, untilID, sinceID string, limit int) ([]*model.ClipNote, error) {
-	return m.listByClip(clipID, viewerID, true, untilID, sinceID, limit)
+// searchWords は実 repo と同じく text / cw への部分一致 (語内 OR、語間 AND)
+// を case-insensitive で再現する (#1562)。
+func (m *MockClipNoteRepository) ListByClipVisible(clipID, viewerID, untilID, sinceID string, limit int, searchWords []string) ([]*model.ClipNote, error) {
+	return m.listByClip(clipID, viewerID, true, untilID, sinceID, limit, searchWords)
 }
 
-func (m *MockClipNoteRepository) listByClip(clipID, viewerID string, filterVisibility bool, untilID, sinceID string, limit int) ([]*model.ClipNote, error) {
+func (m *MockClipNoteRepository) listByClip(clipID, viewerID string, filterVisibility bool, untilID, sinceID string, limit int, searchWords []string) ([]*model.ClipNote, error) {
 	var rows []*model.ClipNote
 	for _, cn := range m.Entries {
 		if cn.ClipID != clipID {
 			continue
 		}
 		if filterVisibility && !noteVisibleToViewer(viewerID, m.Notes[cn.NoteID], m.Following) {
+			continue
+		}
+		if !noteMatchesSearchWords(m.Notes[cn.NoteID], searchWords) {
 			continue
 		}
 		if untilID != "" && cn.ID >= untilID {
@@ -6629,6 +6661,16 @@ func (m *MockClipFavoriteRepository) ListByUser(userID string) ([]*model.ClipFav
 func (m *MockClipFavoriteRepository) Exists(userID, clipID string) (bool, error) {
 	_, ok := m.Favorites[userID+":"+clipID]
 	return ok, nil
+}
+
+func (m *MockClipFavoriteRepository) CountByClip(clipID string) (int64, error) {
+	var count int64
+	for _, f := range m.Favorites {
+		if f.ClipID == clipID {
+			count++
+		}
+	}
+	return count, nil
 }
 
 // MockUserListFavoriteRepository is a test double for repository.UserListFavoriteRepository.


### PR DESCRIPTION
## Summary

互換性監査 issue #1562 で確定した following/* + clips/* の未対応差分 (13 MEDIUM / 6 LOW) のうち、**#1607 (PR #1614) で実装済みを確認した kind/OAuth scope enforcement を除く全項目**を解消する。エラーid/codeはgolden (`golden_error_ids.json`) と突合済み、HTTP statusはmk-go既存慣習 (NO_SUCH_*→404、その他400、permission→403) に整合。

## 主な変更点

### following系 (6項目)

- **following/create — BLOCKING実装**: core/followingの双方向block collapseを`ErrBlocking`/`ErrBlocked`に分離し、TS `UserFollowingService.follow`と同じ順 (blocking判定が先勝ち、相互block時もBLOCKING優先) に変更。handler は `BLOCKING` (4e2206ec...) を返す。`queue/processors/follow.go` のSkipRetryリストにも追加。
- **following/update — 3エラー + packed user返却**: `FOLLOWEE_IS_YOURSELF` (4c4cbaf9...) / `NO_SUCH_USER` (14318698...) / `NOT_FOLLOWING` (b8dc75cf...、`Service.IsFollowing`新設) をTSと同順で実装し、204→packed user (自分) を200で返却。
- **following/invalidate — 2エラー + packed user返却**: `FOLLOWER_IS_YOURSELF` (07dc03b9...) / `NO_SUCH_USER` (b77e6ae6...) を追加、外された相手のpacked userを返却。message はupstreamのtypo "The other use is not following you." まで一致。
- **following/requests/cancel — code/id修正 + packed followee返却**: service内部idを流用していた `NO_FOLLOW_REQUEST` → upstream公開エラー `FOLLOW_REQUEST_NOT_FOUND` (089b125b...) に修正、`NO_SUCH_USER` (4e68c551...) も追加。

### clips系 (7項目 + レビュー起点の追加修正)

- **clip応答のviewer別フィールド (3項目)**: `entity.PackClip` に `ClipExtras` を導入。`favoritedCount` は実カウント (`ClipFavoriteRepository.CountByClip` 新設)、`isFavorited` は認証viewerのみ、`notesCount` はowner閲覧時のみ出力 (ClipEntityService.ts:54-56 一致)。clips/* 全endpointと users/clips に配線。
- **clips/show・notes — 非公開clipの存在秘匿**: private-non-owner を403 ACCESS_DENIED→**404 NO_SUCH_CLIP** (missingと同一応答) に変更。
- **clips mutation 4種の403→404化 (レビュー指摘)**: show/notesだけ封じてもclips/update等の403/404差でenumeration oracleが残るため、update/delete/add-note/remove-noteの非ownerも upstream `findOneBy({id, userId})` と同じ404 NO_SUCH_CLIPに統一。`ErrAccessDenied` は全emit経路が消えたため削除。
- **clips/notes — search param**: 1..100検証、空白区切り語の text/cw ILIKE (語内OR・語間AND)、LIKEメタ文字escape (upstream sqlLikeEscape相当)。ページ過少充填を避けるためvisibilityと同じくLIMIT前にSQL push-down (単一EXISTS内でAND結合しper-word subplanを回避)。
- **clips/notes — muted/blocked-user + blocked-hostフィルタ**: 既存 `notesfilter.LoadMuteBlockSets`/`ApplyMuteBlockChannel` (#1544と同形のpost-fetch) を適用 (channel muteはupstream clips/notesが適用しないため対象外)。blocked-hostは `notesfilter.ApplyBlockedHosts` を新設 (exact + subdomain一致、meta.blockedHosts)。
- **clips/favorite — ALREADY_FAVORITED** (92658936...): 重複favoriteのsilent 204を400に。Existsのerror握り潰しも解消。
- **clips/unfavorite — NO_SUCH_CLIP (2603966e...) + NOT_FAVORITED (90c3a9e8...)**: upstream準拠でvisibilityを見ない生存在チェック (`Service.Exists` 新設。favorite後に非公開化されたclipの解除を許すため)。
- **clips/create・update — 長さ検証 + null正規化**: name 1..100 / description ≤2048 (rune近似、#1624と同方針)。空文字→null に加え、**update はdescription未指定でもNULLクリア** (upstream `ps.description || null` がundefinedもnullに畳む挙動、TSコードで裏取り済み)。

### 横断

- **prohibitMoved**: `middleware.RequireNotMoved()` 新設 (403 `YOUR_ACCOUNT_MOVED` 56f20ec9.../kind=permission)。TSの `prohibitMoved: true` 集合と完全一致する7route (following/create + clips/{create,update,add-note,remove-note,favorite,unfavorite}) に配線。
- **kind/OAuth scope (LOW 1件)**: #1614で `RequireScope` 配線済みを確認し本PR対象外。

## 敵対的レビュー (3 agent並列) → 反映済み

parity正確性 / セキュリティ / 回帰リスクの3観点でレビューを実施し、上記の「mutation 4種の404化」「description未指定NULLクリア」「search EXISTSの単一subquery化」「コメントの過大表記修正」を反映した。

## 意図的divergence・follow-up候補

- **muted-instances / renote入れ子変種のフィルタ未対応**: #1544 (antennas/roles) から継続のfollow-up。clips/notesのmute/block/blocked-hostフィルタはpost-fetch適用 (LIMIT後) のためページ過少充填があり得る点も#1544と同じ容認済みtradeoff。
- **inbound AP FollowのBlocked時挙動**: upstreamはRemote follower→local followeeのblockedでReject配送/blockingで自動unblockするが、mk-goは従来どおりエラー返却 (本PRで挙動クラス不変)。連合互換のfollow-up候補。
- **clip_favorite."clipId" index**: CountByClipはclipId単独indexが無くseq scan (upstreamも同様のN+1でparity等価)。大規模インスタンス向けにindex追加の余地。
- maxLength検証はajvのUTF-16長に対しrune近似 (#1624と同方針)。
- 成功時のpacked userはUserLiteのsuperset (UserDetailed、既存following/create・deleteと同一慣習)。

## テスト

- 追加: following handler (BLOCKING/update 3エラー/invalidate 2エラー/cancel新id)、clips handler (404化/長さ検証/null正規化/search検証+フィルタ3種/favorite・unfavoriteエラー/extras出し分け)、core/clip (search/Exists/非owner404)、core/following (IsFollowing/相互block先勝ち)、repository実DB (search ILIKE escape/CountByClip)、notesfilter (ApplyBlockedHosts 7ケース)、middleware (RequireNotMoved 4ケース)、users/clips (extras出し分け)
- カバレッジ: api/clips 91.4% / api/following 93.8% / core/clip 97.1% / core/following 93.7% / notesfilter 99.1% / entity 96.1% / middleware 96.6% / api/users 90.7%
- `make fmt` / `make lint` / errorid-check (id/status/kind) / limitspec-check / perm-check / shapecheck / `go test ./... -count=1` 全pass
- 実行方法: `go test ./internal/api/clips/ ./internal/api/following/ ./internal/core/clip/ ./internal/core/following/ ./internal/core/notesfilter/ ./internal/repository/ ./internal/server/middleware/`

## Closes

Closes #1562

🤖 Generated with [Claude Code](https://claude.com/claude-code)