### PR TITLE
Perf: clip_favorite の clipId に index を追加

### DIFF
--- a/internal/repository/parity_1562_test.go
+++ b/internal/repository/parity_1562_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/shiroha-a/mk/internal/model"
@@ -100,4 +101,34 @@ func TestClipFavoriteRepository_CountByClip(t *testing.T) {
 	n, err = repo.CountByClip(c.ID)
 	require.NoError(t, err)
 	assert.EqualValues(t, 2, n)
+}
+
+// TestClipFavoriteRepository_ClipIDIndex verifies the #1632 clipId index
+// (migration 000062) exists and is usable for the CountByClip query.
+// testutil.ApplyMigrations は migration のエラーを swallow するため、index が
+// 落ちても CI は沈黙し clip_favorite 肥大に比例して静かに性能退行する。
+// 000059-000061 の TestDriveFileRepository_URLIndexes と同じ regression guard。
+func TestClipFavoriteRepository_ClipIDIndex(t *testing.T) {
+	// 1. index が存在すること (CONCURRENTLY migration が適用されたことの確認)
+	var indexdef string
+	err := testDB.Raw(
+		`SELECT indexdef FROM pg_indexes WHERE tablename = 'clip_favorite' AND indexname = ?`,
+		"IDX_clip_favorite_clipId",
+	).Scan(&indexdef).Error
+	require.NoError(t, err)
+	require.NotEmpty(t, indexdef, "IDX_clip_favorite_clipId must exist (migration 000062 applied)")
+
+	// 2. planner が CountByClip の equality に index を選べること。小さな test
+	//    テーブルでは planner が seq scan を選ぶため enable_seqscan=off で
+	//    index 経路を強制し、plan に index 名が現れることを確認する。
+	tx := testDB.Begin()
+	defer tx.Rollback()
+	require.NoError(t, tx.Exec(`SET LOCAL enable_seqscan = off`).Error)
+	var lines []string
+	require.NoError(t, tx.Raw(
+		`EXPLAIN SELECT count(*) FROM "clip_favorite" WHERE "clipId" = ?`, "clp_idx_probe",
+	).Scan(&lines).Error)
+	plan := strings.Join(lines, "\n")
+	assert.Contains(t, plan, "IDX_clip_favorite_clipId",
+		"CountByClip query should use IDX_clip_favorite_clipId under enable_seqscan=off; plan was:\n%s", plan)
 }

--- a/migration/000062_clip_favorite_clipid_index.down.sql
+++ b/migration/000062_clip_favorite_clipid_index.down.sql
@@ -1,0 +1,3 @@
+-- CONCURRENTLY で作った index は CONCURRENTLY で drop して write block を避ける
+-- (DROP INDEX CONCURRENTLY も transaction 外・単一文でのみ実行可能)。
+DROP INDEX CONCURRENTLY IF EXISTS "IDX_clip_favorite_clipId";

--- a/migration/000062_clip_favorite_clipid_index.up.sql
+++ b/migration/000062_clip_favorite_clipid_index.up.sql
@@ -1,0 +1,18 @@
+-- #1632 (#1562 follow-up): clip 応答の favoritedCount 実カウント化 (PR #1629)
+-- で追加した ClipFavoriteRepository.CountByClip は
+--   SELECT count(*) FROM "clip_favorite" WHERE "clipId" = ?
+-- で引くが、clip_favorite の index は PK / UNIQUE("userId","clipId") /
+-- IDX("userId") のみで clipId 先頭のものが無く seq scan になる (UNIQUE は
+-- userId が第 1 カラムのため clipId 単独検索に使えない)。clips/list・
+-- users/clips (匿名到達可) は 1 リクエストで最大 100 クリップ ×
+-- (CountByClip + Exists) を実行するため、行数に比例して負荷が累積する。
+--
+-- 本家 Misskey TS の MiClipFavorite (ClipFavorite.ts) にも clipId index は
+-- 存在しない (本家の ClipEntityService.pack の countBy も seq scan)。mk-go
+-- では 000059-000061 (drive_file url index) と同じく実 query 経路の保護を
+-- 優先して独自に追加する。
+--
+-- CONCURRENTLY は transaction 外・単一文でのみ実行できるため、この migration
+-- は 1 文のみで構成する。失敗時の回復手順 (INVALID index の DROP + migrate
+-- dirty 解除) は 000054 のコメントを参照 (対象 index 名は読み替える)。
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_clip_favorite_clipId" ON "clip_favorite" ("clipId");


### PR DESCRIPTION
## Summary

#1562 (PR #1629) で追加した`ClipFavoriteRepository.CountByClip` (clip応答の`favoritedCount`実カウント) は、clip_favoriteのindexがPK / `UNIQUE("userId","clipId")` / `IDX("userId")`のみでclipId先頭のものが無く、seq scanになっていた。`clips/list`・`users/clips` (匿名到達可) は1リクエスト最大100クリップ×(CountByClip + Exists)を実行するため、行数に比例して負荷が累積する。clipId index (`IDX_clip_favorite_clipId`) を追加して解消する。

## 主な変更点

- **migration 000062** (`clip_favorite_clipid_index`): `CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_clip_favorite_clipId" ON "clip_favorite" ("clipId")`
  - CONCURRENTLYはトランザクション外・単一文でのみ実行できるため1 migration 1文 (#1625/PR #1627のdrive_file indexと同パターン)。downは`DROP INDEX CONCURRENTLY`
  - upstream `MiClipFavorite` (ClipFavorite.ts) にもclipId indexは存在しない (本家のpack内countByもseq scan) ことを確認の上、実query経路の保護を優先したmk-go独自追加として根拠をコメントに明記
  - 失敗時の回復手順 (INVALID index対応) は000054コメント参照を案内
- **regression guardテスト** (`TestClipFavoriteRepository_ClipIDIndex`): pg_indexesでのindex存在確認 + `enable_seqscan=off`下のEXPLAINでCountByClip相当queryがindexを使うことを固定。`testutil.ApplyMigrations`はmigrationエラーをswallowするため、guardが無いとindex欠落が沈黙して静かに性能退行する (#1627の`TestDriveFileRepository_URLIndexes`と同形)

## テスト

- 使い捨てPostgreSQL 16で検証:
  - `migrate up` → version 62 clean、index作成確認
  - `down -steps 1` → version 61 clean、index消滅確認
  - 再up → version 62 clean、`indisvalid=t`
  - 39,004行投入+ANALYZE後のEXPLAINで`Bitmap Index Scan on IDX_clip_favorite_clipId`を確認 (seq scan解消)
- `TestClipFavoriteRepository_ClipIDIndex` / `TestClipFavoriteRepository_CountByClip` pass
- `make fmt` / `make lint` / `go test ./internal/repository/` 全pass
- 実行方法: `go test ./internal/repository/ -run "TestClipFavoriteRepository"`

## Closes

Closes #1632

🤖 Generated with [Claude Code](https://claude.com/claude-code)