### PR TITLE
Fix federation: inbound Followのblock起因失敗にReject配送を実装

### DIFF
--- a/internal/core/federation/following_delivery_hook.go
+++ b/internal/core/federation/following_delivery_hook.go
@@ -121,6 +121,32 @@ func (h *FollowingDeliveryHook) SendAcceptForInboundFollow(follower, followee *m
 	return h.deliver.DeliverToUser(followee.ID, follower, body)
 }
 
+// SendRejectForInboundFollow implements InboundFollowAcceptor. local followee
+// が remote follower を block している状態で inbound Follow を受けた場合に、
+// original Follow の raw JSON を Reject に包んで follower の inbox に送る
+// (#1631、upstream UserFollowingService.follow の「ブロックしていた場合は
+// エラーにするのではなく Reject を送り返しておしまい」相当)。これが無いと
+// 相手サーバーの pending follow が永遠に解消されず再送が続く。
+func (h *FollowingDeliveryHook) SendRejectForInboundFollow(follower, followee *model.User, originalFollow json.RawMessage) error {
+	if follower == nil || followee == nil {
+		return nil
+	}
+	if follower.IsLocal() || !followee.IsLocal() {
+		return nil
+	}
+	if follower.URI == nil || *follower.URI == "" {
+		return nil
+	}
+	// SendAcceptForInboundFollow と同じく raw をそのまま object に包む。
+	// 相手サーバーが自分の送った Follow の id と matching できる。
+	reject := h.renderer.RenderReject(followee.ID, originalFollow)
+	body, err := json.Marshal(reject)
+	if err != nil {
+		return err
+	}
+	return h.deliver.DeliverToUser(followee.ID, follower, body)
+}
+
 // OnLocalFollowAccepted sends an Accept activity to a remote follower.
 // 引数: follower がリモート、followee がローカル (Accept の actor)。
 func (h *FollowingDeliveryHook) OnLocalFollowAccepted(follower, followee *model.User) {

--- a/internal/core/federation/following_delivery_hook_test.go
+++ b/internal/core/federation/following_delivery_hook_test.go
@@ -207,3 +207,52 @@ func TestFollowingHook_DeliverErrors_DoNotPanic(t *testing.T) {
 	hook.OnLocalUnfollowed(follower, followee)
 	hook.OnLocalFollowAccepted(followee, follower) // ← follower=remote, followee=local だが key不在
 }
+
+// --- SendRejectForInboundFollow (#1631) ---
+
+func TestFollowingHook_SendRejectForInboundFollow_Remote(t *testing.T) {
+	hook, enq, userRepo, keypairRepo := newFollowingHook(t)
+	followee := makeLocal("bob")
+	userRepo.Users["bob"] = followee
+	keypairRepo.Keypairs["bob"] = &model.UserKeypair{UserID: "bob", PrivateKey: "PEM"}
+	follower := makeRemote("alice", "remote.example", "https://remote.example/users/alice", "https://remote.example/users/alice/inbox")
+
+	raw := json.RawMessage(`{"type":"Follow","id":"https://remote.example/follows/xyz","actor":"https://remote.example/users/alice","object":"https://example.com/users/bob"}`)
+	require.NoError(t, hook.SendRejectForInboundFollow(follower, followee, raw))
+	require.Len(t, enq.calls, 1)
+	assert.Equal(t, "https://remote.example/users/alice/inbox", enq.calls[0].Inbox)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(enq.calls[0].Body, &got))
+	assert.Equal(t, "Reject", got["type"])
+	// Misskey/CherryPick の InboxProcessor は id 無し activity を silent drop
+	// するため、Reject 自体の id が必ず入っていること。
+	rejID, _ := got["id"].(string)
+	assert.NotEmpty(t, rejID, "Reject must carry an id")
+	// original Follow が object としてネストされ、id が保持されること。
+	obj, _ := got["object"].(map[string]any)
+	require.NotNil(t, obj, "original Follow must be nested as object")
+	assert.Equal(t, "https://remote.example/follows/xyz", obj["id"])
+	// actor は rejecting user (local followee)。
+	assert.Equal(t, "https://example.com/users/bob", got["actor"])
+}
+
+func TestFollowingHook_SendRejectForInboundFollow_Guards(t *testing.T) {
+	hook, enq, _, _ := newFollowingHook(t)
+	raw := json.RawMessage(`{"type":"Follow"}`)
+
+	// nil 引数は no-op
+	require.NoError(t, hook.SendRejectForInboundFollow(nil, makeLocal("bob"), raw))
+	require.NoError(t, hook.SendRejectForInboundFollow(makeRemote("a", "h", "u", "i"), nil, raw))
+	// local follower / remote followee 方向は AP 配信不要
+	require.NoError(t, hook.SendRejectForInboundFollow(makeLocal("alice"), makeLocal("bob"), raw))
+	require.NoError(t, hook.SendRejectForInboundFollow(
+		makeRemote("a", "remote.example", "https://remote.example/u/a", "https://remote.example/i"),
+		makeRemote("b", "remote.example", "https://remote.example/u/b", "https://remote.example/i"), raw))
+	// URI 無し remote follower は no-op
+	noURI := &model.User{ID: "c", Username: "c", Host: strPtrFed("remote.example")}
+	require.NoError(t, hook.SendRejectForInboundFollow(noURI, makeLocal("bob"), raw))
+	assert.Empty(t, enq.calls)
+}
+
+func strPtrFed(s string) *string { return &s }

--- a/internal/core/federation/inbound_follow_block_test.go
+++ b/internal/core/federation/inbound_follow_block_test.go
@@ -1,0 +1,128 @@
+package federation_test
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/activitypub"
+	coreblocking "github.com/shiroha-a/mk/internal/core/blocking"
+	"github.com/shiroha-a/mk/internal/core/federation"
+	corefollowing "github.com/shiroha-a/mk/internal/core/following"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newProcessorForInboundFollowBlock wires the processor the same way as
+// production (router.go): followingSvc.SetBlockingChecker(blockingSvc) +
+// processor.SetBlockingService(blockingSvc)。remote alice / local bob を
+// pre-seed して resolver の fetch を回避する (#1631)。
+func newProcessorForInboundFollowBlock(t *testing.T) (
+	*federation.Processor,
+	*testutil.MockBlockingRepository,
+	*testutil.MockFollowingRepository,
+	*stubInboundFollowAcceptor,
+) {
+	t.Helper()
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	blockingRepo := testutil.NewMockBlockingRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	resolver := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(aliceActor)}, idGen)
+	followingSvc := corefollowing.NewService(repo, followingRepo, testutil.NewMockFollowRequestRepository(), idGen)
+	blockingSvc := coreblocking.NewService(repo, blockingRepo, followingRepo, idGen)
+	followingSvc.SetBlockingChecker(blockingSvc)
+	p := federation.NewProcessor(resolver, followingSvc, nil, nil, repo, noteRepo)
+	p.SetBlockingService(blockingSvc)
+	p.SetLocalBaseURL("https://example.com")
+
+	// remote alice を URI 付きで pre-seed (resolver は FindByURI hit で再利用)
+	aliceURI := "https://remote.example/users/alice"
+	host := "remote.example"
+	repo.Users["alice1"] = &model.User{ID: "alice1", Username: "alice", UsernameLower: "alice", URI: &aliceURI, Host: &host}
+	// local bob
+	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob", UsernameLower: "bob"}
+
+	acceptor := &stubInboundFollowAcceptor{}
+	p.SetInboundFollowAcceptor(acceptor)
+	return p, blockingRepo, followingRepo, acceptor
+}
+
+var inboundFollowBody = []byte(`{
+	"type": "Follow",
+	"id": "https://remote.example/follows/blocked1",
+	"actor": "https://remote.example/users/alice",
+	"object": "https://example.com/users/bob"
+}`)
+
+// local followee が remote follower を block している場合、エラーではなく
+// Reject を配送して正常終了する (#1631、upstream UserFollowingService.follow)。
+func TestProcess_FollowBlockedSendsReject(t *testing.T) {
+	p, blockingRepo, followingRepo, acceptor := newProcessorForInboundFollowBlock(t)
+	// bob (local) が alice (remote) を block
+	blockingRepo.Blockings["b1"] = &model.Blocking{ID: "b1", BlockerID: "bob", BlockeeID: "alice1"}
+
+	require.NoError(t, p.Process(inboundFollowBody), "blocked inbound follow must ack, not error")
+	assert.Empty(t, followingRepo.Followings, "no following row must be created")
+	assert.Empty(t, acceptor.calls, "accept must not be sent")
+	require.Len(t, acceptor.rejects, 1, "reject must be delivered")
+	assert.Equal(t, "alice1", acceptor.rejects[0].followerID)
+	assert.Equal(t, "bob", acceptor.rejects[0].followeeID)
+	// original Follow の id を含む raw が Reject の object として渡ること
+	assert.Contains(t, acceptor.rejects[0].followRaw, "https://remote.example/follows/blocked1")
+}
+
+// remote follower が local followee を block している場合、upstream と同じく
+// 自動で block を解除して follow を続行する (#1631)。
+func TestProcess_FollowBlockingAutoUnblocks(t *testing.T) {
+	p, blockingRepo, followingRepo, acceptor := newProcessorForInboundFollowBlock(t)
+	// alice (remote) が bob (local) を block している stale な状態
+	blockingRepo.Blockings["b1"] = &model.Blocking{ID: "b1", BlockerID: "alice1", BlockeeID: "bob"}
+
+	require.NoError(t, p.Process(inboundFollowBody))
+	assert.Empty(t, blockingRepo.Blockings, "stale remote block must be auto-unblocked")
+	assert.Len(t, followingRepo.Followings, 1, "follow must proceed after auto-unblock")
+	assert.Empty(t, acceptor.rejects)
+	require.Len(t, acceptor.calls, 1, "accept must be sent for the established follow")
+}
+
+// 相互 block の場合は upstream の else-if 順と同じく blocked (Reject) を
+// 優先し、remote 側の block 行は解除しない (#1631)。
+func TestProcess_FollowMutualBlockPrefersReject(t *testing.T) {
+	p, blockingRepo, followingRepo, acceptor := newProcessorForInboundFollowBlock(t)
+	blockingRepo.Blockings["b1"] = &model.Blocking{ID: "b1", BlockerID: "alice1", BlockeeID: "bob"}
+	blockingRepo.Blockings["b2"] = &model.Blocking{ID: "b2", BlockerID: "bob", BlockeeID: "alice1"}
+
+	require.NoError(t, p.Process(inboundFollowBody))
+	require.Len(t, acceptor.rejects, 1, "reject must be delivered for the mutual block")
+	assert.Empty(t, followingRepo.Followings)
+	assert.Contains(t, blockingRepo.Blockings, "b1", "remote-side block must not be auto-unblocked when blocked wins")
+	assert.Empty(t, acceptor.calls)
+}
+
+// blockingService 未配線の場合は従来どおりエラーで返る (regression guard)。
+func TestProcess_FollowBlockingWithoutBlockingServiceErrors(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	blockingRepo := testutil.NewMockBlockingRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	resolver := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(aliceActor)}, idGen)
+	followingSvc := corefollowing.NewService(repo, followingRepo, testutil.NewMockFollowRequestRepository(), idGen)
+	blockingSvc := coreblocking.NewService(repo, blockingRepo, followingRepo, idGen)
+	followingSvc.SetBlockingChecker(blockingSvc)
+	p := federation.NewProcessor(resolver, followingSvc, nil, nil, repo, noteRepo)
+	p.SetLocalBaseURL("https://example.com")
+	aliceURI := "https://remote.example/users/alice"
+	host := "remote.example"
+	repo.Users["alice1"] = &model.User{ID: "alice1", Username: "alice", UsernameLower: "alice", URI: &aliceURI, Host: &host}
+	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob", UsernameLower: "bob"}
+	blockingRepo.Blockings["b1"] = &model.Blocking{ID: "b1", BlockerID: "alice1", BlockeeID: "bob"}
+
+	assert.Error(t, p.Process(inboundFollowBody),
+		"without blockingService the ErrBlocking must propagate as before")
+}

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -134,11 +134,15 @@ type Processor struct {
 	inboundFollowAcceptor InboundFollowAcceptor
 }
 
-// InboundFollowAcceptor delivers an Accept activity in response to an inbound
-// Follow. The raw Follow (as received on our inbox) is wrapped as the inner
-// object so the remote server can match the Accept to the original Follow id.
+// InboundFollowAcceptor delivers an Accept or Reject activity in response to
+// an inbound Follow. The raw Follow (as received on our inbox) is wrapped as
+// the inner object so the remote server can match the response to the
+// original Follow id.
 type InboundFollowAcceptor interface {
 	SendAcceptForInboundFollow(follower, followee *model.User, originalFollow json.RawMessage) error
+	// SendRejectForInboundFollow is used when the local followee has blocked
+	// the remote follower (#1631、upstream は error でなく Reject を返す)。
+	SendRejectForInboundFollow(follower, followee *model.User, originalFollow json.RawMessage) error
 }
 
 // SetInboundFollowAcceptor wires the sender that delivers Accept activities
@@ -558,6 +562,40 @@ func (p *Processor) handleFollow(act genericActivity) error {
 	// FollowOptions{} (default false) で作成する (#1056)。remote follower の
 	// per-followee withReplies preference は AP protocol 範囲外。
 	result, err := p.followingService.Follow(follower.ID, followee.ID, corefollowing.FollowOptions{})
+	// block 起因の失敗は upstream UserFollowingService.follow と同じ AP 流儀で
+	// 処理する (#1631)。エラーのまま返すと inbox が retry → dead-letter になり
+	// 相手サーバーの pending follow が永遠に解消されない。
+	if errors.Is(err, corefollowing.ErrBlocking) && !follower.IsLocal() && followee.IsLocal() && p.blockingService != nil {
+		// ErrBlocking = remote follower が local followee を block している。
+		// upstream は相互 block なら blocked (Reject) を優先し、blocking 単独
+		// なら自動で block 解除して follow を続行する。
+		blocked, berr := p.blockingService.IsBlocked(followee.ID, follower.ID)
+		if berr != nil {
+			return berr
+		}
+		if blocked {
+			err = corefollowing.ErrBlocked
+		} else {
+			if uerr := p.blockingService.Unblock(follower.ID, followee.ID); uerr != nil {
+				return fmt.Errorf("inbound follow: auto-unblock %s->%s: %w", follower.ID, followee.ID, uerr)
+			}
+			slog.Info("inbound follow: auto-unblocked stale remote block",
+				"follower", follower.ID, "followee", followee.ID)
+			result, err = p.followingService.Follow(follower.ID, followee.ID, corefollowing.FollowOptions{})
+		}
+	}
+	if errors.Is(err, corefollowing.ErrBlocked) && !follower.IsLocal() && followee.IsLocal() {
+		// local followee が remote follower を block している場合は Reject を
+		// 送り返して正常終了する (upstream「エラーにするのではなく Reject を
+		// 送り返しておしまい」)。配送失敗は Accept 側と同じく warn のみ。
+		if p.inboundFollowAcceptor != nil {
+			if rerr := p.inboundFollowAcceptor.SendRejectForInboundFollow(follower, followee, act.raw); rerr != nil {
+				slog.Warn("inbound follow reject delivery failed",
+					"follower", follower.ID, "followee", followee.ID, "err", rerr)
+			}
+		}
+		return nil
+	}
 	alreadyFollowing := errors.Is(err, corefollowing.ErrAlreadyFollowing)
 	// ErrAlreadyRequested はlocked followeeへの再送。既に FollowRequest が
 	// 存在するので何もしなくて良い (Accept は承認時に送られる)。エラーとして

--- a/internal/core/federation/processor_test.go
+++ b/internal/core/federation/processor_test.go
@@ -56,10 +56,14 @@ func TestProcess_FollowHappyPath(t *testing.T) {
 	assert.Len(t, followingRepo.Followings, 1)
 }
 
-// stubInboundFollowAcceptor records SendAcceptForInboundFollow calls for
-// assertion.
+// stubInboundFollowAcceptor records SendAcceptForInboundFollow /
+// SendRejectForInboundFollow calls for assertion.
 type stubInboundFollowAcceptor struct {
 	calls []struct {
+		followerID, followeeID string
+		followRaw              string
+	}
+	rejects []struct {
 		followerID, followeeID string
 		followRaw              string
 	}
@@ -67,6 +71,14 @@ type stubInboundFollowAcceptor struct {
 
 func (s *stubInboundFollowAcceptor) SendAcceptForInboundFollow(follower, followee *model.User, raw json.RawMessage) error {
 	s.calls = append(s.calls, struct {
+		followerID, followeeID string
+		followRaw              string
+	}{follower.ID, followee.ID, string(raw)})
+	return nil
+}
+
+func (s *stubInboundFollowAcceptor) SendRejectForInboundFollow(follower, followee *model.User, raw json.RawMessage) error {
+	s.rejects = append(s.rejects, struct {
 		followerID, followeeID string
 		followRaw              string
 	}{follower.ID, followee.ID, string(raw)})


### PR DESCRIPTION
## Summary

issue #1631 (#1562/PR #1629のレビューで指摘されたfollow-up) の対応。inbound AP Followがblock関係で失敗すると生のerrorがinboxへ返り、mkq inbox (attempts=8) でretry後dead-letterとなって**相手サーバーには何も返らずpending followが永遠に残り再送が続く**連合互換問題を解消する。

upstream `UserFollowingService.follow` (UserFollowingService.ts:131-143) と同じAP流儀で処理する。

## 主な変更点

- **`internal/core/federation/processor.go` (handleFollow)**:
  - `ErrBlocked` (local followeeがremote followerをblock) → `Reject(Follow)`を配送して正常終了 (ack)。upstreamの「エラーにするのではなくRejectを送り返しておしまい」に対応。配送失敗はAccept側と同じくwarn log+正常終了
  - `ErrBlocking` (remote followerがlocal followeeをblock) → 自動でblock解除してfollowをretry続行 (upstreamの「ブロック解除しておく」)
  - 相互blockはupstreamのelse-if順と同じく**blocked (Reject) を優先**し、remote側のblock行は解除しない
  - `blockingService`未配線時は従来どおりerror伝播 (挙動regressionなし)
- **`internal/core/federation/following_delivery_hook.go`**: `SendRejectForInboundFollow`を`SendAcceptForInboundFollow`と対になる形で新設。original Followのraw JSONを`RenderReject`で包んでremote followerのinboxへ配送するため、相手サーバーが自分の送ったFollow idとmatchingできる。`RenderReject`はid (`{baseURL}/{UUID}`) を必ず付与する実装のため、Misskey/CherryPickのInboxProcessorがid無しactivityをsilent dropする既知の罠は踏まない
- `InboundFollowAcceptor` interfaceに`SendRejectForInboundFollow`を追加 (実装はhookとtest stubのみ)

## 既知の許容divergence

- mk-goの`Follow`はexists checkがblock checkより先のため、already-following + blockedの組はErrAlreadyFollowing→Accept再送になる (blockはfollowを切断するため整合状態では到達不能、#1629レビューで容認済みの順序差)

## テスト

- processor: `TestProcess_FollowBlockedSendsReject` (Reject配送+Following行なし+ack) / `TestProcess_FollowBlockingAutoUnblocks` (block行消滅+Following成立+Accept配送) / `TestProcess_FollowMutualBlockPrefersReject` (Reject優先+remote block行残存) / `TestProcess_FollowBlockingWithoutBlockingServiceErrors` (未配線regression guard)
- hook単体: Rejectのshape検証 (id必須 / object=original raw Followでid保持 / actor=local followee / 配送先=follower inbox)、guard 5種 (nil引数・方向・URI無し)
- federationパッケージカバレッジ90.3% (handleFollow 88.2% / SendRejectForInboundFollow 90.9%)
- `make fmt` / `make lint` / `go test ./... -count=1` 全pass
- 実行方法: `go test ./internal/core/federation/ -run "TestProcess_Follow|TestFollowingHook_SendReject"`

## Closes

Closes #1631

🤖 Generated with [Claude Code](https://claude.com/claude-code)