### PR TITLE
Fix reversi: 並行 ready=true で片方が spurious ALREADY_STARTED を返す問題を修正

### DIFF
--- a/internal/core/reversi/service.go
+++ b/internal/core/reversi/service.go
@@ -390,7 +390,19 @@ func (s *Service) UpdateReady(ctx context.Context, gameID, userID string, ready 
 		Ready: &readyVal,
 	})
 	if game.User1Ready && game.User2Ready {
-		return s.StartGame(ctx, game)
+		// 両者 ready=true を並行送信すると、もう一方の UpdateReady が先に
+		// StartGame を完了させ、こちらの再 read が isStarted=true の game を
+		// 観測することがある。その状態で StartGame を呼ぶと冒頭 guard が
+		// ErrAlreadyStarted を返すが、両者 ready で game が開始済み =
+		// 望む終状態に到達しているので idempotent success として nil に倒す
+		// (#1636)。MarkStarted の atomic claim は started イベントを 1 回に
+		// 抑えており、後勝ち側に spurious な ALREADY_STARTED を返さない。
+		// 非並行の「既に開始済み game への ready 操作」は本関数冒頭の
+		// game.IsStarted guard が引き続き ErrAlreadyStarted を返す。
+		if err := s.StartGame(ctx, game); err != nil && !errors.Is(err, ErrAlreadyStarted) {
+			return err
+		}
+		return nil
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

両プレイヤーが ready=true をほぼ同時に送ると、片方の `UpdateReady` が成功 (nil) でなく `ErrAlreadyStarted` を返すことがある問題を修正する。両者 ready=true で game は正しく開始される (望む終状態) のに、後勝ちした側に spurious な ALREADY_STARTED が返っていた。

`TestService_UpdateReady_ConcurrentBothReady_StartsExactlyOnce` (#1626 で追加) が CI の `-race` + 高負荷下で断続的に落ちる flake の原因でもある (`-race -count=40 -cpu=8` でローカル再現 → 修正後安定)。

## 原因

`UpdateReady` (internal/core/reversi/service.go):

1. A の `UpdateReadyState` が user1Ready=true を書き再 read。
2. その間に B が user2Ready=true を書き both-ready 観測 → `StartGame` で isStarted=true に claim。
3. A の再 read が both-ready かつ isStarted=true の game を返す。
4. A は both-ready なので `StartGame(game)` を呼ぶ。
5. StartGame 冒頭の `if game.IsStarted { return ErrAlreadyStarted }` が発火 → A の UpdateReady が ErrAlreadyStarted を返す。

`MarkStarted` の atomic claim (#1626) は started イベントの二重発火は防いでいたが、claim に負けた側の UpdateReady 戻り値が success にならなかった。

## 修正

`UpdateReady` の both-ready → StartGame 呼び出しで、`ErrAlreadyStarted` (= 並行呼び出しが先に start 済み) を idempotent success として nil に倒す。非並行の「既に開始済みの game への ready 操作」は UpdateReady 冒頭の `game.IsStarted` guard が引き続き ErrAlreadyStarted を返すため、セマンティクスは保たれる。

## テスト

- `TestService_UpdateReady_ConcurrentBothReady_StartsExactlyOnce` が `-race -count=40 -cpu=8` で安定 pass (修正前は同条件で再現)
- reversi パッケージ全体 `-race -count=3` pass
- `make fmt` / `make lint` pass

## Closes

Closes #1636

🤖 Generated with [Claude Code](https://claude.com/claude-code)