### PR TITLE
Fix: entity Note packer の shape/値を upstream に整合

### DIFF
--- a/internal/entity/note.go
+++ b/internal/entity/note.go
@@ -4,11 +4,23 @@ import (
 	"context"
 	"encoding/json"
 	"regexp"
+	"strings"
 
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/datatypes"
 )
+
+// firstNonNil returns the first non-nil/non-empty string among the pointers,
+// mirroring upstream `url ?? uri`. Used by the name-prefixed text formatting.
+func firstNonNil(ps ...*string) string {
+	for _, p := range ps {
+		if p != nil && *p != "" {
+			return *p
+		}
+	}
+	return ""
+}
 
 // BufferedReactionsReader reads buffered reaction deltas (Redis-side)
 // for a batch of notes. enableReactionsBuffering=true な instance では
@@ -55,20 +67,28 @@ type NoteEntity struct {
 	Emojis             map[string]string `json:"emojis"`
 	ChannelID          *string           `json:"channelId,omitempty"`
 	Channel            *ChannelLite      `json:"channel,omitempty"`
-	VisibleUserIDs     []string          `json:"visibleUserIds"`
-	Mentions           []string          `json:"mentions"`
-	HasPoll            bool              `json:"hasPoll"`
-	MyReaction         *string           `json:"myReaction,omitempty"`
-	IsHidden           bool              `json:"isHidden,omitempty"`
+	// visibleUserIds / mentions / hasPoll は upstream NoteEntityService が
+	// specified 以外 / 空 / false のとき undefined にして key を落とす
+	// (note.ts optional:true)。mk-go も omitempty + packer 側 conditional で
+	// 揃える (#1561)。
+	VisibleUserIDs []string `json:"visibleUserIds,omitempty"`
+	Mentions       []string `json:"mentions,omitempty"`
+	HasPoll        bool     `json:"hasPoll,omitempty"`
+	MyReaction     *string  `json:"myReaction,omitempty"`
+	IsHidden       bool     `json:"isHidden,omitempty"`
 }
 
 // ChannelLite is the minimal channel info embedded in NoteEntity.
 type ChannelLite struct {
-	ID                    string `json:"id"`
-	Name                  string `json:"name"`
-	Color                 string `json:"color"`
-	IsSensitive           bool   `json:"isSensitive"`
-	AllowRenoteToExternal bool   `json:"allowRenoteToExternal"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	// UserID は channel の作成者。upstream note.ts:194-197 で channel object 内
+	// の non-optional / nullable:true field として定義され、pack 時に必ず含める
+	// (#1561)。system channel 等で nil のときは null を出すため非 omitempty。
+	UserID                *string `json:"userId"`
+	Color                 string  `json:"color"`
+	IsSensitive           bool    `json:"isSensitive"`
+	AllowRenoteToExternal bool    `json:"allowRenoteToExternal"`
 }
 
 // PollEntity is the poll representation in a note.
@@ -137,9 +157,10 @@ func packPoll(p *model.Poll) *PollEntity {
 // counts/hasPoll), so the frontend still renders a "hidden post" placeholder
 // card. Used by both the REST and streaming embed-visibility gates (#1536).
 //
-// visibleUserIds / fileIds / files は non-nil 空スライスにして JSON で [] を出す。
-// upstream hideNote は visibleUserIds を undefined にして key 自体を落とすが、
-// mk-go は全 note で visibleUserIds:[] を出す既存仕様 (packNoteAtDepth) に揃える。
+// fileIds / files は non-nil 空スライスにして JSON で [] を出す。
+// visibleUserIds は upstream hideNote (NoteEntityService.ts:184) と同じく nil に
+// して omitempty で key を落とす (#1561 で packer 全体を specified 限定 +
+// omitempty 化したことに合わせる)。
 func HideNoteEntity(n *NoteEntity) {
 	if n == nil {
 		return
@@ -149,7 +170,7 @@ func HideNoteEntity(n *NoteEntity) {
 	n.Poll = nil
 	n.FileIDs = make([]string, 0)
 	n.Files = []any{}
-	n.VisibleUserIDs = make([]string, 0)
+	n.VisibleUserIDs = nil
 	n.IsHidden = true
 }
 
@@ -164,21 +185,44 @@ func packNoteAtDepth(n *model.Note, idGen id.Generator, depth int) NoteEntity {
 		fileIDs = n.FileIDs
 	}
 
-	visibleUserIDs := make([]string, 0)
-	if n.VisibleUserIDs != nil {
-		visibleUserIDs = n.VisibleUserIDs
+	// visibleUserIds は visibility=specified のときだけ出す (upstream
+	// NoteEntityService.ts:405 `visibility==='specified' ? visibleUserIds :
+	// undefined`、#1561)。それ以外は nil のままにして omitempty で省略する。
+	var visibleUserIDs []string
+	if n.Visibility == model.NoteVisibilitySpecified {
+		visibleUserIDs = make([]string, 0)
+		if n.VisibleUserIDs != nil {
+			visibleUserIDs = n.VisibleUserIDs
+		}
 	}
 
-	mentions := make([]string, 0)
-	if n.Mentions != nil {
+	// mentions は空のとき省略する (upstream NoteEntityService.ts:427
+	// `mentions.length>0 ? mentions : undefined`、#1561)。空 slice を渡すと
+	// omitempty で消えるので nil/空のままで良い。
+	var mentions []string
+	if len(n.Mentions) > 0 {
 		mentions = n.Mentions
+	}
+
+	// name 付き note (AP の Page/Link 等) は upstream NoteEntityService.ts:379-381
+	// と同じく text を `【name】\n{text}\n\n{url??uri}` に整形する (#1561)。
+	text := n.Text
+	if n.Name != nil && *n.Name != "" {
+		if link := firstNonNil(n.URL, n.URI); link != "" {
+			body := ""
+			if n.Text != nil {
+				body = strings.TrimSpace(*n.Text)
+			}
+			formatted := "【" + *n.Name + "】\n" + body + "\n\n" + link
+			text = &formatted
+		}
 	}
 
 	entity := NoteEntity{
 		ID:                 n.ID,
 		CreatedAt:          createdAt,
 		UserID:             n.UserID,
-		Text:               n.Text,
+		Text:               text,
 		CW:                 n.CW,
 		Visibility:         string(n.Visibility),
 		LocalOnly:          n.LocalOnly,
@@ -188,7 +232,7 @@ func packNoteAtDepth(n *model.Note, idGen id.Generator, depth int) NoteEntity {
 		ReactionEmojis:     make(map[string]string),
 		RenoteCount:        n.RenoteCount,
 		RepliesCount:       n.RepliesCount,
-		ClippedCount:       0,
+		ClippedCount:       int(n.ClippedCount),
 		URI:                n.URI,
 		URL:                n.URL,
 		ReplyID:            n.ReplyID,

--- a/internal/entity/note_field_resolver.go
+++ b/internal/entity/note_field_resolver.go
@@ -428,6 +428,7 @@ func applyChannel(n *NoteEntity, chMap map[string]*model.Channel) {
 		target.Channel = &ChannelLite{
 			ID:                    ch.ID,
 			Name:                  ch.Name,
+			UserID:                ch.UserID,
 			Color:                 ch.Color,
 			IsSensitive:           ch.IsSensitive,
 			AllowRenoteToExternal: ch.AllowRenoteToExternal,

--- a/internal/entity/note_hide_test.go
+++ b/internal/entity/note_hide_test.go
@@ -50,8 +50,10 @@ func TestHideNoteEntity_BlanksExactlySevenFields(t *testing.T) {
 	if n.Files == nil || len(n.Files) != 0 {
 		t.Errorf("Files not blanked to empty: %v", n.Files)
 	}
-	if n.VisibleUserIDs == nil || len(n.VisibleUserIDs) != 0 {
-		t.Errorf("VisibleUserIDs not blanked to empty: %v", n.VisibleUserIDs)
+	// #1561: upstream hideNote は visibleUserIds=undefined。mk-go も nil にして
+	// omitempty で省略する。
+	if n.VisibleUserIDs != nil {
+		t.Errorf("VisibleUserIDs must be nil (omitted), got: %v", n.VisibleUserIDs)
 	}
 	if !n.IsHidden {
 		t.Error("IsHidden not set")
@@ -87,13 +89,18 @@ func TestHideNoteEntity_JSONShape(t *testing.T) {
 		t.Fatal(err)
 	}
 	s := string(b)
-	for _, want := range []string{`"text":null`, `"cw":null`, `"fileIds":[]`, `"files":[]`, `"visibleUserIds":[]`, `"isHidden":true`} {
+	for _, want := range []string{`"text":null`, `"cw":null`, `"fileIds":[]`, `"files":[]`, `"isHidden":true`} {
 		if !strings.Contains(s, want) {
 			t.Errorf("hidden JSON missing %s\n%s", want, s)
 		}
 	}
 	if strings.Contains(s, `"poll"`) {
 		t.Errorf("poll must be omitted from hidden JSON\n%s", s)
+	}
+	// #1561: upstream hideNote は visibleUserIds=undefined。omitempty で key 自体
+	// が落ちること (`"visibleUserIds":[]` を出さない) を固定する。
+	if strings.Contains(s, `"visibleUserIds"`) {
+		t.Errorf("visibleUserIds must be omitted from hidden JSON (upstream undefined)\n%s", s)
 	}
 }
 

--- a/internal/entity/note_test.go
+++ b/internal/entity/note_test.go
@@ -189,12 +189,19 @@ func TestPackNote_NilVisibleUserIDs_Mentions(t *testing.T) {
 
 	entity := PackNote(note, idGen)
 
-	// nil → empty slice
-	assert.NotNil(t, entity.VisibleUserIDs)
-	assert.Empty(t, entity.VisibleUserIDs)
-	assert.NotNil(t, entity.Mentions)
-	assert.Empty(t, entity.Mentions)
+	// #1561: public note では visibleUserIds は省略 (specified 限定) / mentions は
+	// 空なら省略 / hasPoll は false なら省略 → いずれも nil で omitempty が落とす。
+	assert.Nil(t, entity.VisibleUserIDs, "public note omits visibleUserIds")
+	assert.Nil(t, entity.Mentions, "empty mentions omitted")
 	assert.False(t, entity.HasPoll)
+
+	// JSON でも該当 key が出ないこと。
+	b, err := json.Marshal(entity)
+	require.NoError(t, err)
+	s := string(b)
+	assert.NotContains(t, s, `"visibleUserIds"`)
+	assert.NotContains(t, s, `"mentions"`)
+	assert.NotContains(t, s, `"hasPoll"`)
 }
 
 func TestNormalizeReactionKey(t *testing.T) {

--- a/internal/entity/parity_1561_test.go
+++ b/internal/entity/parity_1561_test.go
@@ -1,0 +1,113 @@
+package entity
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+)
+
+// #1561 [MEDIUM] clippedCount は model 実値を出す (旧: 0 ハードコード)。
+func TestPackNote_ClippedCountRealValue(t *testing.T) {
+	idGen := newTestIDGen(t)
+	n := &model.Note{
+		ID: idGen.Generate(time.Now()), UserID: "u1",
+		Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}")),
+		ClippedCount: 5,
+	}
+	assert.Equal(t, 5, PackNote(n, idGen).ClippedCount)
+}
+
+// #1561 [MEDIUM] visibleUserIds は specified のときだけ出力する。
+func TestPackNote_VisibleUserIDsSpecifiedOnly(t *testing.T) {
+	idGen := newTestIDGen(t)
+	base := func(vis model.NoteVisibility) *model.Note {
+		return &model.Note{
+			ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: vis,
+			Reactions: datatypes.JSON([]byte("{}")), VisibleUserIDs: []string{"a", "b"},
+		}
+	}
+	// specified: 出力される
+	spec := PackNote(base(model.NoteVisibilitySpecified), idGen)
+	assert.Equal(t, []string{"a", "b"}, spec.VisibleUserIDs)
+	bs, _ := json.Marshal(spec)
+	assert.Contains(t, string(bs), `"visibleUserIds":["a","b"]`)
+	// public: VisibleUserIDs が DB にあっても省略
+	pub := PackNote(base(model.NoteVisibilityPublic), idGen)
+	assert.Nil(t, pub.VisibleUserIDs)
+	bp, _ := json.Marshal(pub)
+	assert.NotContains(t, string(bp), `"visibleUserIds"`)
+}
+
+// #1561 [MEDIUM] name 付き note は text を 【name】prefix 整形する。
+func TestPackNote_NamePrefixedText(t *testing.T) {
+	idGen := newTestIDGen(t)
+	name := "Page Title"
+	body := "  hello body  "
+	url := "https://remote.example/pages/x"
+	n := &model.Note{
+		ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: model.NoteVisibilityPublic,
+		Reactions: datatypes.JSON([]byte("{}")), Name: &name, Text: &body, URL: &url,
+	}
+	got := PackNote(n, idGen)
+	require.NotNil(t, got.Text)
+	assert.Equal(t, "【Page Title】\nhello body\n\nhttps://remote.example/pages/x", *got.Text)
+
+	// url が無く uri があれば uri を使う。text が nil でも空本文で整形。
+	uri := "https://remote.example/notes/y"
+	n2 := &model.Note{
+		ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: model.NoteVisibilityPublic,
+		Reactions: datatypes.JSON([]byte("{}")), Name: &name, URI: &uri,
+	}
+	got2 := PackNote(n2, idGen)
+	require.NotNil(t, got2.Text)
+	assert.Equal(t, "【Page Title】\n\n\nhttps://remote.example/notes/y", *got2.Text)
+
+	// name はあるが url/uri が無ければ整形しない (text そのまま)。
+	n3 := &model.Note{
+		ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: model.NoteVisibilityPublic,
+		Reactions: datatypes.JSON([]byte("{}")), Name: &name, Text: &body,
+	}
+	assert.Equal(t, body, *PackNote(n3, idGen).Text)
+}
+
+// #1561 [MEDIUM] channel.userId が出力される (nil なら null)。
+func TestApplyChannel_UserID(t *testing.T) {
+	owner := "channel-owner"
+	chMap := map[string]*model.Channel{
+		"ch1": {ID: "ch1", Name: "general", UserID: &owner, Color: "#fff"},
+	}
+	chID := "ch1"
+	n := &NoteEntity{ID: "n1", ChannelID: &chID}
+	applyChannel(n, chMap)
+	require.NotNil(t, n.Channel)
+	require.NotNil(t, n.Channel.UserID)
+	assert.Equal(t, "channel-owner", *n.Channel.UserID)
+	b, _ := json.Marshal(n.Channel)
+	assert.Contains(t, string(b), `"userId":"channel-owner"`)
+}
+
+// #1561 [LOW] hasPoll は true のときだけ出力 / mentions は空なら省略。
+func TestPackNote_HasPollAndMentionsOmit(t *testing.T) {
+	idGen := newTestIDGen(t)
+	// hasPoll=true + mentions あり → 出力
+	withPoll := &model.Note{
+		ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: model.NoteVisibilityPublic,
+		Reactions: datatypes.JSON([]byte("{}")), HasPoll: true, Mentions: []string{"m1"},
+	}
+	bp, _ := json.Marshal(PackNote(withPoll, idGen))
+	assert.Contains(t, string(bp), `"hasPoll":true`)
+	assert.Contains(t, string(bp), `"mentions":["m1"]`)
+	// hasPoll=false + mentions 空 → 省略
+	plain := &model.Note{
+		ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: model.NoteVisibilityPublic,
+		Reactions: datatypes.JSON([]byte("{}")),
+	}
+	bn, _ := json.Marshal(PackNote(plain, idGen))
+	assert.NotContains(t, string(bn), `"hasPoll"`)
+	assert.NotContains(t, string(bn), `"mentions"`)
+}


### PR DESCRIPTION
## Summary

互換性監査 issue #1561 (entity:Note packer、1H/4M/6L) の対応。現行コードで未対応だった packer の shape/値の差分を upstream Misskey TS `NoteEntityService` / `note.ts` に整合させる。

**再検証で「既に実装済み」と判明した項目** (監査は #1536/#1568 等の後続実装より前に書かれており古い):
- **[HIGH] shouldHideNote / hideNote / treatVisibility (content blanking / isHidden)**: `internal/api/notehide` + `internal/core/note` (HideEmbedDecision / HideNoteByPrefsDecision) + `entity.HideNoteEntity` で実装済み。isHidden=true もセットされ、treatVisibility 降格 (makeNotesFollowersOnlyBefore) / requireSigninToViewContents / makeNotesHiddenBefore も適用される。**本 PR 対象外**。
- **[LOW] deletedAt**: TS 自身 pack に入れない vestigial schema field。mk-go 出力なしが正。**対象外**。

## 主な変更点 (still-real だった項目)

- **[MEDIUM] clippedCount**: `model.Note.ClippedCount` の実値を出力 (旧: 0 ハードコード)
- **[MEDIUM] visibleUserIds**: `visibility=specified` のときだけ出力し、それ以外は省略 (omitempty + packer conditional、upstream NoteEntityService.ts:405)
- **[MEDIUM] channel.userId**: `ChannelLite` に `userId` (nullable, 常に出力) を追加し applyChannel でセット (upstream note.ts:194-197)
- **[MEDIUM] text の 【name】整形**: name 付き note (AP の Page/Link 等) で `text = 【{name}】\n{text.trim()}\n\n{url??uri}` に整形 (upstream ts:379-381)
- **[LOW] mentions**: 空なら省略 (omitempty、upstream ts:427)
- **[LOW] hasPoll**: false なら省略 (omitempty、upstream ts:428)
- **HideNoteEntity**: visibleUserIds を nil 化 (upstream hideNote=undefined に整合。従来は `[]` を残していた)

## クライアント安全性

省略する field (visibleUserIds/mentions/hasPoll) は misskey-js が `optional` 型 (`?:`) で生成し、json-schema も `optional:true`。**TS server 自身がこれらを省略する**ため、TS 互換クライアント (misskey-js / misskey_dart) は元々欠落に耐える設計で、本変更は drop-in 互換を改善する方向。

## 敵対的レビュー (parity / hide gate 干渉 / client 破壊) → 指摘なし

- specified note は依然 visibleUserIds を保持するため、notehide / stream の specified-hide 判定 (embedFactsFromEntity) は無傷
- HideNoteEntity の nil 化は最終 blank 処理で判定ロジックより後段、二重 hide なし
- 既知の軽微差 (LOW、修正不要): specified かつ visibleUserIds 空の退化ケースで TS=`[]` / mk-go=key 省略。実運用の specified note は必ず 1 人以上指定するため影響なし

## follow-up (本 PR 対象外)

- **[LOW] emojis の local note 省略**: 厳密対応には `Emojis` を pointer 型 (`*map[string]string`) に変える必要がある (value map + omitempty だと remote-empty emojis `{}` を誤って省略し逆方向の差分を生む)。resolver/test への ripple があるため別途。
- **[LOW] reactionAndUserPairCache**: `withReactionAndUserPairCache=true` 時のみ TS が出す opt-in 出力 field。default off。
- **[LOW] myReaction の 2 秒新着 guard / pairCache 優先**: perf 最適化。mk-go は実値を返す (機能的にはより正確)。

## テスト

- entity 単体: clippedCount 実値 / visibleUserIds specified 限定 / 【name】text 整形 (url・uri・text nil・name のみ各ケース) / channel.userId / hasPoll・mentions の omit。既存の HideNoteEntity / PackNote shape テストを新挙動に追従
- `make fmt` / `make lint` / entitycompat (golden_schemas shape gate) / `go test ./... -count=1` 全 pass
- 実行方法: `go test ./internal/entity/`

## Closes

Closes #1561

🤖 Generated with [Claude Code](https://claude.com/claude-code)