### PR TITLE
Fix: Note packer の emojis を remote note のみ出力する

### DIFF
--- a/internal/entity/emoji_resolver.go
+++ b/internal/entity/emoji_resolver.go
@@ -138,25 +138,26 @@ func NewEmojiResolver(lookup EmojiLookup, notes []*model.Note) *EmojiResolver {
 	return r
 }
 
-// PopulateNoteEmojis resolves emoji names stored in note.Emojis to URLs
-// and sets entity.Emojis. no-opの場合entity.Emojisは変更しない
-// (PackNoteが設定した空mapを維持する)。
+// PopulateNoteEmojis resolves emoji names stored in note.Emojis to URLs and
+// fills entity.Emojis. local note (host==nil) は packNoteAtDepth が
+// entity.Emojis を nil にしているため何もしない (upstream は local の emojis を
+// 出さない、#1639)。remote note は packNoteAtDepth が &{} を確保済みなので、
+// 解決できた emoji を流し込む (解決ゼロでも &{} のまま = 空 object 出力)。
 func (r *EmojiResolver) PopulateNoteEmojis(note *model.Note, entity *NoteEntity) {
-	if r == nil || note == nil || entity == nil || len(note.Emojis) == 0 {
+	if r == nil || note == nil || entity == nil || entity.Emojis == nil {
+		return
+	}
+	if len(note.Emojis) == 0 {
 		return
 	}
 	host := ""
 	if note.UserHost != nil {
 		host = *note.UserHost
 	}
-	emojis := make(map[string]string, len(note.Emojis))
 	for _, name := range note.Emojis {
 		if url, ok := r.cache[name+"@"+host]; ok {
-			emojis[name] = url
+			(*entity.Emojis)[name] = url
 		}
-	}
-	if len(emojis) > 0 {
-		entity.Emojis = emojis
 	}
 }
 

--- a/internal/entity/emoji_resolver_test.go
+++ b/internal/entity/emoji_resolver_test.go
@@ -96,13 +96,15 @@ func TestPopulateNoteEmojis(t *testing.T) {
 	}
 
 	r := NewEmojiResolver(lookup, []*model.Note{note})
-	entity := &NoteEntity{}
+	// remote note は packNoteAtDepth が Emojis=&{} を確保する。ここでは
+	// resolver 単体を試すため同様に事前確保する (#1639)。
+	entity := &NoteEntity{Emojis: &map[string]string{}}
 	r.PopulateNoteEmojis(note, entity)
 
 	// note.Emojisに対応するURLがentity.Emojisに設定される
 	require.NotNil(t, entity.Emojis)
-	assert.Equal(t, "https://remote.example/emoji/fire.webp", entity.Emojis["fire"])
-	assert.Equal(t, "https://remote.example/emoji/star.webp", entity.Emojis["star"])
+	assert.Equal(t, "https://remote.example/emoji/fire.webp", (*entity.Emojis)["fire"])
+	assert.Equal(t, "https://remote.example/emoji/star.webp", (*entity.Emojis)["star"])
 }
 
 func TestPopulateNoteEmojis_Empty(t *testing.T) {
@@ -115,12 +117,12 @@ func TestPopulateNoteEmojis_Empty(t *testing.T) {
 	}
 
 	r := NewEmojiResolver(lookup, []*model.Note{note})
-	entity := &NoteEntity{Emojis: map[string]string{"existing": "value"}}
+	entity := &NoteEntity{Emojis: &map[string]string{"existing": "value"}}
 
 	r.PopulateNoteEmojis(note, entity)
 
 	// 空emojisの場合、entity.Emojisは変更されない
-	assert.Equal(t, map[string]string{"existing": "value"}, entity.Emojis)
+	assert.Equal(t, map[string]string{"existing": "value"}, *entity.Emojis)
 }
 
 func TestPopulateUserEmojis(t *testing.T) {
@@ -190,9 +192,9 @@ func TestEmojiResolver_NilLookup(t *testing.T) {
 	assert.Empty(t, r.cache)
 
 	// PopulateNoteEmojisはno-op
-	entity := &NoteEntity{Emojis: map[string]string{"keep": "this"}}
+	entity := &NoteEntity{Emojis: &map[string]string{"keep": "this"}}
 	r.PopulateNoteEmojis(note, entity)
-	assert.Equal(t, map[string]string{"keep": "this"}, entity.Emojis)
+	assert.Equal(t, map[string]string{"keep": "this"}, *entity.Emojis)
 
 	// PopulateUserEmojisもno-op
 	user := &model.User{
@@ -259,11 +261,11 @@ func TestEmojiResolver_LocalEmojis(t *testing.T) {
 	// cacheに "name@" (空host) のキーで格納される
 	assert.Equal(t, "https://local.example/emoji/local_emoji.png", r.cache["local_emoji@"])
 
-	// PopulateNoteEmojisでローカル絵文字が解決される
+	// #1639: local note (UserHost==nil) は emojis field を出さない。packNoteAtDepth
+	// が Emojis=nil にするため、resolver は populate せず nil のままになる。
 	entity := &NoteEntity{}
 	r.PopulateNoteEmojis(note, entity)
-	require.NotNil(t, entity.Emojis)
-	assert.Equal(t, "https://local.example/emoji/local_emoji.png", entity.Emojis["local_emoji"])
+	assert.Nil(t, entity.Emojis, "local note must omit emojis (#1639)")
 }
 
 func TestEmojiResolver_PublicURLFallback(t *testing.T) {
@@ -289,10 +291,10 @@ func TestEmojiResolver_PublicURLFallback(t *testing.T) {
 	// PublicURLが空なのでOriginalURLが使われる
 	assert.Equal(t, "https://remote.example/emoji/rare_orig.png", r.cache["rare@remote.example"])
 
-	entity := &NoteEntity{}
+	entity := &NoteEntity{Emojis: &map[string]string{}}
 	r.PopulateNoteEmojis(note, entity)
 	require.NotNil(t, entity.Emojis)
-	assert.Equal(t, "https://remote.example/emoji/rare_orig.png", entity.Emojis["rare"])
+	assert.Equal(t, "https://remote.example/emoji/rare_orig.png", (*entity.Emojis)["rare"])
 }
 
 func TestEmojiResolver_MultipleHosts(t *testing.T) {
@@ -336,17 +338,17 @@ func TestEmojiResolver_MultipleHosts(t *testing.T) {
 	assert.Equal(t, "https://beta.example/emoji/wave.png", r.cache["wave@beta.example"])
 
 	// note1のemojisはalpha.exampleから解決される
-	entityA := &NoteEntity{}
+	entityA := &NoteEntity{Emojis: &map[string]string{}}
 	r.PopulateNoteEmojis(notes[0], entityA)
 	require.NotNil(t, entityA.Emojis)
-	assert.Equal(t, "https://alpha.example/emoji/smile.png", entityA.Emojis["smile"])
+	assert.Equal(t, "https://alpha.example/emoji/smile.png", (*entityA.Emojis)["smile"])
 
 	// note2のemojisはbeta.exampleから解決される
-	entityB := &NoteEntity{}
+	entityB := &NoteEntity{Emojis: &map[string]string{}}
 	r.PopulateNoteEmojis(notes[1], entityB)
 	require.NotNil(t, entityB.Emojis)
-	assert.Equal(t, "https://beta.example/emoji/smile.png", entityB.Emojis["smile"])
-	assert.Equal(t, "https://beta.example/emoji/wave.png", entityB.Emojis["wave"])
+	assert.Equal(t, "https://beta.example/emoji/smile.png", (*entityB.Emojis)["smile"])
+	assert.Equal(t, "https://beta.example/emoji/wave.png", (*entityB.Emojis)["wave"])
 }
 
 func TestNewEmojiResolver_NilNotesInSlice(t *testing.T) {
@@ -585,12 +587,12 @@ func TestPopulateNoteEmojis_UnresolvedEmojiExcluded(t *testing.T) {
 	}
 
 	r := NewEmojiResolver(lookup, []*model.Note{note})
-	entity := &NoteEntity{}
+	entity := &NoteEntity{Emojis: &map[string]string{}}
 	r.PopulateNoteEmojis(note, entity)
 
 	// cacheに存在する絵文字のみがentity.Emojisに含まれる
 	require.NotNil(t, entity.Emojis)
-	assert.Equal(t, "https://remote.example/emoji/known.png", entity.Emojis["known"])
-	_, exists := entity.Emojis["unknown"]
+	assert.Equal(t, "https://remote.example/emoji/known.png", (*entity.Emojis)["known"])
+	_, exists := (*entity.Emojis)["unknown"]
 	assert.False(t, exists, "unknown emoji should not be in entity.Emojis")
 }

--- a/internal/entity/note.go
+++ b/internal/entity/note.go
@@ -64,9 +64,13 @@ type NoteEntity struct {
 	Files              []any             `json:"files"`
 	Tags               []string          `json:"tags,omitempty"`
 	Poll               *PollEntity       `json:"poll,omitempty"`
-	Emojis             map[string]string `json:"emojis"`
-	ChannelID          *string           `json:"channelId,omitempty"`
-	Channel            *ChannelLite      `json:"channel,omitempty"`
+	// Emojis は upstream NoteEntityService.ts:412 `host != null ? populateEmojis
+	// : undefined` に合わせ、remote note (author host != nil) のみ出力する
+	// (custom emoji が無くても `{}`)。local note は nil → omitempty で省略
+	// (#1639)。pointer 型なので nil(省略) と &{}(空 object 出力) を区別できる。
+	Emojis    *map[string]string `json:"emojis,omitempty"`
+	ChannelID *string            `json:"channelId,omitempty"`
+	Channel   *ChannelLite       `json:"channel,omitempty"`
 	// visibleUserIds / mentions / hasPoll は upstream NoteEntityService が
 	// specified 以外 / 空 / false のとき undefined にして key を落とす
 	// (note.ts optional:true)。mk-go も omitempty + packer 側 conditional で
@@ -204,6 +208,16 @@ func packNoteAtDepth(n *model.Note, idGen id.Generator, depth int) NoteEntity {
 		mentions = n.Mentions
 	}
 
+	// emojis は remote note (author host != nil) のときだけ出力する (upstream
+	// NoteEntityService.ts:412、#1639)。remote は custom emoji が無くても &{} で
+	// 空 object を出し、local は nil のままにして omitempty で key を省略する。
+	// 実際の URL は PopulateNoteEmojis が後段でこの map に流し込む。
+	var emojis *map[string]string
+	if n.UserHost != nil {
+		m := make(map[string]string)
+		emojis = &m
+	}
+
 	// name 付き note (AP の Page/Link 等) は upstream NoteEntityService.ts:379-381
 	// と同じく text を `【name】\n{text}\n\n{url??uri}` に整形する (#1561)。
 	text := n.Text
@@ -240,7 +254,7 @@ func packNoteAtDepth(n *model.Note, idGen id.Generator, depth int) NoteEntity {
 		FileIDs:            fileIDs,
 		Files:              []any{},
 		Tags:               n.Tags,
-		Emojis:             make(map[string]string),
+		Emojis:             emojis,
 		ChannelID:          n.ChannelID,
 		VisibleUserIDs:     visibleUserIDs,
 		Mentions:           mentions,

--- a/internal/entity/note_hide_test.go
+++ b/internal/entity/note_hide_test.go
@@ -80,7 +80,7 @@ func TestHideNoteEntity_JSONShape(t *testing.T) {
 		ID: "n", CreatedAt: "2026-01-02T03:04:05.000Z", UserID: "a",
 		User: UserLite{ID: "a"}, Text: &text, Visibility: "followers",
 		Reactions: datatypes.JSON([]byte(`{}`)), ReactionEmojis: map[string]string{},
-		Emojis: map[string]string{}, FileIDs: []string{"f"}, Files: []any{},
+		FileIDs: []string{"f"}, Files: []any{},
 		VisibleUserIDs: []string{"u"}, Mentions: []string{},
 	}
 	HideNoteEntity(n)

--- a/internal/entity/note_test.go
+++ b/internal/entity/note_test.go
@@ -49,8 +49,8 @@ func TestPackNote_Basic(t *testing.T) {
 	assert.Equal(t, []string{"file1", "file2"}, entity.FileIDs)
 	assert.Equal(t, []string{"tag1"}, entity.Tags)
 	assert.NotEmpty(t, entity.CreatedAt)
-	assert.NotNil(t, entity.Emojis)
-	assert.Empty(t, entity.Emojis)
+	// #1639: local note (UserHost==nil) は emojis を出さない (nil → 省略)。
+	assert.Nil(t, entity.Emojis)
 	assert.NotNil(t, entity.Files)
 	assert.Empty(t, entity.Files)
 }
@@ -348,7 +348,8 @@ func TestPackNotes_EmbeddedRenoteHasInstanceAndEmoji(t *testing.T) {
 	require.NotNil(t, out[0].Renote)
 	require.NotNil(t, out[0].Renote.User.Instance)
 	assert.Equal(t, strPtr("Remote"), out[0].Renote.User.Instance.Name)
-	assert.Equal(t, "https://remote.example/emoji/wave.png", out[0].Renote.Emojis["wave"])
+	require.NotNil(t, out[0].Renote.Emojis)
+	assert.Equal(t, "https://remote.example/emoji/wave.png", (*out[0].Renote.Emojis)["wave"])
 	assert.Equal(t, "https://remote.example/emoji/wave.png", out[0].Renote.User.Emojis["wave"])
 }
 

--- a/internal/entity/parity_1561_test.go
+++ b/internal/entity/parity_1561_test.go
@@ -111,3 +111,43 @@ func TestPackNote_HasPollAndMentionsOmit(t *testing.T) {
 	assert.NotContains(t, string(bn), `"hasPoll"`)
 	assert.NotContains(t, string(bn), `"mentions"`)
 }
+
+// #1639 [LOW] emojis は remote note (host!=nil) のみ出力 (custom emoji 無くても
+// {})、local note (host==nil) は省略する (upstream NoteEntityService.ts:412)。
+func TestPackNote_EmojisRemoteOnly(t *testing.T) {
+	idGen := newTestIDGen(t)
+	remote := "remote.example"
+
+	// local note: emojis 省略 (nil)
+	local := &model.Note{
+		ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: model.NoteVisibilityPublic,
+		Reactions: datatypes.JSON([]byte("{}")),
+	}
+	lp := PackNote(local, idGen)
+	assert.Nil(t, lp.Emojis, "local note omits emojis")
+	// top-level の emojis key が無いことを確認 (user.emojis の null と混同しない
+	// よう unmarshal して top-level key の有無で判定)。
+	var lm map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(mustJSON(t, lp), &lm))
+	_, hasLocal := lm["emojis"]
+	assert.False(t, hasLocal, "local note must omit top-level emojis")
+
+	// remote note: custom emoji 無くても emojis={} を出力
+	rmt := &model.Note{
+		ID: idGen.Generate(time.Now()), UserID: "u2", UserHost: &remote,
+		Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}")),
+	}
+	rp := PackNote(rmt, idGen)
+	require.NotNil(t, rp.Emojis, "remote note always carries emojis object")
+	assert.Empty(t, *rp.Emojis)
+	var rm map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(mustJSON(t, rp), &rm))
+	assert.Equal(t, "{}", string(rm["emojis"]), "remote note outputs emojis:{}")
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}


### PR DESCRIPTION
## Summary

issue #1639 (#1561/PR #1638 の follow-up) の対応。upstream Misskey TS `NoteEntityService.ts:412` は `emojis: host != null ? populateEmojis(note.emojis, host) : undefined` で、**remote note (author host != nil) のみ emojis を出力**し (custom emoji が無くても `{}`)、**local note (host==nil) は field 自体を省略**する (`const host = note.userHost`)。

mk-go は `NoteEntity.Emojis` を常に空 map で初期化し host を問わず出力していたため、local note でも `"emojis":{}` が漏れていた。

## 主な変更点

- `NoteEntity.Emojis` を `map[string]string` → `*map[string]string` (`omitempty`) に変更。pointer 化により nil(local→省略) と `&{}`(remote-empty→`{}` 出力) を区別する。**value map + omitempty では remote-empty emojis (`{}`) も省略されてしまい、逆方向の差分を生む**ため pointer が必須 (#1639 起票時に明記した設計)
- `packNoteAtDepth`: remote note は `&{}` を確保、local note は nil
- `PopulateNoteEmojis`: local (Emojis==nil) は populate せず skip、remote は確保済み map に解決 URL を流し込む

`reactionEmojis` (reaction に使われた emoji) は upstream でも host を問わず populate される別 field で、本変更の対象外 (mk-go でも別フィールド)。

## クライアント安全性

`emojis` は misskey-js が `optional` 型、json-schema も `optional:true`。TS server 自身が local note で省略するため、TS 互換クライアントは欠落に耐える。

## テスト

- 回帰: `TestPackNote_EmojisRemoteOnly` (local→top-level emojis 省略 / remote→`{}` 出力。user.emojis の null と混同しないよう unmarshal して top-level key で判定)
- 既存の emoji resolver テストを pointer 型に追従。`TestEmojiResolver_LocalEmojis` は #1639 の挙動 (local は emojis を出さない) に更新
- `make fmt` / `make lint` / entitycompat (golden_schemas) gate / `go test ./... -count=1` 全 pass

## Closes

Closes #1639

🤖 Generated with [Claude Code](https://claude.com/claude-code)