### PR TITLE
Fix: streaming note event に reactionAndUserPairCache を出力する

### DIFF
--- a/internal/entity/note.go
+++ b/internal/entity/note.go
@@ -79,7 +79,14 @@ type NoteEntity struct {
 	Mentions       []string `json:"mentions,omitempty"`
 	HasPoll        bool     `json:"hasPoll,omitempty"`
 	MyReaction     *string  `json:"myReaction,omitempty"`
-	IsHidden       bool     `json:"isHidden,omitempty"`
+	// ReactionAndUserPairCache は `userId/reaction` 形式の pair 配列で、
+	// クライアントが myReaction を API 無しで解決するために使う。upstream は
+	// opts.withReactionAndUserPairCache=true のときだけ出力し (空でも `[]`)、
+	// その指定は streaming / AP 経路 (NoteCreateService / ApInboxService) に
+	// 限られる (#1640)。REST pack では undefined。pointer 型で nil(REST→省略)
+	// と &[](streaming→空配列出力) を区別する。
+	ReactionAndUserPairCache *[]string `json:"reactionAndUserPairCache,omitempty"`
+	IsHidden                 bool      `json:"isHidden,omitempty"`
 }
 
 // ChannelLite is the minimal channel info embedded in NoteEntity.

--- a/internal/entity/parity_1561_test.go
+++ b/internal/entity/parity_1561_test.go
@@ -151,3 +151,20 @@ func mustJSON(t *testing.T, v any) []byte {
 	require.NoError(t, err)
 	return b
 }
+
+// #1640 [LOW] REST pack (PackNote) は reactionAndUserPairCache を出さない
+// (upstream は withReactionAndUserPairCache=true の streaming/AP 経路のみ出力)。
+func TestPackNote_ReactionAndUserPairCacheOmittedInREST(t *testing.T) {
+	idGen := newTestIDGen(t)
+	n := &model.Note{
+		ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: model.NoteVisibilityPublic,
+		Reactions:                datatypes.JSON([]byte("{}")),
+		ReactionAndUserPairCache: []string{"userA/👍"},
+	}
+	got := PackNote(n, idGen)
+	assert.Nil(t, got.ReactionAndUserPairCache, "REST pack omits reactionAndUserPairCache")
+	var m map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(mustJSON(t, got), &m))
+	_, has := m["reactionAndUserPairCache"]
+	assert.False(t, has, "REST JSON must not contain reactionAndUserPairCache")
+}

--- a/internal/stream/note_publisher.go
+++ b/internal/stream/note_publisher.go
@@ -117,6 +117,17 @@ func (p *NotePublisher) packNote(n *model.Note, author *model.User) []byte {
 	// context.Background() で進める (#657)。将来 PublishNote signature に
 	// ctx を追加するなら一緒に伝播させる。
 	pn := entity.PackNoteWithInstance(context.Background(), &noteForPack, p.idGen, p.instanceLookup, p.emojiLookup, p.reactionReader)
+	// streaming note event は upstream NoteCreateService が
+	// withReactionAndUserPairCache=true で pack する経路に対応するため、
+	// reactionAndUserPairCache を (空でも) 出力する (#1640)。REST pack は
+	// 出さない。mk-go は reaction-user pair を Redis buffer しない (deltas
+	// のみ) ので DB の note.reactionAndUserPairCache をそのまま使う
+	// (buffered pairs の concat は未対応)。
+	pairs := []string(noteForPack.ReactionAndUserPairCache)
+	if pairs == nil {
+		pairs = []string{}
+	}
+	pn.ReactionAndUserPairCache = &pairs
 	// REST 経路と同じ後段 resolver を通して Files / Channel を埋める。
 	// viewer 引数は streaming fanout の性質上「自分宛て」が複数 subscriber
 	// に展開されるため特定不能。viewer=nil で Apply を呼ぶと

--- a/internal/stream/note_publisher_test.go
+++ b/internal/stream/note_publisher_test.go
@@ -704,3 +704,37 @@ func TestDrivePublisher_MarshalErrorIsLogged(t *testing.T) {
 func TestNotificationPublisher_ImplementsServiceInterface(t *testing.T) {
 	var _ corenotification.StreamingPublisher = (*NotificationPublisher)(nil)
 }
+
+// #1640: streaming note event は reactionAndUserPairCache を出力する
+// (upstream NoteCreateService の withReactionAndUserPairCache=true 経路相当)。
+// REST pack は出さないが streaming は空でも [] を出す。
+func TestNotePublisher_EmitsReactionAndUserPairCache(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+
+	// pair あり → 配列を出力
+	pub := &stubPublisher{}
+	np := NewNotePublisher(pub, idGen)
+	n := &model.Note{
+		ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: model.NoteVisibilityPublic,
+		ReactionAndUserPairCache: []string{"userA/👍", "userB/❤"},
+	}
+	np.PublishNote("homeTimeline:u1", n, &model.User{ID: "u1", Username: "alice"})
+	require.Len(t, pub.payloads, 1)
+	var m map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(pub.payloads[0].(json.RawMessage), &m))
+	require.Contains(t, m, "reactionAndUserPairCache")
+	assert.JSONEq(t, `["userA/👍","userB/❤"]`, string(m["reactionAndUserPairCache"]))
+
+	// pair 空 → streaming は [] を出す (REST と異なり key を残す)
+	pub2 := &stubPublisher{}
+	np2 := NewNotePublisher(pub2, idGen)
+	n2 := &model.Note{
+		ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: model.NoteVisibilityPublic,
+	}
+	np2.PublishNote("homeTimeline:u1", n2, &model.User{ID: "u1", Username: "alice"})
+	require.Len(t, pub2.payloads, 1)
+	var m2 map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(pub2.payloads[0].(json.RawMessage), &m2))
+	require.Contains(t, m2, "reactionAndUserPairCache")
+	assert.Equal(t, "[]", string(m2["reactionAndUserPairCache"]))
+}


### PR DESCRIPTION
## Summary

issue #1640 (#1561/PR #1638 の follow-up) の対応。upstream Misskey TS は `opts.withReactionAndUserPairCache=true` のとき note packed に `reactionAndUserPairCache` (`userId/reaction` 形式の pair 配列、空でも `[]`) を出力する。その指定は `NoteCreateService` / `ApInboxService` の **streaming / AP 経路に限られ、REST endpoint では出さない**。

mk-go の streaming note publisher (`stream/note_publisher.go`) は upstream NoteCreateService の pack 経路に対応するため、ここで出力する。REST pack (PackNote/PackNotes) は従来どおり出さない (= TS REST と一致)。

## 主な変更点

- `NoteEntity.ReactionAndUserPairCache` を `*[]string` + `omitempty` で追加。**pointer 型で nil(REST→省略) と `&[]`(streaming→空でも `[]` 出力) を区別**する (value slice + omitempty では streaming-empty も省略され、TS が `[]` を出すのと差が出るため)
- `stream/note_publisher`: `model.Note.ReactionAndUserPairCache` を詰める (空でも `&[]`)

## 既知の制約 (PR本文明記)

mk-go は reaction-user pair を Redis buffer しない (deltas のみ buffer) ため、DB の `note.reactionAndUserPairCache` のみを使う。upstream の buffered pairs の concat (`bufferedReactions.pairs`) は未対応 — enableReactionsBuffering 環境で flush 前の pair が streaming note に載らない差が残るが、機能的には myReaction の client 側解決のヒントが一部欠けるだけで実害は小さい。embed (renote/reply) への伝播も top-level note のみ (upstream は embed にも option を伝播)。

## テスト

- `TestNotePublisher_EmitsReactionAndUserPairCache`: streaming note event が pair ありで配列、空でも `[]` を出力
- `TestPackNote_ReactionAndUserPairCacheOmittedInREST`: REST pack は field を省略
- `make fmt` / `make lint` / entitycompat (golden_schemas) gate / `go test ./... -count=1` 全 pass

## Closes

Closes #1640

🤖 Generated with [Claude Code](https://claude.com/claude-code)