### PR TITLE
Perf: myReaction は reactionCount>0 の note のみ fetch する

### DIFF
--- a/internal/api/notes/resolve_viewer_fields_test.go
+++ b/internal/api/notes/resolve_viewer_fields_test.go
@@ -22,10 +22,13 @@ func TestResolveViewerFields_MyReactionEmbedded(t *testing.T) {
 	reactionRepo.Reactions["renote"] = &model.NoteReaction{ID: "renote", UserID: "v1", NoteID: "n2", Reaction: "❤"}
 	reactionRepo.Reactions["reply"] = &model.NoteReaction{ID: "reply", UserID: "v1", NoteID: "n3", Reaction: "🎉"}
 
+	// #1641: myReaction は reactionCount>0 の note のみ fetch するので、
+	// reaction 登録済み note には ReactionCount を立てる。
 	notes := []entity.NoteEntity{{
-		ID:     "n1",
-		Renote: &entity.NoteEntity{ID: "n2"},
-		Reply:  &entity.NoteEntity{ID: "n3"},
+		ID:            "n1",
+		ReactionCount: 1,
+		Renote:        &entity.NoteEntity{ID: "n2", ReactionCount: 1},
+		Reply:         &entity.NoteEntity{ID: "n3", ReactionCount: 1},
 	}}
 	viewer := &model.User{ID: "v1"}
 

--- a/internal/entity/note_field_resolver.go
+++ b/internal/entity/note_field_resolver.go
@@ -315,15 +315,32 @@ func appendNoteFileIDs(dst []string, n *NoteEntity) []string {
 	return dst
 }
 
+// appendNoteIDs collects note IDs whose viewer myReaction should be batch
+// fetched. reactionCount==0 の note は誰も reaction していない = viewer の
+// reaction もあり得ないので fetch 対象から外す (upstream populateMyReaction の
+// `if (reactionsCount === 0) return undefined` 相当、#1641)。これにより
+// reaction の無い note が多い timeline では IN リストが縮み myReaction の
+// batch SELECT が軽くなる。
+//
+// upstream の「作成 2 秒以内は fetch skip」guard と reactionAndUserPairCache
+// 優先参照は mk-go では採用しない (#1641 の意図的 divergence):
+//   - 2 秒 guard は per-note fetch を避ける TS の最適化だが、mk-go は元から
+//     ページ単位の単一 batch SELECT なので不要。むしろ guard を入れると直前に
+//     自分が reaction した直後 (<2s) の note で myReaction が undefined になり
+//     機能的に劣化する。mk-go は実値を返す方を優先する。
+//   - reactionAndUserPairCache 優先は REST note が pairCache を持たない
+//     (#1640 で streaming 限定) ため REST 経路では効かない。
 func appendNoteIDs(dst []string, n *NoteEntity) []string {
 	if n == nil {
 		return dst
 	}
-	dst = append(dst, n.ID)
-	if n.Renote != nil {
+	if n.ReactionCount > 0 {
+		dst = append(dst, n.ID)
+	}
+	if n.Renote != nil && n.Renote.ReactionCount > 0 {
 		dst = append(dst, n.Renote.ID)
 	}
-	if n.Reply != nil {
+	if n.Reply != nil && n.Reply.ReactionCount > 0 {
 		dst = append(dst, n.Reply.ID)
 	}
 	return dst

--- a/internal/entity/note_field_resolver_test.go
+++ b/internal/entity/note_field_resolver_test.go
@@ -100,11 +100,15 @@ func TestNoteFieldResolver_ResolveViewerFields_EmbedsRenoteAndReply(t *testing.T
 	}}
 	r := NewNoteFieldResolver(nil, nil, nil, reactions, channels, makeIDGen(t))
 
+	// #1641: myReaction は reactionCount>0 の note だけ fetch するので、
+	// reaction を持つ note には ReactionCount を立てる (reaction row があるのに
+	// count=0 は本来あり得ない状態)。
 	notes := []NoteEntity{{
-		ID:        "n1",
-		ChannelID: &chID,
-		Renote:    &NoteEntity{ID: "n2", ChannelID: &chID},
-		Reply:     &NoteEntity{ID: "n3"},
+		ID:            "n1",
+		ChannelID:     &chID,
+		ReactionCount: 1,
+		Renote:        &NoteEntity{ID: "n2", ChannelID: &chID, ReactionCount: 1},
+		Reply:         &NoteEntity{ID: "n3", ReactionCount: 1},
 	}}
 	r.ResolveViewerFields(notes, &model.User{ID: "v1"})
 
@@ -434,4 +438,40 @@ func TestPackPoll(t *testing.T) {
 	assert.Equal(t, 1, got3.Choices[0].Votes)
 	assert.Equal(t, 0, got3.Choices[1].Votes)
 	assert.Equal(t, 0, got3.Choices[2].Votes)
+}
+
+// #1641: reactionCount==0 の note は myReaction fetch 対象から外す
+// (upstream populateMyReaction の reactionsCount===0 skip 相当)。
+type countingReactionLookup struct {
+	rows      map[string]*model.NoteReaction
+	queriedID []string
+}
+
+func (s *countingReactionLookup) FindByUserAndNoteIDs(_ string, noteIDs []string) (map[string]*model.NoteReaction, error) {
+	s.queriedID = append(s.queriedID, noteIDs...)
+	out := make(map[string]*model.NoteReaction, len(noteIDs))
+	for _, nid := range noteIDs {
+		if r, ok := s.rows[nid]; ok {
+			out[nid] = r
+		}
+	}
+	return out, nil
+}
+
+func TestNoteFieldResolver_MyReaction_SkipsZeroReactionNotes(t *testing.T) {
+	reactions := &countingReactionLookup{rows: map[string]*model.NoteReaction{
+		"hot": {NoteID: "hot", Reaction: "👍"},
+	}}
+	r := NewNoteFieldResolver(nil, nil, nil, reactions, nil, makeIDGen(t))
+
+	notes := []NoteEntity{
+		{ID: "hot", ReactionCount: 3},  // reaction あり → fetch 対象
+		{ID: "cold", ReactionCount: 0}, // reaction 無し → skip
+	}
+	r.ResolveViewerFields(notes, &model.User{ID: "v1"})
+
+	// fetch されたのは reactionCount>0 の "hot" のみ
+	assert.Equal(t, []string{"hot"}, reactions.queriedID)
+	require.NotNil(t, notes[0].MyReaction)
+	assert.Nil(t, notes[1].MyReaction, "zero-reaction note must not get myReaction")
 }


### PR DESCRIPTION
## Summary

issue #1641 (#1561/PR #1638 の follow-up) の対応。upstream `populateMyReaction` (`NoteEntityService.ts:233-271`) は `reactionsCount===0` の note で即 `undefined` を返し DB fetch を避ける。mk-go の myReaction batch 解決 (`NoteFieldResolver.ResolveViewerFields` → `appendNoteIDs`) は reaction 数に関係なく全 note を IN リストに入れていた。

## 主な変更点

- `appendNoteIDs` で **ReactionCount>0 の note (top-level / renote / reply) のみ**を myReaction fetch 対象にする。reactionCount==0 は誰も reaction していない = viewer の reaction もあり得ないので安全に skip でき、reaction の少ない timeline では myReaction の batch SELECT の IN リストが縮む。本番では `NoteEntity.ReactionCount = sumReactions(reactions)` なので、viewer の reaction を持つ note は必ず ReactionCount>=1 になり取りこぼしは無い

## 意図的に採用しない upstream 最適化 (コメントで明記)

- **作成 2 秒以内の fetch skip guard**: mk-go は元からページ単位の単一 batch SELECT なので per-note fetch 回避の guard は不要。むしろ導入すると **直前に自分が reaction した直後 (<2s) の note で myReaction が undefined になり機能劣化**する。mk-go は実値返却を優先する (機能的により正確で、TS のこの guard は純粋な per-note-fetch 回避の最適化)
- **reactionAndUserPairCache 優先参照**: REST note は pairCache を持たない (#1640 で streaming 限定にした) ため REST 経路では効かない。mk-go の batch query は既に 1 query/page で、pairCache が回避しようとする per-note fetch がそもそも無い

## テスト

- `TestNoteFieldResolver_MyReaction_SkipsZeroReactionNotes`: reactionCount==0 の note は fetch 対象外 (IN リストに入らない)、reactionCount>0 のみ myReaction 解決
- reaction 登録済み note の既存テスト (`TestNoteFieldResolver_ResolveViewerFields_EmbedsRenoteAndReply` / `TestResolveViewerFields_MyReactionEmbedded`) を、reaction 行があるのに ReactionCount=0 という非現実的な状態から ReactionCount>0 に修正
- `make fmt` / `make lint` / `go test ./... -count=1` 全 pass

## Closes

Closes #1641

🤖 Generated with [Claude Code](https://claude.com/claude-code)