### PR TITLE
Fix federation inbox: Update(Person) full refresh ほか inbound parity 6 件 (#1560 part 1/3)

### DIFF
--- a/internal/core/federation/parity_1560_inbound_test.go
+++ b/internal/core/federation/parity_1560_inbound_test.go
@@ -1,0 +1,155 @@
+package federation_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/activitypub"
+	coreblocking "github.com/shiroha-a/mk/internal/core/blocking"
+	"github.com/shiroha-a/mk/internal/core/federation"
+	corefollowing "github.com/shiroha-a/mk/internal/core/following"
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newProcForInbound1560 wires a processor exposing user/note/following repos
+// for the #1560 inbound tests.
+func newProcForInbound1560(t *testing.T, fetcherBody string) (
+	*federation.Processor, *testutil.MockUserRepository,
+	*testutil.MockNoteRepository, *testutil.MockFollowingRepository,
+) {
+	t.Helper()
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	blockingRepo := testutil.NewMockBlockingRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	resolver := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(fetcherBody)}, idGen)
+	followingSvc := corefollowing.NewService(repo, followingRepo, testutil.NewMockFollowRequestRepository(), idGen)
+	blockingSvc := coreblocking.NewService(repo, blockingRepo, followingRepo, idGen)
+	p := federation.NewProcessor(resolver, followingSvc, nil, nil, repo, noteRepo)
+	p.SetBlockingService(blockingSvc)
+	p.SetLocalBaseURL("https://example.com")
+	return p, repo, noteRepo, followingRepo
+}
+
+// #1560 [MEDIUM] Undo(Accept): remote followee が accept を撤回 → local
+// follower の following を解除する。
+func TestProcess_UndoAccept_Unfollows(t *testing.T) {
+	p, repo, _, followingRepo := newProcForInbound1560(t, aliceActor)
+	// remote followee alice
+	aliceURI := "https://remote.example/users/alice"
+	host := "remote.example"
+	repo.Users["alice1"] = &model.User{ID: "alice1", Username: "alice", UsernameLower: "alice", URI: &aliceURI, Host: &host}
+	// local follower bob が alice を follow 済み
+	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob", UsernameLower: "bob"}
+	followingRepo.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "bob", FolloweeID: "alice1"}
+
+	body := []byte(`{
+		"type": "Undo",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"type": "Accept",
+			"actor": "https://remote.example/users/alice",
+			"object": {
+				"type": "Follow",
+				"actor": "https://example.com/users/bob",
+				"object": "https://remote.example/users/alice"
+			}
+		}
+	}`)
+	require.NoError(t, p.Process(body))
+	assert.Empty(t, followingRepo.Followings, "Undo(Accept) must remove the following")
+}
+
+// #1560 [LOW] suspended remote actor の activity は dispatch 前に drop。
+func TestProcess_SuspendedActorDropped(t *testing.T) {
+	p, repo, noteRepo, _ := newProcForInbound1560(t, aliceActor)
+	suspendedURI := "https://remote.example/users/alice"
+	host := "remote.example"
+	repo.Users["alice1"] = &model.User{ID: "alice1", Username: "alice", URI: &suspendedURI, Host: &host, IsSuspended: true}
+	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob"}
+
+	// suspended actor からの Create は無視され note が作られない
+	body := []byte(`{
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {"id":"https://remote.example/notes/x","type":"Note","attributedTo":"https://remote.example/users/alice","content":"hi","to":["https://www.w3.org/ns/activitystreams#Public"]}
+	}`)
+	require.NoError(t, p.Process(body))
+	assert.Empty(t, noteRepo.Notes, "suspended actor activity must be dropped")
+}
+
+// #1560 [LOW] bearcaps (bear:) object URI は Create/Announce で skip。
+func TestProcess_BearcapsObjectSkipped(t *testing.T) {
+	p, repo, noteRepo, _ := newProcForInbound1560(t, aliceActor)
+	aliceURI := "https://remote.example/users/alice"
+	host := "remote.example"
+	repo.Users["alice1"] = &model.User{ID: "alice1", Username: "alice", URI: &aliceURI, Host: &host}
+
+	create := []byte(`{
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": "bear:?u=https://remote.example/notes/x&t=token"
+	}`)
+	require.NoError(t, p.Process(create), "bearcaps Create must be ack-skipped")
+	assert.Empty(t, noteRepo.Notes)
+
+	announce := []byte(`{
+		"type": "Announce",
+		"actor": "https://remote.example/users/alice",
+		"object": "bear:?u=https://remote.example/notes/y&t=token"
+	}`)
+	require.NoError(t, p.Process(announce), "bearcaps Announce must be ack-skipped")
+	assert.Empty(t, noteRepo.Notes)
+}
+
+// #1560 [LOW] Announce: 非公開 (followers/specified) note の boost は drop。
+func TestProcess_AnnounceNonPublicSkipped(t *testing.T) {
+	p, repo, noteRepo, _ := newProcForInbound1560(t, aliceActor)
+	aliceURI := "https://remote.example/users/alice"
+	host := "remote.example"
+	repo.Users["alice1"] = &model.User{ID: "alice1", Username: "alice", URI: &aliceURI, Host: &host}
+	noteRepo.Notes["nf"] = &model.Note{ID: "nf", UserID: "bob", Visibility: model.NoteVisibilityFollowers}
+
+	body := []byte(`{
+		"type": "Announce",
+		"id": "https://remote.example/announces/a1",
+		"actor": "https://remote.example/users/alice",
+		"object": "https://example.com/notes/nf"
+	}`)
+	require.NoError(t, p.Process(body))
+	for _, n := range noteRepo.Notes {
+		assert.Nil(t, n.RenoteID, "non-public note must not be announced (no renote created)")
+	}
+}
+
+// #1560 [LOW] Announce: published < target createdAt の malformed timestamp は drop。
+func TestProcess_AnnounceMalformedCreatedAtSkipped(t *testing.T) {
+	p, repo, noteRepo, _ := newProcForInbound1560(t, aliceActor)
+	aliceURI := "https://remote.example/users/alice"
+	host := "remote.example"
+	repo.Users["alice1"] = &model.User{ID: "alice1", Username: "alice", URI: &aliceURI, Host: &host}
+
+	// target note を未来時刻の aidx ID で作る → published(過去) より後に created。
+	idGen, _ := id.NewGenerator("aidx")
+	future := time.Now().Add(48 * time.Hour)
+	futureID := idGen.Generate(future)
+	noteRepo.Notes[futureID] = &model.Note{ID: futureID, UserID: "bob", Visibility: model.NoteVisibilityPublic}
+
+	body := []byte(`{
+		"type": "Announce",
+		"id": "https://remote.example/announces/a2",
+		"actor": "https://remote.example/users/alice",
+		"object": "https://example.com/notes/` + futureID + `",
+		"published": "2020-01-01T00:00:00Z"
+	}`)
+	require.NoError(t, p.Process(body))
+	for _, n := range noteRepo.Notes {
+		assert.Nil(t, n.RenoteID, "announce published before target createdAt must be dropped")
+	}
+}

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -346,6 +346,18 @@ func (p *Processor) Process(body []byte) error {
 		return errors.New("activity missing actor")
 	}
 
+	// upstream performOneActivity は actor.isSuspended なら dispatch 前に
+	// 早期 return する (ApInboxService.ts:144、#1560)。mk-go は既知の
+	// suspended remote actor を DB lookup で判定して drop する (新規 actor は
+	// まだ DB に無く suspended にもなり得ないので素通し)。fetch はせず DB read
+	// のみなので追加コストは小さい。
+	if p.userRepo != nil {
+		if actor, err := p.userRepo.FindByURI(act.Actor); err == nil && actor != nil && actor.IsSuspended {
+			slog.Info("federation: dropping activity from suspended actor", "actor", act.Actor, "type", act.Type)
+			return nil
+		}
+	}
+
 	switch strings.ToLower(act.Type) {
 	case "follow":
 		return p.handleFollow(act)
@@ -639,6 +651,8 @@ func (p *Processor) handleUndo(act genericActivity) error {
 		return p.handleUndoAnnounce(act, inner)
 	case "block":
 		return p.handleUndoBlock(act, inner)
+	case "accept":
+		return p.handleUndoAccept(act, inner)
 	case "emojireaction", "emojireact":
 		return p.handleUndoLike(act, inner)
 	case "invite":
@@ -656,6 +670,52 @@ func (p *Processor) handleUndo(act genericActivity) error {
 		return nil
 	}
 	return ErrUnsupportedActivity
+}
+
+// handleUndoAccept processes an inbound Undo(Accept): a remote followee revokes
+// a previously-accepted follow, which means we should drop our local follower's
+// following relationship to them (upstream ApInboxService.undoAccept、#1560)。
+//
+// 二段ネスト: act=Undo, inner=Accept, inner.Object=元の Follow。
+//   - act.Actor       = remote followee (accept を撤回した側)
+//   - Follow.actor     = local follower (フォローしていた側)
+//
+// follower→followee の Following があれば Unfollow する。
+func (p *Processor) handleUndoAccept(act genericActivity, inner genericActivity) error {
+	followee, err := p.resolver.ResolveActor(act.Actor)
+	if err != nil {
+		return err
+	}
+	// inner.Object は元の Follow。その actor が local follower。
+	var follow genericActivity
+	if uerr := json.Unmarshal(inner.Object, &follow); uerr != nil {
+		// object が Follow の URI 文字列だけのケースは follower を特定できない。
+		// upstream は getUserFromApId(activity.object) で解決するが、mk-go では
+		// Follow URI から follower を逆引きする経路が無いので skip (ack)。
+		return nil
+	}
+	follow.normalizeActor(inner.Object)
+	followerURI, err := readActorString(follow)
+	if err != nil || followerURI == "" {
+		return nil
+	}
+	var follower *model.User
+	if localID := p.resolver.ExtractLocalUserID(followerURI); localID != "" {
+		follower, err = p.userRepo.FindByID(localID)
+	} else {
+		follower, err = p.userRepo.FindByURI(followerURI)
+	}
+	if err != nil || follower == nil {
+		return nil
+	}
+	if err := p.followingService.Unfollow(follower.ID, followee.ID); err != nil {
+		// フォローしていなければ no-op (upstream の 'skip: フォローされていない')。
+		if errors.Is(err, corefollowing.ErrNotFollowing) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 // handleUndoFollow undoes a previously created Follow.
@@ -980,6 +1040,12 @@ func encodeAudienceIfChanged(raw json.RawMessage, merged []string) (json.RawMess
 // 1-on-1 chat federation。notes テーブルではなく chat_messages として処理する
 // ため IngestNote をスキップして chatService にルートする (#692)。
 func (p *Processor) handleCreate(act genericActivity) error {
+	// bearcaps (bear:) object URI は未対応として skip する (#1560、upstream
+	// ApInboxService.create の 'skip: bearcaps url not supported')。
+	if isBearcapURI(act.Object) {
+		slog.Info("federation: skipping Create with bearcaps object url", "actor", act.Actor)
+		return nil
+	}
 	actor, err := p.resolver.ResolveActor(act.Actor)
 	if err != nil {
 		if errors.Is(err, ErrHostNotAllowed) {
@@ -1216,6 +1282,12 @@ func (p *Processor) handleLike(act genericActivity) error {
 
 // handleAnnounce creates a renote pointing at the announced note.
 func (p *Processor) handleAnnounce(act genericActivity) error {
+	// bearcaps (bear:) object URI は未対応として skip (#1560、upstream
+	// ApInboxService.announce の 'skip: bearcaps url not supported')。
+	if isBearcapURI(act.Object) {
+		slog.Info("federation: skipping Announce with bearcaps object url", "actor", act.Actor)
+		return nil
+	}
 	announcer, err := p.resolver.ResolveActor(act.Actor)
 	if err != nil {
 		// permanent な actor resolve 失敗は ack して skip (#1183、handleLike
@@ -1250,6 +1322,26 @@ func (p *Processor) handleAnnounce(act genericActivity) error {
 	// 場合のみ relay 由来と判定。
 	if p.relayActorChecker != nil && p.relayActorChecker.IsRelayActor(announcer) {
 		return p.publishRelayDeliveredNote(target, targetURI, act.Actor)
+	}
+	// upstream announceNote の 2 つの skip guard (#1560、ApInboxService.ts:350-361):
+	//   1. !isVisibleForMe(renote, actor): boost は public/home の note にしか
+	//      行えない。followers / specified の note を announce してくる activity は
+	//      不正なので drop する (mk-go は remote-remote の follow graph を持たない
+	//      ため、isVisibleForMe を「対象が public/home か」で近似する)。
+	//   2. activity.published < 対象 note の createdAt: announce が対象 note より
+	//      前に published されたと主張する malformed timestamp は drop する。
+	if target.Visibility != model.NoteVisibilityPublic && target.Visibility != model.NoteVisibilityHome {
+		slog.Info("federation: skipping Announce of non-public note", "object", targetURI, "actor", act.Actor, "visibility", target.Visibility)
+		return nil
+	}
+	if act.Published != "" {
+		if published, perr := time.Parse(time.RFC3339, act.Published); perr == nil {
+			if targetCreated, terr := p.resolver.idGen.ParseTime(target.ID); terr == nil && published.Before(targetCreated) {
+				slog.Info("federation: skipping Announce with malformed createdAt (published before target)",
+					"object", targetURI, "actor", act.Actor)
+				return nil
+			}
+		}
 	}
 	// announce 自身に id があれば URI として保存し、重複検出にも使う。
 	// upstream Misskey #17356 (= 2026.5.1 fix) は同 activity の重複処理 race を
@@ -1485,20 +1577,20 @@ func (p *Processor) handleUpdate(act genericActivity) error {
 		// Question / Article 等は未対応
 		return nil
 	}
-	user, err := p.userRepo.FindByURI(person.ID)
-	if err != nil {
+	if _, err := p.userRepo.FindByURI(person.ID); err != nil {
 		// 未取得のリモートユーザーなら無視 (次回 follow/inbox などで取り込まれる)
 		return nil
 	}
-	fields := map[string]any{}
-	if person.Name != "" {
-		name := person.Name
-		fields["name"] = &name
+	// upstream ApInboxService.update -> ApPersonService.updatePerson は actor を
+	// 強制再取得して name だけでなく avatar/banner/bio/fields/isBot/isCat/
+	// isLocked/movedTo/alsoKnownAs/emojis 等の全プロフィールを更新する (#1560)。
+	// mk-go も ForceResolveActor (TTL バイパスで refreshActor を回す既存経路、
+	// handleMove と同じ) を呼んで full refresh する。旧実装は name のみ反映して
+	// いた。fetch 失敗時は refreshActor が silent に既存値を維持する。
+	if _, err := p.resolver.ForceResolveActor(person.ID); err != nil {
+		return err
 	}
-	if len(fields) == 0 {
-		return nil
-	}
-	return p.userRepo.UpdateUser(user.ID, fields)
+	return nil
 }
 
 // peekObjectType reads only the "type" field from a JSON object body. パース
@@ -1514,6 +1606,33 @@ func peekObjectType(raw json.RawMessage) string {
 		return ""
 	}
 	return obj.Type
+}
+
+// objectAPID extracts the AP id of an activity object whether it is encoded as
+// a bare string URI or as an object with an "id" field (upstream getApId 相当)。
+func objectAPID(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var obj struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(raw, &obj); err == nil {
+		return obj.ID
+	}
+	return ""
+}
+
+// isBearcapURI reports whether the object id is a bearcaps (`bear:`) URI.
+// upstream create()/announce() は bearcaps を未対応として skip する
+// (ApInboxService.ts:401,291、#1560)。mk-go の resolver も bear: を扱えないため
+// fetch で error にする前に cleanly skip する。
+func isBearcapURI(raw json.RawMessage) bool {
+	return strings.HasPrefix(objectAPID(raw), "bear:")
 }
 
 // handleReject undoes a Follow that was rejected by the followee.
@@ -1651,35 +1770,37 @@ func (p *Processor) handleFlag(act genericActivity) error {
 	if len(uris) == 0 {
 		return errors.New("flag: empty object")
 	}
-	// 最初のURIからターゲットユーザーを特定
+	// upstream flag() は object URI を config.url + '/users/' prefix の LOCAL
+	// user URI に絞ってから user id に map し users[0] を報告対象にする
+	// (#1560、ApInboxService.ts:560-577)。mk-go も ExtractLocalUserID で
+	// `{baseURL}/users/{id}` 形式のローカル URI だけを対象にする。旧実装は
+	// 任意 host の user/note URI を受け、note 作者 (リモート可) まで fallback
+	// して別 instance のユーザーを誤って報告し得た。
 	var targetUserID string
 	for _, uri := range uris {
-		if u, err := p.userRepo.FindByURI(uri); err == nil {
+		localID := p.resolver.ExtractLocalUserID(uri)
+		if localID == "" {
+			continue
+		}
+		if u, err := p.userRepo.FindByID(localID); err == nil && u != nil {
 			targetUserID = u.ID
 			break
 		}
 	}
 	if targetUserID == "" {
-		// ノートURIからユーザーを特定する試み
-		for _, uri := range uris {
-			if n, err := p.noteRepo.FindByURI(uri); err == nil {
-				targetUserID = n.UserID
-				break
-			}
-		}
+		// ローカル user を 1 件も解決できない Flag は ack して drop する
+		// (リモート対象や不正 URI。retry しても解決しないため error にしない)。
+		slog.Info("federation: skipping Flag with no resolvable local target", "actor", act.Actor)
+		return nil
 	}
-	if targetUserID == "" {
-		return errors.New("flag: cannot resolve target user")
-	}
-	// contentフィールドを取得
+	// contentフィールドを取得。upstream は comment に flagged URI 一覧を
+	// 付与する (`${content}\n${JSON.stringify(uris)}`、#1560)。
 	var content struct {
 		Content string `json:"content"`
 	}
 	_ = json.Unmarshal(act.raw, &content)
-	comment := content.Content
-	if comment == "" {
-		comment = "(flagged via ActivityPub)"
-	}
+	urisJSON, _ := json.Marshal(uris)
+	comment := content.Content + "\n" + string(urisJSON)
 	report := &model.AbuseUserReport{
 		ID:             p.abuseIDGen.Generate(nowFn()),
 		TargetUserID:   targetUserID,

--- a/internal/core/federation/processor_step_f_test.go
+++ b/internal/core/federation/processor_step_f_test.go
@@ -1051,9 +1051,22 @@ func TestProcess_UpdateNote_RepoErrorPropagates(t *testing.T) {
 }
 
 func TestProcess_UpdatePerson(t *testing.T) {
-	env := newFullProcessor(t, aliceActor)
+	// #1560: Update(Person) は actor を強制再 fetch して name だけでなく
+	// isBot/isLocked 等の full profile を更新する (upstream updatePerson)。
+	// fetcher が返す更新後 actor doc を反映することを検証する (旧実装は inline
+	// object の name のみ反映していた)。
+	updatedActor := `{
+		"@context": "https://www.w3.org/ns/activitystreams",
+		"id": "https://remote.example/users/alice",
+		"type": "Service",
+		"preferredUsername": "alice",
+		"name": "Alice Updated",
+		"manuallyApprovesFollowers": true,
+		"inbox": "https://remote.example/users/alice/inbox"
+	}`
+	env := newFullProcessor(t, updatedActor)
 	uri := "https://remote.example/users/alice"
-	env.userRepo.Users["alice-id"] = &model.User{ID: "alice-id", Username: "alice", URI: &uri}
+	env.userRepo.Users["alice-id"] = &model.User{ID: "alice-id", Username: "alice", URI: &uri, IsBot: false, IsLocked: false}
 	body := []byte(`{
 		"type": "Update",
 		"actor": "https://remote.example/users/alice",
@@ -1064,8 +1077,13 @@ func TestProcess_UpdatePerson(t *testing.T) {
 		}
 	}`)
 	require.NoError(t, env.processor.Process(body))
-	require.NotNil(t, env.userRepo.Users["alice-id"].Name)
-	assert.Equal(t, "Alice Updated", *env.userRepo.Users["alice-id"].Name)
+	updated := env.userRepo.Users["alice-id"]
+	require.NotNil(t, updated.Name)
+	assert.Equal(t, "Alice Updated", *updated.Name)
+	// name 以外も full refresh されること (Service type -> isBot、
+	// manuallyApprovesFollowers -> isLocked)。旧 name-only 実装では false のまま。
+	assert.True(t, updated.IsBot, "Service actor type must update isBot (full refresh)")
+	assert.True(t, updated.IsLocked, "manuallyApprovesFollowers must update isLocked (full refresh)")
 }
 
 func TestProcess_UpdateUnknownActor(t *testing.T) {

--- a/internal/core/federation/processor_test.go
+++ b/internal/core/federation/processor_test.go
@@ -645,7 +645,8 @@ func TestProcess_FlagHappyPath(t *testing.T) {
 	require.NoError(t, p.Process(body))
 	assert.Len(t, abuseRepo.Reports, 1)
 	for _, r := range abuseRepo.Reports {
-		assert.Equal(t, "spam", r.Comment)
+		// #1560: comment は content + "\n" + JSON(flagged URIs)。
+		assert.Equal(t, "spam\n[\"https://example.com/users/bob\"]", r.Comment)
 	}
 }
 


### PR DESCRIPTION
## Summary

互換性監査 issue #1560 (activitypub inbox+renderer、1H/5M/8L) の **inbound processor 群 (6項目)** を解消する。#1560 は inbound / rendering / outbound-delivery の3レイヤ + 2つの新規 cross-package 配信にまたがる大型 issue のため、レビュー単位で **3 PR に分割** する。本 PR はその 1/3 (inbound)。

再検証 (develop 最新): 監査コメント (2026-06-10) 後の merge で 2 件 STALE (Create audience union [既に対応] / Update(Question) [UpdateRemoteNote 経由で概ね対応])、REAL 12 件。本 PR で inbound 6 件。

## 主な変更点 (internal/core/federation/processor.go)

- **[HIGH] Update(Person) full refresh**: handleUpdate の Person 分岐が `name` のみ反映していたのを、`ForceResolveActor` による actor 強制再 fetch (TTL バイパス、handleMove と同じ refreshActor 経路) に変更。avatar/banner/bio/isBot/isCat/isLocked/movedTo/alsoKnownAs/emojis 等の full profile を更新する (upstream ApInboxService.update → ApPersonService.updatePerson)
- **[MEDIUM] Undo(Accept)**: remote followee が accept を撤回した際に local follower の following を解除する `handleUndoAccept` を追加 (Undo→Accept→Follow の二段ネストを解いて follower を特定、upstream undoAccept)
- **[LOW] suspended actor guard**: Process で既知の suspended remote actor (DB lookup) の activity を dispatch 前に drop (upstream performOneActivity の `if (actor.isSuspended) return`)。新規 actor は DB に無く素通し、fetch せず DB read のみ
- **[LOW] Flag**: object URI を `ExtractLocalUserID` で local-user URI に限定 (remote user / note 作者への fallback を除去し、別 instance ユーザーの誤報告を防ぐ)。comment に flagged URI 一覧を付与 (upstream `${content}\n${JSON.stringify(uris)}`)
- **[LOW] bearcaps**: Create/Announce の object id が `bear:` なら ack-skip (upstream 'skip: bearcaps url not supported')
- **[LOW] Announce guards**: 非公開 (followers/specified) note の boost を drop (isVisibleForMe を「対象が public/home か」で近似)、`activity.published < 対象 note の createdAt` の malformed timestamp を drop (upstream announceNote)

## テスト

- 新規 `parity_1560_inbound_test.go`: Undo(Accept)→unfollow / suspended actor drop / bearcaps Create+Announce skip / Announce 非公開 skip / Announce malformed-createdAt skip
- 既存 `TestProcess_UpdatePerson` を full-refresh 検証 (Service type→isBot、manuallyApprovesFollowers→isLocked も更新) に更新、`TestProcess_FlagHappyPath` の comment 期待を URI 一覧付きに更新
- `make fmt` / `make lint` / `go test ./... -count=1` 全 pass

## 関連

#1560 (part 1/3)。後続: rendering 4項目 (empty CW ZWSP / quote inline / mention cc / renderPerson tags)、outbound delivery 2項目 (Block/Undo(Block) 配信 / Update(Person) on i/update)。最後の PR で `Closes #1560`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)