### PR TITLE
Fix federation renderer: outbound Note/Person の AP shape parity 4 件 (#1560 part 2/3)

### DIFF
--- a/internal/activitypub/parity_1560_render_test.go
+++ b/internal/activitypub/parity_1560_render_test.go
@@ -1,0 +1,68 @@
+package activitypub
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// #1560 [LOW] RenderNote: 空文字 CW は summary=ZWSP + sensitive=true。
+func TestRenderNote_EmptyCWZWSP(t *testing.T) {
+	r := newRenderer()
+	idGen := newIDGen(t)
+	empty := ""
+	n := &model.Note{ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: model.NoteVisibilityPublic, CW: &empty}
+	out := r.RenderNote(n, idGen)
+	assert.Equal(t, "​", out.Summary, "empty CW must render ZWSP summary")
+	assert.True(t, out.Sensitive, "any non-nil CW (incl empty) must set sensitive=true")
+
+	// CW=nil は summary 無し / sensitive=false
+	n2 := &model.Note{ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: model.NoteVisibilityPublic}
+	out2 := r.RenderNote(n2, idGen)
+	assert.Empty(t, out2.Summary)
+	assert.False(t, out2.Sensitive)
+}
+
+// #1560 [LOW] RenderNote: quote note は content 末尾に quote-inline span を付ける。
+func TestRenderNote_QuoteInlineHTML(t *testing.T) {
+	r := newRenderer()
+	r.SetNoteResolver(stubNoteResolver1560{uri: "https://remote.example/notes/orig"})
+	idGen := newIDGen(t)
+	text := "my comment"
+	renoteID := "rt1"
+	n := &model.Note{ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: model.NoteVisibilityPublic, Text: &text, RenoteID: &renoteID}
+	out := r.RenderNote(n, idGen)
+	assert.Contains(t, out.Content, `<span class="quote-inline">RE: <a href="https://remote.example/notes/orig">https://remote.example/notes/orig</a></span>`)
+	assert.Equal(t, "https://remote.example/notes/orig", out.QuoteURL)
+}
+
+// #1560 [LOW] RenderPerson: top-level sharedInbox + user.tags Hashtag。
+func TestRenderPerson_SharedInboxAndHashtags(t *testing.T) {
+	r := newRenderer()
+	r.SetHost("example.com")
+	u := &model.User{ID: "u1", Username: "alice", Tags: pq.StringArray{"go", "misskey"}}
+	p := r.RenderPerson(u, nil, "PEM", nil)
+	assert.Equal(t, "https://example.com/inbox", p.SharedInbox, "top-level sharedInbox must be set")
+	assert.Equal(t, "https://example.com/inbox", p.Endpoints.SharedInbox)
+	// user.tags が Hashtag として tag に入る
+	var hashtags int
+	for _, tg := range p.Tag {
+		if h, ok := tg.(Hashtag); ok {
+			hashtags++
+			assert.True(t, strings.HasPrefix(h.Name, "#"))
+		}
+	}
+	assert.Equal(t, 2, hashtags, "user.tags must be rendered as Hashtag entries")
+}
+
+type stubNoteResolver1560 struct{ uri string }
+
+func (s stubNoteResolver1560) FindByID(string) (*model.Note, error) {
+	remote := "remote.example"
+	u := s.uri
+	return &model.Note{ID: "rt1", URI: &u, UserHost: &remote}, nil
+}

--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"html"
 	"log/slog"
 	"strings"
 	"time"
@@ -246,6 +247,7 @@ func (r *Renderer) RenderPerson(u *model.User, profile *model.UserProfile, publi
 		Following:         r.urls.UserFollowing(u.ID),
 		PreferredUsername: u.Username,
 		URL:               uri,
+		SharedInbox:       r.urls.SharedInbox(), // top-level (#1560)
 		Endpoints:         Endpoints{SharedInbox: r.urls.SharedInbox()},
 		PublicKey: PublicKey{
 			ID:           r.urls.UserKeyURI(u.ID),
@@ -308,9 +310,30 @@ func (r *Renderer) RenderPerson(u *model.User, profile *model.UserProfile, publi
 
 	// ユーザーのカスタム絵文字をEmoji tagとして追加
 	r.addEmojiTags(&p.Tag, u.Emojis, nil)
+	// user.tags を Hashtag として追加 (#1560、upstream renderHashtag)。
+	// href/name 形式は RenderNote の Hashtag と揃える。
+	for _, tag := range u.Tags {
+		p.Tag = append(p.Tag, Hashtag{
+			Type: "Hashtag",
+			Href: "https://" + r.host + "/tags/" + tag,
+			Name: "#" + tag,
+		})
+	}
 
 	AddContext(p)
 	return p
+}
+
+// rewriteFieldURLValue wraps an http(s) PropertyValue field value in an
+// `<a rel="me nofollow noopener">` link so non-Misskey clients render it as a
+// verifiable profile link (#1560、upstream tryRewriteUrl)。http(s) で始まらない
+// 値はそのまま返す。href / text とも HTML escape する。
+func rewriteFieldURLValue(value string) string {
+	if !strings.HasPrefix(value, "http://") && !strings.HasPrefix(value, "https://") {
+		return value
+	}
+	esc := html.EscapeString(value)
+	return `<a href="` + esc + `" rel="me nofollow noopener" target="_blank">` + esc + `</a>`
 }
 
 // enrichPersonFromProfile fills profile-derived fields into Person.
@@ -343,7 +366,7 @@ func (r *Renderer) enrichPersonFromProfile(p *Person, profile *model.UserProfile
 				p.Attachment = append(p.Attachment, PropertyValue{
 					Type:  "PropertyValue",
 					Name:  f.Name,
-					Value: f.Value,
+					Value: rewriteFieldURLValue(f.Value),
 				})
 			}
 		}
@@ -370,7 +393,10 @@ func (r *Renderer) RenderNote(n *model.Note, idGen id.Generator) *Note {
 		AttributedTo: r.urls.UserURI(n.UserID),
 		Content:      htmlContent,
 		Published:    parseNoteTime(n.ID, idGen),
-		Sensitive:    n.CW != nil && *n.CW != "",
+		// upstream は sensitive = (note.cw != null) || files.some(isSensitive)
+		// (#1560、ApRendererService.ts:489)。空文字 CW でも cw!=null なら
+		// sensitive=true。file 由来の flip は下の attachment ループで行う。
+		Sensitive: n.CW != nil,
 	}
 
 	// _misskey_content / source: 標準ノードのみなら省略 (TS版 noMisskeyContent)
@@ -383,7 +409,14 @@ func (r *Renderer) RenderNote(n *model.Note, idGen id.Generator) *Note {
 	}
 
 	if n.CW != nil {
-		out.Summary = *n.CW
+		// upstream は summary = cw==='' ? ZWSP(U+200B) : cw (#1560、
+		// ApRendererService.ts:443)。空文字 CW を ZWSP にすることで summary
+		// omitempty に落とされず、受信側が「CW あり (本文は空)」と解釈できる。
+		if *n.CW == "" {
+			out.Summary = "\u200b" // ZWSP (upstream String.fromCharCode(0x200B))
+		} else {
+			out.Summary = *n.CW
+		}
 	}
 	if n.ReplyID != nil {
 		// リモート note への reply の場合、InReplyTo は相手側 (note.URI) を
@@ -399,6 +432,11 @@ func (r *Renderer) RenderNote(n *model.Note, idGen id.Generator) *Note {
 		if quoteURI != "" {
 			out.MisskeyQuote = quoteURI
 			out.QuoteURL = quoteURI
+			// 非 Misskey クライアント向けに content 末尾へ quote-inline span を
+			// 付ける (#1560、upstream ApRendererService.ts:436-441)。class名
+			// `quote-inline` は非 Misskey クライアントの quote 表示に使われる。
+			esc := html.EscapeString(quoteURI)
+			out.Content += `<br><br><span class="quote-inline">RE: <a href="` + esc + `">` + esc + `</a></span>`
 		}
 	}
 
@@ -419,13 +457,20 @@ func (r *Renderer) RenderNote(n *model.Note, idGen id.Generator) *Note {
 
 	to, cc := r.addressing(n)
 
-	// Resolve mentions into Tag entries and add mentioned user URIs to `to`
-	// so receiving instances (特に Misskey) が mention 通知を作成できる。
-	// mentionResolver 未設定なら tag は付けない (テスト互換)。
+	// Resolve mentions into Tag entries and add mentioned user URIs to the
+	// audience so receiving instances (特に Misskey) が mention 通知を作成できる。
+	// upstream は mention URI を public/home/followers では cc に、specified では
+	// to に置く (#1560、ApRendererService.ts:405-416)。mentionResolver 未設定
+	// なら tag は付けない (テスト互換)。
 	if r.mentionResolver != nil && len(n.Mentions) > 0 {
-		seenTo := make(map[string]struct{}, len(to))
+		// specified は to、それ以外は cc に追記する。
+		mentionToCC := n.Visibility != model.NoteVisibilitySpecified
+		seen := make(map[string]struct{}, len(to)+len(cc))
 		for _, v := range to {
-			seenTo[v] = struct{}{}
+			seen[v] = struct{}{}
+		}
+		for _, v := range cc {
+			seen[v] = struct{}{}
 		}
 		for _, uid := range n.Mentions {
 			name, uri, err := r.mentionResolver.ResolveMention(uid)
@@ -446,9 +491,14 @@ func (r *Renderer) RenderNote(n *model.Note, idGen id.Generator) *Note {
 				continue
 			}
 			out.Tag = append(out.Tag, NewMention(uri, name))
-			if _, dup := seenTo[uri]; !dup {
+			if _, dup := seen[uri]; dup {
+				continue
+			}
+			seen[uri] = struct{}{}
+			if mentionToCC {
+				cc = append(cc, uri)
+			} else {
 				to = append(to, uri)
-				seenTo[uri] = struct{}{}
 			}
 		}
 	}

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -351,8 +351,10 @@ func TestRenderer_RenderNote_WithMentions(t *testing.T) {
 	}
 	assert.Equal(t, "@alice", tagged["https://example.com/users/uA"])
 	assert.Equal(t, "@bob@remote.example", tagged["https://remote.example/users/bob"])
-	assert.Contains(t, out.To, "https://example.com/users/uA")
-	assert.Contains(t, out.To, "https://remote.example/users/bob")
+	// #1560: public note の mention URI は to ではなく cc に入る (upstream)。
+	assert.Contains(t, out.CC, "https://example.com/users/uA")
+	assert.Contains(t, out.CC, "https://remote.example/users/bob")
+	assert.NotContains(t, out.To, "https://example.com/users/uA")
 }
 
 func TestRenderer_RenderNote_WithMentions_DuplicateTo(t *testing.T) {
@@ -676,7 +678,8 @@ func TestRenderer_RenderPerson_WithProfile(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "PropertyValue", pv.Type)
 	assert.Equal(t, "Website", pv.Name)
-	assert.Equal(t, "https://example.com", pv.Value)
+	// #1560: http(s) PropertyValue value は <a rel="me"> で wrap される。
+	assert.Equal(t, `<a href="https://example.com" rel="me nofollow noopener" target="_blank">https://example.com</a>`, pv.Value)
 }
 
 func TestRenderer_RenderPerson_BannerAndMovedTo(t *testing.T) {

--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -200,13 +200,17 @@ func (i *Image) UnmarshalJSON(data []byte) error {
 // Person represents a user actor.
 type Person struct {
 	Object
-	Inbox                               string    `json:"inbox"`
-	Outbox                              string    `json:"outbox"`
-	Followers                           string    `json:"followers"`
-	Following                           string    `json:"following"`
-	PreferredUsername                   string    `json:"preferredUsername"`
-	Summary                             string    `json:"summary,omitempty"`
-	URL                                 string    `json:"url,omitempty"`
+	Inbox             string `json:"inbox"`
+	Outbox            string `json:"outbox"`
+	Followers         string `json:"followers"`
+	Following         string `json:"following"`
+	PreferredUsername string `json:"preferredUsername"`
+	Summary           string `json:"summary,omitempty"`
+	URL               string `json:"url,omitempty"`
+	// SharedInbox は upstream renderPerson が endpoints.sharedInbox とは別に
+	// top-level にも出す (#1560、ApRendererService.ts:551)。古い実装/一部の
+	// 受信側は top-level を見るため両方出す。
+	SharedInbox                         string    `json:"sharedInbox,omitempty"`
 	Endpoints                           Endpoints `json:"endpoints,omitzero"`
 	PublicKey                           PublicKey `json:"publicKey"`
 	Icon                                *Image    `json:"icon,omitempty"`


### PR DESCRIPTION
## Summary

互換性監査 issue #1560 (activitypub inbox+renderer) の **rendering 群 (4項目)** を解消する。3 PR 分割の 2/3 (renderer)。

## 主な変更点 (internal/activitypub/renderer.go, types.go)

- **[LOW] RenderNote 空文字 CW**: summary を ZWSP (U+200B) にし、sensitive=true にする (upstream `summary = cw===''?ZWSP:cw` / `sensitive: cw!=null||files.some(isSensitive)`、ApRendererService.ts:443,489)。従来は空 CW で summary 省略 + sensitive=false だった
- **[LOW] RenderNote quote note**: content 末尾に `<br><br><span class="quote-inline">RE: <a href="...">...</a></span>` を append (非 Misskey クライアントの quote 表示用、upstream getNoteHtml の extraHtml、ApRendererService.ts:436-441)。URL は html escape
- **[LOW] RenderNote mention の to/cc**: public/home/followers は mention URI を `cc`、specified は `to` に置く (upstream ApRendererService.ts:405-416)。従来は visibility 問わず `to` に入れていた (配信自体は両リストで行われるため到達性は不変、addressing field の位置のみ修正)
- **[LOW] RenderPerson**: (a) top-level `sharedInbox` を追加 (endpoints.sharedInbox と両方出す、upstream:551)、(b) user.tags を Hashtag tag として追加 (upstream renderHashtag)、(c) PropertyValue の http(s) 値を `<a href=... rel="me nofollow noopener" target="_blank">` で wrap (upstream tryRewriteUrl)。PropertyValue / emoji tag 自体は実装済みだった

## テスト

- 新規 `parity_1560_render_test.go`: 空 CW ZWSP+sensitive / quote-inline span / top-level sharedInbox + user.tags Hashtag
- 既存 `TestRenderer_RenderNote_WithMentions` (mention は cc へ) / `TestRenderer_RenderPerson_WithProfile` (PropertyValue URL wrap) を新挙動に更新
- `make fmt` / `make lint` / `go test ./... -count=1` 全 pass

## 関連

#1560 (part 2/3)。先行: #1645 (inbound 6項目、merged)。後続: outbound delivery 2項目 (Block/Undo(Block) 配信 / Update(Person) on i/update)。最後の PR で `Closes #1560`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)