### PR TITLE
Fix federation: local Block / profile 更新の outbound AP 配信を実装 (#1560 part 3/3)

### DIFF
--- a/internal/activitypub/parity_1560_render_test.go
+++ b/internal/activitypub/parity_1560_render_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // #1560 [LOW] RenderNote: 空文字 CW は summary=ZWSP + sensitive=true。
@@ -65,4 +66,41 @@ func (s stubNoteResolver1560) FindByID(string) (*model.Note, error) {
 	remote := "remote.example"
 	u := s.uri
 	return &model.Note{ID: "rt1", URI: &u, UserHost: &remote}, nil
+}
+
+// #1560 [MEDIUM] RenderBlock / RenderUndoBlock (outbound Block delivery)。
+func TestRenderBlock_AndUndo(t *testing.T) {
+	r := newRenderer()
+	blockee := "https://remote.example/users/bob"
+	bl := r.RenderBlock("alice", blockee)
+	assert.Equal(t, "Block", bl.Type)
+	assert.Equal(t, "https://example.com/users/alice", bl.Actor)
+	assert.Equal(t, blockee, bl.Object)
+	assert.NotEmpty(t, bl.ID)
+	assert.NotNil(t, bl.Context, "standalone Block must carry @context (#1560 review)")
+
+	undo := r.RenderUndoBlock("alice", blockee)
+	assert.Equal(t, "Undo", undo.Type)
+	assert.Equal(t, "https://example.com/users/alice", undo.Actor)
+	inner, ok := undo.Object.(*Block)
+	require.True(t, ok)
+	assert.Equal(t, blockee, inner.Object)
+	assert.Nil(t, inner.Context, "inner Block must not carry @context")
+	// Block と Undo(Block) の inner id は同じ (block 行 id 非依存で決定的)
+	assert.Equal(t, bl.ID, inner.ID)
+}
+
+// #1560 [MEDIUM] RenderUpdate(Person) (outbound profile update delivery)。
+func TestRenderUpdate_Person(t *testing.T) {
+	r := newRenderer()
+	u := &model.User{ID: "alice", Username: "alice"}
+	person := r.RenderPerson(u, nil, "PEM", nil)
+	upd := r.RenderUpdate(person)
+	assert.Equal(t, "Update", upd.Type)
+	assert.Equal(t, "https://example.com/users/alice", upd.Actor)
+	assert.Contains(t, upd.To, Public)
+	inner, ok := upd.Object.(*Person)
+	require.True(t, ok)
+	assert.Nil(t, inner.Context, "inner Person must not carry @context (集約)")
+	assert.Equal(t, "https://example.com/users/alice", inner.ID)
 }

--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -94,6 +94,14 @@ func (b *URLBuilder) FollowURI(followerID, followeeID string) string {
 	return b.baseURL + "/follows/" + followerID + "/" + id
 }
 
+// BlockURI returns a stable URI for a Block activity from blockerID to
+// blockeeURI. block 行 id ではなく (blocker, blockee) から決定的に生成するため、
+// 後で unblock した際の Undo(Block) も同じ id を参照できる (#1560)。
+func (b *URLBuilder) BlockURI(blockerID, blockeeURI string) string {
+	h := sha256.Sum256([]byte(blockeeURI))
+	return b.baseURL + "/blocks/" + blockerID + "/" + hex.EncodeToString(h[:16])
+}
+
 // FollowRelayURI returns the URI for a Follow-Relay activity.
 // Path 形式は upstream と一致させる (`/activities/follow-relay/{relayID}`):
 // Accept / Reject inbox ハンドラがこの正規表現で relay を特定するため、
@@ -719,6 +727,67 @@ func (r *Renderer) RenderFollow(followerID, followeeURI string) *Follow {
 	}
 	AddContext(f)
 	return f
+}
+
+// RenderUpdate wraps a rendered Person in an Update activity, delivered to
+// followers when a local user edits their profile so remote instances refresh
+// the actor (#1560、upstream AccountUpdateService renderUpdate(renderPerson))。
+// inner Person の @context は outer Update に集約するため除去する。
+func (r *Renderer) RenderUpdate(person *Person) *Update {
+	actor := person.ID
+	person.Context = nil
+	u := &Update{
+		Activity: Activity{
+			Object: Object{
+				ID:   actor + "#updates/" + uuid.NewString(),
+				Type: "Update",
+			},
+			Actor:     actor,
+			To:        []string{Public},
+			Published: time.Now().UTC().Format(time.RFC3339),
+		},
+		Object: person,
+	}
+	AddContext(u)
+	return u
+}
+
+// RenderBlock returns a Block activity (actor=blocker, object=blockee URI),
+// delivered when a local user blocks a remote user (#1560、upstream
+// renderBlock + UserBlockingService.block delivery)。
+func (r *Renderer) RenderBlock(blockerID, blockeeURI string) *Block {
+	bl := &Block{
+		Activity: Activity{
+			Object: Object{
+				ID:   r.urls.BlockURI(blockerID, blockeeURI),
+				Type: "Block",
+			},
+			Actor: r.urls.UserURI(blockerID),
+		},
+		Object: blockeeURI,
+	}
+	AddContext(bl)
+	return bl
+}
+
+// RenderUndoBlock wraps a Block in an Undo, delivered when a local user
+// unblocks a remote user (#1560、upstream renderUndo(renderBlock(...)))。
+func (r *Renderer) RenderUndoBlock(blockerID, blockeeURI string) *Undo {
+	inner := r.RenderBlock(blockerID, blockeeURI)
+	inner.Context = nil // inner activity は @context を持たない
+	u := &Undo{
+		Activity: Activity{
+			Object: Object{
+				ID:   inner.ID + "/undo",
+				Type: "Undo",
+			},
+			Actor:     r.urls.UserURI(blockerID),
+			Published: time.Now().UTC().Format(time.RFC3339),
+		},
+		Object: inner,
+	}
+	AddContext(u)
+	return u
 }
 
 // RenderFollowRelay returns the special-purpose Follow activity used to

--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -386,6 +386,12 @@ type Follow struct {
 	Object string `json:"object"` // followee actor URI
 }
 
+// Block represents a Block activity. object is the blockee actor URI.
+type Block struct {
+	Activity
+	Object string `json:"object"` // blockee actor URI
+}
+
 // Accept represents an Accept activity.
 type Accept struct {
 	Activity
@@ -568,6 +574,8 @@ func AddContext(o any) {
 	case *Create:
 		v.Context = ctx
 	case *Follow:
+		v.Context = ctx
+	case *Block:
 		v.Context = ctx
 	case *Accept:
 		v.Context = ctx

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -91,6 +91,9 @@ type Handler struct {
 	// streaming connection に reload signal を流す (#791)。未配線時は
 	// publish skip = 旧挙動 (= reconnect で反映)。
 	hardMutePublisher HardMutePublisher
+	// profileUpdateHook は profile 編集時に Update(Person) を followers へ
+	// 配信する (#1560)。nil なら配信しない。
+	profileUpdateHook ProfileUpdateHook
 	// authInvalidator は i/regenerate-token で旧 token を auth middleware
 	// の cache から即時削除するために使う (#884)。未配線時は cache TTL
 	// (30 秒) 待ちで stale 旧 token が auth 通過する security regression が
@@ -134,12 +137,23 @@ type HardMutePublisher interface {
 	PublishHardMuteReload(userID string)
 }
 
+// ProfileUpdateHook delivers Update(Person) to remote followers on local
+// profile edit (#1560)。実装は core/federation。
+type ProfileUpdateHook interface {
+	OnLocalProfileUpdated(userID string)
+}
+
 // SetHardMutePublisher wires a publisher that emits wordmute reload events
 // when i/update changes hardMutedWords (#791). Optional; nil disables the
 // realtime reload path (the streaming connection still picks up the new
 // rules at the next reconnect).
 func (h *Handler) SetHardMutePublisher(p HardMutePublisher) {
 	h.hardMutePublisher = p
+}
+
+// SetProfileUpdateHook wires the AP Update(Person) delivery hook (#1560)。
+func (h *Handler) SetProfileUpdateHook(hook ProfileUpdateHook) {
+	h.profileUpdateHook = hook
 }
 
 // SetEmailValidationClient wires the outbound HTTP client used by
@@ -1327,6 +1341,11 @@ func (h *Handler) Update(c echo.Context) error {
 	// 取り直して client-side で filter するので publish 不要。
 	if in.HardMutedWords != nil && h.hardMutePublisher != nil {
 		h.hardMutePublisher.PublishHardMuteReload(me.ID)
+	}
+
+	// profile 変更を remote followers に Update(Person) で配信する (#1560)。
+	if h.profileUpdateHook != nil {
+		h.profileUpdateHook.OnLocalProfileUpdated(me.ID)
 	}
 
 	// auth middleware の tokenCache (30 秒 TTL) は name / description などの

--- a/internal/core/blocking/blocking_service.go
+++ b/internal/core/blocking/blocking_service.go
@@ -30,6 +30,21 @@ type Service struct {
 	followingRepo repository.FollowingRepository
 	instanceRepo  repository.InstanceRepository // optional, for #596 incremental counters
 	idGen         id.Generator
+	// federationHook は local user が remote user を (un)block した際に
+	// Block / Undo(Block) を相手 inbox へ配信する (#1560)。nil なら配信しない。
+	federationHook FederationHook
+}
+
+// FederationHook delivers Block / Undo(Block) AP activities to a remote
+// blockee on local block / unblock (#1560)。実装は core/federation。
+type FederationHook interface {
+	OnBlocked(blockerID, blockeeID string)
+	OnUnblocked(blockerID, blockeeID string)
+}
+
+// SetFederationHook wires the AP delivery hook used by Block / Unblock (#1560)。
+func (s *Service) SetFederationHook(h FederationHook) {
+	s.federationHook = h
 }
 
 // NewService constructs a UserBlockingService.
@@ -87,6 +102,11 @@ func (s *Service) Block(blockerID, blockeeID string) (*model.Blocking, error) {
 		s.removeFollowing(blockeeID, blockerID)
 	}
 
+	// remote blockee へ Block activity を配信する (#1560)。
+	if s.federationHook != nil {
+		s.federationHook.OnBlocked(blockerID, blockeeID)
+	}
+
 	return b, nil
 }
 
@@ -99,7 +119,14 @@ func (s *Service) Unblock(blockerID, blockeeID string) error {
 	if err != nil {
 		return ErrNotBlocking
 	}
-	return s.blockingRepo.Delete(b)
+	if err := s.blockingRepo.Delete(b); err != nil {
+		return err
+	}
+	// remote blockee へ Undo(Block) を配信する (#1560)。
+	if s.federationHook != nil {
+		s.federationHook.OnUnblocked(blockerID, blockeeID)
+	}
+	return nil
 }
 
 // IsBlocked reports whether blocker has blocked blockee.

--- a/internal/core/blocking/blocking_service_test.go
+++ b/internal/core/blocking/blocking_service_test.go
@@ -86,6 +86,7 @@ type failingBlockingRepo struct {
 	*testutil.MockBlockingRepository
 	failExists bool
 	failCreate bool
+	failDelete bool
 }
 
 func (f *failingBlockingRepo) Exists(blockerID, blockeeID string) (bool, error) {
@@ -100,6 +101,13 @@ func (f *failingBlockingRepo) Create(b *model.Blocking) error {
 		return stubError
 	}
 	return f.MockBlockingRepository.Create(b)
+}
+
+func (f *failingBlockingRepo) Delete(b *model.Blocking) error {
+	if f.failDelete {
+		return stubError
+	}
+	return f.MockBlockingRepository.Delete(b)
 }
 
 func TestBlock_ExistsError(t *testing.T) {
@@ -212,4 +220,55 @@ func TestBlock_DecrementsInstanceCounters(t *testing.T) {
 	assert.Empty(t, fr.Followings)
 	// remote 側 follower カウントが -1
 	assert.Equal(t, 4, instanceRepo.Instances[host].FollowersCount)
+}
+
+// recordingFederationHook captures hook fires so we can assert that Block /
+// Unblock trigger AP delivery (#1560)。
+type recordingFederationHook struct {
+	blocked   [][2]string
+	unblocked [][2]string
+}
+
+func (h *recordingFederationHook) OnBlocked(blockerID, blockeeID string) {
+	h.blocked = append(h.blocked, [2]string{blockerID, blockeeID})
+}
+
+func (h *recordingFederationHook) OnUnblocked(blockerID, blockeeID string) {
+	h.unblocked = append(h.unblocked, [2]string{blockerID, blockeeID})
+}
+
+// Block / Unblock 成功時に federationHook が発火する (#1560)。
+func TestBlockUnblock_FiresFederationHook(t *testing.T) {
+	svc, ur, _, _ := newSvc(t)
+	addUser(ur, "a")
+	addUser(ur, "b")
+	hook := &recordingFederationHook{}
+	svc.SetFederationHook(hook)
+
+	_, err := svc.Block("a", "b")
+	require.NoError(t, err)
+	require.Equal(t, [][2]string{{"a", "b"}}, hook.blocked)
+
+	require.NoError(t, svc.Unblock("a", "b"))
+	require.Equal(t, [][2]string{{"a", "b"}}, hook.unblocked)
+}
+
+// Unblock で Delete が失敗したら error を返し、hook は発火しない (#1560)。
+func TestUnblock_DeleteError(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	addUser(userRepo, "a")
+	addUser(userRepo, "b")
+	idGen, _ := id.NewGenerator("aidx")
+	repo := &failingBlockingRepo{MockBlockingRepository: testutil.NewMockBlockingRepository()}
+	svc := blocking.NewService(userRepo, repo, nil, idGen)
+	hook := &recordingFederationHook{}
+	svc.SetFederationHook(hook)
+
+	_, err := svc.Block("a", "b")
+	require.NoError(t, err)
+
+	repo.failDelete = true
+	err = svc.Unblock("a", "b")
+	require.ErrorIs(t, err, stubError)
+	assert.Empty(t, hook.unblocked, "Delete 失敗時は Undo(Block) を配信しない")
 }

--- a/internal/core/federation/blocking_delivery_hook.go
+++ b/internal/core/federation/blocking_delivery_hook.go
@@ -1,0 +1,72 @@
+package federation
+
+import (
+	"encoding/json"
+	"log/slog"
+
+	"github.com/shiroha-a/mk/internal/activitypub"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// BlockingDeliveryHook implements core/blocking.FederationHook by delivering
+// Block / Undo(Block) activities to a remote blockee's inbox when a local user
+// blocks / unblocks them (#1560, upstream UserBlockingService.block/unblock の
+// AP delivery)。blockee がローカル or URI 無しなら no-op。
+type BlockingDeliveryHook struct {
+	deliver  *DeliverService
+	userRepo repository.UserRepository
+	renderer *activitypub.Renderer
+}
+
+// NewBlockingDeliveryHook constructs a BlockingDeliveryHook.
+func NewBlockingDeliveryHook(deliver *DeliverService, userRepo repository.UserRepository, renderer *activitypub.Renderer) *BlockingDeliveryHook {
+	return &BlockingDeliveryHook{deliver: deliver, userRepo: userRepo, renderer: renderer}
+}
+
+// OnBlocked delivers a Block activity to the remote blockee (#1560)。
+func (h *BlockingDeliveryHook) OnBlocked(blockerID, blockeeID string) {
+	blocker, blockee, ok := h.resolve(blockerID, blockeeID)
+	if !ok {
+		return
+	}
+	body, err := json.Marshal(h.renderer.RenderBlock(blocker.ID, *blockee.URI))
+	if err != nil {
+		return
+	}
+	if err := h.deliver.DeliverToUser(blocker.ID, blockee, body); err != nil {
+		slog.Warn("blocking delivery: block failed", "blocker", blocker.ID, "blockee", blockee.ID, "err", err)
+	}
+}
+
+// OnUnblocked delivers an Undo(Block) activity to the remote blockee (#1560)。
+func (h *BlockingDeliveryHook) OnUnblocked(blockerID, blockeeID string) {
+	blocker, blockee, ok := h.resolve(blockerID, blockeeID)
+	if !ok {
+		return
+	}
+	body, err := json.Marshal(h.renderer.RenderUndoBlock(blocker.ID, *blockee.URI))
+	if err != nil {
+		return
+	}
+	if err := h.deliver.DeliverToUser(blocker.ID, blockee, body); err != nil {
+		slog.Warn("blocking delivery: undo(block) failed", "blocker", blocker.ID, "blockee", blockee.ID, "err", err)
+	}
+}
+
+// resolve loads blocker / blockee and reports whether AP delivery is needed:
+// blocker がローカル、blockee がリモートで URI / inbox を持つときのみ true。
+func (h *BlockingDeliveryHook) resolve(blockerID, blockeeID string) (blocker, blockee *model.User, ok bool) {
+	if h.deliver == nil || h.userRepo == nil || h.renderer == nil {
+		return nil, nil, false
+	}
+	blocker, err := h.userRepo.FindByID(blockerID)
+	if err != nil || blocker == nil || !blocker.IsLocal() {
+		return nil, nil, false
+	}
+	blockee, err = h.userRepo.FindByID(blockeeID)
+	if err != nil || blockee == nil || blockee.IsLocal() || blockee.URI == nil || *blockee.URI == "" {
+		return nil, nil, false
+	}
+	return blocker, blockee, true
+}

--- a/internal/core/federation/parity_1560_outbound_test.go
+++ b/internal/core/federation/parity_1560_outbound_test.go
@@ -93,3 +93,112 @@ func TestProfileUpdateHook_DeliversToFollowers(t *testing.T) {
 	assert.Equal(t, "Person", inner["type"])
 	assert.Contains(t, inner["id"], "alice")
 }
+
+// resolve の早期 return 分岐: blocker 不在 / blocker が非ローカルなら配信しない。
+func TestBlockingHook_NoDeliveryForMissingOrRemoteBlocker(t *testing.T) {
+	hook, enq, userRepo, _ := newBlockingHook(t)
+	bobURI, bobInbox, host := "https://remote.example/users/bob", "https://remote.example/users/bob/inbox", "remote.example"
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", Host: &host, URI: &bobURI, Inbox: &bobInbox}
+
+	// blocker が存在しない
+	hook.OnBlocked("ghost", "bob")
+	hook.OnUnblocked("ghost", "bob")
+	assert.Empty(t, enq.calls, "missing blocker → no AP delivery")
+
+	// blocker がリモート
+	rhost, rURI := "remote.example", "https://remote.example/users/remoteblocker"
+	userRepo.Users["remoteblocker"] = &model.User{ID: "remoteblocker", Username: "rb", Host: &rhost, URI: &rURI}
+	hook.OnBlocked("remoteblocker", "bob")
+	assert.Empty(t, enq.calls, "remote blocker → no AP delivery")
+}
+
+// OnLocalProfileUpdated の早期 return: user 不在 / 非ローカル / keypair 不在では配信しない。
+func TestProfileUpdateHook_NoDeliveryForMissingOrRemoteOrNoKeypair(t *testing.T) {
+	hook, enq, userRepo, _, keypairRepo := newProfileUpdateHook(t)
+
+	// user 不在
+	hook.OnLocalProfileUpdated("ghost")
+	assert.Empty(t, enq.calls, "missing user → no delivery")
+
+	// 非ローカル user
+	host := "remote.example"
+	userRepo.Users["remote"] = &model.User{ID: "remote", Username: "remote", Host: &host}
+	hook.OnLocalProfileUpdated("remote")
+	assert.Empty(t, enq.calls, "remote user → no delivery")
+
+	// keypair 不在 (local user だが鍵が無い)
+	userRepo.Users["nokey"] = &model.User{ID: "nokey", Username: "nokey"}
+	hook.OnLocalProfileUpdated("nokey")
+	assert.Empty(t, enq.calls, "no keypair → no delivery")
+
+	// keypair はあるが follower が居なければ enqueue 0 件 (profile 行無しでも続行)
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	keypairRepo.Keypairs["alice"] = &model.UserKeypair{UserID: "alice", PrivateKey: "PEM"}
+	hook.OnLocalProfileUpdated("alice")
+	assert.Empty(t, enq.calls, "no remote followers → no enqueue")
+}
+
+// SetKeypairExtraRepo を設定すると配信 Person に ed25519 assertionMethod が載る。
+// + lookupEd25519 の各分岐 (有効 PEM / 不正 PEM / row 無し) を網羅する。
+func TestProfileUpdateHook_Ed25519AndRelay(t *testing.T) {
+	hook, enq, userRepo, followingRepo, keypairRepo := newProfileUpdateHook(t)
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	keypairRepo.Keypairs["alice"] = &model.UserKeypair{UserID: "alice", PrivateKey: "PEM"}
+	followingRepo.RemoteInboxes["alice"] = []string{"https://remote.example/users/bob/inbox"}
+
+	_, pubPEM, err := activitypub.GenerateEd25519Keypair()
+	require.NoError(t, err)
+	extraRepo := testutil.NewMockUserKeypairExtraRepository()
+	require.NoError(t, extraRepo.Upsert(&model.UserKeypairExtra{UserID: "alice", Ed25519PublicKey: pubPEM, Ed25519PrivateKey: "x"}))
+	hook.SetKeypairExtraRepo(extraRepo)
+	relay := &fakeRelayBroadcaster{}
+	hook.SetRelayBroadcaster(relay)
+
+	hook.OnLocalProfileUpdated("alice")
+	require.Len(t, enq.calls, 1)
+	var upd map[string]any
+	require.NoError(t, json.Unmarshal(enq.calls[0].Body, &upd))
+	inner := upd["object"].(map[string]any)
+	assert.NotNil(t, inner["assertionMethod"], "ed25519 row があれば assertionMethod が載る")
+	require.Len(t, relay.calls, 1, "relay subscriber にも fan-out する")
+	assert.Equal(t, "alice", relay.calls[0].SignerID)
+
+	// 不正な PEM は黙って RSA-only に fallback (assertionMethod 無し)。
+	enq.calls = nil
+	require.NoError(t, extraRepo.Upsert(&model.UserKeypairExtra{UserID: "alice", Ed25519PublicKey: "not-a-pem", Ed25519PrivateKey: "x"}))
+	hook.OnLocalProfileUpdated("alice")
+	require.Len(t, enq.calls, 1)
+	var upd2 map[string]any
+	require.NoError(t, json.Unmarshal(enq.calls[0].Body, &upd2))
+	inner2 := upd2["object"].(map[string]any)
+	assert.Nil(t, inner2["assertionMethod"], "不正 PEM は assertionMethod を載せない")
+
+	// row 無し (extra repo はあるが該当 user の行が無い) も RSA-only。
+	enq.calls = nil
+	require.NoError(t, extraRepo.Delete("alice"))
+	hook.OnLocalProfileUpdated("alice")
+	require.Len(t, enq.calls, 1)
+}
+
+// 配送 enqueue が失敗しても hook は panic せず log のみ (best-effort)。
+func TestOutboundHooks_DeliverErrorIsBestEffort(t *testing.T) {
+	bhook, benq, buserRepo, bkeypairRepo := newBlockingHook(t)
+	benq.err = assert.AnError
+	buserRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	bkeypairRepo.Keypairs["alice"] = &model.UserKeypair{UserID: "alice", PrivateKey: "PEM"}
+	bobURI, bobInbox, host := "https://remote.example/users/bob", "https://remote.example/users/bob/inbox", "remote.example"
+	buserRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", Host: &host, URI: &bobURI, Inbox: &bobInbox}
+	assert.NotPanics(t, func() {
+		bhook.OnBlocked("alice", "bob")
+		bhook.OnUnblocked("alice", "bob")
+	})
+
+	phook, penq, puserRepo, pfollowingRepo, pkeypairRepo := newProfileUpdateHook(t)
+	penq.err = assert.AnError
+	puserRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	pkeypairRepo.Keypairs["alice"] = &model.UserKeypair{UserID: "alice", PrivateKey: "PEM"}
+	pfollowingRepo.RemoteInboxes["alice"] = []string{"https://remote.example/users/bob/inbox"}
+	relay := &fakeRelayBroadcaster{err: assert.AnError}
+	phook.SetRelayBroadcaster(relay)
+	assert.NotPanics(t, func() { phook.OnLocalProfileUpdated("alice") })
+}

--- a/internal/core/federation/parity_1560_outbound_test.go
+++ b/internal/core/federation/parity_1560_outbound_test.go
@@ -1,0 +1,95 @@
+package federation_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/activitypub"
+	"github.com/shiroha-a/mk/internal/core/federation"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newBlockingHook(t *testing.T) (*federation.BlockingDeliveryHook, *stubEnqueuer, *testutil.MockUserRepository, *testutil.MockUserKeypairRepository) {
+	t.Helper()
+	enq := &stubEnqueuer{}
+	userRepo := testutil.NewMockUserRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	keypairRepo := testutil.NewMockUserKeypairRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	deliver := federation.NewDeliverService(enq, userRepo, followingRepo, keypairRepo, urls)
+	renderer := activitypub.NewRenderer(urls)
+	hook := federation.NewBlockingDeliveryHook(deliver, userRepo, renderer)
+	return hook, enq, userRepo, keypairRepo
+}
+
+// #1560 [MEDIUM] local→remote の Block / Undo(Block) を相手 inbox へ配信。
+func TestBlockingHook_DeliversBlockAndUndo(t *testing.T) {
+	hook, enq, userRepo, keypairRepo := newBlockingHook(t)
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"} // local
+	keypairRepo.Keypairs["alice"] = &model.UserKeypair{UserID: "alice", PrivateKey: "PEM"}
+	bobURI, bobInbox, host := "https://remote.example/users/bob", "https://remote.example/users/bob/inbox", "remote.example"
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", Host: &host, URI: &bobURI, Inbox: &bobInbox}
+
+	hook.OnBlocked("alice", "bob")
+	require.Len(t, enq.calls, 1)
+	var blk map[string]any
+	require.NoError(t, json.Unmarshal(enq.calls[0].Body, &blk))
+	assert.Equal(t, "Block", blk["type"])
+	assert.Equal(t, bobURI, blk["object"])
+	assert.Contains(t, blk["actor"], "alice")
+
+	hook.OnUnblocked("alice", "bob")
+	require.Len(t, enq.calls, 2)
+	var undo map[string]any
+	require.NoError(t, json.Unmarshal(enq.calls[1].Body, &undo))
+	assert.Equal(t, "Undo", undo["type"])
+	inner, ok := undo["object"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Block", inner["type"])
+	assert.Equal(t, bobURI, inner["object"])
+}
+
+// blockee がローカル or URI 無しなら配信しない。
+func TestBlockingHook_NoDeliveryForLocalOrUnknown(t *testing.T) {
+	hook, enq, userRepo, _ := newBlockingHook(t)
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["carol"] = &model.User{ID: "carol", Username: "carol"} // local blockee
+	hook.OnBlocked("alice", "carol")
+	assert.Empty(t, enq.calls, "local blockee → no AP delivery")
+}
+
+func newProfileUpdateHook(t *testing.T) (*federation.ProfileUpdateDeliveryHook, *stubEnqueuer, *testutil.MockUserRepository, *testutil.MockFollowingRepository, *testutil.MockUserKeypairRepository) {
+	t.Helper()
+	enq := &stubEnqueuer{}
+	userRepo := testutil.NewMockUserRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	keypairRepo := testutil.NewMockUserKeypairRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	deliver := federation.NewDeliverService(enq, userRepo, followingRepo, keypairRepo, urls)
+	renderer := activitypub.NewRenderer(urls)
+	hook := federation.NewProfileUpdateDeliveryHook(deliver, renderer, userRepo, keypairRepo)
+	return hook, enq, userRepo, followingRepo, keypairRepo
+}
+
+// #1560 [MEDIUM] profile 編集で Update(Person) を remote followers へ配信。
+func TestProfileUpdateHook_DeliversToFollowers(t *testing.T) {
+	hook, enq, userRepo, followingRepo, keypairRepo := newProfileUpdateHook(t)
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"} // local
+	keypairRepo.Keypairs["alice"] = &model.UserKeypair{UserID: "alice", PrivateKey: "PEM"}
+	// remote follower bob の inbox を登録
+	followingRepo.RemoteInboxes["alice"] = []string{"https://remote.example/users/bob/inbox"}
+
+	hook.OnLocalProfileUpdated("alice")
+	require.Len(t, enq.calls, 1)
+	assert.Equal(t, "https://remote.example/users/bob/inbox", enq.calls[0].Inbox)
+	var upd map[string]any
+	require.NoError(t, json.Unmarshal(enq.calls[0].Body, &upd))
+	assert.Equal(t, "Update", upd["type"])
+	inner, ok := upd["object"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Person", inner["type"])
+	assert.Contains(t, inner["id"], "alice")
+}

--- a/internal/core/federation/profile_update_delivery_hook.go
+++ b/internal/core/federation/profile_update_delivery_hook.go
@@ -1,0 +1,105 @@
+package federation
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/shiroha-a/mk/internal/activitypub"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// ProfileUpdateDeliveryHook implements api/i.ProfileUpdateHook by rendering an
+// Update(Person) and delivering it to the local user's remote followers when
+// they edit their profile (#1560, upstream AccountUpdateService)。これにより
+// remote instance が name/avatar/bio 等の変更を即座に反映できる。
+//
+// 配信用 Person は RSA-only (ed25519 assertionMethod は付けない) で十分:
+// Update activity 自体は DeliverActivity が signer の RSA 鍵で署名し、
+// assertionMethod は verify capability の advertise でしかないため。
+type ProfileUpdateDeliveryHook struct {
+	deliver     *DeliverService
+	renderer    *activitypub.Renderer
+	userRepo    repository.UserRepository
+	keypairRepo repository.UserKeypairRepository
+	// keypairExtraRepo は ed25519 公開鍵 (FEP-521a Multikey) を Person の
+	// assertionMethod に含めるための optional 依存。配信する Update(Person) を
+	// actor endpoint と同じ shape にし、follower 側 cache merge で ed25519
+	// verify capability が一時的に落ちないようにする (#1560 review)。
+	keypairExtraRepo repository.UserKeypairExtraRepository
+	// relay は profile 更新を relay subscriber にも fan-out する optional 依存
+	// (upstream AccountUpdateService.publishToFollowers + deliverToRelays、
+	// #1560 review)。nil なら relay 配送 skip。
+	relay RelayBroadcaster
+}
+
+// NewProfileUpdateDeliveryHook constructs a ProfileUpdateDeliveryHook.
+func NewProfileUpdateDeliveryHook(deliver *DeliverService, renderer *activitypub.Renderer, userRepo repository.UserRepository, keypairRepo repository.UserKeypairRepository) *ProfileUpdateDeliveryHook {
+	return &ProfileUpdateDeliveryHook{deliver: deliver, renderer: renderer, userRepo: userRepo, keypairRepo: keypairRepo}
+}
+
+// SetKeypairExtraRepo wires the Ed25519 keypair repo so the delivered
+// Update(Person) carries assertionMethod like the actor endpoint (#1560)。
+func (h *ProfileUpdateDeliveryHook) SetKeypairExtraRepo(r repository.UserKeypairExtraRepository) {
+	h.keypairExtraRepo = r
+}
+
+// SetRelayBroadcaster wires the relay fan-out target (#1560)。
+func (h *ProfileUpdateDeliveryHook) SetRelayBroadcaster(r RelayBroadcaster) {
+	h.relay = r
+}
+
+// lookupEd25519 returns the user's Ed25519 public key when a row exists
+// (read-only; backfill は actor endpoint 側が担う)。無ければ nil で RSA-only。
+func (h *ProfileUpdateDeliveryHook) lookupEd25519(userID string) ed25519.PublicKey {
+	if h.keypairExtraRepo == nil {
+		return nil
+	}
+	row, err := h.keypairExtraRepo.FindByUserID(userID)
+	if err != nil || row == nil {
+		return nil
+	}
+	pub, err := activitypub.ParseEd25519PublicKeyPEM(row.Ed25519PublicKey)
+	if err != nil {
+		return nil
+	}
+	return pub
+}
+
+// OnLocalProfileUpdated renders Update(Person) and fans it out to the user's
+// remote followers (#1560)。失敗はベストエフォートで log のみ。
+func (h *ProfileUpdateDeliveryHook) OnLocalProfileUpdated(userID string) {
+	if h.deliver == nil || h.renderer == nil || h.userRepo == nil || h.keypairRepo == nil {
+		return
+	}
+	user, err := h.userRepo.FindByID(userID)
+	if err != nil || user == nil || !user.IsLocal() {
+		return
+	}
+	profile, err := h.userRepo.FindProfileByUserID(userID)
+	if err != nil {
+		// profile 行が無くても actor の基本フィールドは出せるので nil で続行。
+		profile = nil
+	}
+	keypair, err := h.keypairRepo.FindByUserID(userID)
+	if err != nil || keypair == nil {
+		slog.Warn("profile update delivery: keypair lookup failed", "userID", userID, "err", err)
+		return
+	}
+	person := h.renderer.RenderPerson(user, profile, keypair.PublicKey, h.lookupEd25519(userID))
+	update := h.renderer.RenderUpdate(person)
+	body, err := json.Marshal(update)
+	if err != nil {
+		return
+	}
+	if err := h.deliver.DeliverToFollowers(userID, body); err != nil {
+		slog.Warn("profile update delivery: deliver to followers failed", "userID", userID, "err", err)
+	}
+	// relay subscriber にも配信する (upstream deliverToRelays、#1560)。
+	if h.relay != nil {
+		if err := h.relay.DeliverToAccepted(context.Background(), userID, update); err != nil {
+			slog.Warn("profile update delivery: relay deliver failed", "userID", userID, "err", err)
+		}
+	}
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -604,6 +604,9 @@ func (s *Server) setupRoutes() {
 	// Follow の id を保持したまま相手に返すため、service 層を経由しない)。
 	federationProcessor.SetInboundFollowAcceptor(followingDeliveryHook)
 	reactionService.SetFederationHook(corefederation.NewReactionDeliveryHook(deliverService, apRenderer, apURLs, idGen, userRepo))
+	// local user が remote user を (un)block した際に Block / Undo(Block) を
+	// 相手 inbox へ配信する (#1560)。
+	blockingService.SetFederationHook(corefederation.NewBlockingDeliveryHook(deliverService, userRepo, apRenderer))
 	noteDeleteHook := corefederation.NewNoteDeleteDeliveryHook(deliverService, apRenderer, apURLs)
 	noteDeleteHook.SetUserRepo(userRepo)
 	noteDeleteService.SetFederationHook(noteDeleteHook)
@@ -1818,6 +1821,13 @@ func (s *Server) setupRoutes() {
 	// と同じ topic 名を共有 (= stream.WordMuteReloadTopic)。
 	streamManager.SubscribeWordMuteReload()
 	iHandler.SetHardMutePublisher(&hardMutePublisherAdapter{pubsub: streamPubSub})
+	// profile 編集を remote followers に Update(Person) で配信する (#1560)。
+	// actor endpoint と同じ shape にするため ed25519 keypair を、follower 以外の
+	// relay subscriber にも届けるため relay broadcaster を配線する。
+	profileUpdateHook := corefederation.NewProfileUpdateDeliveryHook(deliverService, apRenderer, userRepo, keypairRepo)
+	profileUpdateHook.SetKeypairExtraRepo(keypairExtraRepo)
+	profileUpdateHook.SetRelayBroadcaster(relaySvc)
+	iHandler.SetProfileUpdateHook(profileUpdateHook)
 	notePublisher := stream.NewNotePublisher(streamPubSub, idGen)
 	notePublisher.SetEmojiLookup(emojiRepo)
 	notePublisher.SetInstanceLookup(instanceRepo)


### PR DESCRIPTION
## Summary

互換性監査 issue #1560 (activitypub inbox+renderer) の **outbound delivery 群 (2項目)** を解消し、issue を完了する。3 PR 分割の 3/3 (新規 cross-package 配信)。

## 主な変更点

### [MEDIUM] Block / Undo(Block) の outbound 配信

local user が remote user を block/unblock した際、Block / Undo(Block) を相手 inbox へ配送する (upstream UserBlockingService.block:89 / unblock:181)。

- `activitypub`: `Block` type、`URLBuilder.BlockURI` (block 行 id 非依存で (blocker,blockee) から決定的に生成 → unblock 後の Undo でも同 id を参照可)、`RenderBlock` / `RenderUndoBlock`
- `core/blocking`: `FederationHook` interface + Block/Unblock 成功後の発火
- `core/federation`: `BlockingDeliveryHook` (blocker=local && blockee=remote のときのみ配送)

### [MEDIUM] profile 更新の Update(Person) 配信

local user の profile 編集時に Update(Person) を remote followers + relay に配送する (upstream AccountUpdateService)。

- `activitypub`: `RenderUpdate` (Person を Update に wrap)
- `core/federation`: `ProfileUpdateDeliveryHook` (`DeliverToFollowers` + relay `DeliverToAccepted`)
- `api/i`: `ProfileUpdateHook` interface + i/update の UpdateProfile 成功後に発火

## 敵対的レビュー (AP 互換 / 配信条件 / ループ / プライバシー) → 指摘反映

- **[実 interop バグ] `AddContext` に `*Block` case が無く standalone Block が @context 欠落** → case 追加。strict JSON-LD consumer (Mastodon 等) の拒否を防ぐ
- RenderUpdate / RenderUndoBlock に `published` を付与 (upstream 同様)
- profile Update に ed25519 assertionMethod (actor endpoint と同 shape、follower の cache merge で verify capability が落ちないように) と relay 配送を追加

確認済み (指摘なし): 配信方向 (local→remote のみ、inbound と誤混同なし) / フック発火は DB 成功後 / inbound Update(ForceResolveActor) と outbound Update は相互誘発せずループしない / Update(Person) は remote follower inbox のみで非 follower に漏れない / 署名は signer の RSA で正しく付与。

## テスト

- 新規 `parity_1560_outbound_test.go`: Block/Undo 配信 (local→remote のみ) / 非 remote は no-op / profile Update を follower inbox へ配送
- `parity_1560_render_test.go`: RenderBlock (+@context) / RenderUndoBlock (inner 同 id) / RenderUpdate(Person)
- `make fmt` / `make lint` / `go test ./... -count=1` 全 pass

## #1560 全体の完了状況

| グループ | 項目 | PR |
|---|---|---|
| inbound (6) | Update(Person) full refresh [H] / Undo(Accept) / suspended guard / Flag / bear: / Announce guards | #1645 |
| rendering (4) | empty CW ZWSP / quote inline / mention cc / renderPerson tags | #1646 |
| outbound (2) | Block 配信 / Update(Person) 配信 | 本 PR |

STALE 2 件 (Create audience union / Update(Question)) は既存実装で対応済みを再検証で確認。

## Closes

Closes #1560

🤖 Generated with [Claude Code](https://claude.com/claude-code)