### PR TITLE
Fix notification: note/login/createToken/test 通知 type を実装 (#1559 part 1/3)

### DIFF
--- a/internal/api/auth/handler.go
+++ b/internal/api/auth/handler.go
@@ -27,6 +27,16 @@ type Handler struct {
 	// userRepo は miauth/:session/check で承認ユーザーを UserDetailedNotMe で
 	// pack するために使う (#1224)。未配線時は user フィールドを省く。
 	userRepo repository.UserRepository
+	// tokenNotifier は gen-token で access token を生成した時に本人へ
+	// 'createToken' 通知を送る (#1559)。未配線なら通知しない。
+	tokenNotifier TokenNotifier
+}
+
+// TokenNotifier records a 'createToken' notification when a token is generated
+// (#1559)。循環依存を避けるため interface で受け取る (実装は
+// core/notification.Hook)。
+type TokenNotifier interface {
+	OnCreateToken(userID string)
 }
 
 // NewHandler creates a new auth handler.
@@ -37,6 +47,10 @@ func NewHandler(repo repository.AuthSessionRepository, cfg *config.Config, idGen
 // SetUserRepo wires the user repository used by MiAuthCheck to pack the
 // approving user.
 func (h *Handler) SetUserRepo(r repository.UserRepository) { h.userRepo = r }
+
+// SetTokenNotifier attaches a TokenNotifier so gen-token creates a
+// 'createToken' notification (upstream miauth/gen-token)。
+func (h *Handler) SetTokenNotifier(n TokenNotifier) { h.tokenNotifier = n }
 
 // SessionGenerate handles POST /api/auth/session/generate.
 func (h *Handler) SessionGenerate(c echo.Context) error {
@@ -217,6 +231,11 @@ func (h *Handler) GenToken(c echo.Context) error {
 	}
 	if err := h.repo.CreateAccessToken(accessToken); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+
+	// createToken 通知を本人へ送る (upstream miauth/gen-token、#1559)。
+	if h.tokenNotifier != nil {
+		go h.tokenNotifier.OnCreateToken(user.ID)
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{"token": tokenStr})

--- a/internal/api/auth/handler_test.go
+++ b/internal/api/auth/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
@@ -489,6 +490,29 @@ func TestGenToken_Success(t *testing.T) {
 		// SHA-256ハッシュ化の検証: HashはTokenと異なり、sha256Hexの結果と一致する
 		assert.NotEqual(t, at.Token, at.Hash, "Hash should differ from raw Token")
 		assert.Equal(t, sha256Hex(at.Token), at.Hash, "Hash should be SHA-256 of Token")
+	}
+}
+
+// chanTokenNotifier captures OnCreateToken asynchronously (#1559)。
+type chanTokenNotifier struct{ ch chan string }
+
+func (n *chanTokenNotifier) OnCreateToken(userID string) { n.ch <- userID }
+
+// #1559 [LOW] gen-token 成功時に createToken 通知が発火する。
+func TestGenToken_FiresTokenNotifier(t *testing.T) {
+	h, _ := newTestHandler()
+	user := &model.User{ID: "u1", Username: "testuser"}
+	notifier := &chanTokenNotifier{ch: make(chan string, 1)}
+	h.SetTokenNotifier(notifier)
+
+	rec := post(h.GenToken, `{"permission":["read:account"]}`, user)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	select {
+	case uid := <-notifier.ch:
+		assert.Equal(t, "u1", uid)
+	case <-time.After(2 * time.Second):
+		t.Fatal("token notifier was not fired")
 	}
 }
 

--- a/internal/api/notifications/handler.go
+++ b/internal/api/notifications/handler.go
@@ -28,12 +28,24 @@ type Handler struct {
 	followReqRepo repository.FollowRequestRepository
 	instanceRepo  repository.InstanceRepository
 	emojiRepo     repository.EmojiRepository
+	testNotifier  TestNotifier
 }
 
 // NewHandler creates a new notifications Handler.
 func NewHandler(svc *notification.Service, idGen id.Generator) *Handler {
 	return &Handler{svc: svc, idGen: idGen}
 }
+
+// TestNotifier creates a 'test' notification on the caller's own stream so the
+// test-notification endpoint can verify web push / streaming delivery (#1559)。
+// 循環依存を避けるため interface で受け取る (実装は core/notification.Hook)。
+type TestNotifier interface {
+	OnTest(userID string)
+}
+
+// SetTestNotifier attaches a TestNotifier used by TestNotification so the test
+// notification also fires web push (upstream notifications/test-notification)。
+func (h *Handler) SetTestNotifier(n TestNotifier) { h.testNotifier = n }
 
 // SetRepos attaches repositories for resolving user/note objects in notifications.
 func (h *Handler) SetRepos(userRepo repository.UserRepository, noteRepo repository.NoteRepository) {
@@ -345,6 +357,12 @@ func (h *Handler) Flush(c echo.Context) error {
 }
 
 // TestNotification handles POST /api/notifications/test-notification.
+// 本人へ 'test' 通知を送り、web push / streaming の疎通を確認できるようにする
+// (upstream notifications/test-notification、#1559)。
 func (h *Handler) TestNotification(c echo.Context) error {
+	user := middleware.GetUser(c)
+	if h.testNotifier != nil && user != nil {
+		h.testNotifier.OnTest(user.ID)
+	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/notifications/handler_test.go
+++ b/internal/api/notifications/handler_test.go
@@ -418,6 +418,23 @@ func TestTestNotification_Success(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
+// recordingTestNotifier captures OnTest calls (#1559)。
+type recordingTestNotifier struct{ called []string }
+
+func (n *recordingTestNotifier) OnTest(userID string) { n.called = append(n.called, userID) }
+
+// #1559 [LOW] test-notification は notifier が配線されていれば OnTest を発火する。
+func TestTestNotification_FiresNotifier(t *testing.T) {
+	h, _ := newTestHandler(t)
+	notifier := &recordingTestNotifier{}
+	h.SetTestNotifier(notifier)
+	c, rec := newJSONRequest(t, "/api/notifications/test-notification", `{}`)
+	setAuth(c, &model.User{ID: "alice"})
+	require.NoError(t, h.TestNotification(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, []string{"alice"}, notifier.called)
+}
+
 func TestShow_WithUserAndNoteResolution(t *testing.T) {
 	h, svc := newTestHandler(t)
 	userRepo := testutil.NewMockUserRepository()

--- a/internal/api/signin/handler.go
+++ b/internal/api/signin/handler.go
@@ -47,6 +47,19 @@ type Handler struct {
 	idGen               id.Generator
 	mainStreamPublisher MainStreamPublisher
 	totpReplayGuard     twofactor.ReplayGuard
+	loginNotifier       LoginNotifier
+}
+
+// LoginNotifier records a 'login' notification on signin success (#1559)。
+// 循環依存を避けるため interface で受け取る (実装は core/notification.Hook)。
+type LoginNotifier interface {
+	OnLogin(userID string)
+}
+
+// SetLoginNotifier attaches a LoginNotifier so successful signins create a
+// 'login' notification (upstream SigninService)。
+func (h *Handler) SetLoginNotifier(n LoginNotifier) {
+	h.loginNotifier = n
 }
 
 // SetIPLogger attaches an IPLogger and enables IP logging.
@@ -335,6 +348,11 @@ func (h *Handler) ok(c echo.Context, user *model.User) error {
 	if h.signinRepo != nil && h.idGen != nil {
 		hdrs := c.Request().Header.Clone()
 		go h.recordSignin(user.ID, c.RealIP(), hdrs)
+	}
+	// login 通知を本人へ送る (upstream SigninService、#1559)。signin の
+	// レイテンシに乗らないよう非同期で発火する。
+	if h.loginNotifier != nil {
+		go h.loginNotifier.OnLogin(user.ID)
 	}
 	token := ""
 	if user.Token != nil {

--- a/internal/api/signin/handler_test.go
+++ b/internal/api/signin/handler_test.go
@@ -93,6 +93,29 @@ func TestSignin_Step2_Success(t *testing.T) {
 	assert.Equal(t, "testtoken1234567", resp["i"])
 }
 
+// chanLoginNotifier captures OnLogin asynchronously (#1559)。
+type chanLoginNotifier struct{ ch chan string }
+
+func (n *chanLoginNotifier) OnLogin(userID string) { n.ch <- userID }
+
+// #1559 [LOW] signin 成功時に login 通知が発火する。
+func TestSignin_FiresLoginNotifier(t *testing.T) {
+	h, repo := newTestHandler(t)
+	createTestUser(repo, "admin", "pass123")
+	notifier := &chanLoginNotifier{ch: make(chan string, 1)}
+	h.SetLoginNotifier(notifier)
+
+	rec := doPost(h.Signin, `{"username":"admin","password":"pass123"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	select {
+	case uid := <-notifier.ch:
+		assert.Equal(t, "u1", uid)
+	case <-time.After(2 * time.Second):
+		t.Fatal("login notifier was not fired")
+	}
+}
+
 func TestSignin_WrongPassword(t *testing.T) {
 	h, repo := newTestHandler(t)
 	createTestUser(repo, "admin", "pass123")

--- a/internal/core/notification/hooks.go
+++ b/internal/core/notification/hooks.go
@@ -47,6 +47,11 @@ type Hook struct {
 	notePacker     NotePacker
 	userPacker     UserPacker
 	noteUnreadRepo repository.NoteUnreadRepository
+	// followingRepo / renoteMutingRepo は note 通知 (notify='normal' フォロワー
+	// への投稿通知) の fan-out に使う optional 依存 (#1559)。未配線なら note 通知
+	// を発火しない。
+	followingRepo    repository.FollowingRepository
+	renoteMutingRepo repository.RenoteMutingRepository
 }
 
 // NewHook constructs a Hook bound to a NotificationService and userRepo.
@@ -81,6 +86,15 @@ func (h *Hook) SetPackers(u UserPacker, n NotePacker) {
 // notification-proxy implementation of HasUnreadSpecifiedNotes.
 func (h *Hook) SetNoteUnreadRepo(r repository.NoteUnreadRepository) {
 	h.noteUnreadRepo = r
+}
+
+// SetNoteNotifyRepos attaches the repositories required to fan out 'note'
+// notifications to notify='normal' followers (#1559). renoteMutingRepo may be
+// nil; pure renotes will then notify all opted-in followers. followingRepo nil
+// disables note-notification fan-out entirely.
+func (h *Hook) SetNoteNotifyRepos(following repository.FollowingRepository, renoteMuting repository.RenoteMutingRepository) {
+	h.followingRepo = following
+	h.renoteMutingRepo = renoteMuting
 }
 
 // OnNoteCreated is called by note.CreateService after persisting a new note.
@@ -164,6 +178,78 @@ func (h *Hook) OnNoteCreated(n *model.Note, author *model.User, replyTarget, ren
 			NoteVisibility: string(n.Visibility),
 		})
 	}
+
+	// note 通知: notify='normal' フォロワーへ投稿を fan-out する (#1559)。
+	h.notifyFollowersOfNote(ctx, n, author)
+}
+
+// notifyFollowersOfNote fans a 'note' notification out to followers who set
+// notify='normal' on their follow edge (upstream NoteCreateService)。
+//
+// upstream の発火条件をそのまま踏襲する:
+//   - reply には付かない (data.reply == null のときだけ)
+//   - visibility が specified のノートは対象外
+//   - pure renote は、その投稿者の renote を mute しているフォロワーには送らない
+func (h *Hook) notifyFollowersOfNote(ctx context.Context, n *model.Note, author *model.User) {
+	if h.followingRepo == nil {
+		return
+	}
+	// reply / specified は対象外。
+	if n.ReplyID != nil || n.Visibility == model.NoteVisibilitySpecified {
+		return
+	}
+	followers, err := h.followingRepo.ListFollowersToNotify(author.ID)
+	if err != nil {
+		slog.Warn("note notification: list followers failed", "noteId", n.ID, "err", err)
+		return
+	}
+	// quote でない renote (= pure renote) のみ renote-mute の対象。
+	isPureRenote := n.RenoteID != nil && !isQuote(n)
+	for _, f := range followers {
+		if f.FollowerID == author.ID {
+			continue
+		}
+		if isPureRenote && h.renoteMutingRepo != nil {
+			if muted, err := h.renoteMutingRepo.Exists(f.FollowerID, author.ID); err == nil && muted {
+				continue
+			}
+		}
+		h.notifyLocalUser(ctx, f.FollowerID, CreateInput{
+			NotifieeID:     f.FollowerID,
+			NotifierID:     author.ID,
+			Type:           TypeNote,
+			NoteID:         n.ID,
+			NoteVisibility: string(n.Visibility),
+		})
+	}
+}
+
+// OnLogin records a 'login' notification on a user's own stream after a
+// successful signin (upstream SigninService)。notifier を持たない。
+func (h *Hook) OnLogin(userID string) {
+	h.notifyLocalUser(context.Background(), userID, CreateInput{
+		NotifieeID: userID,
+		Type:       TypeLogin,
+	})
+}
+
+// OnCreateToken records a 'createToken' notification after a miauth access
+// token is generated (upstream miauth/gen-token)。notifier を持たない。
+func (h *Hook) OnCreateToken(userID string) {
+	h.notifyLocalUser(context.Background(), userID, CreateInput{
+		NotifieeID: userID,
+		Type:       TypeCreateToken,
+	})
+}
+
+// OnTest records a 'test' notification on the caller's own stream so that the
+// notifications/test-notification endpoint can verify web push / streaming
+// delivery (upstream notifications/test-notification)。notifier を持たない。
+func (h *Hook) OnTest(userID string) {
+	h.notifyLocalUser(context.Background(), userID, CreateInput{
+		NotifieeID: userID,
+		Type:       TypeTest,
+	})
 }
 
 // notifyVisibleToTarget reports whether `targetID` should receive a notification

--- a/internal/core/notification/notification_service.go
+++ b/internal/core/notification/notification_service.go
@@ -54,6 +54,21 @@ const (
 	// 発火)。notifier を持たず、解除した実績名を Extra["achievement"] に格納して
 	// entity の Extra spread で surface する。
 	TypeAchievementEarned Type = "achievementEarned"
+	// TypeNote: notify='normal' フォロワーが、フォロイーの新規ノートを受け取る
+	// 通知 (upstream NoteCreateService の createNotification(followerId,'note',
+	// {noteId},userId))。reply 以外 + visibility != specified のノートで発火し、
+	// pure renote は renote-mute 済みフォロワーには送らない。
+	TypeNote Type = "note"
+	// TypeLogin: signin 成功時に本人へ送る通知 (upstream SigninService)。
+	// notifier を持たない。
+	TypeLogin Type = "login"
+	// TypeCreateToken: miauth gen-token で access token を生成した時に本人へ送る
+	// 通知 (upstream miauth/gen-token)。notifier を持たない。
+	TypeCreateToken Type = "createToken"
+	// TypeTest: notifications/test-notification が web push / stream の疎通確認用
+	// に本人へ送るテスト通知 (upstream notifications/test-notification)。notifier
+	// を持たない。
+	TypeTest Type = "test"
 )
 
 // MaxPerUser caps how many notifications are kept per user in the Redis stream.

--- a/internal/core/notification/parity_1559_note_test.go
+++ b/internal/core/notification/parity_1559_note_test.go
@@ -1,0 +1,216 @@
+package notification
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newNoteNotifyHook wires a Hook with following / renote-muting repos so the
+// 'note' notification fan-out (#1559) is active.
+func newNoteNotifyHook(t *testing.T) (*Hook, *Service, *testutil.MockUserRepository, *testutil.MockFollowingRepository, *testutil.MockRenoteMutingRepository) {
+	t.Helper()
+	h, svc, userRepo := newTestHook(t)
+	followingRepo := testutil.NewMockFollowingRepository()
+	renoteMutingRepo := testutil.NewMockRenoteMutingRepository()
+	h.SetNoteNotifyRepos(followingRepo, renoteMutingRepo)
+	return h, svc, userRepo, followingRepo, renoteMutingRepo
+}
+
+// addNotifyFollower registers `follower` as a local user that follows
+// `followee` with notify='normal'.
+func addNotifyFollower(repo *testutil.MockUserRepository, fr *testutil.MockFollowingRepository, follower, followee string) {
+	addLocalUser(repo, follower, follower)
+	normal := "normal"
+	fr.Followings[follower+"->"+followee] = &model.Following{
+		ID:         follower + "->" + followee,
+		FollowerID: follower,
+		FolloweeID: followee,
+		Notify:     &normal,
+	}
+}
+
+// #1559 [MEDIUM] notify='normal' フォロワーは通常ノートで 'note' 通知を受け取る。
+func TestHook_OnNoteCreated_NoteNotificationToNotifyFollower(t *testing.T) {
+	h, svc, repo, fr, _ := newNoteNotifyHook(t)
+	addLocalUser(repo, "alice", "alice")
+	addNotifyFollower(repo, fr, "bob", "alice")
+
+	note := &model.Note{ID: "n1", UserID: "alice", Visibility: model.NoteVisibilityPublic}
+	h.OnNoteCreated(note, &model.User{ID: "alice"}, nil, nil)
+
+	out, err := svc.List(context.Background(), "bob", 10)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, TypeNote, out[0].Type)
+	assert.Equal(t, "alice", out[0].NotifierID)
+	assert.Equal(t, "n1", out[0].NoteID)
+}
+
+// reply には note 通知を付けない (upstream は data.reply == null のときだけ発火)。
+func TestHook_OnNoteCreated_NoteNotificationSkippedForReply(t *testing.T) {
+	h, svc, repo, fr, _ := newNoteNotifyHook(t)
+	addLocalUser(repo, "alice", "alice")
+	addNotifyFollower(repo, fr, "bob", "alice")
+
+	parent := &model.Note{ID: "p", UserID: "carol"}
+	replyID := "p"
+	note := &model.Note{ID: "n1", UserID: "alice", Visibility: model.NoteVisibilityPublic, ReplyID: &replyID}
+	h.OnNoteCreated(note, &model.User{ID: "alice"}, parent, nil)
+
+	out, _ := svc.List(context.Background(), "bob", 10)
+	assert.Empty(t, out, "reply は note 通知を発火しない")
+}
+
+// specified 可視性は note 通知の対象外。
+func TestHook_OnNoteCreated_NoteNotificationSkippedForSpecified(t *testing.T) {
+	h, svc, repo, fr, _ := newNoteNotifyHook(t)
+	addLocalUser(repo, "alice", "alice")
+	addNotifyFollower(repo, fr, "bob", "alice")
+
+	note := &model.Note{ID: "n1", UserID: "alice", Visibility: model.NoteVisibilitySpecified}
+	h.OnNoteCreated(note, &model.User{ID: "alice"}, nil, nil)
+
+	out, _ := svc.List(context.Background(), "bob", 10)
+	assert.Empty(t, out, "specified note は note 通知を発火しない")
+}
+
+// pure renote は、その投稿者の renote を mute しているフォロワーには送らない。
+func TestHook_OnNoteCreated_NoteNotificationSkipsRenoteMuted(t *testing.T) {
+	h, svc, repo, fr, rm := newNoteNotifyHook(t)
+	addLocalUser(repo, "alice", "alice")
+	addNotifyFollower(repo, fr, "bob", "alice")
+	// bob は alice の renote を mute している
+	rm.Mutings["m1"] = &model.RenoteMuting{ID: "m1", MuterID: "bob", MuteeID: "alice"}
+
+	target := "t1"
+	original := &model.Note{ID: target, UserID: "carol"}
+	note := &model.Note{ID: "r1", UserID: "alice", Visibility: model.NoteVisibilityPublic, RenoteID: &target}
+	h.OnNoteCreated(note, &model.User{ID: "alice"}, nil, original)
+
+	out, _ := svc.List(context.Background(), "bob", 10)
+	assert.Empty(t, out, "renote-mute 済みフォロワーには pure renote の note 通知を送らない")
+}
+
+// quote renote は renote-mute の対象外で、note 通知が届く。
+func TestHook_OnNoteCreated_NoteNotificationQuoteIgnoresRenoteMute(t *testing.T) {
+	h, svc, repo, fr, rm := newNoteNotifyHook(t)
+	addLocalUser(repo, "alice", "alice")
+	addNotifyFollower(repo, fr, "bob", "alice")
+	rm.Mutings["m1"] = &model.RenoteMuting{ID: "m1", MuterID: "bob", MuteeID: "alice"}
+
+	target := "t1"
+	original := &model.Note{ID: target, UserID: "carol"}
+	text := "quoted"
+	note := &model.Note{ID: "q1", UserID: "alice", Visibility: model.NoteVisibilityPublic, RenoteID: &target, Text: &text}
+	h.OnNoteCreated(note, &model.User{ID: "alice"}, nil, original)
+
+	out, err := svc.List(context.Background(), "bob", 10)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, TypeNote, out[0].Type)
+}
+
+// notify を設定していないフォロワーには note 通知を送らない。
+func TestHook_OnNoteCreated_NoteNotificationSkipsNonNotifyFollower(t *testing.T) {
+	h, svc, repo, fr, _ := newNoteNotifyHook(t)
+	addLocalUser(repo, "alice", "alice")
+	addLocalUser(repo, "bob", "bob")
+	// notify 無しの follow edge
+	fr.Followings["bob->alice"] = &model.Following{ID: "f", FollowerID: "bob", FolloweeID: "alice"}
+
+	note := &model.Note{ID: "n1", UserID: "alice", Visibility: model.NoteVisibilityPublic}
+	h.OnNoteCreated(note, &model.User{ID: "alice"}, nil, nil)
+
+	out, _ := svc.List(context.Background(), "bob", 10)
+	assert.Empty(t, out, "notify 未設定のフォロワーには送らない")
+}
+
+// followingRepo 未配線なら note 通知の fan-out 自体が無効。
+func TestHook_OnNoteCreated_NoteNotificationDisabledWithoutRepo(t *testing.T) {
+	h, svc, repo := newTestHook(t) // SetNoteNotifyRepos を呼ばない
+	addLocalUser(repo, "alice", "alice")
+
+	note := &model.Note{ID: "n1", UserID: "alice", Visibility: model.NoteVisibilityPublic}
+	h.OnNoteCreated(note, &model.User{ID: "alice"}, nil, nil)
+
+	out, _ := svc.List(context.Background(), "alice", 10)
+	assert.Empty(t, out)
+}
+
+// #1559 login / createToken / test は notifier を持たず本人へ届く bare 通知。
+func TestHook_SelfNotifications(t *testing.T) {
+	cases := []struct {
+		name string
+		fire func(h *Hook, userID string)
+		want Type
+	}{
+		{"login", func(h *Hook, u string) { h.OnLogin(u) }, TypeLogin},
+		{"createToken", func(h *Hook, u string) { h.OnCreateToken(u) }, TypeCreateToken},
+		{"test", func(h *Hook, u string) { h.OnTest(u) }, TypeTest},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h, svc, repo := newTestHook(t)
+			addLocalUser(repo, "alice", "alice")
+			c.fire(h, "alice")
+			out, err := svc.List(context.Background(), "alice", 10)
+			require.NoError(t, err)
+			require.Len(t, out, 1)
+			assert.Equal(t, c.want, out[0].Type)
+			assert.Empty(t, out[0].NotifierID, "self-notification は notifier を持たない")
+		})
+	}
+}
+
+// 自己通知でも remote user 宛ては送られない (notifyLocalUser の host guard)。
+func TestHook_SelfNotifications_RemoteSkipped(t *testing.T) {
+	h, svc, repo := newTestHook(t)
+	addRemoteUser(repo, "remote", "remote", "example.com")
+	h.OnLogin("remote")
+	out, _ := svc.List(context.Background(), "remote", 10)
+	assert.Empty(t, out)
+}
+
+// 自己フォロー edge (follower == author) は note 通知から除外する。
+func TestHook_OnNoteCreated_NoteNotificationSkipsSelfFollow(t *testing.T) {
+	h, svc, repo, fr, _ := newNoteNotifyHook(t)
+	addLocalUser(repo, "alice", "alice")
+	normal := "normal"
+	fr.Followings["self"] = &model.Following{ID: "self", FollowerID: "alice", FolloweeID: "alice", Notify: &normal}
+
+	note := &model.Note{ID: "n1", UserID: "alice", Visibility: model.NoteVisibilityPublic}
+	h.OnNoteCreated(note, &model.User{ID: "alice"}, nil, nil)
+
+	out, _ := svc.List(context.Background(), "alice", 10)
+	assert.Empty(t, out, "自己フォロー edge には note 通知を送らない")
+}
+
+// failingFollowingNotifyRepo は ListFollowersToNotify でエラーを返す。
+type failingFollowingNotifyRepo struct {
+	*testutil.MockFollowingRepository
+}
+
+func (f *failingFollowingNotifyRepo) ListFollowersToNotify(string) ([]*model.Following, error) {
+	return nil, assertErr{}
+}
+
+type assertErr struct{}
+
+func (assertErr) Error() string { return "boom" }
+
+// ListFollowersToNotify が失敗しても panic せず、note 通知を発火しない。
+func TestHook_OnNoteCreated_NoteNotificationListError(t *testing.T) {
+	h, svc, repo := newTestHook(t)
+	addLocalUser(repo, "alice", "alice")
+	h.SetNoteNotifyRepos(&failingFollowingNotifyRepo{MockFollowingRepository: testutil.NewMockFollowingRepository()}, nil)
+
+	note := &model.Note{ID: "n1", UserID: "alice", Visibility: model.NoteVisibilityPublic}
+	assert.NotPanics(t, func() { h.OnNoteCreated(note, &model.User{ID: "alice"}, nil, nil) })
+	out, _ := svc.List(context.Background(), "alice", 10)
+	assert.Empty(t, out)
+}

--- a/internal/entitycompat/runtime_test.go
+++ b/internal/entitycompat/runtime_test.go
@@ -411,6 +411,12 @@ func TestNotificationShapeL2(t *testing.T) {
 		{notification.TypeReceiveFollowReq, true, false, nil},
 		{notification.TypePollVote, true, true, nil},
 		{notification.TypeImportCompleted, false, false, map[string]any{"fileId": "df_1"}},
+		// #1559: note は notifier(user) + note を伴う。login/createToken/test は
+		// notifier も extra も持たない bare shape (id/createdAt/type)。
+		{notification.TypeNote, true, true, nil},
+		{notification.TypeLogin, false, false, nil},
+		{notification.TypeCreateToken, false, false, nil},
+		{notification.TypeTest, false, false, nil},
 	}
 
 	allow, err := LoadAllowlist(filepath.Join("testdata", "allowlist_l2.json"))

--- a/internal/repository/following.go
+++ b/internal/repository/following.go
@@ -23,6 +23,11 @@ type FollowingRepository interface {
 	// compute `isFollowed` across a user list (#1144).
 	FilterFollowingsToAnchor(anchorID string, candidateIDs []string) ([]string, error)
 	ListFollowers(userID string, limit, offset int) ([]*model.Following, error)
+	// ListFollowersToNotify returns Following rows where followeeId matches and
+	// notify='normal'. Used by note.CreateService to fan out 'note'
+	// notifications to followers who opted into post notifications (upstream
+	// NoteCreateService の findBy({followeeId, notify:'normal'}))。
+	ListFollowersToNotify(userID string) ([]*model.Following, error)
 	ListFollowing(userID string, limit, offset int) ([]*model.Following, error)
 	// ListFollowingForList returns Following rows where followerID matches,
 	// optionally filtered by `notify IS NOT NULL` (= notification=true) and
@@ -130,6 +135,19 @@ func (r *followingRepository) ListFollowers(userID string, limit, offset int) ([
 		Order("id DESC").
 		Limit(limit).
 		Offset(offset).
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// ListFollowersToNotify returns Following rows where followeeId matches and
+// notify='normal'. note 通知の fan-out 対象を絞る (#1559)。`notify` 列は
+// null=OFF / 'normal'=ON という Misskey 互換 semantics で、TS NoteCreateService は
+// findBy({followeeId, notify:'normal'}) と完全一致で絞るため値も 'normal' に揃える。
+func (r *followingRepository) ListFollowersToNotify(userID string) ([]*model.Following, error) {
+	var rows []*model.Following
+	if err := r.db.Where(`"followeeId" = ? AND notify = ?`, userID, "normal").
 		Find(&rows).Error; err != nil {
 		return nil, err
 	}

--- a/internal/repository/following_test.go
+++ b/internal/repository/following_test.go
@@ -174,6 +174,31 @@ func TestFollowingRepository_ListFollowers_ListFollowing(t *testing.T) {
 	assert.Len(t, followingsOfA, 2)
 }
 
+// ListFollowersToNotify は notify='normal' の follower row だけを返す (#1559)。
+func TestFollowingRepository_ListFollowersToNotify(t *testing.T) {
+	repo := NewFollowingRepository(testDB)
+	followee := insertTestUser(t, "u_ntf_fe", "ntffe")
+	defer cleanupUser(t, followee.ID)
+	notifyFollower := insertTestUser(t, "u_ntf_on", "ntfon")
+	defer cleanupUser(t, notifyFollower.ID)
+	silentFollower := insertTestUser(t, "u_ntf_off", "ntfoff")
+	defer cleanupUser(t, silentFollower.ID)
+
+	// notify='normal' の follow edge
+	normal := "normal"
+	on := &model.Following{ID: "ntf_on", FollowerID: notifyFollower.ID, FolloweeID: followee.ID, Notify: &normal}
+	require.NoError(t, testDB.Create(on).Error)
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, on.ID)
+	// notify 無し (null) の follow edge は対象外
+	insertFollowing(t, "ntf_off", silentFollower.ID, followee.ID)
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, "ntf_off")
+
+	rows, err := repo.ListFollowersToNotify(followee.ID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, notifyFollower.ID, rows[0].FollowerID)
+}
+
 func TestFollowingRepository_QueryErrors(t *testing.T) {
 	// cancelledなcontextを使ってgorm経由でerrorを発生させる
 	ctx, cancel := context.WithCancel(context.Background())
@@ -185,6 +210,9 @@ func TestFollowingRepository_QueryErrors(t *testing.T) {
 	assert.Error(t, err)
 
 	_, err = repo.ListFollowers("a", 10, 0)
+	assert.Error(t, err)
+
+	_, err = repo.ListFollowersToNotify("a")
 	assert.Error(t, err)
 
 	_, err = repo.ListFollowing("a", 10, 0)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -306,6 +306,8 @@ func (s *Server) setupRoutes() {
 	notificationService.SetNoteUnreadRepo(noteUnreadRepo)
 	notificationHook := corenotification.NewHook(notificationService, userRepo)
 	notificationHook.SetNoteUnreadRepo(noteUnreadRepo)
+	// note 通知 (notify='normal' フォロワーへの投稿通知、#1559) の fan-out 依存。
+	notificationHook.SetNoteNotifyRepos(followingRepo, renoteMutingRepo)
 	noteCreateService.SetNotificationHook(notificationHook)
 	noteCreateService.SetUserRepo(userRepo)
 	followingService.SetNotificationHook(notificationHook)
@@ -1101,6 +1103,7 @@ func (s *Server) setupRoutes() {
 	// signin履歴レコード注入
 	signinRepo := repository.NewSigninRepository(s.db)
 	signinHandler.SetSigninRepo(signinRepo, idGen)
+	signinHandler.SetLoginNotifier(notificationHook)
 	api.POST("/signin", signinHandler.Signin)
 	api.POST("/signin-flow", signinHandler.SigninFlow)
 	api.POST("/signin-with-passkey", signinHandler.SigninWithPasskey)
@@ -1469,6 +1472,7 @@ func (s *Server) setupRoutes() {
 	notificationsHandler.SetFollowRequestRepo(followRequestRepo)
 	notificationsHandler.SetInstanceRepo(instanceRepo)
 	notificationsHandler.SetEmojiRepo(emojiRepo)
+	notificationsHandler.SetTestNotifier(notificationHook)
 	api.POST("/i/notifications", notificationsHandler.Show, middleware.RequireAuth(), middleware.RequireScope("read:notifications"))
 	api.POST("/i/notifications-grouped", notificationsHandler.Grouped, middleware.RequireAuth(), middleware.RequireScope("read:notifications"))
 	api.POST("/notifications/mark-all-as-read", notificationsHandler.MarkAllAsRead, middleware.RequireAuth(), middleware.RequireScope("write:notifications"))
@@ -2248,6 +2252,7 @@ func (s *Server) setupRoutes() {
 	// miauth/:session/check — 3rd-party client が session 紐付き token を取得する
 	// (#1224)。token をまだ持たない client が叩くため RequireAuth は付けない。
 	authHandler.SetUserRepo(userRepo)
+	authHandler.SetTokenNotifier(notificationHook)
 	api.POST("/miauth/:session/check", authHandler.MiAuthCheck)
 
 	// app/* — アプリ管理API

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -4966,6 +4966,18 @@ func (m *MockFollowingRepository) ListFollowing(userID string, limit, offset int
 	return paginate(rows, limit, offset), nil
 }
 
+// ListFollowersToNotify mirrors the production repo: followeeId match +
+// notify='normal'.
+func (m *MockFollowingRepository) ListFollowersToNotify(userID string) ([]*model.Following, error) {
+	var rows []*model.Following
+	for _, f := range m.Followings {
+		if f.FolloweeID == userID && f.Notify != nil && *f.Notify == "normal" {
+			rows = append(rows, f)
+		}
+	}
+	return rows, nil
+}
+
 // ListFollowingForList mirrors repository.followingRepository.ListFollowingForList
 // (cursor + notification filter for /api/following/list)。
 func (m *MockFollowingRepository) ListFollowingForList(followerID, sinceID, untilID string, notification bool, limit int) ([]*model.Following, error) {


### PR DESCRIPTION
## Summary

Misskey TS 互換性監査 (#1559) の notification type 領域から、upstream で発火するが mk-go で未発火だった通知 4 件を実装する。#1559 は再検証の結果 stale (既に他 PR で解消済み) が 3 件あり、real 項目を層ごとに 3 PR に分割する。本 PR はその part 1/3 (notification type の発火、role/invitation packing を伴わない 4 件)。

## 主な変更点

- **note 通知**: notify='normal' フォロワーが、フォロイーの新規ノートを受け取る (upstream `NoteCreateService`)。発火条件は upstream に揃える:
  - reply ではない (`data.reply == null` 相当の `n.ReplyID == nil`)
  - visibility != specified
  - pure renote は、その投稿者の renote を mute しているフォロワーには送らない (quote は対象外)
  - `FollowingRepository.ListFollowersToNotify` を追加し、fan-out 対象を `notify='normal'` に絞る (TS の `findBy({followeeId, notify:'normal'})` と等価)
- **login 通知**: signin 成功時に本人へ送る (upstream `SigninService`)。notifier 無し。
- **createToken 通知**: miauth gen-token で token 生成時に本人へ送る (upstream `miauth/gen-token`)。notifier 無し。
- **test 通知**: `notifications/test-notification` が web push / streaming の疎通確認用に本人へ送る (upstream `notifications/test-notification`)。従来は no-op stub だった。

login/createToken/test は notifier を持たない self-notification。いずれも `notification.Hook` 経由で発火させ、remote 宛て除外と web push enqueue を共通化する。各ハンドラへは循環依存を避けるため interface (`LoginNotifier`/`TokenNotifier`/`TestNotifier`) で配線する。

## テスト

- `internal/core/notification/parity_1559_note_test.go` (新規): note fan-out の発火条件 (reply/specified/pure-renote-mute/quote例外/notify未設定/自己フォロー/repo未配線/list失敗) と login/createToken/test の self-notification を網羅
- `internal/repository/following_test.go`: `ListFollowersToNotify` の実 DB integration test (notify='normal' のみ返す / null 除外 / query error)
- `internal/api/{signin,auth,notifications}/handler_test.go`: 各 notifier の配線・発火検証
- `internal/entitycompat/runtime_test.go`: Notification union L2 検証に note/login/createToken/test の 4 ケースを追加 (golden union と一致を確認)
- 対象パッケージ coverage: notification 92.2% / signin 94.6% / auth 100% / notifications 95.1% / repository 90.5%
- `make fmt` / `go vet ./...` / `go test ./...` 全 pass

実行方法:
```
go test ./internal/core/notification/ ./internal/api/signin/ ./internal/api/auth/ ./internal/api/notifications/ ./internal/repository/ ./internal/entitycompat/ -count=1
```

## 関連

#1559 (part 1/3)。残りの real 項目は後続 PR で扱う:
- part 2/3: roleAssigned / chatRoomInvitationReceived (role/invitation の entity packing を伴う)
- part 3/3: error registry (AUTHENTICATION_FAILED / YOUR_ACCOUNT_SUSPENDED / ACCESS_DENIED 定数整理)

監査の HIGH 項目 (PERMISSION_DENIED) を含む 3 件 (PERMISSION_DENIED / notifications-grouped / YOUR_ACCOUNT_MOVED) は再検証で既に解消済み (stale) と判明したため対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)