### PR TITLE
Fix notification: roleAssigned 通知 type を実装 (#1559 part 2/3)

### DIFF
--- a/internal/api/notifications/grouped.go
+++ b/internal/api/notifications/grouped.go
@@ -46,7 +46,7 @@ func (h *Handler) Grouped(c echo.Context) error {
 			Note: noteByID[n.NoteID],
 		})
 	}
-	packed := entity.PackNotifications(items, h.idGen, h.instanceLookup(), h.emojiLookup())
+	packed := entity.PackNotifications(items, h.idGen, h.instanceLookup(), h.emojiLookup(), h.notificationOptions()...)
 	// depth-2 embed hide (#1570): grouping の前に通知 note の renote/reply embed と
 	// 著者設定ゲートを viewer 可視性で適用する。Show と同じく #1444 CanSeeNote gate は
 	// 落とすだけで embed に再帰しないため、ここで hide しないと grouped 経由で

--- a/internal/api/notifications/handler.go
+++ b/internal/api/notifications/handler.go
@@ -29,6 +29,16 @@ type Handler struct {
 	instanceRepo  repository.InstanceRepository
 	emojiRepo     repository.EmojiRepository
 	testNotifier  TestNotifier
+	roleLookup    entity.RoleLookup
+}
+
+// SetRoleLookup wires the lookup used to pack roleAssigned notifications'
+// embedded role (#1559)。
+func (h *Handler) SetRoleLookup(fn entity.RoleLookup) { h.roleLookup = fn }
+
+// notificationOptions returns the per-call packing options (role lookup etc.)。
+func (h *Handler) notificationOptions() []entity.NotificationOption {
+	return []entity.NotificationOption{entity.WithRoleLookup(h.roleLookup)}
 }
 
 // NewHandler creates a new notifications Handler.
@@ -141,7 +151,7 @@ func (h *Handler) Show(c echo.Context) error {
 			Note: noteByID[n.NoteID],
 		})
 	}
-	out := entity.PackNotifications(items, h.idGen, h.instanceLookup(), h.emojiLookup())
+	out := entity.PackNotifications(items, h.idGen, h.instanceLookup(), h.emojiLookup(), h.notificationOptions()...)
 	// depth-2 embed hide (#1570): collectNotifications の #1444 CanSeeNote gate は
 	// 見えない note を丸ごと落とすが embed (renote/reply) には再帰しない。通知 note の
 	// embed と著者設定ゲートを viewer 可視性で適用する。これを欠くと #1570 で塞いだ

--- a/internal/core/notification/hooks.go
+++ b/internal/core/notification/hooks.go
@@ -252,6 +252,18 @@ func (h *Hook) OnTest(userID string) {
 	})
 }
 
+// OnRoleAssigned records a 'roleAssigned' notification on the assigned user's
+// stream (upstream RoleService.assign)。notifier を持たず、role ID を Extra に
+// 格納する (entity 側で read 時に packed role へ解決する)。リモートユーザー
+// 宛ては notifyLocalUser の host guard で除外される。
+func (h *Hook) OnRoleAssigned(userID, roleID string) {
+	h.notifyLocalUser(context.Background(), userID, CreateInput{
+		NotifieeID: userID,
+		Type:       TypeRoleAssigned,
+		Extra:      map[string]any{"roleId": roleID},
+	})
+}
+
 // notifyVisibleToTarget reports whether `targetID` should receive a notification
 // about note `n`, based on its visibility (upstream #17335 / triage #1006 +
 // upstream #17363 / triage #1010)。

--- a/internal/core/notification/notification_service.go
+++ b/internal/core/notification/notification_service.go
@@ -69,6 +69,10 @@ const (
 	// に本人へ送るテスト通知 (upstream notifications/test-notification)。notifier
 	// を持たない。
 	TypeTest Type = "test"
+	// TypeRoleAssigned: local public role が割り当てられた時に被割当ユーザーへ
+	// 送る通知 (upstream RoleService.assign)。Extra["roleId"] に role ID を持ち、
+	// entity 側で read 時に packed role へ解決する (role 削除済なら通知を drop)。
+	TypeRoleAssigned Type = "roleAssigned"
 )
 
 // MaxPerUser caps how many notifications are kept per user in the Redis stream.
@@ -273,6 +277,12 @@ func (s *Service) Create(ctx context.Context, in CreateInput) (*Notification, er
 	var packed any = n
 	if s.packer != nil {
 		packed = s.packer.Pack(in.NotifieeID, n)
+		if packed == nil {
+			// packer が通知を drop した (roleAssigned で role 削除済など)。upstream
+			// は stream へ出す前に filter するので、永続化済みの本通知は realtime
+			// publish (PublishNotification / unreadNotification) だけ skip する。
+			return n, nil
+		}
 	}
 	if s.publisher != nil {
 		// Publisher が packed bodyを受け取れる場合は渡して double-pack

--- a/internal/core/notification/parity_1559_note_test.go
+++ b/internal/core/notification/parity_1559_note_test.go
@@ -167,6 +167,28 @@ func TestHook_SelfNotifications(t *testing.T) {
 	}
 }
 
+// #1559 [MEDIUM] OnRoleAssigned は roleId を Extra に格納した通知を本人へ作る。
+func TestHook_OnRoleAssigned(t *testing.T) {
+	h, svc, repo := newTestHook(t)
+	addLocalUser(repo, "alice", "alice")
+	h.OnRoleAssigned("alice", "role1")
+	out, err := svc.List(context.Background(), "alice", 10)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, TypeRoleAssigned, out[0].Type)
+	assert.Empty(t, out[0].NotifierID)
+	assert.Equal(t, "role1", out[0].Extra["roleId"])
+}
+
+// roleAssigned 通知も remote user 宛ては送られない。
+func TestHook_OnRoleAssigned_RemoteSkipped(t *testing.T) {
+	h, svc, repo := newTestHook(t)
+	addRemoteUser(repo, "remote", "remote", "example.com")
+	h.OnRoleAssigned("remote", "role1")
+	out, _ := svc.List(context.Background(), "remote", 10)
+	assert.Empty(t, out)
+}
+
 // 自己通知でも remote user 宛ては送られない (notifyLocalUser の host guard)。
 func TestHook_SelfNotifications_RemoteSkipped(t *testing.T) {
 	h, svc, repo := newTestHook(t)

--- a/internal/core/role/role_service.go
+++ b/internal/core/role/role_service.go
@@ -124,6 +124,23 @@ type Service struct {
 	rolesListMu        sync.RWMutex
 	rolesListCache     []*model.Role
 	rolesListExpiresAt time.Time
+
+	// roleAssignNotifier は local public role 割当時に被割当ユーザーへ
+	// 'roleAssigned' 通知を送る (#1559)。循環依存を避けるため interface で
+	// 受け取る (実装は core/notification.Hook)。nil なら通知しない。
+	roleAssignNotifier RoleAssignNotifier
+}
+
+// RoleAssignNotifier records a 'roleAssigned' notification on role assignment
+// (#1559)。実装は core/notification。
+type RoleAssignNotifier interface {
+	OnRoleAssigned(userID, roleID string)
+}
+
+// SetRoleAssignNotifier wires the notifier used by Assign to send a
+// 'roleAssigned' notification for public roles (upstream RoleService.assign)。
+func (s *Service) SetRoleAssignNotifier(n RoleAssignNotifier) {
+	s.roleAssignNotifier = n
 }
 
 // NewService constructs a RoleService.
@@ -901,7 +918,8 @@ func aggregateChatAvailability(values []any) any {
 
 // Assign assigns a role to a user with an optional expiration.
 func (s *Service) Assign(userID, roleID string, expiresAt *time.Time) error {
-	if _, err := s.roleRepo.FindByID(roleID); err != nil {
+	role, err := s.roleRepo.FindByID(roleID)
+	if err != nil {
 		return ErrRoleNotFound
 	}
 	exists, err := s.assignmentRepo.Exists(userID, roleID)
@@ -921,6 +939,12 @@ func (s *Service) Assign(userID, roleID string, expiresAt *time.Time) error {
 		return err
 	}
 	s.InvalidateUserRoleCache(userID)
+	// public role の割当のみ通知する (upstream RoleService.assign の
+	// `if (role.isPublic && user.host === null)`)。local 判定は notifier 側の
+	// notifyLocalUser が host==nil で担保するので、ここでは isPublic だけ見る。
+	if role != nil && role.IsPublic && s.roleAssignNotifier != nil {
+		s.roleAssignNotifier.OnRoleAssigned(userID, roleID)
+	}
 	return nil
 }
 

--- a/internal/core/role/role_service_test.go
+++ b/internal/core/role/role_service_test.go
@@ -627,6 +627,35 @@ func TestAssign_WithExpiry(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// recordingRoleAssignNotifier captures OnRoleAssigned calls (#1559)。
+type recordingRoleAssignNotifier struct{ calls [][2]string }
+
+func (n *recordingRoleAssignNotifier) OnRoleAssigned(userID, roleID string) {
+	n.calls = append(n.calls, [2]string{userID, roleID})
+}
+
+// #1559 [MEDIUM] public role 割当時に roleAssigned 通知が発火する。
+func TestAssign_FiresRoleAssignedForPublicRole(t *testing.T) {
+	svc, roleRepo, _, _ := newTestService(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "VIP", IsPublic: true}
+	notifier := &recordingRoleAssignNotifier{}
+	svc.SetRoleAssignNotifier(notifier)
+
+	require.NoError(t, svc.Assign("user1", "r1", nil))
+	require.Equal(t, [][2]string{{"user1", "r1"}}, notifier.calls)
+}
+
+// 非 public role の割当では通知しない (upstream の role.isPublic ガード)。
+func TestAssign_NoNotificationForNonPublicRole(t *testing.T) {
+	svc, roleRepo, _, _ := newTestService(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Hidden", IsPublic: false}
+	notifier := &recordingRoleAssignNotifier{}
+	svc.SetRoleAssignNotifier(notifier)
+
+	require.NoError(t, svc.Assign("user1", "r1", nil))
+	assert.Empty(t, notifier.calls, "non-public role は通知しない")
+}
+
 func TestUnassign_Success(t *testing.T) {
 	svc, _, assignRepo, _ := newTestService(t)
 	assignRepo.Assignments["user1:r1"] = &model.RoleAssignment{

--- a/internal/entity/notification.go
+++ b/internal/entity/notification.go
@@ -23,6 +23,38 @@ type NotificationItem struct {
 	Note *model.Note
 }
 
+// RoleLookup resolves a role ID to its packed representation, returning false
+// when the role no longer exists. Used to embed `role` on roleAssigned
+// notifications and to drop the notification when the role was deleted
+// (upstream NotificationEntityService が role==null で null を返すのと同じ)。
+type RoleLookup func(roleID string) (map[string]any, bool)
+
+// packOptions carries the optional read-time lookups required by notification
+// types that embed a related entity which must be packed fresh. Threaded via
+// functional options so existing call sites stay unchanged.
+type packOptions struct {
+	role RoleLookup
+}
+
+// NotificationOption configures optional notification packing behavior.
+type NotificationOption func(*packOptions)
+
+// WithRoleLookup supplies the RoleLookup used to pack roleAssigned
+// notifications (#1559)。
+func WithRoleLookup(fn RoleLookup) NotificationOption {
+	return func(o *packOptions) { o.role = fn }
+}
+
+func buildPackOptions(opts []NotificationOption) *packOptions {
+	o := &packOptions{}
+	for _, fn := range opts {
+		if fn != nil {
+			fn(o)
+		}
+	}
+	return o
+}
+
 // PackNotification converts a Notification record into the map shape
 // emitted over the `main` WebSocket channel and returned by
 // /api/i/notifications. Matches Misskey's NotificationEntityService.pack
@@ -38,11 +70,11 @@ type NotificationItem struct {
 // 都度作るので、ループから呼ぶと N+1 クエリになる。複数件をまとめて pack
 // する callsite (例: /api/i/notifications) は PackNotifications を使うこと
 // (#428)。
-func PackNotification(n *notification.Notification, user *model.User, note *model.Note, idGen id.Generator, instLookup InstanceLookup, emojiLookup EmojiLookup) map[string]any {
+func PackNotification(n *notification.Notification, user *model.User, note *model.Note, idGen id.Generator, instLookup InstanceLookup, emojiLookup EmojiLookup, opts ...NotificationOption) map[string]any {
 	if n == nil {
 		return nil
 	}
-	out := PackNotifications([]NotificationItem{{N: n, User: user, Note: note}}, idGen, instLookup, emojiLookup)
+	out := PackNotifications([]NotificationItem{{N: n, User: user, Note: note}}, idGen, instLookup, emojiLookup, opts...)
 	if len(out) == 0 {
 		return nil
 	}
@@ -60,7 +92,8 @@ func PackNotification(n *notification.Notification, user *model.User, note *mode
 // 約 80 クエリ → 各 1 回に削減される (host / 絵文字名は内部で uniq 化)。
 //
 // items 内で N == nil の要素は単純に skip する。残りは入力順序を保って返す。
-func PackNotifications(items []NotificationItem, idGen id.Generator, instLookup InstanceLookup, emojiLookup EmojiLookup) []map[string]any {
+func PackNotifications(items []NotificationItem, idGen id.Generator, instLookup InstanceLookup, emojiLookup EmojiLookup, opts ...NotificationOption) []map[string]any {
+	packOpts := buildPackOptions(opts)
 	// 全 item の notifier user + 埋め込み note.user / Renote/Reply author を
 	// flatten して resolver の入力にする。
 	notifierUsers := make([]*model.User, 0, len(items))
@@ -99,7 +132,7 @@ func PackNotifications(items []NotificationItem, idGen id.Generator, instLookup 
 
 	out := make([]map[string]any, 0, len(items))
 	for _, it := range items {
-		if packed := packNotificationCore(it.N, it.User, it.Note, idGen, instResolver, emojiResolver); packed != nil {
+		if packed := packNotificationCore(it.N, it.User, it.Note, idGen, instResolver, emojiResolver, packOpts); packed != nil {
 			out = append(out, packed)
 		}
 	}
@@ -109,7 +142,7 @@ func PackNotifications(items []NotificationItem, idGen id.Generator, instLookup 
 // packNotificationCore is the resolver-aware body shared by the single-item
 // PackNotification entry point and the batched PackNotifications. Resolvers
 // are passed in so the same instance can be re-used across many items.
-func packNotificationCore(n *notification.Notification, user *model.User, note *model.Note, idGen id.Generator, instResolver *InstanceResolver, emojiResolver *EmojiResolver) map[string]any {
+func packNotificationCore(n *notification.Notification, user *model.User, note *model.Note, idGen id.Generator, instResolver *InstanceResolver, emojiResolver *EmojiResolver, opts *packOptions) map[string]any {
 	if n == nil {
 		return nil
 	}
@@ -118,6 +151,20 @@ func packNotificationCore(n *notification.Notification, user *model.User, note *
 		"id":        n.ID,
 		"createdAt": n.CreatedAt.UTC().Format(tsFormat),
 		"type":      string(n.Type),
+	}
+	// roleAssigned は Extra["roleId"] を read 時に packed role へ解決する。
+	// role 削除済 / lookup 未配線なら通知ごと drop する (TS
+	// NotificationEntityService が role==null で null を返すのと同じ挙動)。
+	if n.Type == notification.TypeRoleAssigned {
+		roleID, _ := n.Extra["roleId"].(string)
+		if opts == nil || opts.role == nil {
+			return nil
+		}
+		packed, ok := opts.role(roleID)
+		if !ok {
+			return nil
+		}
+		out["role"] = packed
 	}
 	if n.NotifierID != "" {
 		// TS本家はnotifierIdを"userId"として返す。
@@ -153,6 +200,11 @@ func packNotificationCore(n *notification.Notification, user *model.User, note *
 	// core keyと衝突する場合は extra 側をskip (packerの契約を壊さない)。
 	for k, v := range n.Extra {
 		if _, collides := out[k]; collides {
+			continue
+		}
+		// roleAssigned の roleId は packed role (out["role"]) に解決済なので
+		// raw ID を surface しない (TS は role のみ返し roleId は出さない)。
+		if k == "roleId" {
 			continue
 		}
 		// exportCompleted 通知の exportedEntity は misskey_dart / Misskey TS が

--- a/internal/entity/notification_test.go
+++ b/internal/entity/notification_test.go
@@ -238,3 +238,51 @@ func TestPackNotifications_NoteAndUserShareInstanceFetch(t *testing.T) {
 	assert.Len(t, instLookup.calls, 1, "host 重複は uniq 化されて 1 回の fetch")
 	assert.ElementsMatch(t, []string{host}, instLookup.calls[0])
 }
+
+// #1559 roleAssigned: lookup が role を返せば packed role を embed し roleId は出さない。
+func TestPackNotification_RoleAssigned_PacksRole(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	n := &notification.Notification{
+		ID:        idGen.Generate(time.Now()),
+		CreatedAt: time.Now(),
+		Type:      notification.TypeRoleAssigned,
+		Extra:     map[string]any{"roleId": "r1"},
+	}
+	lookup := func(roleID string) (map[string]any, bool) {
+		assert.Equal(t, "r1", roleID)
+		return map[string]any{"id": "r1", "name": "VIP"}, true
+	}
+	out := PackNotification(n, nil, nil, idGen, nil, nil, WithRoleLookup(lookup))
+	require.NotNil(t, out)
+	assert.Equal(t, "roleAssigned", out["type"])
+	role, ok := out["role"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "VIP", role["name"])
+	_, hasRoleID := out["roleId"]
+	assert.False(t, hasRoleID, "roleId は packed role に解決済なので surface しない")
+}
+
+// role 削除済 (lookup が false) なら通知ごと drop する。
+func TestPackNotification_RoleAssigned_DroppedWhenRoleDeleted(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	n := &notification.Notification{
+		ID:        idGen.Generate(time.Now()),
+		CreatedAt: time.Now(),
+		Type:      notification.TypeRoleAssigned,
+		Extra:     map[string]any{"roleId": "gone"},
+	}
+	lookup := func(string) (map[string]any, bool) { return nil, false }
+	assert.Nil(t, PackNotification(n, nil, nil, idGen, nil, nil, WithRoleLookup(lookup)))
+}
+
+// role lookup 未配線でも安全側に倒して通知を drop する。
+func TestPackNotification_RoleAssigned_DroppedWhenLookupUnset(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	n := &notification.Notification{
+		ID:        idGen.Generate(time.Now()),
+		CreatedAt: time.Now(),
+		Type:      notification.TypeRoleAssigned,
+		Extra:     map[string]any{"roleId": "r1"},
+	}
+	assert.Nil(t, PackNotification(n, nil, nil, idGen, nil, nil))
+}

--- a/internal/entitycompat/runtime_test.go
+++ b/internal/entitycompat/runtime_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/shiroha-a/mk/internal/core/notification"
+	corerole "github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -200,7 +201,7 @@ func loadUnions(t *testing.T) map[string]map[string]Schema {
 
 // notifFixture builds a packed notification map for a given type using the
 // same construction pattern as the entity package's own packer tests.
-func notifFixture(typ notification.Type, withUser, withNote bool, extra map[string]any) map[string]any {
+func notifFixture(typ notification.Type, withUser, withNote bool, extra map[string]any, opts ...entity.NotificationOption) map[string]any {
 	idGen, _ := id.NewGenerator("aidx")
 	n := &notification.Notification{
 		ID:         "n1",
@@ -222,7 +223,12 @@ func notifFixture(typ notification.Type, withUser, withNote bool, extra map[stri
 	if typ == notification.TypeReaction {
 		n.Reaction = ":smile:"
 	}
-	return entity.PackNotification(n, user, note, idGen, nil, nil)
+	// roleAssigned は notifier を持たない (RoleService.assign は system/moderator
+	// 起点で notifier 概念が無い)。golden union の variant も userId を含まない。
+	if typ == notification.TypeRoleAssigned {
+		n.NotifierID = ""
+	}
+	return entity.PackNotification(n, user, note, idGen, nil, nil, opts...)
 }
 
 func TestEmbeddedGolden(t *testing.T) {
@@ -396,27 +402,34 @@ func TestNotificationShapeL2(t *testing.T) {
 		}
 	}
 
+	idGenRole, _ := id.NewGenerator("aidx")
+	roleLookup := entity.WithRoleLookup(func(string) (map[string]any, bool) {
+		return entity.PackRole(&model.Role{ID: "r1", Name: "VIP", IsPublic: true}, 0, idGenRole, corerole.DefaultPolicies()), true
+	})
 	cases := []struct {
 		typ      notification.Type
 		withUser bool
 		withNote bool
 		extra    map[string]any
+		opts     []entity.NotificationOption
 	}{
-		{notification.TypeFollow, true, false, nil},
-		{notification.TypeReaction, true, true, nil},
-		{notification.TypeMention, true, true, nil},
-		{notification.TypeReply, true, true, nil},
-		{notification.TypeRenote, true, true, nil},
-		{notification.TypeQuote, true, true, nil},
-		{notification.TypeReceiveFollowReq, true, false, nil},
-		{notification.TypePollVote, true, true, nil},
-		{notification.TypeImportCompleted, false, false, map[string]any{"fileId": "df_1"}},
+		{notification.TypeFollow, true, false, nil, nil},
+		{notification.TypeReaction, true, true, nil, nil},
+		{notification.TypeMention, true, true, nil, nil},
+		{notification.TypeReply, true, true, nil, nil},
+		{notification.TypeRenote, true, true, nil, nil},
+		{notification.TypeQuote, true, true, nil, nil},
+		{notification.TypeReceiveFollowReq, true, false, nil, nil},
+		{notification.TypePollVote, true, true, nil, nil},
+		{notification.TypeImportCompleted, false, false, map[string]any{"fileId": "df_1"}, nil},
 		// #1559: note は notifier(user) + note を伴う。login/createToken/test は
 		// notifier も extra も持たない bare shape (id/createdAt/type)。
-		{notification.TypeNote, true, true, nil},
-		{notification.TypeLogin, false, false, nil},
-		{notification.TypeCreateToken, false, false, nil},
-		{notification.TypeTest, false, false, nil},
+		{notification.TypeNote, true, true, nil, nil},
+		{notification.TypeLogin, false, false, nil, nil},
+		{notification.TypeCreateToken, false, false, nil, nil},
+		{notification.TypeTest, false, false, nil, nil},
+		// #1559: roleAssigned は Extra["roleId"] を read 時に packed role へ解決する。
+		{notification.TypeRoleAssigned, false, false, map[string]any{"roleId": "r1"}, []entity.NotificationOption{roleLookup}},
 	}
 
 	allow, err := LoadAllowlist(filepath.Join("testdata", "allowlist_l2.json"))
@@ -426,7 +439,7 @@ func TestNotificationShapeL2(t *testing.T) {
 
 	var gated []Finding
 	for _, c := range cases {
-		out := notifFixture(c.typ, c.withUser, c.withNote, c.extra)
+		out := notifFixture(c.typ, c.withUser, c.withNote, c.extra, c.opts...)
 		for _, f := range ValidateUnionValue("Notification", out, notif) {
 			if f.Sev == SevHigh || f.Sev == SevMed {
 				gated = append(gated, f)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -310,6 +310,16 @@ func (s *Server) setupRoutes() {
 	notificationHook.SetNoteNotifyRepos(followingRepo, renoteMutingRepo)
 	noteCreateService.SetNotificationHook(notificationHook)
 	noteCreateService.SetUserRepo(userRepo)
+	// roleAssigned 通知 (#1559): local public role 割当時に発火し、entity 側で
+	// read 時に packed role へ解決する。lookup は role 削除済なら (nil,false)。
+	roleService.SetRoleAssignNotifier(notificationHook)
+	roleNotifLookup := func(roleID string) (map[string]any, bool) {
+		r, err := roleRepo.FindByID(roleID)
+		if err != nil || r == nil {
+			return nil, false
+		}
+		return entity.PackRole(r, roleService.CountAssignedUsers(roleID), idGen, corerole.DefaultPolicies()), true
+	}
 	followingService.SetNotificationHook(notificationHook)
 	reactionService.SetNotificationHook(notificationHook)
 
@@ -1473,6 +1483,7 @@ func (s *Server) setupRoutes() {
 	notificationsHandler.SetInstanceRepo(instanceRepo)
 	notificationsHandler.SetEmojiRepo(emojiRepo)
 	notificationsHandler.SetTestNotifier(notificationHook)
+	notificationsHandler.SetRoleLookup(roleNotifLookup)
 	api.POST("/i/notifications", notificationsHandler.Show, middleware.RequireAuth(), middleware.RequireScope("read:notifications"))
 	api.POST("/i/notifications-grouped", notificationsHandler.Grouped, middleware.RequireAuth(), middleware.RequireScope("read:notifications"))
 	api.POST("/notifications/mark-all-as-read", notificationsHandler.MarkAllAsRead, middleware.RequireAuth(), middleware.RequireScope("write:notifications"))
@@ -1845,6 +1856,7 @@ func (s *Server) setupRoutes() {
 	// gate (#1471) に必要。未配線時は CanSeeNote semantics に合わせて
 	// followers note を本人以外に embed しない (= fail-closed)。
 	notificationPublisher.SetFollowingChecker(followingRepo)
+	notificationPublisher.SetRoleLookup(roleNotifLookup)
 	drivePublisher := stream.NewDrivePublisher(streamPubSub)
 	reversiPublisher := stream.NewReversiGamePublisher(streamPubSub)
 	mainStreamPublisher := stream.NewMainStreamPublisher(streamPubSub)

--- a/internal/stream/note_publisher.go
+++ b/internal/stream/note_publisher.go
@@ -190,6 +190,7 @@ type NotificationPublisher struct {
 	idGen          id.Generator
 	instanceLookup entity.InstanceLookup
 	emojiLookup    entity.EmojiLookup
+	roleLookup     entity.RoleLookup
 }
 
 // NewNotificationPublisher constructs a NotificationPublisher.
@@ -226,6 +227,12 @@ func (p *NotificationPublisher) SetEmojiLookup(lookup entity.EmojiLookup) {
 // の `followingChecker == nil` semantics。
 func (p *NotificationPublisher) SetFollowingChecker(c NotificationFollowingChecker) {
 	p.followingRepo = c
+}
+
+// SetRoleLookup attaches the lookup used to pack roleAssigned notifications'
+// embedded role on the streaming payload (#1559)。
+func (p *NotificationPublisher) SetRoleLookup(fn entity.RoleLookup) {
+	p.roleLookup = fn
 }
 
 // Pack implements core/notification.Packer. Returns the packed map shape
@@ -265,7 +272,14 @@ func (p *NotificationPublisher) Pack(notifieeID string, n *corenotification.Noti
 			}
 		}
 	}
-	return entity.PackNotification(n, user, note, p.idGen, p.instanceLookup, p.emojiLookup)
+	packed := entity.PackNotification(n, user, note, p.idGen, p.instanceLookup, p.emojiLookup, entity.WithRoleLookup(p.roleLookup))
+	if packed == nil {
+		// packer が通知を drop した (例: roleAssigned で role 削除済)。nil map を
+		// any に box すると非 nil interface になり、downstream の nil guard を
+		// すり抜けて null が publish されてしまう。明示的に true nil を返す。
+		return nil
+	}
+	return packed
 }
 
 // noteVisibleToNotifiee mirrors core/note.CanSeeNote: returns true when
@@ -320,7 +334,13 @@ func (p *NotificationPublisher) PublishNotification(notifieeID string, n *coreno
 	if p.pub == nil || notifieeID == "" || n == nil {
 		return
 	}
-	p.publishPacked(notifieeID, p.Pack(notifieeID, n))
+	packed := p.Pack(notifieeID, n)
+	if packed == nil {
+		// Pack が通知を drop した (roleAssigned で role 削除済など)。null を
+		// publish しないよう PublishPackedNotification と同じく guard する。
+		return
+	}
+	p.publishPacked(notifieeID, packed)
 }
 
 // PublishPackedNotification publishes an already-packed body to

--- a/internal/stream/note_publisher_test.go
+++ b/internal/stream/note_publisher_test.go
@@ -338,6 +338,51 @@ func TestNotificationPublisher_WithRepos_PacksUserAndNote(t *testing.T) {
 	assert.True(t, hasNote)
 }
 
+// #1559 roleAssigned: SetRoleLookup で配線した lookup が role を packed して
+// streaming payload に embed する。
+func TestNotificationPublisher_RoleAssigned_PacksRole(t *testing.T) {
+	pub := &stubPublisher{}
+	np := NewNotificationPublisher(pub)
+	idGen, _ := id.NewGenerator("aidx")
+	np.SetRepos(&stubNotifUserRepo{user: &model.User{ID: "alice", Username: "alice"}}, &stubNotifNoteRepo{}, idGen)
+	np.SetRoleLookup(func(roleID string) (map[string]any, bool) {
+		return map[string]any{"id": roleID, "name": "VIP"}, true
+	})
+	n := &corenotification.Notification{
+		ID:    idGen.Generate(time.Now()),
+		Type:  corenotification.TypeRoleAssigned,
+		Extra: map[string]any{"roleId": "r1"},
+	}
+	np.PublishNotification("alice", n)
+	require.Len(t, pub.payloads, 1)
+	raw, ok := pub.payloads[0].(json.RawMessage)
+	require.True(t, ok)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(raw, &body))
+	assert.Equal(t, "roleAssigned", body["type"])
+	role, ok := body["role"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "VIP", role["name"])
+}
+
+// role 削除済 (lookup が false) の roleAssigned は stream に publish しない
+// (Pack が true nil を返して downstream の nil guard で drop される、#1559)。
+func TestNotificationPublisher_RoleAssigned_DroppedWhenRoleDeleted(t *testing.T) {
+	pub := &stubPublisher{}
+	np := NewNotificationPublisher(pub)
+	idGen, _ := id.NewGenerator("aidx")
+	np.SetRepos(&stubNotifUserRepo{user: &model.User{ID: "alice", Username: "alice"}}, &stubNotifNoteRepo{}, idGen)
+	np.SetRoleLookup(func(string) (map[string]any, bool) { return nil, false })
+	n := &corenotification.Notification{
+		ID:    idGen.Generate(time.Now()),
+		Type:  corenotification.TypeRoleAssigned,
+		Extra: map[string]any{"roleId": "gone"},
+	}
+	assert.Nil(t, np.Pack("alice", n), "Pack は drop 時 true nil を返す")
+	np.PublishNotification("alice", n)
+	assert.Empty(t, pub.payloads, "削除済 role の roleAssigned は publish しない")
+}
+
 func TestNotificationPublisher_Pack_NilNotification(t *testing.T) {
 	np := NewNotificationPublisher(nil)
 	assert.Nil(t, np.Pack("alice", nil))


### PR DESCRIPTION
## Summary

Misskey TS 互換性監査 (#1559) の notification type 領域から `roleAssigned` 通知を実装する。#1559 の part 2/3 (related entity の packing を伴う通知)。

upstream `RoleService.assign` は `role.isPublic && user.host === null` のとき被割当ユーザーへ `roleAssigned` 通知を発火し、`NotificationEntityService.pack` が **read 時** に `role` (packed Role) を embed する。role が削除済なら通知ごと `null` で drop する。

## 主な変更点

- **発火** (`core/role.Service.Assign`): role.IsPublic のときだけ `RoleAssignNotifier` を発火する。local 判定 (TS の `user.host === null`) は notifier 側 `notifyLocalUser` の host guard に委ねる。
- **通知作成** (`core/notification.Hook.OnRoleAssigned`): notifier を持たない通知で、roleId を Extra に格納する。
- **packing** (`entity.PackNotification(s)`): functional option `WithRoleLookup` を追加。roleAssigned は read 時に `roleId` → packed role へ解決して `role` を emit し、`roleId` は raw 出力しない。lookup 未配線 / role 削除済なら通知ごと drop (`PackNotification` が nil)。既存の呼び出し元は variadic option のため無改変。
- **配線** (`router.go`): role lookup closure (`roleRepo.FindByID` + `CountAssignedUsers` + `DefaultPolicies` 経由で `entity.PackRole`) を REST handler・grouped・stream publisher の全 pack 経路へ注入。`roleService.SetRoleAssignNotifier(notificationHook)`。
- **stream の null 抑止**: role 削除レースで packer が通知を drop した場合、`Pack` は nil map を box した非 nil interface ではなく **true nil** を返す。`PublishNotification` / `Service.Create` も nil を publish しないよう guard する (upstream は stream へ出す前に filter する)。

## テスト

- `internal/entity/notification_test.go`: roleAssigned packing (role embed / roleId 非出力 / role 削除で drop / lookup 未配線で drop)
- `internal/core/role/role_service_test.go`: Assign が public role で発火・非 public では発火しない
- `internal/core/notification/parity_1559_note_test.go`: `OnRoleAssigned` が roleId 付き通知を作る・remote 宛て除外
- `internal/stream/note_publisher_test.go`: stream で role を packed する・role 削除済は publish しない
- `internal/entitycompat/runtime_test.go`: Notification union L2 検証に roleAssigned ケースを追加 (golden union `{createdAt,id,role,type}` と一致)
- 対象パッケージ coverage: entity 96.3% / role 95.2% / notification 91.9% / stream 90.7% / notifications 94.7%
- `make fmt` / `go vet ./...` / `go test ./...` 全 pass

実行方法:
```
go test ./internal/entity/ ./internal/core/role/ ./internal/core/notification/ ./internal/stream/ ./internal/api/notifications/ ./internal/entitycompat/ -count=1
```

## 関連

#1559 (part 2/3)。残り: part 3/3 で chatRoomInvitationReceived (chat invitation packing) + error registry (AUTHENTICATION_FAILED / YOUR_ACCOUNT_SUSPENDED / ACCESS_DENIED 整理) を扱う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)