### PR TITLE
Fix notification: chatRoomInvitationReceived 通知 type を実装 (#1559 part 3/4)

### DIFF
--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -35,6 +35,9 @@ type Handler struct {
 	// UserLite) で invitee user を解決するために使う (#... H-PR9a)。未配線時は
 	// user field を省略する。
 	userRepo repository.UserRepository
+	// invitationNotifier は invitations/create で被招待ユーザーへ
+	// 'chatRoomInvitationReceived' 通知を送る (#1559)。未配線なら通知しない。
+	invitationNotifier ChatInvitationNotifier
 }
 
 // maxRoomMembers mirrors upstream ChatService.MAX_ROOM_MEMBERS。join /
@@ -57,6 +60,50 @@ func (h *Handler) SetModeratorChecker(m ModeratorChecker) { h.moderatorChecker =
 // SetUserRepo wires the user repository for resolving invitee UserLite in the
 // invitations/create response.
 func (h *Handler) SetUserRepo(r repository.UserRepository) { h.userRepo = r }
+
+// ChatInvitationNotifier records a 'chatRoomInvitationReceived' notification on
+// the invitee's stream (#1559)。循環依存を避けるため interface で受け取る
+// (実装は core/notification.Hook)。
+type ChatInvitationNotifier interface {
+	OnChatRoomInvitationReceived(inviteeID, inviterID, invitationID string)
+}
+
+// SetInvitationNotifier wires the notifier used by invitations/create to send a
+// 'chatRoomInvitationReceived' notification (upstream ChatService の招待作成)。
+func (h *Handler) SetInvitationNotifier(n ChatInvitationNotifier) { h.invitationNotifier = n }
+
+// PackInvitationByID loads an invitation by ID (with room + invitee user) and
+// packs it for the given viewer, returning false when it no longer exists. Used
+// as the read-time lookup for chatRoomInvitationReceived notifications (#1559)。
+func (h *Handler) PackInvitationByID(invitationID, viewerID string) (map[string]any, bool) {
+	if h.repo == nil {
+		return nil, false
+	}
+	inv, err := h.repo.FindInvitationByID(invitationID)
+	if err != nil || inv == nil {
+		return nil, false
+	}
+	// room は schema 上必須。load 失敗時は通知を drop する (= 不完全な
+	// invitation を embed しない)。
+	room, err := h.repo.FindRoomByID(inv.RoomID)
+	if err != nil || room == nil {
+		return nil, false
+	}
+	inv.Room = room
+	// user (被招待者 UserLite) も schema 上必須。upstream packRoomInvitation は
+	// user 解決失敗で throw → NotificationEntityService が null で drop する。
+	// mk-go も解決不能なら通知を drop して shape 不完全な invitation を embed
+	// しない (= 通知 packing 経路は degraded path を取らない)。
+	if h.userRepo == nil {
+		return nil, false
+	}
+	u, uerr := h.userRepo.FindByID(inv.UserID)
+	if uerr != nil || u == nil {
+		return nil, false
+	}
+	inv.User = u
+	return h.packInvitationDetailed(inv, viewerID), true
+}
 
 // NewHandler creates a new chat handler.
 func NewHandler(repo repository.ChatRepository, idGen id.Generator) *Handler {
@@ -922,10 +969,12 @@ func (h *Handler) InvitationsCreate(c echo.Context) error {
 	if err := h.repo.CreateInvitation(inv); err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	// upstream は chatRoomInvitationReceived 通知も作成するが、mk-go の通知基盤
-	// (notification type + entity packer + handler 配線) が未対応のため本 PR では
-	// 未実装。通知対応は H-PR9 follow-up で別途扱う。
-	//
+	// 被招待ユーザー (local) へ chatRoomInvitationReceived 通知を送る (#1559)。
+	// notifier は招待者 (= room owner = request user)。リモート invitee は
+	// notifyLocalUser の host guard で除外される。
+	if h.invitationNotifier != nil {
+		h.invitationNotifier.OnChatRoomInvitationReceived(req.UserID, user.ID, inv.ID)
+	}
 	// invitee が remote user なら Invite activity を配送する (CherryPick group
 	// chat federation, #1201)。local invitee なら service 側で no-op。
 	if h.svc != nil {

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -683,6 +683,81 @@ func TestInvitationsCreate_Success(t *testing.T) {
 
 // userRepo 配線時に invitee user が存在しない (FindByID err) なら、upstream
 // packRoomInvitation の throw と同じく 500 を返し、invitation 行も作らない。
+// recordingInvitationNotifier captures OnChatRoomInvitationReceived calls (#1559)。
+type recordingInvitationNotifier struct{ calls [][3]string }
+
+func (n *recordingInvitationNotifier) OnChatRoomInvitationReceived(invitee, inviter, invID string) {
+	n.calls = append(n.calls, [3]string{invitee, inviter, invID})
+}
+
+// #1559 [MEDIUM] invitations/create で被招待ユーザーへ通知が発火し、notifier は
+// 招待者 (room owner)。
+func TestInvitationsCreate_FiresNotifier(t *testing.T) {
+	h, repo := newTestHandler()
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["u2"] = u2
+	h.SetUserRepo(userRepo)
+	notifier := &recordingInvitationNotifier{}
+	h.SetInvitationNotifier(notifier)
+	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "r1", Name: "General", OwnerID: u1.ID, Owner: u1}))
+
+	rec := post(h.InvitationsCreate, `{"roomId":"r1","userId":"u2"}`, u1)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, notifier.calls, 1)
+	assert.Equal(t, "u2", notifier.calls[0][0], "invitee")
+	assert.Equal(t, "u1", notifier.calls[0][1], "inviter = room owner")
+	assert.NotEmpty(t, notifier.calls[0][2], "invitation ID")
+}
+
+// #1559 PackInvitationByID: 招待を packed ChatRoomInvitation に解決する。
+func TestPackInvitationByID(t *testing.T) {
+	h, repo := newTestHandler()
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["u2"] = u2
+	h.SetUserRepo(userRepo)
+	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "r1", Name: "General", OwnerID: u1.ID, Owner: u1}))
+	require.NoError(t, repo.CreateInvitation(&model.ChatRoomInvitation{ID: "inv1", UserID: "u2", RoomID: "r1"}))
+
+	packed, ok := h.PackInvitationByID("inv1", "u2")
+	require.True(t, ok)
+	assert.Equal(t, "inv1", packed["id"])
+	assert.Equal(t, "r1", packed["roomId"])
+	room, ok := packed["room"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "r1", room["id"])
+
+	// 削除済 (存在しない) invitation は (nil,false)。
+	_, ok = h.PackInvitationByID("gone", "u2")
+	assert.False(t, ok)
+}
+
+// room load 失敗時は通知を drop する (= 不完全な invitation を embed しない)。
+func TestPackInvitationByID_NoRoom(t *testing.T) {
+	h, repo := newTestHandler()
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["u2"] = u2
+	h.SetUserRepo(userRepo)
+	require.NoError(t, repo.CreateInvitation(&model.ChatRoomInvitation{ID: "inv1", UserID: "u2", RoomID: "missing"}))
+	_, ok := h.PackInvitationByID("inv1", "u2")
+	assert.False(t, ok, "room が無ければ drop")
+}
+
+// 被招待者 user が解決できなければ通知を drop する (upstream の throw→null 相当)。
+func TestPackInvitationByID_UnresolvableUser(t *testing.T) {
+	h, repo := newTestHandler()
+	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "r1", Name: "R", OwnerID: u1.ID}))
+	require.NoError(t, repo.CreateInvitation(&model.ChatRoomInvitation{ID: "inv1", UserID: "ghost", RoomID: "r1"}))
+
+	// userRepo 未配線 → drop
+	_, ok := h.PackInvitationByID("inv1", "ghost")
+	assert.False(t, ok, "userRepo 未配線なら drop")
+
+	// userRepo 配線済だが invitee user が存在しない → drop
+	h.SetUserRepo(testutil.NewMockUserRepository())
+	_, ok = h.PackInvitationByID("inv1", "ghost")
+	assert.False(t, ok, "invitee user 解決不能なら drop")
+}
+
 func TestInvitationsCreate_InviteeNotFound(t *testing.T) {
 	h, repo := newTestHandler()
 	h.SetUserRepo(testutil.NewMockUserRepository()) // invitee 未登録

--- a/internal/api/notifications/grouped.go
+++ b/internal/api/notifications/grouped.go
@@ -46,7 +46,7 @@ func (h *Handler) Grouped(c echo.Context) error {
 			Note: noteByID[n.NoteID],
 		})
 	}
-	packed := entity.PackNotifications(items, h.idGen, h.instanceLookup(), h.emojiLookup(), h.notificationOptions()...)
+	packed := entity.PackNotifications(items, h.idGen, h.instanceLookup(), h.emojiLookup(), h.notificationOptions(user.ID)...)
 	// depth-2 embed hide (#1570): grouping の前に通知 note の renote/reply embed と
 	// 著者設定ゲートを viewer 可視性で適用する。Show と同じく #1444 CanSeeNote gate は
 	// 落とすだけで embed に再帰しないため、ここで hide しないと grouped 経由で

--- a/internal/api/notifications/handler.go
+++ b/internal/api/notifications/handler.go
@@ -20,25 +20,37 @@ import (
 
 // Handler handles notifications-related API endpoints.
 type Handler struct {
-	svc           *notification.Service
-	idGen         id.Generator
-	userRepo      repository.UserRepository
-	noteRepo      repository.NoteRepository
-	queryService  *corenote.QueryService
-	followReqRepo repository.FollowRequestRepository
-	instanceRepo  repository.InstanceRepository
-	emojiRepo     repository.EmojiRepository
-	testNotifier  TestNotifier
-	roleLookup    entity.RoleLookup
+	svc                  *notification.Service
+	idGen                id.Generator
+	userRepo             repository.UserRepository
+	noteRepo             repository.NoteRepository
+	queryService         *corenote.QueryService
+	followReqRepo        repository.FollowRequestRepository
+	instanceRepo         repository.InstanceRepository
+	emojiRepo            repository.EmojiRepository
+	testNotifier         TestNotifier
+	roleLookup           entity.RoleLookup
+	chatInvitationLookup entity.ChatInvitationLookup
 }
 
 // SetRoleLookup wires the lookup used to pack roleAssigned notifications'
 // embedded role (#1559)。
 func (h *Handler) SetRoleLookup(fn entity.RoleLookup) { h.roleLookup = fn }
 
-// notificationOptions returns the per-call packing options (role lookup etc.)。
-func (h *Handler) notificationOptions() []entity.NotificationOption {
-	return []entity.NotificationOption{entity.WithRoleLookup(h.roleLookup)}
+// SetChatInvitationLookup wires the lookup used to pack
+// chatRoomInvitationReceived notifications' embedded invitation (#1559)。
+func (h *Handler) SetChatInvitationLookup(fn entity.ChatInvitationLookup) {
+	h.chatInvitationLookup = fn
+}
+
+// notificationOptions returns the per-call packing options (role / chat
+// invitation lookups, viewer) for the given viewer (= notifiee)。
+func (h *Handler) notificationOptions(viewerID string) []entity.NotificationOption {
+	return []entity.NotificationOption{
+		entity.WithRoleLookup(h.roleLookup),
+		entity.WithChatInvitationLookup(h.chatInvitationLookup),
+		entity.WithViewer(viewerID),
+	}
 }
 
 // NewHandler creates a new notifications Handler.
@@ -151,7 +163,7 @@ func (h *Handler) Show(c echo.Context) error {
 			Note: noteByID[n.NoteID],
 		})
 	}
-	out := entity.PackNotifications(items, h.idGen, h.instanceLookup(), h.emojiLookup(), h.notificationOptions()...)
+	out := entity.PackNotifications(items, h.idGen, h.instanceLookup(), h.emojiLookup(), h.notificationOptions(user.ID)...)
 	// depth-2 embed hide (#1570): collectNotifications の #1444 CanSeeNote gate は
 	// 見えない note を丸ごと落とすが embed (renote/reply) には再帰しない。通知 note の
 	// embed と著者設定ゲートを viewer 可視性で適用する。これを欠くと #1570 で塞いだ

--- a/internal/core/chat/room_federation_test.go
+++ b/internal/core/chat/room_federation_test.go
@@ -59,6 +59,30 @@ func TestCreateInvitationViaAP_CreatesAndIdempotent(t *testing.T) {
 	assert.Equal(t, firstID, inv2.ID)
 }
 
+// recordingInvitationNotifier captures OnChatRoomInvitationReceived calls (#1559)。
+type recordingInvitationNotifier struct{ calls [][3]string }
+
+func (n *recordingInvitationNotifier) OnChatRoomInvitationReceived(invitee, inviter, invID string) {
+	n.calls = append(n.calls, [3]string{invitee, inviter, invID})
+}
+
+// #1559 [MEDIUM] AP 経由の招待でも local invitee へ通知し、notifier は room owner。
+func TestCreateInvitationViaAP_FiresNotifier(t *testing.T) {
+	svc, repo := newRoomFedService(t)
+	require.NoError(t, repo.CreateRoom(&model.ChatRoom{ID: "room1", Name: "R", OwnerID: "remoteOwner"}))
+	notifier := &recordingInvitationNotifier{}
+	svc.SetInvitationNotifier(notifier)
+
+	require.NoError(t, svc.CreateInvitationViaAP("room1", "localUser"))
+	require.Len(t, notifier.calls, 1)
+	assert.Equal(t, "localUser", notifier.calls[0][0])
+	assert.Equal(t, "remoteOwner", notifier.calls[0][1], "notifier は room owner")
+
+	// 重複招待では通知しない (no-op)。
+	require.NoError(t, svc.CreateInvitationViaAP("room1", "localUser"))
+	assert.Len(t, notifier.calls, 1)
+}
+
 func TestAddMemberViaAP_RequiresPendingInvitation(t *testing.T) {
 	svc, repo := newRoomFedService(t)
 	// 招待が無い相手の Accept は membership 化しない (なりすまし防止)。

--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -104,6 +104,21 @@ type Service struct {
 	// いないか判定する (upstream ChatService の YOU_HAVE_BEEN_BLOCKED gate)。
 	// nil なら block check は skip。
 	blockingRepo repository.BlockingRepository
+	// invitationNotifier: AP 経由で受け取った招待を local invitee へ通知する
+	// (#1559)。未配線なら通知しない。
+	invitationNotifier ChatInvitationNotifier
+}
+
+// ChatInvitationNotifier records a 'chatRoomInvitationReceived' notification on
+// the invitee's stream (#1559)。実装は core/notification.Hook。
+type ChatInvitationNotifier interface {
+	OnChatRoomInvitationReceived(inviteeID, inviterID, invitationID string)
+}
+
+// SetInvitationNotifier wires the notifier used by CreateInvitationViaAP to
+// notify local invitees of inbound (federated) chat room invitations (#1559)。
+func (s *Service) SetInvitationNotifier(n ChatInvitationNotifier) {
+	s.invitationNotifier = n
 }
 
 // NewService constructs a chat Service.
@@ -445,9 +460,23 @@ func (s *Service) CreateInvitationViaAP(roomID, inviteeUserID string) error {
 	if _, err := s.repo.FindInvitation(inviteeUserID, roomID); err == nil {
 		return nil
 	}
-	return s.repo.CreateInvitation(&model.ChatRoomInvitation{
+	inv := &model.ChatRoomInvitation{
 		ID: s.idGen.Generate(time.Now()), UserID: inviteeUserID, RoomID: roomID,
-	})
+	}
+	if err := s.repo.CreateInvitation(inv); err != nil {
+		return err
+	}
+	// local invitee へ chatRoomInvitationReceived 通知を送る (#1559)。notifier
+	// は招待者 (= room owner)。room load 失敗時は notifier 引数を空にして発火する
+	// (notifier 不明でも通知自体は出す)。
+	if s.invitationNotifier != nil {
+		inviterID := ""
+		if room, err := s.repo.FindRoomByID(roomID); err == nil && room != nil {
+			inviterID = room.OwnerID
+		}
+		s.invitationNotifier.OnChatRoomInvitationReceived(inviteeUserID, inviterID, inv.ID)
+	}
+	return nil
 }
 
 // AddMemberViaAP records a chat room membership for a (typically remote) user

--- a/internal/core/notification/hooks.go
+++ b/internal/core/notification/hooks.go
@@ -264,6 +264,20 @@ func (h *Hook) OnRoleAssigned(userID, roleID string) {
 	})
 }
 
+// OnChatRoomInvitationReceived records a 'chatRoomInvitationReceived'
+// notification on the invitee's stream (upstream ChatService の招待作成)。
+// notifier は招待者で、invitation ID を Extra に格納する (entity 側で read 時に
+// packed invitation へ解決する)。リモート invitee 宛ては notifyLocalUser の
+// host guard で除外される。
+func (h *Hook) OnChatRoomInvitationReceived(inviteeID, inviterID, invitationID string) {
+	h.notifyLocalUser(context.Background(), inviteeID, CreateInput{
+		NotifieeID: inviteeID,
+		NotifierID: inviterID,
+		Type:       TypeChatRoomInvitationReceived,
+		Extra:      map[string]any{"invitationId": invitationID},
+	})
+}
+
 // notifyVisibleToTarget reports whether `targetID` should receive a notification
 // about note `n`, based on its visibility (upstream #17335 / triage #1006 +
 // upstream #17363 / triage #1010)。

--- a/internal/core/notification/notification_service.go
+++ b/internal/core/notification/notification_service.go
@@ -73,6 +73,11 @@ const (
 	// 送る通知 (upstream RoleService.assign)。Extra["roleId"] に role ID を持ち、
 	// entity 側で read 時に packed role へ解決する (role 削除済なら通知を drop)。
 	TypeRoleAssigned Type = "roleAssigned"
+	// TypeChatRoomInvitationReceived: chat room へ招待された時に被招待ユーザーへ
+	// 送る通知 (upstream ChatService の招待作成)。notifier は招待者、
+	// Extra["invitationId"] に invitation ID を持ち、entity 側で read 時に packed
+	// ChatRoomInvitation へ解決する (招待削除済なら通知を drop)。
+	TypeChatRoomInvitationReceived Type = "chatRoomInvitationReceived"
 )
 
 // MaxPerUser caps how many notifications are kept per user in the Redis stream.

--- a/internal/core/notification/parity_1559_note_test.go
+++ b/internal/core/notification/parity_1559_note_test.go
@@ -189,6 +189,30 @@ func TestHook_OnRoleAssigned_RemoteSkipped(t *testing.T) {
 	assert.Empty(t, out)
 }
 
+// #1559 [MEDIUM] OnChatRoomInvitationReceived は notifier(招待者) と invitationId
+// を持つ通知を被招待ユーザーへ作る。
+func TestHook_OnChatRoomInvitationReceived(t *testing.T) {
+	h, svc, repo := newTestHook(t)
+	addLocalUser(repo, "invitee", "invitee")
+	addLocalUser(repo, "inviter", "inviter")
+	h.OnChatRoomInvitationReceived("invitee", "inviter", "inv1")
+	out, err := svc.List(context.Background(), "invitee", 10)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, TypeChatRoomInvitationReceived, out[0].Type)
+	assert.Equal(t, "inviter", out[0].NotifierID)
+	assert.Equal(t, "inv1", out[0].Extra["invitationId"])
+}
+
+// remote invitee 宛ては送られない。
+func TestHook_OnChatRoomInvitationReceived_RemoteSkipped(t *testing.T) {
+	h, svc, repo := newTestHook(t)
+	addRemoteUser(repo, "remote", "remote", "example.com")
+	h.OnChatRoomInvitationReceived("remote", "inviter", "inv1")
+	out, _ := svc.List(context.Background(), "remote", 10)
+	assert.Empty(t, out)
+}
+
 // 自己通知でも remote user 宛ては送られない (notifyLocalUser の host guard)。
 func TestHook_SelfNotifications_RemoteSkipped(t *testing.T) {
 	h, svc, repo := newTestHook(t)

--- a/internal/entity/notification.go
+++ b/internal/entity/notification.go
@@ -29,11 +29,22 @@ type NotificationItem struct {
 // (upstream NotificationEntityService が role==null で null を返すのと同じ)。
 type RoleLookup func(roleID string) (map[string]any, bool)
 
+// ChatInvitationLookup resolves a chat room invitation ID to its packed
+// representation for the given viewer, returning false when the invitation no
+// longer exists. Used to embed `invitation` on chatRoomInvitationReceived
+// notifications and to drop the notification when the invitation was deleted
+// (upstream NotificationEntityService が invitation==null で null を返すのと同じ)。
+type ChatInvitationLookup func(invitationID, viewerID string) (map[string]any, bool)
+
 // packOptions carries the optional read-time lookups required by notification
 // types that embed a related entity which must be packed fresh. Threaded via
 // functional options so existing call sites stay unchanged.
 type packOptions struct {
-	role RoleLookup
+	role           RoleLookup
+	chatInvitation ChatInvitationLookup
+	// viewer は invitation pack の視点 (= notifiee)。chatRoomInvitationReceived
+	// の room.isMuted / invitationExists を viewer 視点で算出するために渡す。
+	viewer string
 }
 
 // NotificationOption configures optional notification packing behavior.
@@ -43,6 +54,18 @@ type NotificationOption func(*packOptions)
 // notifications (#1559)。
 func WithRoleLookup(fn RoleLookup) NotificationOption {
 	return func(o *packOptions) { o.role = fn }
+}
+
+// WithChatInvitationLookup supplies the ChatInvitationLookup used to pack
+// chatRoomInvitationReceived notifications (#1559)。
+func WithChatInvitationLookup(fn ChatInvitationLookup) NotificationOption {
+	return func(o *packOptions) { o.chatInvitation = fn }
+}
+
+// WithViewer sets the viewer (= notifiee) used by viewer-dependent embeds such
+// as the chat invitation's room flags (#1559)。
+func WithViewer(viewerID string) NotificationOption {
+	return func(o *packOptions) { o.viewer = viewerID }
 }
 
 func buildPackOptions(opts []NotificationOption) *packOptions {
@@ -166,6 +189,19 @@ func packNotificationCore(n *notification.Notification, user *model.User, note *
 		}
 		out["role"] = packed
 	}
+	// chatRoomInvitationReceived は Extra["invitationId"] を read 時に packed
+	// invitation へ解決する。削除済 / lookup 未配線なら通知ごと drop する。
+	if n.Type == notification.TypeChatRoomInvitationReceived {
+		invID, _ := n.Extra["invitationId"].(string)
+		if opts == nil || opts.chatInvitation == nil {
+			return nil
+		}
+		packed, ok := opts.chatInvitation(invID, opts.viewer)
+		if !ok {
+			return nil
+		}
+		out["invitation"] = packed
+	}
 	if n.NotifierID != "" {
 		// TS本家はnotifierIdを"userId"として返す。
 		out["userId"] = n.NotifierID
@@ -202,9 +238,10 @@ func packNotificationCore(n *notification.Notification, user *model.User, note *
 		if _, collides := out[k]; collides {
 			continue
 		}
-		// roleAssigned の roleId は packed role (out["role"]) に解決済なので
-		// raw ID を surface しない (TS は role のみ返し roleId は出さない)。
-		if k == "roleId" {
+		// roleAssigned の roleId / chatRoomInvitationReceived の invitationId は
+		// packed entity (out["role"] / out["invitation"]) に解決済なので raw ID を
+		// surface しない (TS は packed entity のみ返す)。
+		if k == "roleId" || k == "invitationId" {
 			continue
 		}
 		// exportCompleted 通知の exportedEntity は misskey_dart / Misskey TS が

--- a/internal/entity/notification_test.go
+++ b/internal/entity/notification_test.go
@@ -286,3 +286,56 @@ func TestPackNotification_RoleAssigned_DroppedWhenLookupUnset(t *testing.T) {
 	}
 	assert.Nil(t, PackNotification(n, nil, nil, idGen, nil, nil))
 }
+
+// #1559 chatRoomInvitationReceived: lookup が invitation を返せば packed
+// invitation を embed し invitationId は出さない。
+func TestPackNotification_ChatRoomInvitation_PacksInvitation(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	n := &notification.Notification{
+		ID:         idGen.Generate(time.Now()),
+		CreatedAt:  time.Now(),
+		Type:       notification.TypeChatRoomInvitationReceived,
+		NotifierID: "u_inviter",
+		Extra:      map[string]any{"invitationId": "inv1"},
+	}
+	inviter := &model.User{ID: "u_inviter", Username: "inviter"}
+	lookup := func(invID, viewerID string) (map[string]any, bool) {
+		assert.Equal(t, "inv1", invID)
+		assert.Equal(t, "u_me", viewerID)
+		return map[string]any{"id": invID, "roomId": "room1"}, true
+	}
+	out := PackNotification(n, inviter, nil, idGen, nil, nil, WithChatInvitationLookup(lookup), WithViewer("u_me"))
+	require.NotNil(t, out)
+	assert.Equal(t, "chatRoomInvitationReceived", out["type"])
+	assert.Equal(t, "u_inviter", out["userId"], "notifier(招待者) は userId として出る")
+	inv, ok := out["invitation"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "room1", inv["roomId"])
+	_, hasInvID := out["invitationId"]
+	assert.False(t, hasInvID, "invitationId は packed invitation に解決済なので surface しない")
+}
+
+// invitation 削除済 (lookup が false) なら通知ごと drop する。
+func TestPackNotification_ChatRoomInvitation_DroppedWhenDeleted(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	n := &notification.Notification{
+		ID:        idGen.Generate(time.Now()),
+		CreatedAt: time.Now(),
+		Type:      notification.TypeChatRoomInvitationReceived,
+		Extra:     map[string]any{"invitationId": "gone"},
+	}
+	lookup := func(string, string) (map[string]any, bool) { return nil, false }
+	assert.Nil(t, PackNotification(n, nil, nil, idGen, nil, nil, WithChatInvitationLookup(lookup)))
+}
+
+// lookup 未配線でも安全側に倒して通知を drop する。
+func TestPackNotification_ChatRoomInvitation_DroppedWhenLookupUnset(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	n := &notification.Notification{
+		ID:        idGen.Generate(time.Now()),
+		CreatedAt: time.Now(),
+		Type:      notification.TypeChatRoomInvitationReceived,
+		Extra:     map[string]any{"invitationId": "inv1"},
+	}
+	assert.Nil(t, PackNotification(n, nil, nil, idGen, nil, nil))
+}

--- a/internal/entitycompat/runtime_test.go
+++ b/internal/entitycompat/runtime_test.go
@@ -406,6 +406,12 @@ func TestNotificationShapeL2(t *testing.T) {
 	roleLookup := entity.WithRoleLookup(func(string) (map[string]any, bool) {
 		return entity.PackRole(&model.Role{ID: "r1", Name: "VIP", IsPublic: true}, 0, idGenRole, corerole.DefaultPolicies()), true
 	})
+	chatInvLookup := entity.WithChatInvitationLookup(func(invID, _ string) (map[string]any, bool) {
+		return map[string]any{
+			"id": invID, "createdAt": "2026-05-25T00:00:00.000Z",
+			"userId": "u_invitee", "roomId": "room1",
+		}, true
+	})
 	cases := []struct {
 		typ      notification.Type
 		withUser bool
@@ -430,6 +436,9 @@ func TestNotificationShapeL2(t *testing.T) {
 		{notification.TypeTest, false, false, nil, nil},
 		// #1559: roleAssigned は Extra["roleId"] を read 時に packed role へ解決する。
 		{notification.TypeRoleAssigned, false, false, map[string]any{"roleId": "r1"}, []entity.NotificationOption{roleLookup}},
+		// #1559: chatRoomInvitationReceived は Extra["invitationId"] を read 時に
+		// packed invitation へ解決する。notifier(招待者) を持つので userId も出る。
+		{notification.TypeChatRoomInvitationReceived, true, false, map[string]any{"invitationId": "inv1"}, []entity.NotificationOption{chatInvLookup}},
 	}
 
 	allow, err := LoadAllowlist(filepath.Join("testdata", "allowlist_l2.json"))

--- a/internal/repository/chat.go
+++ b/internal/repository/chat.go
@@ -41,6 +41,9 @@ type ChatRepository interface {
 	CreateInvitation(inv *model.ChatRoomInvitation) error
 	DeleteInvitation(id string) error
 	FindInvitation(userID, roomID string) (*model.ChatRoomInvitation, error)
+	// FindInvitationByID looks up an invitation by its primary key. Used to
+	// pack chatRoomInvitationReceived notifications at read time (#1559)。
+	FindInvitationByID(id string) (*model.ChatRoomInvitation, error)
 	UpdateInvitation(inv *model.ChatRoomInvitation) error
 
 	// Unread count
@@ -273,6 +276,14 @@ func (r *chatRepository) UpdateInvitation(inv *model.ChatRoomInvitation) error {
 func (r *chatRepository) FindInvitation(userID, roomID string) (*model.ChatRoomInvitation, error) {
 	var inv model.ChatRoomInvitation
 	if err := r.db.Where(`"userId" = ? AND "roomId" = ?`, userID, roomID).First(&inv).Error; err != nil {
+		return nil, err
+	}
+	return &inv, nil
+}
+
+func (r *chatRepository) FindInvitationByID(id string) (*model.ChatRoomInvitation, error) {
+	var inv model.ChatRoomInvitation
+	if err := r.db.Where(`"id" = ?`, id).First(&inv).Error; err != nil {
 		return nil, err
 	}
 	return &inv, nil

--- a/internal/repository/chat_test.go
+++ b/internal/repository/chat_test.go
@@ -588,6 +588,14 @@ func TestChatRepository_Invitation(t *testing.T) {
 	_, err = repo.FindInvitation("ghost", room.ID)
 	assert.Error(t, err)
 
+	// FindInvitationByID (#1559)
+	byID, err := repo.FindInvitationByID("inv_1")
+	require.NoError(t, err)
+	assert.Equal(t, user.ID, byID.UserID)
+	assert.Equal(t, room.ID, byID.RoomID)
+	_, err = repo.FindInvitationByID("ghost")
+	assert.Error(t, err)
+
 	// DeleteInvitation
 	require.NoError(t, repo.DeleteInvitation("inv_1"))
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2336,6 +2336,14 @@ func (s *Server) setupRoutes() {
 	chatHandler.SetDriveFileRepo(driveFileRepo)
 	chatHandler.SetModeratorChecker(roleService)
 	chatHandler.SetUserRepo(userRepo)
+	// chatRoomInvitationReceived 通知 (#1559): 招待作成 (local handler / AP service)
+	// で発火し、entity 側で read 時に packed invitation へ解決する。lookup は
+	// 招待削除済なら (nil,false)。chatHandler が PackInvitationByID を提供する
+	// ため、notification packer (REST handler / stream) への配線はここで行う。
+	chatHandler.SetInvitationNotifier(notificationHook)
+	chatService.SetInvitationNotifier(notificationHook)
+	notificationsHandler.SetChatInvitationLookup(chatHandler.PackInvitationByID)
+	notificationPublisher.SetChatInvitationLookup(chatHandler.PackInvitationByID)
 	api.POST("/drive/files/attached-chat-messages", chatHandler.AttachedChatMessages, middleware.RequireAuth(), middleware.RequireScope("read:drive"))
 	api.POST("/chat/rooms/create", chatHandler.RoomsCreate, middleware.RequireAuth(), middleware.RequireScope("write:chat"))
 	api.POST("/chat/rooms/show", chatHandler.RoomsShow, middleware.RequireAuth(), middleware.RequireScope("read:chat"))

--- a/internal/stream/note_publisher.go
+++ b/internal/stream/note_publisher.go
@@ -183,14 +183,15 @@ type NotificationFollowingChecker interface {
 // the outbound JSON is packed via entity.PackNotification so the WebSocket
 // body matches Misskey's NotificationEntityService.pack shape.
 type NotificationPublisher struct {
-	pub            PubSubPublisher
-	userRepo       NotificationUserRepo
-	noteRepo       NotificationNoteRepo
-	followingRepo  NotificationFollowingChecker
-	idGen          id.Generator
-	instanceLookup entity.InstanceLookup
-	emojiLookup    entity.EmojiLookup
-	roleLookup     entity.RoleLookup
+	pub                  PubSubPublisher
+	userRepo             NotificationUserRepo
+	noteRepo             NotificationNoteRepo
+	followingRepo        NotificationFollowingChecker
+	idGen                id.Generator
+	instanceLookup       entity.InstanceLookup
+	emojiLookup          entity.EmojiLookup
+	roleLookup           entity.RoleLookup
+	chatInvitationLookup entity.ChatInvitationLookup
 }
 
 // NewNotificationPublisher constructs a NotificationPublisher.
@@ -235,6 +236,13 @@ func (p *NotificationPublisher) SetRoleLookup(fn entity.RoleLookup) {
 	p.roleLookup = fn
 }
 
+// SetChatInvitationLookup attaches the lookup used to pack
+// chatRoomInvitationReceived notifications' embedded invitation on the
+// streaming payload (#1559)。
+func (p *NotificationPublisher) SetChatInvitationLookup(fn entity.ChatInvitationLookup) {
+	p.chatInvitationLookup = fn
+}
+
 // Pack implements core/notification.Packer. Returns the packed map shape
 // when repos are wired, otherwise the raw Notification so callers can
 // fall back to prior behaviour.
@@ -272,7 +280,10 @@ func (p *NotificationPublisher) Pack(notifieeID string, n *corenotification.Noti
 			}
 		}
 	}
-	packed := entity.PackNotification(n, user, note, p.idGen, p.instanceLookup, p.emojiLookup, entity.WithRoleLookup(p.roleLookup))
+	packed := entity.PackNotification(n, user, note, p.idGen, p.instanceLookup, p.emojiLookup,
+		entity.WithRoleLookup(p.roleLookup),
+		entity.WithChatInvitationLookup(p.chatInvitationLookup),
+		entity.WithViewer(notifieeID))
 	if packed == nil {
 		// packer が通知を drop した (例: roleAssigned で role 削除済)。nil map を
 		// any に box すると非 nil interface になり、downstream の nil guard を

--- a/internal/stream/note_publisher_test.go
+++ b/internal/stream/note_publisher_test.go
@@ -383,6 +383,35 @@ func TestNotificationPublisher_RoleAssigned_DroppedWhenRoleDeleted(t *testing.T)
 	assert.Empty(t, pub.payloads, "削除済 role の roleAssigned は publish しない")
 }
 
+// #1559 chatRoomInvitationReceived: SetChatInvitationLookup で配線した lookup が
+// invitation を pack して streaming payload に embed する。viewer は notifiee。
+func TestNotificationPublisher_ChatInvitation_PacksInvitation(t *testing.T) {
+	pub := &stubPublisher{}
+	np := NewNotificationPublisher(pub)
+	idGen, _ := id.NewGenerator("aidx")
+	np.SetRepos(&stubNotifUserRepo{user: &model.User{ID: "inviter", Username: "inviter"}}, &stubNotifNoteRepo{}, idGen)
+	np.SetChatInvitationLookup(func(invID, viewerID string) (map[string]any, bool) {
+		assert.Equal(t, "invitee", viewerID, "viewer は notifiee")
+		return map[string]any{"id": invID, "roomId": "room1"}, true
+	})
+	n := &corenotification.Notification{
+		ID:         idGen.Generate(time.Now()),
+		Type:       corenotification.TypeChatRoomInvitationReceived,
+		NotifierID: "inviter",
+		Extra:      map[string]any{"invitationId": "inv1"},
+	}
+	np.PublishNotification("invitee", n)
+	require.Len(t, pub.payloads, 1)
+	raw, ok := pub.payloads[0].(json.RawMessage)
+	require.True(t, ok)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(raw, &body))
+	assert.Equal(t, "chatRoomInvitationReceived", body["type"])
+	inv, ok := body["invitation"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "room1", inv["roomId"])
+}
+
 func TestNotificationPublisher_Pack_NilNotification(t *testing.T) {
 	np := NewNotificationPublisher(nil)
 	assert.Nil(t, np.Pack("alice", nil))

--- a/internal/testutil/mock_chat.go
+++ b/internal/testutil/mock_chat.go
@@ -303,6 +303,15 @@ func (m *MockChatRepository) UpdateInvitation(inv *model.ChatRoomInvitation) err
 	return nil
 }
 
+func (m *MockChatRepository) FindInvitationByID(id string) (*model.ChatRoomInvitation, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if inv, ok := m.Invitations[id]; ok {
+		return inv, nil
+	}
+	return nil, ErrNotFound
+}
+
 func (m *MockChatRepository) FindInvitation(userID, roomID string) (*model.ChatRoomInvitation, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
## Summary

Misskey TS 互換性監査 (#1559) の notification type 領域から `chatRoomInvitationReceived` 通知を実装する。#1559 の part 3/4 (related entity の packing を伴う通知)。

upstream `ChatService` は chat room 招待作成時に被招待ユーザーへ `chatRoomInvitationReceived` 通知 (notifier=招待者) を発火し、`NotificationEntityService.pack` が **read 時** に `invitation` (packed ChatRoomInvitation) を embed する。invitation が削除済なら通知ごと drop する。

## 主な変更点

- **発火**: 招待は 2 経路で作られるため両方で発火する:
  - ローカル `InvitationsCreate` ハンドラ (inviter = room owner = request user)
  - AP 経由 `CreateInvitationViaAP` (inviter = room owner、invitee = local)
- **通知作成** (`core/notification.Hook.OnChatRoomInvitationReceived`): notifier を招待者に設定し、invitationId を Extra に格納する (roleAssigned と違い notifier を持つ)。
- **packing** (`entity`): `WithChatInvitationLookup` / `WithViewer` option を追加。chatRoomInvitationReceived は read 時に `invitationId` → packed invitation へ解決して `invitation` を emit し、`invitationId` は raw 出力しない。lookup 未配線 / 招待削除済なら通知ごと drop。
- **lookup 実体** (`chat.Handler.PackInvitationByID`): invitation を ID で load → room + 被招待者 user を解決して pack。room / user が解決できなければ drop する (upstream `packRoomInvitation` の throw→null 相当で、shape 不完全な invitation を embed しない)。
- **repository**: `ChatRepository.FindInvitationByID` を追加。
- **配線** (`router.go`): `chatHandler.PackInvitationByID` を REST handler / stream publisher の両方へ注入。notifier を chat handler / service の両方へ配線 (ローカル経路と AP 経路の両方で発火)。

## テスト

- `internal/entity/notification_test.go`: invitation packing (embed / invitationId 非出力 / 削除で drop / lookup 未配線で drop)
- `internal/api/chat/handler_test.go`: InvitationsCreate が notifier を発火・`PackInvitationByID` (解決 / 削除 / room 無し / user 解決不能で drop)
- `internal/core/chat/room_federation_test.go`: `CreateInvitationViaAP` が notifier を発火 (inviter=room owner)・重複招待で発火しない
- `internal/core/notification/parity_1559_note_test.go`: `OnChatRoomInvitationReceived` が notifier 付き通知を作る・remote 宛て除外
- `internal/stream/note_publisher_test.go`: stream で invitation を pack する
- `internal/repository/chat_test.go`: `FindInvitationByID` (found / not found)
- `internal/entitycompat/runtime_test.go`: Notification union L2 検証に chatRoomInvitationReceived ケースを追加
- 対象パッケージ coverage: entity 96.3% / api/chat 92.9% / core/chat 91.1% / repository 90.6% / stream 90.7% / notification 92.0%
- `make fmt` / `go vet ./...` / `go test ./...` 全 pass

## 関連

#1559 (part 3/4)。残り: part 4/4 で error registry (AUTHENTICATION_FAILED / YOUR_ACCOUNT_SUSPENDED / ACCESS_DENIED 整理) を扱う。これで通知 type の real 項目 (note/login/createToken/test/roleAssigned/chatRoomInvitationReceived) は完了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)