### PR TITLE
Fix auth: AUTHENTICATION_FAILED / YOUR_ACCOUNT_SUSPENDED / ACCESS_DENIED 整理 (#1559 part 4/4)

### DIFF
--- a/internal/api/apierr/errors.go
+++ b/internal/api/apierr/errors.go
@@ -56,10 +56,32 @@ const (
 	// しない (上流は endpoint 固有 NO_SUCH_* を使う) ため mk-go 固有の
 	// 安定 UUID を発番する。frontend 側の i18n には未対応だが、code+id 組
 	// が安定するので将来 locale 引きを追加できる (#673 Phase A)。
-	UUIDNotFound     = "8e6f5b1d-4f62-4ae0-9d3c-7c8d5b2e9f12"
-	UUIDNoSuchNote   = "24fcbfc6-2e37-42b6-8388-c29b3861a08d"
-	UUIDNoSuchUser   = "4362f8dc-731f-4ad8-a694-be5a88922a24"
+	UUIDNotFound   = "8e6f5b1d-4f62-4ae0-9d3c-7c8d5b2e9f12"
+	UUIDNoSuchNote = "24fcbfc6-2e37-42b6-8388-c29b3861a08d"
+	UUIDNoSuchUser = "4362f8dc-731f-4ad8-a694-be5a88922a24"
+	// UUIDAccessDenied は endpoint 固有 ACCESS_DENIED の UUID。upstream の
+	// admin/accounts/create や i/2fa/update-key 等が使う endpoint-specific 値で、
+	// framework の secure accessDenied (UUIDAccessDeniedSecure) とは別物。汎用
+	// helper AccessDenied() はこちらを返すので、secure endpoint 文脈で誤用しない
+	// こと (#1559)。
 	UUIDAccessDenied = "1fb7cb09-d46a-4fff-b8df-057708cce513"
+	// UUIDAccessDeniedSecure は upstream `ApiCallService.ts` の framework secure
+	// accessDenied (= secure:true endpoint を非 secure token で叩いた時) の UUID。
+	// endpoint 固有 ACCESS_DENIED (UUIDAccessDenied) と区別する。RequireSecure
+	// middleware が使う (#1559)。
+	UUIDAccessDeniedSecure = "56f35758-7dd5-468b-8439-5d6fb8ec9b8e"
+
+	// UUIDCredentialRequired は requireCredential endpoint で未認証時に投げる
+	// CREDENTIAL_REQUIRED の UUID (upstream ApiCallService.ts)。auth middleware が使う。
+	UUIDCredentialRequired = "1384574d-a912-4b81-8601-c7b1c4085df1"
+	// UUIDAuthenticationFailed は upstream `ApiCallService.ts` が token 認証失敗
+	// (AuthenticationError = 無効 token) 時に投げる AUTHENTICATION_FAILED の UUID
+	// (kind:client、401 + WWW-Authenticate: error=invalid_token)。
+	UUIDAuthenticationFailed = "b0a7f5f8-dc2f-4171-b91f-de88ad238e14"
+	// UUIDYourAccountSuspended は upstream `ApiCallService.ts` が requireCredential
+	// 系 endpoint で user.isSuspended のとき投げる YOUR_ACCOUNT_SUSPENDED の UUID
+	// (kind:permission、403)。
+	UUIDYourAccountSuspended = "a8c724b3-6e9c-4b46-b1a8-bc3ed6258370"
 
 	// UUIDRolePermissionDenied は upstream `ApiCallService.ts` で requiredRolePolicy
 	// 違反時に投げられる ROLE_PERMISSION_DENIED の UUID (upstream #17121 / triage
@@ -260,9 +282,34 @@ func NoSuchNoteDraft() map[string]any {
 	return Error("NO_SUCH_NOTE_DRAFT", "No such note draft.", UUIDNoSuchNoteDraft)
 }
 
-// AccessDenied returns a 403 ACCESS_DENIED error response.
+// AccessDenied returns a 403 ACCESS_DENIED error response with the
+// endpoint-specific UUID (UUIDAccessDenied)。framework の secure accessDenied
+// (= secure endpoint を非 secure token で叩いた時) は別 UUID なので、その文脈
+// では本 helper ではなく UUIDAccessDeniedSecure を使うこと (#1559)。
 func AccessDenied() map[string]any {
 	return Error("ACCESS_DENIED", "Access denied.", UUIDAccessDenied)
+}
+
+// CredentialRequired returns a 401 CREDENTIAL_REQUIRED error response.
+// requireCredential endpoint で未認証のとき auth middleware が返す
+// (upstream ApiCallService.ts)。
+func CredentialRequired() map[string]any {
+	return Error("CREDENTIAL_REQUIRED", "Authentication is required.", UUIDCredentialRequired)
+}
+
+// AuthenticationFailed returns a 401 AUTHENTICATION_FAILED error response
+// (invalid token)。kind:client。WWW-Authenticate: error=invalid_token は
+// WWWAuthenticate middleware が body から判定して付ける (upstream
+// ApiCallService.ts の #sendAuthenticationError)。
+func AuthenticationFailed() map[string]any {
+	return Error("AUTHENTICATION_FAILED", "Authentication failed. Please ensure your token is correct.", UUIDAuthenticationFailed)
+}
+
+// YourAccountSuspended returns a 403 YOUR_ACCOUNT_SUSPENDED error response.
+// requireCredential 系 endpoint で凍結アカウントが叩いたとき auth middleware が
+// 返す (upstream ApiCallService.ts、kind:permission)。
+func YourAccountSuspended() map[string]any {
+	return ErrorWithKind("YOUR_ACCOUNT_SUSPENDED", "Your account has been suspended.", UUIDYourAccountSuspended, KindPermission)
 }
 
 // RolePermissionDenied returns a 403 ROLE_PERMISSION_DENIED error response.

--- a/internal/api/apierr/errors_test.go
+++ b/internal/api/apierr/errors_test.go
@@ -45,6 +45,9 @@ func TestHelperKinds(t *testing.T) {
 		{"AccessDenied", AccessDenied(), KindClient},
 		{"RestrictedByRole", RestrictedByRole(), KindClient},
 		{"RateLimitExceeded", RateLimitExceeded(), KindClient},
+		{"CredentialRequired", CredentialRequired(), KindClient},
+		{"AuthenticationFailed", AuthenticationFailed(), KindClient},
+		{"YourAccountSuspended", YourAccountSuspended(), KindPermission},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			errObj := tc.body["error"].(map[string]any)
@@ -92,6 +95,26 @@ func TestInternalError(t *testing.T) {
 	assert.Equal(t, UUIDInternalError, errObj["id"])
 	// upstream の引数なし new ApiError() は kind 'server'。
 	assert.Equal(t, "server", errObj["kind"])
+}
+
+// #1559 framework auth errors の code / id を upstream ApiCallService.ts と固定。
+func TestAuthFrameworkErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		body     map[string]any
+		wantCode string
+		wantID   string
+	}{
+		{"CredentialRequired", CredentialRequired(), "CREDENTIAL_REQUIRED", "1384574d-a912-4b81-8601-c7b1c4085df1"},
+		{"AuthenticationFailed", AuthenticationFailed(), "AUTHENTICATION_FAILED", "b0a7f5f8-dc2f-4171-b91f-de88ad238e14"},
+		{"YourAccountSuspended", YourAccountSuspended(), "YOUR_ACCOUNT_SUSPENDED", "a8c724b3-6e9c-4b46-b1a8-bc3ed6258370"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			errObj := tc.body["error"].(map[string]any)
+			assert.Equal(t, tc.wantCode, errObj["code"])
+			assert.Equal(t, tc.wantID, errObj["id"])
+		})
+	}
 }
 
 func TestNoSuchNote(t *testing.T) {

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -17,6 +17,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
+	"gorm.io/gorm"
 )
 
 // errOrphanedAccessToken は access_token 行は残っているが Preload した
@@ -34,6 +35,12 @@ const (
 	// authenticated request. RequireScope reads it to enforce endpoint
 	// meta.kind against an app token's permission array (#1552).
 	AuthScopeContextKey contextKey = "misskeyAuthScope"
+	// suspendedContextKey flags that the request carried a valid token whose
+	// account is suspended. The user is kept out of UserContextKey (so public
+	// endpoints treat it as anonymous, #962 P2) but credential-required gates
+	// read this flag to return 403 YOUR_ACCOUNT_SUSPENDED instead of 401
+	// CREDENTIAL_REQUIRED (upstream ApiCallService.ts、#1559)。
+	suspendedContextKey contextKey = "misskeySuspended"
 )
 
 // AuthScope is the OAuth scope view of an authenticated request. IsApp is
@@ -115,23 +122,35 @@ func (a *AuthMiddleware) Authenticate() echo.MiddlewareFunc {
 
 			user, scopes, isApp, err := a.resolveUser(token)
 			if err != nil {
+				// token はあるが解決できない。token 不在 (= 無効 token) は
+				// upstream ApiCallService が AuthenticationError として 401
+				// AUTHENTICATION_FAILED を返す経路なのでそれに揃える (#1559)。
+				// WWW-Authenticate: error=invalid_token は WWWAuthenticate
+				// middleware が body から判定して付ける。orphaned access_token
+				// (#514) や transient な DB error は誤って全 request を 401 に
+				// しないよう従来どおり anonymous に落とし、後続の認可に委ねる。
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return c.JSON(http.StatusUnauthorized, apierr.AuthenticationFailed())
+				}
 				return next(c)
 			}
 
-			// 論理削除 / 凍結された user を anonymous request 扱いに落とす
-			// (#962 P2)。upstream Misskey は signin handler で isSuspended
-			// だけ check しているが (signin/handler.go:112)、有効 token を
-			// 既に持っている session は post-auth pipeline では gate されず、
-			// tokenCache (30s TTL) 経由でも bypass できてしまう。本 gate を
-			// 入れることで cache miss → DB fetch 経路では確実に弾ける。
-			//
-			// 限界: cache hit (= 凍結前にキャッシュされた entry) は stale
-			// な isSuspended=false を返すので gate は fire しない。
-			// self-mutation 経由 (i/delete-account #962 P0) は handler 側
-			// で InvalidateToken を呼ぶので 30s → μs window。admin 経由
-			// (admin/suspend-user 等、他 user の token を強制 invalidate
-			// する経路) は本 PR scope 外、別 issue で追跡する想定。
-			if user.IsSuspended || user.IsDeleted {
+			// 論理削除された user は anonymous request 扱いに落とす (#962 P2)。
+			if user.IsDeleted {
+				return next(c)
+			}
+			// 凍結された user は公開 endpoint では anonymous 扱いに落とす
+			// (#962 P2) が、credential 必須 endpoint では 403
+			// YOUR_ACCOUNT_SUSPENDED を返せるよう flag を積む (upstream
+			// ApiCallService.ts、#1559)。upstream は signin handler で
+			// isSuspended だけ check しているが、有効 token を既に持っている
+			// session は post-auth pipeline では gate されず tokenCache
+			// (30s TTL) 経由でも bypass できてしまうため、cache miss → DB
+			// fetch 経路で確実に弾く。cache hit (凍結前 entry) は stale な
+			// isSuspended=false を返すので self-mutation / admin 経路は
+			// InvalidateToken(sForUser) で 30s → μs window に縮める。
+			if user.IsSuspended {
+				c.Set(string(suspendedContextKey), true)
 				return next(c)
 			}
 
@@ -191,20 +210,25 @@ func (a *AuthMiddleware) touchLastActive(userID string) {
 	}(userID, now)
 }
 
+// credentialRequiredResponse writes the error for a credential-required gate
+// when GetUser is nil: 403 YOUR_ACCOUNT_SUSPENDED when the request carried a
+// valid token for a suspended account (upstream ApiCallService.ts、#1559)、else
+// 401 CREDENTIAL_REQUIRED. Shared by RequireAuth / RequireSecure /
+// RequireAdmin / RequireModerator so the suspended branch stays consistent.
+func credentialRequiredResponse(c echo.Context) error {
+	if v, _ := c.Get(string(suspendedContextKey)).(bool); v {
+		return c.JSON(http.StatusForbidden, apierr.YourAccountSuspended())
+	}
+	return c.JSON(http.StatusUnauthorized, apierr.CredentialRequired())
+}
+
 // RequireAuth is a middleware that requires authentication.
 func RequireAuth() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			user := GetUser(c)
 			if user == nil {
-				return c.JSON(http.StatusUnauthorized, map[string]any{
-					"error": map[string]any{
-						"message": "Authentication is required.",
-						"code":    "CREDENTIAL_REQUIRED",
-						"id":      "1384574d-a912-4b81-8601-c7b1c4085df1",
-						"kind":    apierr.KindClient,
-					},
-				})
+				return credentialRequiredResponse(c)
 			}
 			return next(c)
 		}
@@ -226,24 +250,15 @@ func RequireSecure() echo.MiddlewareFunc {
 		return func(c echo.Context) error {
 			user := GetUser(c)
 			if user == nil {
-				return c.JSON(http.StatusUnauthorized, map[string]any{
-					"error": map[string]any{
-						"message": "Authentication is required.",
-						"code":    "CREDENTIAL_REQUIRED",
-						"id":      "1384574d-a912-4b81-8601-c7b1c4085df1",
-						"kind":    apierr.KindClient,
-					},
-				})
+				return credentialRequiredResponse(c)
 			}
 			if user.Token == nil || *user.Token != GetToken(c) {
-				return c.JSON(http.StatusForbidden, map[string]any{
-					"error": map[string]any{
-						"message": "Access denied.",
-						"code":    "ACCESS_DENIED",
-						"id":      "56f35758-7dd5-468b-8439-5d6fb8ec9b8e",
-						"kind":    apierr.KindClient,
-					},
-				})
+				return c.JSON(http.StatusForbidden, apierr.ErrorWithKind(
+					"ACCESS_DENIED",
+					"Access denied.",
+					apierr.UUIDAccessDeniedSecure,
+					apierr.KindClient,
+				))
 			}
 			return next(c)
 		}
@@ -342,14 +357,7 @@ func RequireAdmin(checker RoleChecker) echo.MiddlewareFunc {
 		return func(c echo.Context) error {
 			user := GetUser(c)
 			if user == nil {
-				return c.JSON(http.StatusUnauthorized, map[string]any{
-					"error": map[string]any{
-						"message": "Authentication is required.",
-						"code":    "CREDENTIAL_REQUIRED",
-						"id":      "1384574d-a912-4b81-8601-c7b1c4085df1",
-						"kind":    apierr.KindClient,
-					},
-				})
+				return credentialRequiredResponse(c)
 			}
 			if !checker.IsAdministrator(user.ID) {
 				return c.JSON(http.StatusForbidden, map[string]any{
@@ -372,14 +380,7 @@ func RequireModerator(checker RoleChecker) echo.MiddlewareFunc {
 		return func(c echo.Context) error {
 			user := GetUser(c)
 			if user == nil {
-				return c.JSON(http.StatusUnauthorized, map[string]any{
-					"error": map[string]any{
-						"message": "Authentication is required.",
-						"code":    "CREDENTIAL_REQUIRED",
-						"id":      "1384574d-a912-4b81-8601-c7b1c4085df1",
-						"kind":    apierr.KindClient,
-					},
-				})
+				return credentialRequiredResponse(c)
 			}
 			if !checker.IsModerator(user.ID) {
 				return c.JSON(http.StatusForbidden, map[string]any{

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -214,8 +215,15 @@ func TestRequireAuth_SuspendedRejected(t *testing.T) {
 		return nil
 	}))
 	require.NoError(t, chained(c))
-	assert.Equal(t, http.StatusUnauthorized, rec.Code,
-		"凍結 user は RequireAuth で 401 が返る")
+	// 凍結 user が credential 必須 endpoint を叩くと 403 YOUR_ACCOUNT_SUSPENDED
+	// が返る (upstream ApiCallService.ts、#1559)。
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj := resp["error"].(map[string]any)
+	assert.Equal(t, "YOUR_ACCOUNT_SUSPENDED", errObj["code"])
+	assert.Equal(t, "a8c724b3-6e9c-4b46-b1a8-bc3ed6258370", errObj["id"])
+	assert.Equal(t, apierr.KindPermission, errObj["kind"])
 }
 
 func TestAuthenticate_QueryParam(t *testing.T) {
@@ -353,15 +361,20 @@ func TestAuthenticate_InvalidToken(t *testing.T) {
 	c := e.NewContext(req, rec)
 
 	handler := auth.Authenticate()(func(c echo.Context) error {
-		user := GetUser(c)
-		// 無効なトークンの場合、ユーザーはnilだがリクエストは継続する
-		assert.Nil(t, user)
-		return c.String(http.StatusOK, "ok")
+		t.Fatal("無効 token では handler に到達しない")
+		return nil
 	})
 
+	// 無効 (= 解決不能) token は upstream ApiCallService と同じく 401
+	// AUTHENTICATION_FAILED を返す (#1559)。
 	err := handler(c)
 	assert.NoError(t, err)
-	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj := resp["error"].(map[string]any)
+	assert.Equal(t, "AUTHENTICATION_FAILED", errObj["code"])
+	assert.Equal(t, "b0a7f5f8-dc2f-4171-b91f-de88ad238e14", errObj["id"])
 }
 
 func TestRequireAuth_Authenticated(t *testing.T) {
@@ -967,4 +980,77 @@ func TestRequireNotMoved_AnonymousPasses(t *testing.T) {
 	require.NoError(t, h(c))
 	assert.True(t, called)
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// #1559 無効 token の 401 AUTHENTICATION_FAILED 応答に WWWAuthenticate
+// middleware が WWW-Authenticate: error=invalid_token を付ける (full chain)。
+func TestAuthenticate_InvalidToken_WWWAuthenticateHeader(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	tokenRepo := testutil.NewMockAccessTokenRepository()
+	auth := NewAuthMiddleware(userRepo, tokenRepo)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/notes/create", nil)
+	req.Header.Set("Authorization", "Bearer bogustoken")
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	chained := WWWAuthenticate()(auth.Authenticate()(func(c echo.Context) error {
+		t.Fatal("無効 token では handler に到達しない")
+		return nil
+	}))
+	require.NoError(t, chained(c))
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	assert.Contains(t, rec.Header().Get("WWW-Authenticate"), `error="invalid_token"`)
+}
+
+// #1559 凍結 user は RequireSecure / RequireAdmin / RequireModerator でも
+// 403 YOUR_ACCOUNT_SUSPENDED を返す (credential 必須 gate 共通)。
+func TestSuspendedUser_403OnAllCredentialGates(t *testing.T) {
+	gates := map[string]echo.MiddlewareFunc{
+		"RequireAuth":      RequireAuth(),
+		"RequireSecure":    RequireSecure(),
+		"RequireAdmin":     RequireAdmin(&stubRoleChecker{admin: true}),
+		"RequireModerator": RequireModerator(&stubRoleChecker{moderator: true}),
+	}
+	for name, gate := range gates {
+		t.Run(name, func(t *testing.T) {
+			userRepo := testutil.NewMockUserRepository()
+			tokenRepo := testutil.NewMockAccessTokenRepository()
+			token := "frozen-token-" + name
+			userRepo.Tokens[token] = &model.User{ID: "u_s", Username: "frozen", IsSuspended: true}
+			auth := NewAuthMiddleware(userRepo, tokenRepo)
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			chained := auth.Authenticate()(gate(func(c echo.Context) error {
+				t.Fatal("凍結 user は gate を通過しない")
+				return nil
+			}))
+			require.NoError(t, chained(c))
+			assert.Equal(t, http.StatusForbidden, rec.Code)
+			var resp map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			assert.Equal(t, "YOUR_ACCOUNT_SUSPENDED", resp["error"].(map[string]any)["code"])
+		})
+	}
+}
+
+// 未認証 (token 無し) は従来どおり 401 CREDENTIAL_REQUIRED (凍結 flag 無し)。
+func TestCredentialRequired_NoToken(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	handler := RequireAuth()(func(c echo.Context) error { return nil })
+	require.NoError(t, handler(c))
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "CREDENTIAL_REQUIRED", resp["error"].(map[string]any)["code"])
 }


### PR DESCRIPTION
## Summary

Misskey TS 互換性監査 (#1559) の common error registry 領域を upstream `ApiCallService.ts` に揃える。#1559 の part 4/4 (最終) で、auth middleware のエラー応答 parity を扱う。これで #1559 の real 項目を全て解消する。

## 主な変更点

- **AUTHENTICATION_FAILED**: token が present だが解決不能 (= 無効 token) のとき、従来の anonymous fallback ではなく `401 AUTHENTICATION_FAILED` (id b0a7f5f8-..., kind:client) を返す。判別は `gorm.ErrRecordNotFound` に限定し、orphaned access_token (#514) や transient な DB error は従来どおり anonymous に落として全 request を巻き込まない。`WWW-Authenticate: error=invalid_token` は既存の `WWWAuthenticate` middleware が body から判定して付ける。
- **YOUR_ACCOUNT_SUSPENDED**: 凍結アカウントが credential 必須 endpoint を叩くと `403 YOUR_ACCOUNT_SUSPENDED` (id a8c724b3-..., kind:permission) を返す。凍結 user は `UserContextKey` に attach せず (公開 endpoint では #962 P2 どおり anonymous を維持)、`suspendedContextKey` フラグを立てて `credentialRequiredResponse` が user==nil 時に 403 (suspended) / 401 (CREDENTIAL_REQUIRED) を出し分ける。`RequireAuth` / `RequireSecure` / `RequireAdmin` / `RequireModerator` の 4 gate で共通。
- **ACCESS_DENIED 整理**: framework secure ACCESS_DENIED の UUID (56f35758) を named 定数 `UUIDAccessDeniedSecure` に切り出し、endpoint 固有 ACCESS_DENIED (1fb7cb09) と区別。汎用 helper `AccessDenied()` の doc も「endpoint 固有値を返す。secure 文脈では使わない」と明確化。

`apierr` に `UUIDAuthenticationFailed` / `UUIDYourAccountSuspended` / `UUIDCredentialRequired` 定数と `AuthenticationFailed()` / `YourAccountSuspended()` / `CredentialRequired()` helper を追加し、middleware の inline error literal を集約する。

### 挙動変化の注意

- 公開 endpoint に **無効 token** を付けたリクエストが、従来 anonymous で 200 だったのが `401 AUTHENTICATION_FAILED` になる。これは upstream `ApiCallService` (authenticate を endpoint logic より前に走らせ、unknown token を AuthenticationError で 401) と一致する drop-in 互換挙動。
- 凍結 user は公開 endpoint では従来どおり anonymous 扱い (#962 P2 維持)。credential 必須 endpoint でのみ 403。

## テスト

- `internal/server/middleware/auth_test.go`: 無効 token → 401 AUTHENTICATION_FAILED (+ WWW-Authenticate header の full-chain 検証)、凍結 user → 403 YOUR_ACCOUNT_SUSPENDED (RequireAuth/Secure/Admin/Moderator 全 gate)、no-token → 401 CREDENTIAL_REQUIRED
- `internal/api/apierr/errors_test.go`: 新 helper の code / id / kind を upstream 値で固定
- 対象パッケージ coverage: server/middleware 96.6% / apierr 100%
- `make fmt` / `go vet ./...` / `go test ./...` 全 pass (full suite regression なし)

## 関連

Closes #1559 (part 4/4)。

#1559 は再検証の結果、HIGH の PERMISSION_DENIED を含む 3 件 (PERMISSION_DENIED / notifications-grouped / YOUR_ACCOUNT_MOVED) が既に他 PR で解消済み (stale) と判明した。real 項目は 4 PR に分割して解消:
- part 1/4 (#1648): note / login / createToken / test
- part 2/4 (#1649): roleAssigned
- part 3/4 (#1650): chatRoomInvitationReceived
- part 4/4 (本 PR): error registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)