### PR TITLE
Fix entity:User: followedMessage / count visibility の privacy gate (#1558 part 1/2)

### DIFF
--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -364,6 +364,11 @@ func (h *Handler) Show(c echo.Context) error {
 			resolver.FillUserLite(&detailed.UserLite)
 			h.populateUserEmojis(b.User, &detailed.UserLite)
 			h.applyModerationNote(&detailed, iAmModerator, b.Profile)
+			// bulk は per-user の follow 関係を解決しないため isFollowing=false で
+			// gate する (#1558)。self / moderator は count を保持。non-public
+			// visibility の非 follower count は 0 化される (privacy 安全側)。
+			isMe := viewer != nil && viewer.ID == b.User.ID
+			entity.GateCountVisibility(&detailed, isMe, iAmModerator, false)
 			out = append(out, detailed)
 		}
 		return c.JSON(http.StatusOK, out)
@@ -455,6 +460,9 @@ func (h *Handler) Show(c echo.Context) error {
 	// viewerがログインしている場合、viewer依存フィールドを並列取得する。
 	// 各リポジトリへのクエリは完全に独立しているためgoroutineで並列実行し、
 	// 全結果が揃ってからdetailedに反映する。
+	// viewerIsFollowing は relation ブロックで解決し、count / followedMessage の
+	// viewer-dependent gate (#1558) でも参照するため関数スコープに持つ。
+	viewerIsFollowing := false
 	if viewer != nil && viewer.ID != bundle.User.ID {
 		var (
 			isFollowing, isFollowed      bool
@@ -500,10 +508,16 @@ func (h *Handler) Show(c echo.Context) error {
 		if h.followingRepo != nil {
 			detailed.IsFollowing = &isFollowing
 			detailed.IsFollowed = &isFollowed
+			viewerIsFollowing = isFollowing
 			if followRec != nil {
 				detailed.Notify = followRec.Notify
 				wr := followRec.WithReplies
 				detailed.WithReplies = &wr
+			}
+			// followedMessage は follower にだけ見せる (upstream relation ブロックの
+			// `relation.isFollowing ? profile.followedMessage : undefined`、#1558)。
+			if isFollowing && bundle.Profile != nil {
+				detailed.FollowedMessage = bundle.Profile.FollowedMessage
 			}
 		}
 		if h.blockingRepo != nil {
@@ -539,6 +553,10 @@ func (h *Handler) Show(c echo.Context) error {
 		me.Policies = corerole.DefaultPolicies()
 		return c.JSON(http.StatusOK, me)
 	}
+	// followers/following count を visibility で gate する (#1558)。ここに来るのは
+	// non-self (anonymous 含む)。isMe=false、isFollowing は relation ブロックで
+	// 解決済 (anonymous / 未配線なら false = 非 follower 扱い)。
+	entity.GateCountVisibility(&detailed, false, iAmModerator, viewerIsFollowing)
 	return c.JSON(http.StatusOK, detailed)
 }
 
@@ -579,6 +597,9 @@ func (h *Handler) Search(c echo.Context) error {
 		return apierr.JSONInternalError(c)
 	}
 
+	viewer := middleware.GetUser(c)
+	iAmModerator := viewer != nil && h.moderatorChecker != nil && h.moderatorChecker.IsModerator(viewer.ID)
+
 	resolver := entity.NewInstanceResolver(h.instanceLookup(), users...)
 
 	// detail は default true。false のとき UserLite を返す (upstream search.ts:56、#1547)。
@@ -607,6 +628,12 @@ func (h *Handler) Search(c echo.Context) error {
 		d := entity.PackUserDetailed(u, profiles[u.ID], h.idGen)
 		resolver.FillUserLite(&d.UserLite)
 		h.populateUserEmojis(u, &d.UserLite)
+		// moderator viewer には moderationNote を出す (#1558、users/show と対称)。
+		h.applyModerationNote(&d, iAmModerator, profiles[u.ID])
+		// count visibility gate (#1558)。search は per-user の follow 関係を
+		// 解決しないため isFollowing=false。self / moderator は count を保持。
+		isMe := viewer != nil && viewer.ID == u.ID
+		entity.GateCountVisibility(&d, isMe, iAmModerator, false)
 		out = append(out, d)
 	}
 	return c.JSON(http.StatusOK, out)
@@ -967,6 +994,9 @@ func (h *Handler) packRelationItems(
 	// する (singleflight が同 key dedup、cache 1h で次 scroll は HTTP 0)。
 	remoteStatsMap := h.batchRemoteStatsOverride(ctx, bundleByID)
 
+	// count visibility gate (#1558) 用。moderator viewer は全 count を見られる。
+	iAmModerator := viewer != nil && h.moderatorChecker != nil && h.moderatorChecker.IsModerator(viewer.ID)
+
 	out := make([]relationItem, 0, len(filtered))
 	for _, f := range filtered {
 		item := relationItem{ID: f.ID, FollowerID: f.FollowerID, FolloweeID: f.FolloweeID}
@@ -983,8 +1013,10 @@ func (h *Handler) packRelationItems(
 			d := entity.PackUserDetailed(b.User, b.Profile, h.idGen)
 			resolver.FillUserLite(&d.UserLite)
 			h.populateUserEmojis(b.User, &d.UserLite)
+			isMe := viewer != nil && viewer.ID == b.User.ID
+			isFollowing := false
 			if viewer != nil && viewer.ID != b.User.ID {
-				isFollowing := followingMap[b.User.ID]
+				isFollowing = followingMap[b.User.ID]
 				isFollowed := followedMap[b.User.ID]
 				d.IsFollowing = &isFollowing
 				d.IsFollowed = &isFollowed
@@ -999,12 +1031,18 @@ func (h *Handler) packRelationItems(
 				// batch を壊さないため per-user lookup は避ける) ので best-effort
 				// false で埋める。正確な値は users/show 単体で取得される。
 				d.EnsureRelationFlags()
+				// follower にだけ followedMessage を見せる (#1558)。
+				if isFollowing && b.Profile != nil {
+					d.FollowedMessage = b.Profile.FollowedMessage
+				}
 			}
 			if stats := remoteStatsMap[b.User.ID]; stats != nil {
 				d.NotesCount = stats.NotesCount
 				d.FollowersCount = stats.FollowersCount
 				d.FollowingCount = stats.FollowingCount
 			}
+			// count visibility gate は remote stats override の後に適用する (#1558)。
+			entity.GateCountVisibility(&d, isMe, iAmModerator, isFollowing)
 			if followers {
 				item.Follower = &d
 			} else {

--- a/internal/api/users/parity_1558_test.go
+++ b/internal/api/users/parity_1558_test.go
@@ -1,0 +1,211 @@
+package users
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/server/middleware"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+)
+
+// modByID treats a single user ID as moderator (test stub for the
+// ModeratorChecker interface, scoped to package users).
+type modByID struct{ id string }
+
+func (m modByID) IsModerator(userID string) bool     { return userID == m.id }
+func (m modByID) IsAdministrator(userID string) bool { return userID == m.id }
+
+// showWithViewer invokes users/show for target with an optional viewer.
+func showWithViewer(t *testing.T, h *Handler, targetID string, viewer *model.User) map[string]any {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/users/show", strings.NewReader(`{"userId":"`+targetID+`"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if viewer != nil {
+		c.Set(string(middleware.UserContextKey), viewer)
+	}
+	require.NoError(t, h.Show(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	return resp
+}
+
+func newTargetWithProfile(repo *testutil.MockUserRepository, id string, profile *model.UserProfile) *model.User {
+	u := &model.User{ID: id, Username: id, UsernameLower: id, AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users[id] = u
+	profile.UserID = id
+	if profile.Fields == nil {
+		profile.Fields = datatypes.JSON([]byte("[]"))
+	}
+	repo.Profiles[id] = profile
+	return u
+}
+
+// #1558 [MEDIUM] followedMessage は follower / self だけに見せる。
+func TestShow_FollowedMessage_FollowerOnly(t *testing.T) {
+	msg := "Thanks for following!"
+
+	t.Run("non-follower omits", func(t *testing.T) {
+		h, repo := newTestHandler(t)
+		newTargetWithProfile(repo, "target1", &model.UserProfile{FollowedMessage: &msg})
+		resp := showWithViewer(t, h, "target1", &model.User{ID: "viewer1", Username: "viewer"})
+		_, has := resp["followedMessage"]
+		assert.False(t, has, "非 follower には followedMessage を出さない")
+	})
+
+	t.Run("anonymous omits", func(t *testing.T) {
+		h, repo := newTestHandler(t)
+		newTargetWithProfile(repo, "target1", &model.UserProfile{FollowedMessage: &msg})
+		resp := showWithViewer(t, h, "target1", nil)
+		_, has := resp["followedMessage"]
+		assert.False(t, has, "anonymous には followedMessage を出さない")
+	})
+
+	t.Run("follower sees it", func(t *testing.T) {
+		h, repo := newTestHandler(t)
+		newTargetWithProfile(repo, "target1", &model.UserProfile{FollowedMessage: &msg})
+		fRepo := testutil.NewMockFollowingRepository()
+		fRepo.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "viewer1", FolloweeID: "target1"}
+		h.SetFollowingRepo(fRepo)
+		resp := showWithViewer(t, h, "target1", &model.User{ID: "viewer1", Username: "viewer"})
+		assert.Equal(t, msg, resp["followedMessage"], "follower には followedMessage を出す")
+	})
+
+	t.Run("self sees it (MeDetailed always present)", func(t *testing.T) {
+		h, repo := newTestHandler(t)
+		newTargetWithProfile(repo, "self1", &model.UserProfile{FollowedMessage: &msg})
+		resp := showWithViewer(t, h, "self1", &model.User{ID: "self1", Username: "self1"})
+		assert.Equal(t, msg, resp["followedMessage"])
+	})
+}
+
+// #1558 [MEDIUM] followersCount / followingCount は restricted visibility で 0 化。
+func TestShow_CountVisibility(t *testing.T) {
+	mkProfile := func(fv, gv model.FollowingVisibility) *model.UserProfile {
+		return &model.UserProfile{FollowersVisibility: fv, FollowingVisibility: gv}
+	}
+	withCounts := func(repo *testutil.MockUserRepository, id string) {
+		repo.Users[id].FollowersCount = 7
+		repo.Users[id].FollowingCount = 9
+	}
+
+	t.Run("followers visibility hidden from non-follower", func(t *testing.T) {
+		h, repo := newTestHandler(t)
+		newTargetWithProfile(repo, "target1", mkProfile(model.FollowingVisibilityFollowers, model.FollowingVisibilityFollowers))
+		withCounts(repo, "target1")
+		resp := showWithViewer(t, h, "target1", &model.User{ID: "viewer1", Username: "viewer"})
+		assert.EqualValues(t, 0, resp["followersCount"])
+		assert.EqualValues(t, 0, resp["followingCount"])
+	})
+
+	t.Run("followers visibility shown to follower", func(t *testing.T) {
+		h, repo := newTestHandler(t)
+		newTargetWithProfile(repo, "target1", mkProfile(model.FollowingVisibilityFollowers, model.FollowingVisibilityFollowers))
+		withCounts(repo, "target1")
+		fRepo := testutil.NewMockFollowingRepository()
+		fRepo.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "viewer1", FolloweeID: "target1"}
+		h.SetFollowingRepo(fRepo)
+		resp := showWithViewer(t, h, "target1", &model.User{ID: "viewer1", Username: "viewer"})
+		assert.EqualValues(t, 7, resp["followersCount"])
+		assert.EqualValues(t, 9, resp["followingCount"])
+	})
+
+	t.Run("private hidden from anonymous", func(t *testing.T) {
+		h, repo := newTestHandler(t)
+		newTargetWithProfile(repo, "target1", mkProfile(model.FollowingVisibilityPrivate, model.FollowingVisibilityPrivate))
+		withCounts(repo, "target1")
+		resp := showWithViewer(t, h, "target1", nil)
+		assert.EqualValues(t, 0, resp["followersCount"])
+		assert.EqualValues(t, 0, resp["followingCount"])
+	})
+
+	t.Run("private shown to moderator", func(t *testing.T) {
+		h, repo := newTestHandler(t)
+		newTargetWithProfile(repo, "target1", mkProfile(model.FollowingVisibilityPrivate, model.FollowingVisibilityPrivate))
+		withCounts(repo, "target1")
+		h.SetModeratorChecker(modByID{id: "mod1"})
+		resp := showWithViewer(t, h, "target1", &model.User{ID: "mod1", Username: "mod"})
+		assert.EqualValues(t, 7, resp["followersCount"])
+		assert.EqualValues(t, 9, resp["followingCount"])
+	})
+
+	t.Run("public always shown", func(t *testing.T) {
+		h, repo := newTestHandler(t)
+		newTargetWithProfile(repo, "target1", mkProfile(model.FollowingVisibilityPublic, model.FollowingVisibilityPublic))
+		withCounts(repo, "target1")
+		resp := showWithViewer(t, h, "target1", nil)
+		assert.EqualValues(t, 7, resp["followersCount"])
+		assert.EqualValues(t, 9, resp["followingCount"])
+	})
+
+	t.Run("self always shown", func(t *testing.T) {
+		h, repo := newTestHandler(t)
+		newTargetWithProfile(repo, "self1", mkProfile(model.FollowingVisibilityPrivate, model.FollowingVisibilityPrivate))
+		withCounts(repo, "self1")
+		resp := showWithViewer(t, h, "self1", &model.User{ID: "self1", Username: "self1"})
+		assert.EqualValues(t, 7, resp["followersCount"])
+		assert.EqualValues(t, 9, resp["followingCount"])
+	})
+}
+
+// #1558 [MEDIUM 2-gap] users/search でも moderator viewer に moderationNote を出す。
+func TestSearch_ModerationNoteForModerator(t *testing.T) {
+	h, repo := newTestHandler(t)
+	note := "watch this user"
+	newTargetWithProfile(repo, "suspect", &model.UserProfile{
+		ModerationNote:      &note,
+		FollowersVisibility: model.FollowingVisibilityPublic,
+		FollowingVisibility: model.FollowingVisibilityPublic,
+	})
+	h.SetModeratorChecker(modByID{id: "mod1"})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/users/search", strings.NewReader(`{"query":"suspect"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), &model.User{ID: "mod1", Username: "mod"})
+	require.NoError(t, h.Search(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp)
+	assert.Equal(t, note, resp[0]["moderationNote"], "moderator の search 結果に moderationNote を出す")
+}
+
+// 非 moderator の search では moderationNote を出さない。
+func TestSearch_NoModerationNoteForNonModerator(t *testing.T) {
+	h, repo := newTestHandler(t)
+	note := "watch this user"
+	newTargetWithProfile(repo, "suspect", &model.UserProfile{
+		ModerationNote:      &note,
+		FollowersVisibility: model.FollowingVisibilityPublic,
+		FollowingVisibility: model.FollowingVisibilityPublic,
+	})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/users/search", strings.NewReader(`{"query":"suspect"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), &model.User{ID: "viewer1", Username: "viewer"})
+	require.NoError(t, h.Search(c))
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp)
+	_, has := resp[0]["moderationNote"]
+	assert.False(t, has, "非 moderator には moderationNote を出さない")
+}

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -696,6 +696,14 @@ func (s *Service) publishMeUpdated(bundle *UserWithProfile) {
 	// profile update / pin / unpin は頻度が低く hot path ではないため
 	// full pack する (UserLite ではなく UserDetailed)。
 	body := entity.PackUserDetailed(bundle.User, bundle.Profile, s.idGen)
+	// meUpdated は本人自身の main channel に流す self event なので、
+	// follower-only の followedMessage も本人には見せる (#1558)。PackUserDetailed
+	// は followedMessage を set しない (privacy gate) ため、self event では
+	// profile から補填する。これを欠くと i/update で followedMessage を変更しても
+	// frontend の $i.followedMessage が即時反映されない。
+	if bundle.Profile != nil {
+		body.FollowedMessage = bundle.Profile.FollowedMessage
+	}
 	// PackUserDetailed は pinnedNoteIDs を空で返すため、piningRepo が
 	// あれば pin ID だけ埋める (full note pack は不要で frontend 側で
 	// 必要に応じて fetch する)。piningRepo がない read-only 構成や

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -672,6 +672,28 @@ func TestService_UpdateProfile_PublishesMeUpdated(t *testing.T) {
 	assert.Equal(t, "hello", m["description"])
 }
 
+// #1558 meUpdated は本人の self event なので follower-only の followedMessage も
+// 含む。PackUserDetailed が followedMessage を set しなくなった回帰を防ぐ。
+func TestService_UpdateProfile_MeUpdatedCarriesFollowedMessage(t *testing.T) {
+	svc, repo, _, _ := newFullSvc(t)
+	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+
+	msg := "thanks for following"
+	_, err := svc.UpdateProfile("u1", user.UpdateInput{
+		FollowedMessage: ptr(ptr(msg)),
+	})
+	require.NoError(t, err)
+
+	require.Len(t, pub.calls, 1)
+	raw, err := json.Marshal(pub.calls[0].body)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(raw, &m))
+	assert.Equal(t, msg, m["followedMessage"], "meUpdated body は本人の followedMessage を含む")
+}
+
 func TestService_UpdateProfile_UserUpdateError_DoesNotPublish(t *testing.T) {
 	mockUR := testutil.NewMockUserRepository()
 	mockUR.Users["u1"] = &model.User{ID: "u1", Username: "alice"}

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -81,16 +81,20 @@ type UserLite struct {
 // (#1251)。よって base UserDetailed には含めない。
 type UserDetailed struct {
 	UserLite
-	BannerURL           *string        `json:"bannerUrl"`
-	BannerBlurhash      *string        `json:"bannerBlurhash"`
-	IsLocked            bool           `json:"isLocked"`
-	IsSilenced          bool           `json:"isSilenced"`
-	IsSuspended         bool           `json:"isSuspended"`
-	Description         *string        `json:"description"`
-	Location            *string        `json:"location"`
-	Birthday            *string        `json:"birthday"`
-	Lang                *string        `json:"lang"`
-	FollowedMessage     *string        `json:"followedMessage"`
+	BannerURL      *string `json:"bannerUrl"`
+	BannerBlurhash *string `json:"bannerBlurhash"`
+	IsLocked       bool    `json:"isLocked"`
+	IsSilenced     bool    `json:"isSilenced"`
+	IsSuspended    bool    `json:"isSuspended"`
+	Description    *string `json:"description"`
+	Location       *string `json:"location"`
+	Birthday       *string `json:"birthday"`
+	Lang           *string `json:"lang"`
+	// FollowedMessage は follower / self だけに見せる private 文字列なので
+	// omitempty で「非 follower には省略」を表現する。packer はこの field を
+	// set せず、self は AsMeDetailed、follower は users/show handler が set する
+	// (upstream UserEntityService の relation/isMe ブロックでのみ emit、#1558)。
+	FollowedMessage     *string        `json:"followedMessage,omitempty"`
 	PublicReactions     bool           `json:"publicReactions"`
 	Fields              datatypes.JSON `json:"fields"`
 	VerifiedLinks       []string       `json:"verifiedLinks"`
@@ -166,6 +170,11 @@ type UserDetailed struct {
 // scoped to self-view (#968 / sibling of #693 ChatScope drift).
 type MeDetailed struct {
 	UserDetailed
+	// FollowedMessage は MeDetailed では required (self は isMe ブロックで必ず
+	// emit、null 可)。base UserDetailed 側は omitempty で「非 follower には省略」
+	// を表すため、MeDetailed では omitempty 無しの field で shadow して常に出す
+	// (#1558)。encoding/json は浅い深さの本 field を優先する。
+	FollowedMessage *string `json:"followedMessage"`
 	// avatarId / bannerId は self view 専用 (#1251)。misskey_dart の dispatch が
 	// `avatarId` key の存在で MeDetailed を判別するため、MeDetailed のみが出す。
 	AvatarID                 *string `json:"avatarId"`
@@ -326,6 +335,9 @@ func AsMeDetailed(d UserDetailed, u *model.User, profile *model.UserProfile) MeD
 		TwoFactorBackupCodesStock: "none",
 	}
 	if profile != nil {
+		// self は upstream の isMe ブロックで followedMessage を必ず見られる
+		// (#1558)。base packer は set しないので MeDetailed で埋め直す。
+		out.FollowedMessage = profile.FollowedMessage
 		out.NoCrawle = profile.NoCrawle
 		out.PreventAiLearning = profile.PreventAiLearning
 		out.AutoSensitive = profile.AutoSensitive
@@ -524,7 +536,9 @@ func PackUserDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Ge
 		d.Location = profile.Location
 		d.Birthday = profile.Birthday
 		d.Lang = profile.Lang
-		d.FollowedMessage = profile.FollowedMessage
+		// followedMessage は viewer-dependent (follower / self のみ)。packer は
+		// set せず、self は AsMeDetailed、follower は users/show handler が埋める
+		// (#1558 privacy gate)。base detailed には出さない。
 		d.PublicReactions = profile.PublicReactions
 		d.Fields = profile.Fields
 		if len(profile.VerifiedLinks) > 0 {
@@ -543,6 +557,28 @@ func PackUserDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Ge
 	}
 
 	return d
+}
+
+// countVisible reports whether a followers/following count is visible to a
+// viewer, per upstream UserEntityService (followingCount/followersCount are
+// nulled → 0 unless): visibility=='public' OR self OR moderator OR
+// (visibility=='followers' && the viewer follows the target) (#1558)。
+func countVisible(visibility string, isMe, isModerator, isFollowing bool) bool {
+	return visibility == string(model.FollowingVisibilityPublic) || isMe || isModerator ||
+		(visibility == string(model.FollowingVisibilityFollowers) && isFollowing)
+}
+
+// GateCountVisibility zeroes followersCount / followingCount on a packed
+// UserDetailed when the viewer must not see them, mirroring upstream's null →
+// 0 for restricted (followers / private) visibility (#1558)。d.FollowersVisibility
+// / d.FollowingVisibility は PackUserDetailed が profile から埋めた値を読む。
+func GateCountVisibility(d *UserDetailed, isMe, isModerator, isFollowing bool) {
+	if !countVisible(d.FollowersVisibility, isMe, isModerator, isFollowing) {
+		d.FollowersCount = 0
+	}
+	if !countVisible(d.FollowingVisibility, isMe, isModerator, isFollowing) {
+		d.FollowingCount = 0
+	}
 }
 
 // backupCodesStock returns the 2FA backup-codes stock level. Mirrors upstream

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -307,6 +307,38 @@ func TestPackUserDetailed_ProfileVisibility(t *testing.T) {
 	assert.Equal(t, "private", detailed.FollowingVisibility)
 }
 
+// #1558 GateCountVisibility は visibility / viewer 関係に応じて count を 0 化する。
+func TestGateCountVisibility(t *testing.T) {
+	cases := []struct {
+		name                           string
+		followersVis, followingVis     string
+		isMe, isModerator, isFollowing bool
+		wantFollowers, wantFollowing   int
+	}{
+		{"public always shown", "public", "public", false, false, false, 10, 20},
+		{"private hidden from non-follower", "private", "private", false, false, false, 0, 0},
+		{"private shown to self", "private", "private", true, false, false, 10, 20},
+		{"private shown to moderator", "private", "private", false, true, false, 10, 20},
+		{"followers hidden from non-follower", "followers", "followers", false, false, false, 0, 0},
+		{"followers shown to follower", "followers", "followers", false, false, true, 10, 20},
+		{"private hidden even from follower", "private", "private", false, false, true, 0, 0},
+		{"mixed: public followers + private following", "public", "private", false, false, false, 10, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := &UserDetailed{
+				FollowersCount:      10,
+				FollowingCount:      20,
+				FollowersVisibility: c.followersVis,
+				FollowingVisibility: c.followingVis,
+			}
+			GateCountVisibility(d, c.isMe, c.isModerator, c.isFollowing)
+			assert.Equal(t, c.wantFollowers, d.FollowersCount)
+			assert.Equal(t, c.wantFollowing, d.FollowingCount)
+		})
+	}
+}
+
 func TestPackUserDetailed_VerifiedLinks(t *testing.T) {
 	u := &model.User{
 		ID:                "user6",


### PR DESCRIPTION
## Summary

Misskey TS 互換性監査 (#1558: entity:User packer, 0H 3M 3L) の再検証のうえ、viewer 視点で gate すべき privacy 項目を解消する。#1558 の part 1/2 (privacy MEDIUM 2 件 + moderationNote の search 適用漏れ)。

再検証の結果、監査 6 項目のうち **moderationNote (MEDIUM)** は users/show では既に `applyModerationNote` で実装済 (stale) で、users/search への適用漏れのみ残っていた。本 PR で残りの real 項目を扱う。

## 主な変更点

- **followedMessage の漏洩修正** (privacy): 従来 `PackUserDetailed` が無条件 emit していた follower-only の `followedMessage` を、follower / self だけに見せる (upstream `UserEntityService` の relation / isMe ブロックでのみ emit)。
  - base `UserDetailed.FollowedMessage` は `omitempty` にし、packer は set しない。
  - self は `AsMeDetailed` が、follower は users/show 単体 / followers-following list handler が profile から set する。bulk / search は set しない (= 非 follower 扱いで省略)。
  - `MeDetailed` では `followedMessage` が required なので、omitempty 無しの shadow field を `MeDetailed` struct に追加して self では常に emit (null 可)。
  - `meUpdated` self event も本人の followedMessage を補填する (packer 変更による self-event 欠落の回帰を修正)。
- **followersCount / followingCount の visibility gate** (privacy): `entity.GateCountVisibility` が `visibility=='public' OR self OR moderator OR (visibility=='followers' && isFollowing)` でなければ count を 0 化する (upstream の null→0)。
  - users/show 単体は解決済 relation で precise gate、followers/following list も per-item `isFollowing` で precise gate。
  - bulk / users/search は per-user relation を解決しないため `isFollowing=false` (= 非 follower 扱い、privacy 安全側) で gate。self / moderator は real count を保持。
- **moderationNote**: users/search でも moderator viewer に出す (users/show は実装済の `applyModerationNote` を search にも展開)。

## テスト

- `internal/entity/user_test.go`: `TestGateCountVisibility` (public / followers / private × self / moderator / follower の全分岐)
- `internal/api/users/parity_1558_test.go` (新規): users/show の followedMessage gate (非follower/anonymous 省略・follower/self 表示) と count visibility (各 visibility × viewer)、users/search の moderationNote (moderator のみ)
- `internal/core/user/user_service_test.go`: meUpdated self event が followedMessage を含む (回帰防止)
- 対象パッケージ coverage: entity 96.3% / users 91.0% / core/user 92.1%
- `make fmt` / `go vet ./...` / `go test ./...` 全 pass

## 関連

#1558 (part 1/2)。残り part 2/2 で LOW 3 件 (avatarBlurhash/bannerUrl/bannerBlurhash の null gate、notify/withReplies の default emit、badgeRoles の remote omit) を扱う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)