### PR TITLE
Fix entity:User: blurhash null gate + notify/withReplies default (#1558 part 2/2)

### DIFF
--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -509,11 +509,24 @@ func (h *Handler) Show(c echo.Context) error {
 			detailed.IsFollowing = &isFollowing
 			detailed.IsFollowed = &isFollowed
 			viewerIsFollowing = isFollowing
+			// notify / withReplies は relation ブロックが存在する限り (= authed
+			// 非self viewer) 常に emit する。upstream は
+			// `notify: relation.following?.notify ?? 'none'` /
+			// `withReplies: relation.following?.withReplies ?? false` で、follow row
+			// が無い / notify 未設定でも default を出す (#1558)。
+			none := "none"
+			withReplies := false
 			if followRec != nil {
-				detailed.Notify = followRec.Notify
-				wr := followRec.WithReplies
-				detailed.WithReplies = &wr
+				if followRec.Notify != nil {
+					detailed.Notify = followRec.Notify
+				} else {
+					detailed.Notify = &none
+				}
+				withReplies = followRec.WithReplies
+			} else {
+				detailed.Notify = &none
 			}
+			detailed.WithReplies = &withReplies
 			// followedMessage は follower にだけ見せる (upstream relation ブロックの
 			// `relation.isFollowing ? profile.followedMessage : undefined`、#1558)。
 			if isFollowing && bundle.Profile != nil {

--- a/internal/api/users/parity_1558_test.go
+++ b/internal/api/users/parity_1558_test.go
@@ -159,6 +159,49 @@ func TestShow_CountVisibility(t *testing.T) {
 	})
 }
 
+// #1558 [LOW] notify / withReplies は authed 非self viewer なら following row が
+// 無くても default ('none' / false) を emit する。
+func TestShow_NotifyWithRepliesDefaults(t *testing.T) {
+	t.Run("non-following authed viewer gets defaults", func(t *testing.T) {
+		h, repo := newTestHandler(t)
+		newTargetWithProfile(repo, "target1", &model.UserProfile{
+			FollowersVisibility: model.FollowingVisibilityPublic,
+			FollowingVisibility: model.FollowingVisibilityPublic,
+		})
+		resp := showWithViewer(t, h, "target1", &model.User{ID: "viewer1", Username: "viewer"})
+		assert.Equal(t, "none", resp["notify"], "follow row が無くても notify='none'")
+		assert.Equal(t, false, resp["withReplies"], "follow row が無くても withReplies=false")
+	})
+
+	t.Run("following viewer gets actual values", func(t *testing.T) {
+		h, repo := newTestHandler(t)
+		newTargetWithProfile(repo, "target1", &model.UserProfile{
+			FollowersVisibility: model.FollowingVisibilityPublic,
+			FollowingVisibility: model.FollowingVisibilityPublic,
+		})
+		fRepo := testutil.NewMockFollowingRepository()
+		normal := "normal"
+		fRepo.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "viewer1", FolloweeID: "target1", Notify: &normal, WithReplies: true}
+		h.SetFollowingRepo(fRepo)
+		resp := showWithViewer(t, h, "target1", &model.User{ID: "viewer1", Username: "viewer"})
+		assert.Equal(t, "normal", resp["notify"])
+		assert.Equal(t, true, resp["withReplies"])
+	})
+
+	t.Run("anonymous omits notify/withReplies", func(t *testing.T) {
+		h, repo := newTestHandler(t)
+		newTargetWithProfile(repo, "target1", &model.UserProfile{
+			FollowersVisibility: model.FollowingVisibilityPublic,
+			FollowingVisibility: model.FollowingVisibilityPublic,
+		})
+		resp := showWithViewer(t, h, "target1", nil)
+		_, hasNotify := resp["notify"]
+		_, hasWR := resp["withReplies"]
+		assert.False(t, hasNotify, "anonymous には relation field を出さない")
+		assert.False(t, hasWR)
+	})
+}
+
 // #1558 [MEDIUM 2-gap] users/search でも moderator viewer に moderationNote を出す。
 func TestSearch_ModerationNoteForModerator(t *testing.T) {
 	h, repo := newTestHandler(t)

--- a/internal/entity/mediaurl_test.go
+++ b/internal/entity/mediaurl_test.go
@@ -284,7 +284,7 @@ func TestAvatarBannerProxying(t *testing.T) {
 		}
 	})
 	t.Run("remote banner is proxied", func(t *testing.T) {
-		u0 := &model.User{Username: "dave", Host: sp(remoteHost), BannerURL: sp("https://" + remoteHost + "/b.png")}
+		u0 := &model.User{Username: "dave", Host: sp(remoteHost), BannerID: sp("b1"), BannerURL: sp("https://" + remoteHost + "/b.png")}
 		d := PackUserDetailed(u0, nil)
 		if d.BannerURL == nil || !strings.HasPrefix(*d.BannerURL, testInternalProxy+"/image.webp?") {
 			t.Errorf("remote banner not proxied: %v", d.BannerURL)

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -445,14 +445,37 @@ func IdenticonURL(u *model.User) string {
 // 30s TTL の in-memory cache (core/avatardecoration.Resolver) で hit 時は
 // DB を叩かない。cache miss / TTL 切れでのみ admin catalog の List を 1 回
 // 引く (#521 / #524 review)。
+// blurhashIfPresent returns the cached blurhash only when the backing media id
+// is set, mirroring upstream's `id == null ? null : blurhash` (#1558)。avatarId
+// / bannerId が null なのに *Url / *Blurhash 列が stale-non-null なケースで
+// upstream と同じ null を返す。
+func blurhashIfPresent(mediaID, blurhash *string) *string {
+	if mediaID == nil {
+		return nil
+	}
+	return blurhash
+}
+
+// bannerURLIfPresent returns the proxied banner URL only when bannerId is set,
+// mirroring upstream's `bannerId == null ? null : bannerUrl` (#1558)。
+func bannerURLIfPresent(bannerID, bannerURL *string) *string {
+	if bannerID == nil {
+		return nil
+	}
+	return currentMediaURLContext().ProxyBannerURL(bannerURL)
+}
+
 func PackUserLite(u *model.User) UserLite {
 	out := UserLite{
-		ID:                u.ID,
-		Name:              u.Name,
-		Username:          u.Username,
-		Host:              u.Host,
-		AvatarURL:         IdenticonURL(u),
-		AvatarBlurhash:    u.AvatarBlurhash,
+		ID:        u.ID,
+		Name:      u.Name,
+		Username:  u.Username,
+		Host:      u.Host,
+		AvatarURL: IdenticonURL(u),
+		// avatarId が null のとき avatarBlurhash も null にする (upstream
+		// `user.avatarId == null ? null : user.avatarBlurhash`、#1558)。avatarUrl
+		// 自体は IdenticonURL fallback があるので gate しない (TS も `?? identicon`)。
+		AvatarBlurhash:    blurhashIfPresent(u.AvatarID, u.AvatarBlurhash),
 		AvatarDecorations: resolveAvatarDecorations(u.AvatarDecorations),
 		IsBot:             u.IsBot,
 		IsCat:             u.IsCat,
@@ -485,10 +508,11 @@ func PackUserLite(u *model.User) UserLite {
 func PackUserDetailed(u *model.User, profile *model.UserProfile, idGens ...id.Generator) UserDetailed {
 	d := UserDetailed{
 		UserLite: PackUserLite(u),
-		// remote user の bannerUrl も remote origin を指すため proxy 経由に
-		// 書き換える (#1529)。local は素通し。
-		BannerURL:           currentMediaURLContext().ProxyBannerURL(u.BannerURL),
-		BannerBlurhash:      u.BannerBlurhash,
+		// bannerId が null のとき bannerUrl / bannerBlurhash も null にする
+		// (upstream `user.bannerId == null ? null : ...`、#1558)。remote user の
+		// bannerUrl は remote origin を指すため proxy 経由に書き換える (#1529)。
+		BannerURL:           bannerURLIfPresent(u.BannerID, u.BannerURL),
+		BannerBlurhash:      blurhashIfPresent(u.BannerID, u.BannerBlurhash),
 		IsLocked:            u.IsLocked,
 		IsSuspended:         u.IsSuspended,
 		FollowersCount:      u.FollowersCount,

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -65,11 +65,13 @@ func TestPackUserLite(t *testing.T) {
 	name := "Test User"
 	avatarURL := "https://example.com/avatar.png"
 	blurhash := "LEHV6nWB2yk8"
+	avatarID := "avatar1"
 
 	u := &model.User{
 		ID:                "user1",
 		Username:          "testuser",
 		Name:              &name,
+		AvatarID:          &avatarID,
 		AvatarURL:         &avatarURL,
 		AvatarBlurhash:    &blurhash,
 		AvatarDecorations: datatypes.JSON([]byte("[]")),
@@ -137,6 +139,7 @@ func TestPackUserLite_ExistingAvatarURL(t *testing.T) {
 func TestPackUserDetailed(t *testing.T) {
 	name := "Detailed User"
 	bannerURL := "https://example.com/banner.png"
+	bannerID := "banner1"
 	desc := "A test user"
 	location := "Tokyo"
 	birthday := "2000-01-01"
@@ -146,6 +149,7 @@ func TestPackUserDetailed(t *testing.T) {
 		ID:                "user3",
 		Username:          "detailed",
 		Name:              &name,
+		BannerID:          &bannerID,
 		BannerURL:         &bannerURL,
 		IsLocked:          true,
 		IsSuspended:       false,
@@ -305,6 +309,41 @@ func TestPackUserDetailed_ProfileVisibility(t *testing.T) {
 
 	assert.Equal(t, "followers", detailed.FollowersVisibility)
 	assert.Equal(t, "private", detailed.FollowingVisibility)
+}
+
+// #1558 avatarId / bannerId が null のとき blurhash / bannerUrl も null にする。
+func TestPackUser_BlurhashGatedByMediaID(t *testing.T) {
+	blur := "LEHV6nWB2yk8"
+	bannerURL := "https://example.com/banner.png"
+
+	t.Run("avatarId nil → avatarBlurhash nil", func(t *testing.T) {
+		u := &model.User{ID: "u", Username: "u", AvatarBlurhash: &blur, AvatarDecorations: datatypes.JSON([]byte("[]"))}
+		lite := PackUserLite(u)
+		assert.Nil(t, lite.AvatarBlurhash, "avatarId が無ければ blurhash も出さない")
+	})
+
+	t.Run("avatarId set → avatarBlurhash kept", func(t *testing.T) {
+		aid := "a1"
+		u := &model.User{ID: "u", Username: "u", AvatarID: &aid, AvatarBlurhash: &blur, AvatarDecorations: datatypes.JSON([]byte("[]"))}
+		lite := PackUserLite(u)
+		assert.Equal(t, &blur, lite.AvatarBlurhash)
+	})
+
+	t.Run("bannerId nil → bannerUrl / bannerBlurhash nil", func(t *testing.T) {
+		u := &model.User{ID: "u", Username: "u", BannerURL: &bannerURL, BannerBlurhash: &blur}
+		d := PackUserDetailed(u, nil)
+		assert.Nil(t, d.BannerURL, "bannerId が無ければ bannerUrl も出さない")
+		assert.Nil(t, d.BannerBlurhash, "bannerId が無ければ bannerBlurhash も出さない")
+	})
+
+	t.Run("bannerId set → banner kept", func(t *testing.T) {
+		bid := "b1"
+		u := &model.User{ID: "u", Username: "u", BannerID: &bid, BannerURL: &bannerURL, BannerBlurhash: &blur}
+		d := PackUserDetailed(u, nil)
+		require.NotNil(t, d.BannerURL)
+		assert.Equal(t, bannerURL, *d.BannerURL)
+		assert.Equal(t, &blur, d.BannerBlurhash)
+	})
 }
 
 // #1558 GateCountVisibility は visibility / viewer 関係に応じて count を 0 化する。


### PR DESCRIPTION
## Summary

Misskey TS 互換性監査 (#1558: entity:User packer) の LOW 項目 2 件を解消する。#1558 の part 2/2 (shape nuances)。これで #1558 の real 項目 (part 1 の privacy 2 件 + 本 PR の 2 件) を解消し、残る 1 件は follow-up に切り出す。

## 主な変更点

- **avatarBlurhash / bannerUrl / bannerBlurhash の null gate**: `avatarId` / `bannerId` が null のとき、対応する `avatarBlurhash` / `bannerUrl` / `bannerBlurhash` も null にする (upstream `UserEntityService` の `user.avatarId == null ? null : user.avatarBlurhash` 等)。`*Id` 列が null なのに cached `*Url` / `*Blurhash` 列が stale-non-null なケースで upstream と同じ null を返す。`avatarUrl` 自体は IdenticonURL fallback があるので gate しない (TS も `?? getIdenticonUrl`)。
- **notify / withReplies の default emit**: users/show の relation ブロックは authed 非self viewer なら follow row が無くても `notify` ('none') / `withReplies` (false) を emit する (upstream `relation.following?.notify ?? 'none'` / `?? false`)。従来は `followRec != nil` のときだけ set していたため、authed 非follower viewer で省略されていた。

## テスト

- `internal/entity/user_test.go`: `TestPackUser_BlurhashGatedByMediaID` (avatarId/bannerId の有無で blurhash/bannerUrl が null/値)。既存 `TestPackUserLite` / `TestPackUserDetailed` / `TestAvatarBannerProxying` の fixture に avatarId/bannerId を追加 (consistent case)
- `internal/api/users/parity_1558_test.go`: `TestShow_NotifyWithRepliesDefaults` (非following authed → default、following → 実値、anonymous → 省略)
- 対象パッケージ coverage: entity 96.4% / users 91.0%
- `make fmt` / `go vet ./...` / `go test ./...` 全 pass

## 関連

Closes #1558。

残る LOW 項目 (badgeRoles の remote-user omit + `showRoleBadgesOfRemoteUsers` meta フラグ対応) は entity packer への meta lookup 基盤追加 + `*[]any` 型変更を要し、現状の挙動 (`[]`) も FE-safe / 既存コードで意図的な follow-up と明記されているため、#1653 に切り出した。

#1558 の項目別結果:
- followedMessage 漏洩 (M) → part 1 (#1652)
- followersCount/followingCount visibility (M) → part 1 (#1652)
- moderationNote (M) → 既に users/show 実装済 (stale)、search 適用漏れのみ part 1 で解消
- avatarBlurhash/bannerUrl/bannerBlurhash null gate (L) → 本 PR
- notify/withReplies default (L) → 本 PR
- badgeRoles remote omit (L) → #1653 に follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)