### PR TITLE
Fix entity:User: badgeRoles を remote-user で省略 + showRoleBadgesOfRemoteUsers 対応 (#1653)

### DIFF
--- a/internal/api/admin/aidx_helpers_test.go
+++ b/internal/api/admin/aidx_helpers_test.go
@@ -40,3 +40,17 @@ func TestAidxCreatedAtString_InvalidID(t *testing.T) {
 	assert.Error(t, err)
 	assert.False(t, errors.Is(err, ErrIDGenMissing), "non-aidx parse failure must not be reported as ErrIDGenMissing")
 }
+
+// #1653 badgeRolesForMap は nil (remote user で showRoleBadgesOfRemoteUsers off)
+// を空配列に coerce し、map 経路で schema-invalid な null を出さない。
+func TestBadgeRolesForMap(t *testing.T) {
+	// nil → 空配列 (admin map では `[]` を維持)
+	assert.NotNil(t, badgeRolesForMap(nil))
+	assert.Empty(t, badgeRolesForMap(nil))
+
+	// non-nil → そのまま deref
+	roles := []any{map[string]any{"name": "Badge"}}
+	got := badgeRolesForMap(&roles)
+	require.Len(t, got, 1)
+	assert.Equal(t, "Badge", got[0].(map[string]any)["name"])
+}

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -590,7 +590,7 @@ func (h *Handler) AccountsCreate(c echo.Context) error {
 		"isCat":             detailed.IsCat,
 		"emojis":            detailed.Emojis,
 		"onlineStatus":      detailed.OnlineStatus,
-		"badgeRoles":        detailed.BadgeRoles,
+		"badgeRoles":        badgeRolesForMap(detailed.BadgeRoles),
 		// UserDetailed
 		"bannerUrl":      detailed.BannerURL,
 		"bannerBlurhash": detailed.BannerBlurhash,
@@ -761,6 +761,19 @@ func (h *Handler) ShowUsers(c echo.Context) error {
 	return c.JSON(http.StatusOK, result)
 }
 
+// badgeRolesForMap returns badgeRoles for admin map-based responses. The packer
+// now returns *[]any (nil = absent for remote users with
+// showRoleBadgesOfRemoteUsers off, #1653), but admin endpoints serialise via
+// map[string]any which ignores omitempty — a nil pointer would emit
+// schema-invalid `null` (UserLite.badgeRoles is nullable:false). Coerce nil to
+// `[]` so the admin response keeps its previous `[]` shape.
+func badgeRolesForMap(br *[]any) []any {
+	if br == nil {
+		return []any{}
+	}
+	return *br
+}
+
 // packAdminUser returns a MeDetailed-equivalent response for admin endpoints.
 func (h *Handler) packAdminUser(u *model.User, profile *model.UserProfile) map[string]any {
 	detailed := entity.PackUserDetailed(u, profile)
@@ -771,7 +784,7 @@ func (h *Handler) packAdminUser(u *model.User, profile *model.UserProfile) map[s
 		"avatarBlurhash": detailed.AvatarBlurhash, "avatarDecorations": detailed.AvatarDecorations,
 		"isBot": detailed.IsBot, "isCat": detailed.IsCat,
 		"emojis": detailed.Emojis, "onlineStatus": detailed.OnlineStatus,
-		"badgeRoles": detailed.BadgeRoles,
+		"badgeRoles": badgeRolesForMap(detailed.BadgeRoles),
 		// UserDetailed
 		"bannerUrl": detailed.BannerURL, "bannerBlurhash": detailed.BannerBlurhash,
 		"isLocked": detailed.IsLocked, "isSilenced": false, "isSuspended": detailed.IsSuspended,

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -53,7 +53,11 @@ type UserLite struct {
 	IsCat             bool                   `json:"isCat"`
 	Emojis            map[string]string      `json:"emojis"`
 	OnlineStatus      string                 `json:"onlineStatus"`
-	BadgeRoles        []any                  `json:"badgeRoles"`
+	// BadgeRoles は local user では常に present (空でも `[]`)、remote user では
+	// meta.showRoleBadgesOfRemoteUsers が off なら省略する (upstream: undefined)。
+	// 「空配列 present」と「absent」を区別するため *[]any + omitempty を使う
+	// (#1653)。
+	BadgeRoles *[]any `json:"badgeRoles,omitempty"`
 	// CanChat は upstream Misskey TS の boolean field (#692)。FE の
 	// /chat/room.vue が `!user.canChat` で「DM 受け付け不可」warning を
 	// 出すので、出さないと local user 同士で DM できないと誤表示される。

--- a/internal/entity/user_roles.go
+++ b/internal/entity/user_roles.go
@@ -39,6 +39,37 @@ func SetUserRolesLookup(l UserRolesLookup) {
 	userRolesLookupMu.Unlock()
 }
 
+// showRemoteBadgesLookup resolves meta.showRoleBadgesOfRemoteUsers so
+// packBadgeRoles can decide whether a remote user's badge roles are exposed
+// (upstream `meta.showRoleBadgesOfRemoteUsers || user.host == null`、#1653)。
+// Router wires this once at startup with a closure that reads the cached meta.
+// nil leaves it false, which keeps the conservative local-only default for
+// tests that don't wire it.
+var (
+	showRemoteBadgesMu     sync.RWMutex
+	showRemoteBadgesLookup func() bool
+)
+
+// SetShowRemoteBadgesLookup wires the meta.showRoleBadgesOfRemoteUsers
+// accessor used by packBadgeRoles (#1653)。Pass nil to clear (used in tests).
+func SetShowRemoteBadgesLookup(fn func() bool) {
+	showRemoteBadgesMu.Lock()
+	showRemoteBadgesLookup = fn
+	showRemoteBadgesMu.Unlock()
+}
+
+// resolveShowRemoteBadges reports whether remote users' badge roles should be
+// exposed, falling back to false (= local-only) when the lookup is unwired.
+func resolveShowRemoteBadges() bool {
+	showRemoteBadgesMu.RLock()
+	fn := showRemoteBadgesLookup
+	showRemoteBadgesMu.RUnlock()
+	if fn == nil {
+		return false
+	}
+	return fn()
+}
+
 // resolveUserRolesSorted returns the user's assigned roles sorted by
 // displayOrder descending (= upstream sort key). Returns a fresh slice so
 // callers can iterate / filter freely without mutating the role service's
@@ -73,20 +104,25 @@ func resolveUserRolesSorted(userID string) []*model.Role {
 // viewer context; that is a follow-up to thread viewer through the entity
 // pack path).
 //
-// `(meta.showRoleBadgesOfRemoteUsers || user.host == null)` 条件は本実装で
-// は「local user (= u.Host == nil) のみ」に限定する upstream の保守的な
-// デフォルト挙動を採用する。meta フラグ参照は別 lookup pattern を要する
-// ため、scope を core bug fix に絞って follow-up に回す。
+// upstream の `(meta.showRoleBadgesOfRemoteUsers || user.host == null)` 条件を
+// 再現する (#1653)。local user (host==nil) は常に pack し、remote user は
+// meta.showRoleBadgesOfRemoteUsers が on のときだけ pack する。
 //
-// Always returns a non-nil slice ([]any{}) so the JSON output is `[]` not
-// `null` (drop-in 互換: upstream は undefined を返すが mk-go の現実装は
-// JSON `[]` 固定なので、その shape を維持する)。
-func packBadgeRoles(u *model.User) []any {
-	out := []any{}
-	if u == nil || u.Host != nil {
-		// remote user は upstream default で badge を出さない
-		return out
+// 戻り値で「省略 (nil)」と「空配列 present (&[]any{})」を区別する:
+//   - local user: 常に non-nil (badge が無くても &[]any{} = JSON `[]`)
+//   - remote + flag off: nil (= upstream undefined、JSON では omitempty で省略)
+//   - remote + flag on: badge を pack した non-nil slice
+//
+// BadgeRoles は *[]any + omitempty なので nil → 省略、non-nil → present。
+func packBadgeRoles(u *model.User) *[]any {
+	if u == nil {
+		return nil
 	}
+	if u.Host != nil && !resolveShowRemoteBadges() {
+		// remote user は flag off なら badge を出さない (upstream: undefined)
+		return nil
+	}
+	out := []any{}
 	roles := resolveUserRolesSorted(u.ID)
 	for _, r := range roles {
 		if r == nil || !r.AsBadge || !r.IsPublic {
@@ -101,7 +137,7 @@ func packBadgeRoles(u *model.User) []any {
 			"displayOrder": r.DisplayOrder,
 		})
 	}
-	return out
+	return &out
 }
 
 // packPublicRoles returns the user's public roles ready for JSON

--- a/internal/entity/user_roles_test.go
+++ b/internal/entity/user_roles_test.go
@@ -95,7 +95,9 @@ func TestPackBadgeRoles_FiltersAsBadgeAndIsPublic(t *testing.T) {
 			{ID: "r4", Name: "Badge2", AsBadge: true, IsPublic: true, DisplayOrder: 10},
 		},
 	}})
-	got := packBadgeRoles(&model.User{ID: "u1"})
+	gotPtr := packBadgeRoles(&model.User{ID: "u1"})
+	require.NotNil(t, gotPtr)
+	got := *gotPtr
 	require.Len(t, got, 2)
 	// displayOrder desc: r4 (10) → r1 (3)
 	got0 := got[0].(map[string]any)
@@ -106,31 +108,44 @@ func TestPackBadgeRoles_FiltersAsBadgeAndIsPublic(t *testing.T) {
 	assert.Equal(t, 3, got1["displayOrder"])
 }
 
-// packBadgeRoles: remote user (u.Host != nil) は upstream default で badge
-// 非表示 (meta.showRoleBadgesOfRemoteUsers 対応は follow-up)。
-func TestPackBadgeRoles_RemoteUserReturnsEmpty(t *testing.T) {
-	t.Cleanup(func() { SetUserRolesLookup(nil) })
+// packBadgeRoles: remote user は meta.showRoleBadgesOfRemoteUsers が off なら
+// nil を返し (= upstream undefined / JSON 省略)、on なら badge を pack する (#1653)。
+func TestPackBadgeRoles_RemoteUserGatedByMetaFlag(t *testing.T) {
+	t.Cleanup(func() { SetUserRolesLookup(nil); SetShowRemoteBadgesLookup(nil) })
 	SetUserRolesLookup(&stubRolesLookup{roles: map[string][]*model.Role{
-		"u1": {{ID: "r1", AsBadge: true, IsPublic: true}},
+		"u1": {{ID: "r1", Name: "Badge", AsBadge: true, IsPublic: true}},
 	}})
 	host := "remote.example"
-	got := packBadgeRoles(&model.User{ID: "u1", Host: &host})
-	assert.Empty(t, got)
+	remote := &model.User{ID: "u1", Host: &host}
+
+	// flag 未配線 (= off) → nil (omit)
+	assert.Nil(t, packBadgeRoles(remote))
+
+	// flag off → nil (omit)
+	SetShowRemoteBadgesLookup(func() bool { return false })
+	assert.Nil(t, packBadgeRoles(remote))
+
+	// flag on → badge を pack
+	SetShowRemoteBadgesLookup(func() bool { return true })
+	got := packBadgeRoles(remote)
+	require.NotNil(t, got)
+	require.Len(t, *got, 1)
+	assert.Equal(t, "Badge", (*got)[0].(map[string]any)["name"])
 }
 
-// packBadgeRoles: ロールがゼロでも空配列を返す。
-func TestPackBadgeRoles_EmptyReturnsEmptySlice(t *testing.T) {
+// packBadgeRoles: local user はロールがゼロでも空配列 present (&[]any{}) を返す。
+func TestPackBadgeRoles_LocalEmptyReturnsPresentEmpty(t *testing.T) {
 	t.Cleanup(func() { SetUserRolesLookup(nil) })
 	SetUserRolesLookup(nil)
 	got := packBadgeRoles(&model.User{ID: "u1"})
-	assert.NotNil(t, got)
-	assert.Empty(t, got)
+	require.NotNil(t, got, "local user は badge が無くても present (空配列)")
+	assert.Empty(t, *got)
 }
 
-// packBadgeRoles / packPublicRoles: nil user は安全に空配列を返す。
+// packBadgeRoles: nil user は nil (omit)、packPublicRoles は空配列。
 func TestPackRoles_NilUserReturnsEmpty(t *testing.T) {
 	t.Cleanup(func() { SetUserRolesLookup(nil) })
-	assert.Empty(t, packBadgeRoles(nil))
+	assert.Nil(t, packBadgeRoles(nil))
 	assert.Empty(t, packPublicRoles(nil))
 }
 
@@ -163,8 +178,9 @@ func TestPackUserLite_IncludesBadgeRoles(t *testing.T) {
 		},
 	}})
 	lite := PackUserLite(&model.User{ID: "u1", Username: "alice"})
-	require.Len(t, lite.BadgeRoles, 1)
-	br := lite.BadgeRoles[0].(map[string]any)
+	require.NotNil(t, lite.BadgeRoles)
+	require.Len(t, *lite.BadgeRoles, 1)
+	br := (*lite.BadgeRoles)[0].(map[string]any)
 	assert.Equal(t, "Cool", br["name"])
 	assert.Equal(t, &icon, br["iconUrl"])
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1409,6 +1409,13 @@ func (s *Server) setupRoutes() {
 	// に表示されなかった。roleService.GetUserRoles も in-memory cache 経由
 	// (#761) で hot path コスト無し。
 	entity.SetUserRolesLookup(corerole.NewUserRolesLookup(roleService))
+	// remote user の badgeRoles を出すかは meta.showRoleBadgesOfRemoteUsers
+	// 次第 (upstream)。CachedMetaRepository.Fetch は cache 経由で hot path
+	// コスト無し。fetch 失敗時は false (= local-only の保守的 default) (#1653)。
+	entity.SetShowRemoteBadgesLookup(func() bool {
+		m, err := metaRepo.Fetch()
+		return err == nil && m != nil && m.ShowRoleBadgesOfRemoteUsers
+	})
 	// PackDriveFile / IdenticonURL が remote origin の media URL (note 添付・
 	// avatar・banner 等) を pack 時に media proxy 経由へ書き換えられるよう
 	// context を登録する (#1529)。これが無いと remote の url/thumbnailUrl/


### PR DESCRIPTION
## Summary

#1558 (entity:User packer) から follow-up として切り出した `badgeRoles` の parity 2 点を解消する。

upstream `UserEntityService.ts:517-525`:
```ts
badgeRoles: (meta.showRoleBadgesOfRemoteUsers || user.host == null)
  ? (...roles...) : undefined
```

従来 mk-go は remote user に常に `badgeRoles: []` を emit し、`meta.showRoleBadgesOfRemoteUsers` フラグも参照していなかった。

## 主な変更点

- **remote-user gate + meta フラグ**: local user (host==nil) は常に present (badge が無くても `[]`)、remote user は `meta.showRoleBadgesOfRemoteUsers` が on のときだけ pack し、off なら省略する (upstream の undefined)。
- **「空配列 present」と「absent」の区別**: `UserLite.BadgeRoles` を `[]any` → `*[]any` + omitempty に変更。`packBadgeRoles` は local / remote+flag-on で `&[]any{...}` (空でも `&[]any{}`)、remote+flag-off / nil user で nil を返す。
- **meta フラグ lookup**: entity の global lookup (`SetShowRemoteBadgesLookup`、`SetSilencedLookup` 等と同じ pattern) 経由で参照し、router が `CachedMetaRepository.Fetch` を読む closure で配線する (未配線時は false = 保守的 local-only)。local user は lookup を呼ばず short-circuit するので hot path コスト無し。
- **admin endpoint の null 回帰防止**: admin は `UserDetailed` を `map[string]any` に再展開して serialize するため omitempty が効かず、nil `*[]any` が schema-invalid な `null` になる (UserLite.badgeRoles は nullable:false)。`badgeRolesForMap` で nil を `[]` に coerce し、admin レスポンスの従来 shape (`[]`) を維持する。

## テスト

- `internal/entity/user_roles_test.go`: `TestPackBadgeRoles_RemoteUserGatedByMetaFlag` (flag 未配線/off → nil、on → badge)、`TestPackBadgeRoles_LocalEmptyReturnsPresentEmpty` (local は空でも present)、既存 badge テストを `*[]any` 向けに更新
- `internal/api/admin/aidx_helpers_test.go`: `TestBadgeRolesForMap` (nil → `[]` coerce)
- 対象パッケージ coverage: entity 96.4% (新規 lookup/packBadgeRoles は 100%) / admin pass
- `make fmt` / `go vet ./...` / `go test ./...` 全 pass (UserLite を embed する timeline/note/notification/list 等の全レスポンスで回帰なしを確認)

## 関連

Closes #1653 (#1558 part 2/2 から切り出した follow-up)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)