### PR TITLE
Fix app/auth: App.isAuthorized 計算 + app/create permission 正規化 (#1557 part 1/4)

### DIFF
--- a/internal/api/app/handler.go
+++ b/internal/api/app/handler.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"net/http"
+	"regexp"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -14,10 +15,48 @@ import (
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
+// legacyPermRe matches the legacy `account/read` / `notes-write` permission
+// form so it can be migrated to the canonical `read:account` / `write:notes`
+// (upstream app/create.ts の `v.replace(/^(.+)(\/|-)(read|write)$/, '$3:$1')`)。
+var legacyPermRe = regexp.MustCompile(`^(.+)(/|-)(read|write)$`)
+
+// normalizeAppPermissions migrates legacy permission strings to the canonical
+// `<read|write>:<entity>` form and de-duplicates (preserving first-occurrence
+// order), mirroring upstream app/create.ts の `unique(ps.permission.map(...))`
+// (#1557)。
+func normalizeAppPermissions(perms []string) pq.StringArray {
+	seen := make(map[string]struct{}, len(perms))
+	out := make(pq.StringArray, 0, len(perms))
+	for _, p := range perms {
+		if m := legacyPermRe.FindStringSubmatch(p); m != nil {
+			p = m[3] + ":" + m[1]
+		}
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	return out
+}
+
 // Handler handles app-related API endpoints.
 type Handler struct {
 	repo  repository.AuthSessionRepository
 	idGen id.Generator
+}
+
+// isAuthorizedFor reports the App.isAuthorized value for a viewer (#1557)。
+// Returns nil when me is nil so the caller omits the field (upstream は me!=null
+// のときだけ含める)。non-nil のときは access_token が存在するか
+// (= accessTokensRepository.countBy({appId,userId}) > 0) を返す。
+func (h *Handler) isAuthorizedFor(appID string, me *model.User) *bool {
+	if me == nil {
+		return nil
+	}
+	_, err := h.repo.FindAccessTokenByAppAndUser(appID, me.ID)
+	v := err == nil
+	return &v
 }
 
 // NewHandler creates a new app Handler.
@@ -38,9 +77,10 @@ func (h *Handler) Create(c echo.Context) error {
 	}
 
 	// 認証済みユーザーのIDを取得（任意）
+	me := middleware.GetUser(c)
 	var userID *string
-	if u := middleware.GetUser(c); u != nil {
-		userID = &u.ID
+	if me != nil {
+		userID = &me.ID
 	}
 
 	now := time.Now()
@@ -51,14 +91,18 @@ func (h *Handler) Create(c echo.Context) error {
 		Secret:      misc.SecureRandomHex(32),
 		Name:        req.Name,
 		Description: req.Description,
-		Permission:  pq.StringArray(req.Permission),
+		// legacy permission の正規化 + de-dup (upstream app/create.ts、#1557)。
+		Permission:  normalizeAppPermissions(req.Permission),
 		CallbackURL: req.CallbackURL,
 	}
 	if err := h.repo.CreateApp(a); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
-	return c.JSON(http.StatusOK, packApp(a, true))
+	// upstream app/create.ts は pack(app, null, ...) と me を null 固定で渡すため
+	// isAuthorized を常に省略する (authenticated でも含めない、#1557)。me は
+	// userID 取得にのみ使う。
+	return c.JSON(http.StatusOK, packApp(a, true, nil))
 }
 
 // Show handles POST /api/app/show.
@@ -76,12 +120,13 @@ func (h *Handler) Show(c echo.Context) error {
 	}
 
 	// 認証済み && 自分のアプリならsecretも返す
+	me := middleware.GetUser(c)
 	includeSecret := false
-	if u := middleware.GetUser(c); u != nil && a.UserID != nil && *a.UserID == u.ID {
+	if me != nil && a.UserID != nil && *a.UserID == me.ID {
 		includeSecret = true
 	}
 
-	return c.JSON(http.StatusOK, packApp(a, includeSecret))
+	return c.JSON(http.StatusOK, packApp(a, includeSecret, h.isAuthorizedFor(a.ID, me)))
 }
 
 // MyApps handles POST /api/my/apps.
@@ -117,18 +162,22 @@ func (h *Handler) MyApps(c echo.Context) error {
 
 	result := make([]map[string]any, len(apps))
 	for i, a := range apps {
-		result[i] = packApp(a, true)
+		result[i] = packApp(a, true, h.isAuthorizedFor(a.ID, u))
 	}
 	return c.JSON(http.StatusOK, result)
 }
 
-func packApp(a *model.App, includeSecret bool) map[string]any {
+// packApp builds the App entity response. isAuthorized is included only when
+// non-nil (upstream は me!=null のときだけ含める、#1557)。
+func packApp(a *model.App, includeSecret bool, isAuthorized *bool) map[string]any {
 	resp := map[string]any{
-		"id":           a.ID,
-		"name":         a.Name,
-		"callbackUrl":  a.CallbackURL,
-		"permission":   a.Permission,
-		"isAuthorized": false,
+		"id":          a.ID,
+		"name":        a.Name,
+		"callbackUrl": a.CallbackURL,
+		"permission":  a.Permission,
+	}
+	if isAuthorized != nil {
+		resp["isAuthorized"] = *isAuthorized
 	}
 	if includeSecret {
 		resp["secret"] = a.Secret

--- a/internal/api/app/handler_test.go
+++ b/internal/api/app/handler_test.go
@@ -60,7 +60,12 @@ func (m *mockAuthSessionRepo) FindSessionByTokenAndAppID(string, string) (*model
 }
 func (m *mockAuthSessionRepo) UpdateSessionUserID(string, string) error { return nil }
 func (m *mockAuthSessionRepo) DeleteSession(string) error               { return nil }
-func (m *mockAuthSessionRepo) FindAccessTokenByAppAndUser(string, string) (*model.AccessToken, error) {
+func (m *mockAuthSessionRepo) FindAccessTokenByAppAndUser(appID, userID string) (*model.AccessToken, error) {
+	for _, t := range m.accessTokens {
+		if t.AppID != nil && *t.AppID == appID && t.UserID == userID {
+			return t, nil
+		}
+	}
 	return nil, assert.AnError
 }
 func (m *mockAuthSessionRepo) CreateAccessToken(t *model.AccessToken) error {
@@ -153,13 +158,22 @@ func TestCreate_WithUser(t *testing.T) {
 	h, repo := newTestHandler()
 	user := &model.User{ID: "u1"}
 
-	rec := post(h.Create, `{"name":"App","description":"d","permission":["read:account"]}`, user)
+	rec := post(h.Create, `{"name":"App","description":"d","permission":["account/read","read:account"]}`, user)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	for _, a := range repo.apps {
 		require.NotNil(t, a.UserID)
 		assert.Equal(t, "u1", *a.UserID)
+		// #1557 permission は正規化 + de-dup される (account/read と read:account は同一)。
+		assert.Equal(t, []string{"read:account"}, []string(a.Permission))
 	}
+
+	// #1557 app/create は upstream が pack(app, null) するため、authenticated
+	// でも isAuthorized を含めない。
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	_, hasAuth := resp["isAuthorized"]
+	assert.False(t, hasAuth, "app/create は isAuthorized を省略する")
 }
 
 func TestCreate_InvalidParam(t *testing.T) {
@@ -195,6 +209,29 @@ func TestShow_Success(t *testing.T) {
 	// 認証なし→secret非公開
 	_, hasSecret := resp["secret"]
 	assert.False(t, hasSecret)
+	// 認証なし (me==null) → isAuthorized は省略される (#1557)。
+	_, hasAuth := resp["isAuthorized"]
+	assert.False(t, hasAuth)
+}
+
+// #1557 app/show: 認証 viewer が access_token を持つ → isAuthorized true、
+// 持たない → false。me!=null では field を含める。
+func TestShow_IsAuthorized(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.apps["app1"] = &model.App{ID: "app1", Name: "MyApp", Permission: pq.StringArray{"read:account"}}
+
+	// token 無し viewer → isAuthorized false (present)
+	rec := post(h.Show, `{"appId":"app1"}`, &model.User{ID: "viewer1"})
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["isAuthorized"])
+
+	// token あり viewer → isAuthorized true
+	appID := "app1"
+	repo.accessTokens["t1"] = &model.AccessToken{ID: "t1", AppID: &appID, UserID: "viewer2"}
+	rec = post(h.Show, `{"appId":"app1"}`, &model.User{ID: "viewer2"})
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["isAuthorized"])
 }
 
 func TestShow_WithOwner(t *testing.T) {
@@ -322,13 +359,32 @@ func TestSecureRandomHex(t *testing.T) {
 
 func TestPackApp_NoSecret(t *testing.T) {
 	a := &model.App{ID: "a1", Name: "App", Permission: pq.StringArray{"read:account"}}
-	result := packApp(a, false)
+	result := packApp(a, false, nil)
 	_, has := result["secret"]
 	assert.False(t, has)
+	// isAuthorized は nil 渡し (me==null 相当) で省略される (#1557)。
+	_, hasAuth := result["isAuthorized"]
+	assert.False(t, hasAuth)
 }
 
 func TestPackApp_WithSecret(t *testing.T) {
 	a := &model.App{ID: "a1", Name: "App", Secret: "s123", Permission: pq.StringArray{"read:account"}}
-	result := packApp(a, true)
+	result := packApp(a, true, nil)
 	assert.Equal(t, "s123", result["secret"])
+}
+
+// #1557 isAuthorized は non-nil 渡しで値が出る。
+func TestPackApp_IsAuthorized(t *testing.T) {
+	a := &model.App{ID: "a1", Name: "App", Permission: pq.StringArray{"read:account"}}
+	yes := true
+	assert.Equal(t, true, packApp(a, false, &yes)["isAuthorized"])
+	no := false
+	assert.Equal(t, false, packApp(a, false, &no)["isAuthorized"])
+}
+
+// #1557 legacy permission の正規化 + de-dup。
+func TestNormalizeAppPermissions(t *testing.T) {
+	got := normalizeAppPermissions([]string{"account/read", "notes-write", "read:account", "read:drive", "read:drive"})
+	// account/read -> read:account (既存と重複し dedup)、notes-write -> write:notes
+	assert.Equal(t, []string{"read:account", "write:notes", "read:drive"}, []string(got))
 }

--- a/internal/api/auth/handler.go
+++ b/internal/api/auth/handler.go
@@ -98,7 +98,16 @@ func (h *Handler) SessionShow(c echo.Context) error {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_SESSION", "No such session.", "bd72c97d-eba7-4adb-a467-f171b8847250"))
 	}
 
-	return c.JSON(http.StatusOK, packSession(session))
+	// app.isAuthorized は認証済 caller (me) のときのみ含める (upstream
+	// AppEntityService、#1557)。me が app の access_token を持つかで判定する。
+	var isAuthorized *bool
+	if me := middleware.GetUser(c); me != nil && session.App != nil {
+		_, atErr := h.repo.FindAccessTokenByAppAndUser(session.App.ID, me.ID)
+		v := atErr == nil
+		isAuthorized = &v
+	}
+
+	return c.JSON(http.StatusOK, packSession(session, isAuthorized))
 }
 
 // Accept handles POST /api/auth/accept.
@@ -276,18 +285,23 @@ func (h *Handler) MiAuthCheck(c echo.Context) error {
 	return c.JSON(http.StatusOK, resp)
 }
 
-func packSession(s *model.AuthSession) map[string]any {
+func packSession(s *model.AuthSession, isAuthorized *bool) map[string]any {
 	result := map[string]any{
 		"id":    s.ID,
 		"token": s.Token,
 	}
 	if s.App != nil {
-		result["app"] = map[string]any{
+		app := map[string]any{
 			"id":          s.App.ID,
 			"name":        s.App.Name,
 			"callbackUrl": s.App.CallbackURL,
 			"permission":  s.App.Permission,
 		}
+		// isAuthorized は me!=null のときだけ含める (upstream、#1557)。
+		if isAuthorized != nil {
+			app["isAuthorized"] = *isAuthorized
+		}
+		result["app"] = app
 	}
 	return result
 }

--- a/internal/api/auth/handler_test.go
+++ b/internal/api/auth/handler_test.go
@@ -454,10 +454,25 @@ func TestSha256Hex(t *testing.T) {
 
 func TestPackSession_NilApp(t *testing.T) {
 	s := &model.AuthSession{ID: "s1", Token: "t1"}
-	result := packSession(s)
+	result := packSession(s, nil)
 	assert.Equal(t, "s1", result["id"])
 	_, hasApp := result["app"]
 	assert.False(t, hasApp)
+}
+
+// #1557 app.isAuthorized は non-nil 渡しのときだけ含める。
+func TestPackSession_AppIsAuthorized(t *testing.T) {
+	s := &model.AuthSession{ID: "s1", Token: "t1", App: &model.App{ID: "a1", Name: "App"}}
+
+	// isAuthorized nil (me==null) → 省略
+	app := packSession(s, nil)["app"].(map[string]any)
+	_, has := app["isAuthorized"]
+	assert.False(t, has)
+
+	// isAuthorized non-nil → 値が出る
+	yes := true
+	app2 := packSession(s, &yes)["app"].(map[string]any)
+	assert.Equal(t, true, app2["isAuthorized"])
 }
 
 func TestPackUserDetailed_NilUser(t *testing.T) {


### PR DESCRIPTION
## Summary

Misskey TS 互換性監査 (#1557: small parity 群) の App entity 関連 3 項目を解消する。#1557 の part 1/4。

#1557 は再検証の結果、HIGH 2 件 (ap/show full entity, auth/session/userkey UserDetailedNotMe) と test-notification (M) が既に解消済 (stale) で、real は 6 件。本 PR はそのうち App entity 関連 3 件を扱う。

## 主な変更点

- **App.isAuthorized** (app/show, my/apps, auth/session/show): upstream `AppEntityService` は `me != null` のときだけ `isAuthorized: accessTokensRepository.countBy({appId,userId}) > 0` を含める。従来 mk-go は `isAuthorized: false` を無条件 hardcode していたのを、`me != null` のとき `FindAccessTokenByAppAndUser` の成否 (= access_token 存在 = count>0 と等価) で計算し、`me == null` なら field を省略するよう変更。`packApp` / `packSession` に `isAuthorized *bool` を渡し、nil で省略する。
- **app/create**: upstream `app/create.ts` は `pack(app, null, ...)` と `me` を null 固定で渡すため `isAuthorized` を常に省略する (authenticated でも含めない)。mk-go もこれに揃える。
- **app/create permission 正規化**: upstream `unique(ps.permission.map(v=>v.replace(/^(.+)(\/|-)(read|write)$/,'$3:$1')))` を `normalizeAppPermissions` で再現 (legacy `account/read`→`read:account`, `notes-write`→`write:notes` + first-occurrence de-dup)。miauth gen-token は upstream 同様 正規化しない。

## テスト

- `internal/api/app/handler_test.go`: `packApp` の isAuthorized presence/value、`normalizeAppPermissions` (正規化 + de-dup)、app/show の isAuthorized (token あり→true / 無し→false / anonymous→省略)、app/create が isAuthorized 省略 + permission 正規化
- `internal/api/auth/handler_test.go`: `packSession` の app.isAuthorized presence/value
- 対象パッケージ coverage: app 100% / auth 97.1%
- `make fmt` / `go vet ./...` / `go test ./...` 全 pass

## 関連

#1557 (part 1/4)。残り: part 2 ap/show error codes (M)、part 3 notifications/create token fallback (M)、part 4 mute/create past-expiresAt no-op (L)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)