### PR TITLE
Fix ap/show: federation-allow gate + error code parity (#1557 part 2/4)

### DIFF
--- a/internal/api/ap/handler.go
+++ b/internal/api/ap/handler.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/labstack/echo/v4"
@@ -35,6 +36,15 @@ type RemoteResolver interface {
 	ResolveNote(uri string) (*model.Note, error)
 }
 
+// HostBlockChecker reports whether a remote host is blocked / federation-allowed
+// under the running instance's federation policy (none / specified / blockedHosts)。
+// APIShow uses it to reject lookups of non-federated hosts (#1557、upstream
+// UtilityService.isFederationAllowedUri)。
+type HostBlockChecker interface {
+	IsBlocked(host string) bool
+	IsAllowed(host string) bool
+}
+
 // Handler handles ActivityPub resource endpoints.
 type Handler struct {
 	renderer         *activitypub.Renderer
@@ -46,6 +56,11 @@ type Handler struct {
 	remoteFetcher    RemoteFetcher
 	remoteResolver   RemoteResolver
 	nonAPFallback    echo.HandlerFunc
+	// hostBlocker / localHost は APIShow の federation-allow gate (#1557) に使う。
+	// localHost は自インスタンスの hostname (gate を skip する判定用)。未配線
+	// (nil) なら gate 無効 = 全 host 許可 (legacy 挙動)。
+	hostBlocker HostBlockChecker
+	localHost   string
 	// backfillGroup collapses parallel lazy-backfill 経路の Generate +
 	// InsertIfAbsent を同 user ID で 1 回に集約する。多 goroutine が
 	// 同時に backfill しても entropy / CPU を浪費しない (#1081 review #1)。
@@ -56,6 +71,13 @@ type Handler struct {
 func (h *Handler) SetRemote(fetcher RemoteFetcher, resolver RemoteResolver) {
 	h.remoteFetcher = fetcher
 	h.remoteResolver = resolver
+}
+
+// SetFederationGate wires the federation-policy checker and the local hostname
+// used by APIShow to reject lookups of blocked / non-federated hosts (#1557)。
+func (h *Handler) SetFederationGate(c HostBlockChecker, localHost string) {
+	h.hostBlocker = c
+	h.localHost = localHost
 }
 
 // SetNonAPFallback registers a handler to serve when the incoming Accept
@@ -343,6 +365,21 @@ func (h *Handler) APIShow(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "uri is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
+	// URI を解析して host を得る。http(s) でない / host 無しは URI_INVALID
+	// (upstream uriInvalid 1a5eab56)。
+	host, hostErr := apShowURIHost(req.URI)
+	if hostErr != nil {
+		return c.JSON(http.StatusBadRequest, apierr.Error("URI_INVALID", "URI is invalid.", "1a5eab56-e47b-48c2-8d5e-217b897d70db"))
+	}
+	// federation-allow gate (upstream isFederationAllowedUri、#1557)。自 host は
+	// skip し、remote host が blocked / 非 federation なら FEDERATION_NOT_ALLOWED
+	// (974b799e) を返す。gate 未配線なら全許可 (legacy)。
+	if host != "" && host != h.localHost && h.hostBlocker != nil {
+		if h.hostBlocker.IsBlocked(host) || !h.hostBlocker.IsAllowed(host) {
+			return c.JSON(http.StatusForbidden, apierr.Error("FEDERATION_NOT_ALLOWED", "Federation for this host is not allowed.", "974b799e-1a29-4889-b706-18d4dd93e266"))
+		}
+	}
+
 	// ローカルのノートURIかチェック (/notes/ を含む)
 	if noteID := extractLocalID(req.URI, "/notes/"); noteID != "" {
 		n, err := h.queryService.Show(nil, noteID)
@@ -368,34 +405,55 @@ func (h *Handler) APIShow(c echo.Context) error {
 	// リモートオブジェクトをフェッチしてType判定
 	// Note の場合は ResolveNote でローカルDBに取り込み、local ID を返す。
 	// これにより後続の notes/reactions/create などが local note を見つけられる。
+	//
+	// fetchRequestFailed: fetch が 404/410 (= 不在) 以外の理由 (5xx / network /
+	// timeout) で失敗したときに立てる。webfinger fallback も失敗した場合に
+	// NO_SUCH_OBJECT ではなく REQUEST_FAILED (81b539cf) を返すための記録。
+	fetchRequestFailed := false
 	if h.remoteFetcher != nil {
-		if data, err := h.remoteFetcher.FetchObject(req.URI); err == nil {
+		data, fetchErr := h.remoteFetcher.FetchObject(req.URI)
+		switch {
+		case fetchErr != nil:
+			// 404 / 410 は「不在」なので NO_SUCH_OBJECT 経路へ。それ以外は
+			// REQUEST_FAILED 候補として記録 (webfinger fallback を先に試す)。
+			var se *activitypub.StatusError
+			if !(errors.As(fetchErr, &se) && (se.StatusCode == http.StatusNotFound || se.StatusCode == http.StatusGone)) {
+				fetchRequestFailed = true
+			}
+		default:
 			var parsed map[string]any
-			if json.Unmarshal(data, &parsed) == nil {
-				t, _ := parsed["type"].(string)
-				switch t {
-				case "Note", "Article", "Question":
-					if h.remoteResolver != nil {
-						if remoteNote, err := h.remoteResolver.ResolveNote(req.URI); err == nil {
-							return c.JSON(http.StatusOK, map[string]any{
-								"type":   "Note",
-								"object": h.packNoteForAPI(middleware.GetUser(c), remoteNote),
-							})
-						}
+			if json.Unmarshal(data, &parsed) != nil {
+				// fetch できたが JSON として不正 → RESPONSE_INVALID (70193c39)。
+				return c.JSON(http.StatusBadGateway, apierr.Error("RESPONSE_INVALID", "Response from remote server is invalid.", "70193c39-54f3-4813-82f0-70a680f7495b"))
+			}
+			// AP object は id 必須。欠落は upstream の `object.id == null` →
+			// responseInvalid に対応する。
+			if objID, _ := parsed["id"].(string); objID == "" {
+				return c.JSON(http.StatusBadGateway, apierr.Error("RESPONSE_INVALID", "Response from remote server is invalid.", "70193c39-54f3-4813-82f0-70a680f7495b"))
+			}
+			t, _ := parsed["type"].(string)
+			switch t {
+			case "Note", "Article", "Question":
+				if h.remoteResolver != nil {
+					if remoteNote, err := h.remoteResolver.ResolveNote(req.URI); err == nil {
+						return c.JSON(http.StatusOK, map[string]any{
+							"type":   "Note",
+							"object": h.packNoteForAPI(middleware.GetUser(c), remoteNote),
+						})
 					}
-					// Resolver 無し or ResolveNote 失敗時は raw AP JSON を返す
-					return c.JSON(http.StatusOK, map[string]any{
-						"type":   "Note",
-						"object": parsed,
-					})
-				case "Person", "Service", "Application", "Organization", "Group":
-					if h.remoteResolver != nil {
-						if remoteUser, err := h.remoteResolver.ResolveActor(req.URI); err == nil {
-							return c.JSON(http.StatusOK, map[string]any{
-								"type":   "User",
-								"object": h.packUserForAPI(remoteUser, h.userService.GetProfile(remoteUser.ID)),
-							})
-						}
+				}
+				// Resolver 無し or ResolveNote 失敗時は raw AP JSON を返す
+				return c.JSON(http.StatusOK, map[string]any{
+					"type":   "Note",
+					"object": parsed,
+				})
+			case "Person", "Service", "Application", "Organization", "Group":
+				if h.remoteResolver != nil {
+					if remoteUser, err := h.remoteResolver.ResolveActor(req.URI); err == nil {
+						return c.JSON(http.StatusOK, map[string]any{
+							"type":   "User",
+							"object": h.packUserForAPI(remoteUser, h.userService.GetProfile(remoteUser.ID)),
+						})
 					}
 				}
 			}
@@ -413,7 +471,23 @@ func (h *Handler) APIShow(c echo.Context) error {
 		}
 	}
 
+	// fetch が transport 失敗 (5xx / network) だった場合は REQUEST_FAILED、
+	// それ以外 (404/410 / 純粋に不在) は NO_SUCH_OBJECT。
+	if fetchRequestFailed {
+		return c.JSON(http.StatusBadGateway, apierr.Error("REQUEST_FAILED", "Request failed.", "81b539cf-4f57-4b29-bc98-032c33c0792e"))
+	}
 	return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_OBJECT", "No such object.", "dc94d745-1262-4e63-a17d-fecaa57efc82"))
+}
+
+// apShowURIHost parses an ap/show URI and returns its hostname. Returns an
+// error for non-http(s) schemes or a missing host so the caller can emit
+// URI_INVALID (#1557)。
+func apShowURIHost(uri string) (string, error) {
+	u, err := url.Parse(uri)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return "", errors.New("ap: invalid uri")
+	}
+	return u.Hostname(), nil
 }
 
 // resolveLocal attempts to resolve a local URI to an AP object.

--- a/internal/api/ap/handler_test.go
+++ b/internal/api/ap/handler_test.go
@@ -680,7 +680,7 @@ func TestAPIShow_RemoteFetchNote(t *testing.T) {
 	h, _, _, _ := newHandler(t)
 	// ResolveNote fails -> fall through to raw AP JSON echo.
 	h.SetRemote(
-		&mockFetcher{data: []byte(`{"type":"Note","content":"hello"}`)},
+		&mockFetcher{data: []byte(`{"type":"Note","id":"https://remote.example/notes/1","content":"hello"}`)},
 		&mockResolver{noteErr: assert.AnError},
 	)
 	rec := postJSON(h.APIShow, `{"uri":"https://remote.example/notes/1"}`)
@@ -692,7 +692,7 @@ func TestAPIShow_RemoteFetchNote_ResolveNoteSuccess(t *testing.T) {
 	h, _, _, _ := newHandler(t)
 	// ResolveNote succeeds -> return the ingested local note object.
 	h.SetRemote(
-		&mockFetcher{data: []byte(`{"type":"Note","content":"hello"}`)},
+		&mockFetcher{data: []byte(`{"type":"Note","id":"https://remote.example/notes/1","content":"hello"}`)},
 		&mockResolver{note: &model.Note{ID: "ln1", UserID: "u1", Visibility: model.NoteVisibilityPublic, User: &model.User{ID: "u1", Username: "alice"}}},
 	)
 	rec := postJSON(h.APIShow, `{"uri":"https://remote.example/notes/1"}`)
@@ -704,7 +704,7 @@ func TestAPIShow_RemoteFetchNote_ResolveNoteSuccess(t *testing.T) {
 func TestAPIShow_RemoteFetchArticle_NoResolver(t *testing.T) {
 	h, _, _, _ := newHandler(t)
 	// Fetcher returns an Article; no resolver wired -> raw AP JSON.
-	h.SetRemote(&mockFetcher{data: []byte(`{"type":"Article","content":"long form"}`)}, nil)
+	h.SetRemote(&mockFetcher{data: []byte(`{"type":"Article","id":"https://remote.example/articles/1","content":"long form"}`)}, nil)
 	rec := postJSON(h.APIShow, `{"uri":"https://remote.example/articles/1"}`)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), `"type":"Note"`)
@@ -739,7 +739,7 @@ func TestAPIShow_RemoteFetchServiceType(t *testing.T) {
 	// Coverage for actor subtypes: Service/Application/Organization/Group
 	// all take the same branch.
 	h.SetRemote(
-		&mockFetcher{data: []byte(`{"type":"Service"}`)},
+		&mockFetcher{data: []byte(`{"type":"Service","id":"https://remote.example/users/svc"}`)},
 		&mockResolver{user: &model.User{ID: "svc1", Username: "svc"}},
 	)
 	rec := postJSON(h.APIShow, `{"uri":"https://remote.example/users/svc"}`)
@@ -747,14 +747,84 @@ func TestAPIShow_RemoteFetchServiceType(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), `"type":"User"`)
 }
 
-func TestAPIShow_RemoteNothing(t *testing.T) {
+// apShowHostBlocker は federation gate test 用 stub。
+type apShowHostBlocker struct {
+	blocked map[string]bool
+	allowed map[string]bool // nil = 全 allow
+}
+
+func (b apShowHostBlocker) IsBlocked(host string) bool { return b.blocked[host] }
+func (b apShowHostBlocker) IsAllowed(host string) bool {
+	if b.allowed == nil {
+		return true
+	}
+	return b.allowed[host]
+}
+
+// #1557 不正な URI (http(s) でない / host 無し) → URI_INVALID。
+func TestAPIShow_URIInvalid(t *testing.T) {
+	h, _, _, _ := newHandler(t)
+	for _, uri := range []string{`not a url`, `ftp://example.com/x`, `/relative/path`, `https://`} {
+		rec := postJSON(h.APIShow, `{"uri":"`+uri+`"}`)
+		assert.Equal(t, http.StatusBadRequest, rec.Code, uri)
+		assert.Contains(t, rec.Body.String(), "URI_INVALID", uri)
+	}
+}
+
+// #1557 blocked / 非 federation host の URI → FEDERATION_NOT_ALLOWED。
+func TestAPIShow_FederationNotAllowed(t *testing.T) {
+	h, _, _, _ := newHandler(t)
+	h.SetFederationGate(apShowHostBlocker{blocked: map[string]bool{"blocked.example": true}}, "local.example")
+
+	rec := postJSON(h.APIShow, `{"uri":"https://blocked.example/users/x"}`)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "FEDERATION_NOT_ALLOWED")
+
+	// 自 host は gate を skip する (blocked 判定に巻き込まれない)。
+	h.SetFederationGate(apShowHostBlocker{allowed: map[string]bool{}}, "local.example")
+	rec = postJSON(h.APIShow, `{"uri":"https://local.example/notes/ghost"}`)
+	assert.NotEqual(t, http.StatusForbidden, rec.Code, "自 host は federation gate で弾かない")
+}
+
+// #1557 fetch できたが id 欠落 / JSON 不正 → RESPONSE_INVALID。
+func TestAPIShow_ResponseInvalid(t *testing.T) {
+	h, _, _, _ := newHandler(t)
+	// id 欠落
+	h.SetRemote(&mockFetcher{data: []byte(`{"type":"Note","content":"no id"}`)}, nil)
+	rec := postJSON(h.APIShow, `{"uri":"https://remote.example/notes/1"}`)
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+	assert.Contains(t, rec.Body.String(), "RESPONSE_INVALID")
+
+	// JSON 不正
+	h.SetRemote(&mockFetcher{data: []byte(`not json`)}, nil)
+	rec = postJSON(h.APIShow, `{"uri":"https://remote.example/notes/2"}`)
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+	assert.Contains(t, rec.Body.String(), "RESPONSE_INVALID")
+}
+
+// #1557 remote が 404/410 (= 不在) を返し fallback も失敗 → NO_SUCH_OBJECT。
+func TestAPIShow_RemoteNotFound(t *testing.T) {
+	h, _, _, _ := newHandler(t)
+	h.SetRemote(
+		&mockFetcher{err: &activitypub.StatusError{StatusCode: http.StatusNotFound}},
+		&mockResolver{err: assert.AnError},
+	)
+	rec := postJSON(h.APIShow, `{"uri":"https://remote.example/unknown"}`)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_OBJECT")
+}
+
+// #1557 remote fetch が 404 以外 (network / 5xx) で失敗し fallback も失敗 →
+// REQUEST_FAILED (upstream の catch-all requestFailed)。
+func TestAPIShow_RemoteRequestFailed(t *testing.T) {
 	h, _, _, _ := newHandler(t)
 	h.SetRemote(
 		&mockFetcher{err: assert.AnError},
 		&mockResolver{err: assert.AnError},
 	)
 	rec := postJSON(h.APIShow, `{"uri":"https://remote.example/unknown"}`)
-	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+	assert.Contains(t, rec.Body.String(), "REQUEST_FAILED")
 }
 
 // --- UserByAcct + Accept header negotiation ---

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1644,6 +1644,11 @@ func (s *Server) setupRoutes() {
 	// ActivityPub resource endpoints
 	apHandler := ap.NewHandler(apRenderer, userService, noteQueryService, keypairRepo, idGen)
 	apHandler.SetRemote(apFetcher, federationResolver)
+	// ap/show の federation-allow gate (#1557)。instanceService が blocked /
+	// federation policy を判定する。local host は port 無しの hostname
+	// (config 起動時に validate 済で非空保証) を渡す — IsBlocked/IsAllowed は
+	// hostname suffix match のため。
+	apHandler.SetFederationGate(instanceService, s.config.Hostname)
 	// FEP-521a Multikey 対応で actor JSON に assertionMethod[] を expose する
 	// ため Ed25519 keypair repo を wire (#1067 / #1069)。
 	apHandler.SetKeypairExtraRepo(keypairExtraRepo)


### PR DESCRIPTION
## Summary

Misskey TS 互換性監査 (#1557) の ap/show error code 4 件を解消する。#1557 の part 2/4。upstream `ap/show.ts` の `federationNotAllowed` / `uriInvalid` / `requestFailed` / `responseInvalid` に対応する。従来 mk-go は INVALID_PARAM / NO_SUCH_OBJECT しか返さず、federation-allow gate も無かった。

## 主な変更点

- **URI_INVALID**: URI を parse して http(s) でない / host 無しを 400 で弾く (1a5eab56)。
- **FEDERATION_NOT_ALLOWED**: remote fetch の **前** に federation-allow gate を効かせる (974b799e)。自 host (`config.Hostname`) は skip、remote host が `IsBlocked` or `!IsAllowed` なら 403。`instanceService` (HostBlockChecker) で判定、未配線なら全許可 (legacy)。blocked host の object を fetch する前に弾けるので SSRF / IP 漏洩防止になる。
- **REQUEST_FAILED / RESPONSE_INVALID**: remote fetch のエラーを mapping。404/410 は NO_SUCH_OBJECT、それ以外の fetch 失敗 (5xx/network) で fallback も失敗なら REQUEST_FAILED (81b539cf)。fetch 成功だが JSON 不正 / AP object の `id` 欠落なら RESPONSE_INVALID (70193c39、upstream の `object.id == null` 相当)。

error code / UUID は `golden_error_ids.json` (ap/show) と完全一致 (`TestErrorIDDrift` で担保)。HTTP status は ap/show が `golden_error_status` 対象外のため semantic な値 (既存 NO_SUCH_OBJECT の 404 踏襲) を使う。

## テスト

- `internal/api/ap/handler_test.go`: URI_INVALID (不正 URI 各種)、FEDERATION_NOT_ALLOWED (blocked host / 自 host skip)、RESPONSE_INVALID (id 欠落 / JSON 不正)、NO_SUCH_OBJECT (404 fetch + fallback 失敗)、REQUEST_FAILED (generic fetch 失敗)。既存の Note/Person 解決・raw AP JSON fallback・webfinger fallback の stub を realistic な id 付き AP object に更新
- 対象パッケージ coverage: ap 96.4%
- `make fmt` / `go vet ./...` / `go test ./...` 全 pass (error-id gate 含む)

## 関連

#1557 (part 2/4)。残り: part 3 notifications/create token fallback (M)、part 4 mute/create past-expiresAt no-op (L)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)