### PR TITLE
Fix notifications/create: token-derived header/icon fallback + appAccessTokenId (#1557 part 3/4)

### DIFF
--- a/internal/api/notifications/handler.go
+++ b/internal/api/notifications/handler.go
@@ -2,6 +2,8 @@
 package notifications
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"log/slog"
 	"net/http"
 
@@ -31,6 +33,17 @@ type Handler struct {
 	testNotifier         TestNotifier
 	roleLookup           entity.RoleLookup
 	chatInvitationLookup entity.ChatInvitationLookup
+	// accessTokenRepo は notifications/create の 'app' 通知で、リクエストに使われた
+	// access token を raw token から再解決し、header/icon の fallback (token.name /
+	// token.iconUrl) + appAccessTokenId を埋めるために使う (#1557)。未配線なら
+	// fallback 無し。
+	accessTokenRepo repository.AccessTokenRepository
+}
+
+// SetAccessTokenRepo wires the access token repo used by notifications/create
+// to resolve the request's app token for header/icon fallback (#1557)。
+func (h *Handler) SetAccessTokenRepo(r repository.AccessTokenRepository) {
+	h.accessTokenRepo = r
 }
 
 // SetRoleLookup wires the lookup used to pack roleAssigned notifications'
@@ -326,10 +339,13 @@ func (h *Handler) MarkAllAsRead(c echo.Context) error {
 // header / icon は任意。body / header / icon は Extra に格納し、entity の
 // Extra spread で notification 出力に surface される (#1217)。
 //
-// 注: upstream は header/icon が無い場合 token.name / token.iconUrl に
-// フォールバックし appAccessTokenId も記録するが、mk-go の request context は
-// raw token 文字列のみで AccessToken オブジェクトを持たないため、ここでは
-// 渡された body / header / icon のみを使う (token 由来の fallback は省略)。
+// header / icon は upstream 同様 `ps.header ?? token?.name ?? null` /
+// `ps.icon ?? token?.iconUrl ?? null` で、リクエスト値が無ければ access token の
+// name / iconUrl にフォールバックする (#1557)。token は raw token から
+// 再解決する (native session token は access_token 行が無いので nil = fallback
+// 無し)。'app' 通知の header/icon は schema 上 required + nullable なので、
+// 値が無くても null で常に present にする。appAccessTokenId も記録する
+// (内部メタデータ、レスポンスには出さない)。
 func (h *Handler) Create(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req struct {
@@ -347,24 +363,61 @@ func (h *Handler) Create(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)
 	}
 
-	extra := map[string]any{"body": *req.Body}
+	// リクエストの access token を再解決する (header/icon fallback + appAccessTokenId)。
+	token := h.resolveRequestToken(c)
+
+	// header = ps.header ?? token?.name ?? null。icon も同様。nil のままにすると
+	// Extra spread で `null` として出力され、required + nullable な schema に揃う。
+	var header any
 	if req.Header != nil {
-		extra["header"] = *req.Header
+		header = *req.Header
+	} else if token != nil && token.Name != nil {
+		header = *token.Name
 	}
+	var icon any
 	if req.Icon != nil {
-		extra["icon"] = *req.Icon
+		icon = *req.Icon
+	} else if token != nil && token.IconURL != nil {
+		icon = *token.IconURL
 	}
+	extra := map[string]any{"body": *req.Body, "header": header, "icon": icon}
+
+	appAccessTokenID := ""
+	if token != nil {
+		appAccessTokenID = token.ID
+	}
+
 	// app 通知は notifier を持たない。NotifierID を空にすることで
 	// service.Create の self-notification ガード (NotifierID == NotifieeID) も
 	// 回避する。upstream 同様 fire-and-forget なので結果は 204 固定。
 	if _, err := h.svc.Create(c.Request().Context(), notification.CreateInput{
-		NotifieeID: user.ID,
-		Type:       notification.TypeApp,
-		Extra:      extra,
+		NotifieeID:       user.ID,
+		Type:             notification.TypeApp,
+		Extra:            extra,
+		AppAccessTokenID: appAccessTokenID,
 	}); err != nil {
 		slog.Warn("notifications/create failed", "user", user.ID, "err", err)
 	}
 	return c.NoContent(http.StatusNoContent)
+}
+
+// resolveRequestToken re-resolves the request's raw token to its AccessToken
+// row (#1557)。native session login token は access_token 行を持たないので nil
+// (= header/icon fallback 無し)。repo 未配線 / token 無し / 解決失敗も nil。
+func (h *Handler) resolveRequestToken(c echo.Context) *model.AccessToken {
+	if h.accessTokenRepo == nil {
+		return nil
+	}
+	raw := middleware.GetToken(c)
+	if raw == "" {
+		return nil
+	}
+	sum := sha256.Sum256([]byte(raw))
+	at, err := h.accessTokenRepo.FindByHashOrToken(hex.EncodeToString(sum[:]), raw)
+	if err != nil {
+		return nil
+	}
+	return at
 }
 
 // Flush handles POST /api/notifications/flush.

--- a/internal/api/notifications/handler_test.go
+++ b/internal/api/notifications/handler_test.go
@@ -326,11 +326,67 @@ func TestCreate_BodyOnly(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp))
 	require.Len(t, resp, 1)
 	assert.Equal(t, "just body", resp[0]["body"])
-	// 未指定の header / icon はキーごと省略されること。
-	_, hasHeader := resp[0]["header"]
-	assert.False(t, hasHeader)
-	_, hasIcon := resp[0]["icon"]
-	assert.False(t, hasIcon)
+	// #1557: 'app' 通知の header / icon は required + nullable なので、未指定 +
+	// token fallback 無し (accessTokenRepo 未配線) のときは present かつ null。
+	hVal, hasHeader := resp[0]["header"]
+	assert.True(t, hasHeader)
+	assert.Nil(t, hVal)
+	iVal, hasIcon := resp[0]["icon"]
+	assert.True(t, hasIcon)
+	assert.Nil(t, iVal)
+}
+
+// #1557 notifications/create: header/icon 未指定なら access token の name/iconUrl に
+// fallback し、appAccessTokenId も記録する。
+func TestCreate_TokenFallback(t *testing.T) {
+	h, _ := newTestHandler(t)
+	atRepo := testutil.NewMockAccessTokenRepository()
+	appName, appIcon := "My App", "https://app.example/icon.png"
+	atRepo.Tokens["hash1"] = &model.AccessToken{ID: "at1", Token: "rawtoken", Name: &appName, IconURL: &appIcon}
+	h.SetAccessTokenRepo(atRepo)
+
+	c, rec := newJSONRequest(t, "/api/notifications/create", `{"body":"hi"}`)
+	setAuth(c, &model.User{ID: "alice"})
+	c.Set(string(middleware.TokenContextKey), "rawtoken")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	c2, rec2 := newJSONRequest(t, "/api/i/notifications", `{"limit":50}`)
+	setAuth(c2, &model.User{ID: "alice"})
+	require.NoError(t, h.Show(c2))
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "hi", resp[0]["body"])
+	assert.Equal(t, appName, resp[0]["header"], "header は token.name に fallback")
+	assert.Equal(t, appIcon, resp[0]["icon"], "icon は token.iconUrl に fallback")
+	// appAccessTokenId は内部メタデータでレスポンスには出さない。
+	_, hasATID := resp[0]["appAccessTokenId"]
+	assert.False(t, hasATID)
+}
+
+// 明示 header/icon は token fallback より優先される。
+func TestCreate_ExplicitHeaderIconOverridesToken(t *testing.T) {
+	h, _ := newTestHandler(t)
+	atRepo := testutil.NewMockAccessTokenRepository()
+	appName := "My App"
+	atRepo.Tokens["hash1"] = &model.AccessToken{ID: "at1", Token: "rawtoken", Name: &appName}
+	h.SetAccessTokenRepo(atRepo)
+
+	c, rec := newJSONRequest(t, "/api/notifications/create", `{"body":"hi","header":"Custom","icon":"https://x/i.png"}`)
+	setAuth(c, &model.User{ID: "alice"})
+	c.Set(string(middleware.TokenContextKey), "rawtoken")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	c2, rec2 := newJSONRequest(t, "/api/i/notifications", `{"limit":50}`)
+	setAuth(c2, &model.User{ID: "alice"})
+	require.NoError(t, h.Show(c2))
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "Custom", resp[0]["header"])
+	assert.Equal(t, "https://x/i.png", resp[0]["icon"])
 }
 
 func TestCreate_MissingBody(t *testing.T) {

--- a/internal/core/notification/notification_service.go
+++ b/internal/core/notification/notification_service.go
@@ -110,6 +110,11 @@ type Notification struct {
 	// no note (e.g. follow / followRequestAccepted).
 	NoteVisibility string         `json:"noteVisibility,omitempty"`
 	Extra          map[string]any `json:"extra,omitempty"`
+	// AppAccessTokenID records the access token that created an 'app'
+	// notification (upstream notifications/create の appAccessTokenId、#1557)。
+	// 内部メタデータで API レスポンスには出さない (entity packer は spread
+	// しない)。
+	AppAccessTokenID string `json:"appAccessTokenId,omitempty"`
 }
 
 // CreateInput is the parameter set for Service.Create.
@@ -125,6 +130,8 @@ type CreateInput struct {
 	Reaction       string
 	Choice         *int
 	Extra          map[string]any
+	// AppAccessTokenID は 'app' 通知を作った access token の ID (#1557)。
+	AppAccessTokenID string
 }
 
 // StreamingPublisher receives a freshly created notification so that
@@ -242,15 +249,16 @@ func (s *Service) Create(ctx context.Context, in CreateInput) (*Notification, er
 
 	now := time.Now()
 	n := &Notification{
-		ID:             s.idGen.Generate(now),
-		CreatedAt:      now,
-		Type:           in.Type,
-		NotifierID:     in.NotifierID,
-		NoteID:         in.NoteID,
-		NoteVisibility: in.NoteVisibility,
-		Reaction:       in.Reaction,
-		Choice:         in.Choice,
-		Extra:          in.Extra,
+		ID:               s.idGen.Generate(now),
+		CreatedAt:        now,
+		Type:             in.Type,
+		NotifierID:       in.NotifierID,
+		NoteID:           in.NoteID,
+		NoteVisibility:   in.NoteVisibility,
+		Reaction:         in.Reaction,
+		Choice:           in.Choice,
+		Extra:            in.Extra,
+		AppAccessTokenID: in.AppAccessTokenID,
 	}
 
 	payload, err := json.Marshal(n)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1491,6 +1491,9 @@ func (s *Server) setupRoutes() {
 	notificationsHandler.SetEmojiRepo(emojiRepo)
 	notificationsHandler.SetTestNotifier(notificationHook)
 	notificationsHandler.SetRoleLookup(roleNotifLookup)
+	// notifications/create の 'app' 通知で header/icon を token.name/iconUrl に
+	// fallback するため access token repo を配線 (#1557)。
+	notificationsHandler.SetAccessTokenRepo(repository.NewAccessTokenRepository(s.db))
 	api.POST("/i/notifications", notificationsHandler.Show, middleware.RequireAuth(), middleware.RequireScope("read:notifications"))
 	api.POST("/i/notifications-grouped", notificationsHandler.Grouped, middleware.RequireAuth(), middleware.RequireScope("read:notifications"))
 	api.POST("/notifications/mark-all-as-read", notificationsHandler.MarkAllAsRead, middleware.RequireAuth(), middleware.RequireScope("write:notifications"))


### PR DESCRIPTION
## Summary

Misskey TS 互換性監査 (#1557) の notifications/create 'app' 通知の parity を解消する。#1557 の part 3/4。upstream `notifications/create.ts` の token-derived header/icon fallback + appAccessTokenId に対応する。

## 主な変更点

- **header/icon の token fallback**: upstream の `customHeader = ps.header ?? token?.name ?? null` / `customIcon = ps.icon ?? token?.iconUrl ?? null` を再現。mk-go の request context は raw token 文字列のみなので、handler が `accessTokenRepo.FindByHashOrToken(sha256(token), token)` で AccessToken を再解決して name / iconUrl を引く。native session token は access_token 行が無いので nil = fallback 無し (upstream で native session の `token` が undefined なのと一致)。
- **header/icon の presence**: 'app' 通知の header/icon は json-schema 上 `optional:false, nullable:true` (= 常に present、値が無ければ null)。従来は未指定時に key ごと省略していた parity bug を、常に present (null) にするよう修正。
- **appAccessTokenId**: `Notification` / `CreateInput` の dedicated field に記録する。entity packer は `Extra` のみ spread し本 field を出さないので API レスポンスには出ない (upstream の `NotificationEntityService` も 'app' 応答に appAccessTokenId を含めない)。Redis 保存のみ (将来の機能向けデータ捕捉)。

## テスト

- `internal/api/notifications/handler_test.go`: `TestCreate_TokenFallback` (header/icon が token.name/iconUrl に fallback + appAccessTokenId がレスポンスに出ない)、`TestCreate_ExplicitHeaderIconOverridesToken` (明示値が優先)、`TestCreate_BodyOnly` を「header/icon は present + null」に更新
- 対象パッケージ coverage: notifications 93.8%
- `make fmt` / `go vet ./...` / `go test ./...` 全 pass

## 関連

#1557 (part 3/4)。残り: part 4 mute/create past-expiresAt no-op (L)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)