### PR TITLE
Fix mute/create: past expiresAt は no-op で再 mute 可能に保つ (#1557 part 4/4)

### DIFF
--- a/internal/core/muting/muting_service.go
+++ b/internal/core/muting/muting_service.go
@@ -53,6 +53,14 @@ func (s *Service) Mute(muterID, muteeID string, expiresAt *time.Time) (*model.Mu
 		return nil, ErrAlreadyMuting
 	}
 
+	// 既に失効している expiresAt (<= now) の mute は no-op で成功扱いにする
+	// (upstream mute/create.ts の `if (ps.expiresAt && ps.expiresAt <= Date.now())
+	// return;`、#1557)。Muting row を作らないことで対象を re-muteable のまま残す。
+	// self / not-found / already-muting の検証より後 (= upstream の順序) に置く。
+	if expiresAt != nil && !expiresAt.After(time.Now()) {
+		return nil, nil
+	}
+
 	rec := &model.Muting{
 		ID:        s.idGen.Generate(time.Now()),
 		MuterID:   muterID,

--- a/internal/core/muting/muting_service_test.go
+++ b/internal/core/muting/muting_service_test.go
@@ -67,6 +67,25 @@ func TestMute_WithExpiry(t *testing.T) {
 	assert.NotNil(t, rec.ExpiresAt)
 }
 
+// #1557 過去 (<= now) の expiresAt を渡した mute は no-op (row を作らず成功) で、
+// 対象を re-muteable のまま残す (upstream mute/create.ts)。
+func TestMute_PastExpiryIsNoOp(t *testing.T) {
+	svc, ur, mr := newMuteService(t)
+	addUser(ur, "a")
+	addUser(ur, "b")
+
+	past := time.Now().Add(-time.Hour)
+	rec, err := svc.Mute("a", "b", &past)
+	require.NoError(t, err)
+	assert.Nil(t, rec, "past-expiry は Muting record を返さない")
+	assert.Empty(t, mr.Mutings, "Muting row を作らない")
+
+	// re-muteable: 後から有効な mute を作れる (= ALREADY_MUTING にならない)。
+	rec2, err := svc.Mute("a", "b", nil)
+	require.NoError(t, err)
+	require.NotNil(t, rec2)
+}
+
 // failingMutingRepo lets us trigger Exists/Create errors.
 type failingMutingRepo struct {
 	*testutil.MockMutingRepository


### PR DESCRIPTION
## Summary

Misskey TS 互換性監査 (#1557) の mute/create の past-expiry 挙動を解消する。#1557 の part 4/4 (最終)。これで #1557 の real 項目を全て解消する。

upstream `mute/create.ts` は self / not-found / already-muting の検証後に `if (ps.expiresAt && ps.expiresAt <= Date.now()) return;` で、既に失効した expiresAt の mute を silently no-op し、対象を re-muteable のまま残す。

mk-go は従来 past-expiry の Muting row をそのまま insert し、次の create が ALREADY_MUTING を返す regression があった。

## 主な変更点

- `muting.Service.Mute` に `expiresAt != nil && !expiresAt.After(now)` で `(nil, nil)` を返す guard を、upstream と同じく **already-muting 検証の後・insert の前** に追加。handler は `(nil, nil)` を成功扱いし 204 を返すので row は作られない。
- CSV import 経路 (`transfer/import_csv.go`) は nil expiry を渡すので影響しない。

## テスト

- `internal/core/muting/muting_service_test.go`: `TestMute_PastExpiryIsNoOp` (past-expiry → row 作らず success、その後 re-muteable で ALREADY_MUTING にならない)
- 対象パッケージ coverage: muting 100% / mute 93.2%
- `make fmt` / `go vet ./...` / `go test ./...` 全 pass

## 関連

Closes #1557 (part 4/4)。

#1557 の項目別結果:
- ap/show full entity (H) / auth/session/userkey UserDetailedNotMe (H) / notifications/test-notification (M) → 既に解消済 (stale)
- App.isAuthorized + app/create permission 正規化 (M/L) → part 1 (#1656)
- ap/show error codes (M) → part 2 (#1657)
- notifications/create token fallback (L) → part 3 (#1658)
- mute/create past-expiry (L) → 本 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)