### PR TITLE
Fix entity:misc: following / i/favorites の createdAt を ms 精度 ISO-8601 に統一 (#1556 part 1/4)

### DIFF
--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -192,7 +192,8 @@ func (h *Handler) Favorites(c echo.Context) error {
 			"id":     f.ID,
 			"noteId": f.NoteID,
 			// Misskey 本家互換のため createdAt を含める (#424 Devin review)。
-			"createdAt": f.CreatedAt.UTC().Format(time.RFC3339Nano),
+			// 他 packer と同じ固定 ms 精度 ISO-8601 で出す (#1556)。
+			"createdAt": f.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
 		}
 		if f.Note != nil {
 			if pn, ok := byID[f.Note.ID]; ok {

--- a/internal/api/i/handler_extra_test.go
+++ b/internal/api/i/handler_extra_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/core/notification"
@@ -264,6 +265,10 @@ func TestFavorites_WithNote(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	require.Len(t, resp, 1)
 	shapetest.Assert(t, "NoteFavorite", resp[0]) // L3 (#1286)
+	// #1556 createdAt は固定 ms 精度 ISO-8601 (RFC3339Nano ではない)。
+	createdAt, _ := resp[0]["createdAt"].(string)
+	_, perr := time.Parse("2006-01-02T15:04:05.000Z", createdAt)
+	assert.NoError(t, perr, "createdAt は ms 精度 ISO-8601: %q", createdAt)
 }
 
 // untilId 経由の cursor pagination が repo に正しく伝わり、cursor 以下の

--- a/internal/entity/following.go
+++ b/internal/entity/following.go
@@ -4,8 +4,6 @@
 package entity
 
 import (
-	"time"
-
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 )
@@ -53,7 +51,10 @@ func PackFollowing(
 	}
 	if idGen != nil {
 		if t, err := idGen.ParseTime(f.ID); err == nil {
-			out.CreatedAt = t.UTC().Format(time.RFC3339Nano)
+			// createdAt は他 packer と同じ固定 ms 精度 ISO-8601 で出す
+			// (upstream JS toISOString 互換、#1556)。RFC3339Nano は精度が
+			// 可変 (末尾ゼロ trim / 端数無し) になり drift するため使わない。
+			out.CreatedAt = t.UTC().Format("2006-01-02T15:04:05.000Z")
 		}
 	}
 	if populateFollowee && lookup != nil {

--- a/internal/entity/following_test.go
+++ b/internal/entity/following_test.go
@@ -1,0 +1,23 @@
+package entity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #1556 PackFollowing.createdAt は他 packer と同じ固定 ms 精度 ISO-8601 で出す
+// (RFC3339Nano の可変精度ではない)。
+func TestPackFollowing_CreatedAtMsISO(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	fid := idGen.Generate(time.Now())
+	out := PackFollowing(&model.Following{ID: fid, FolloweeID: "a", FollowerID: "b"}, false, false, nil, idGen)
+
+	require.NotEmpty(t, out.CreatedAt)
+	_, err := time.Parse("2006-01-02T15:04:05.000Z", out.CreatedAt)
+	assert.NoError(t, err, "createdAt は ms 精度 ISO-8601: %q", out.CreatedAt)
+}


### PR DESCRIPTION
## Summary

Misskey TS 互換性監査 (#1556: entity:misc packers) の createdAt format drift 2 件を解消する。#1556 の part 1/4。

`PackFollowing` (following/list, users/{followers,following}) と i/favorites は createdAt を `time.RFC3339Nano` で出していたため、末尾ゼロ trim / 端数無しで精度が可変になり、他の全 packer が使う固定 ms 精度 ISO-8601 (`2006-01-02T15:04:05.000Z` = upstream JS `toISOString`) と drift していた。両者を固定 ms 精度に揃える。

i/favorites の note は `f.Note != nil` のときだけ set する既存挙動は upstream と一致しているため変更しない (本 PR は createdAt format のみ)。

## テスト

- `internal/entity/following_test.go` (新規): `PackFollowing.createdAt` が ms 精度 ISO-8601 に parse できることを検証
- `internal/api/i/handler_extra_test.go`: i/favorites の createdAt format を検証
- `make fmt` / `go vet ./...` / `go test ./...` 全 pass

## 関連

#1556 (part 1/4)。#1556 は再検証で 4 件が既に解消済 (stale: channels isMuting/pinnedNotes、app isAuthorized=#1656、notifications grouped=#1559、clips favoritedCount)。残り real: part 2 emojis list (url fallback + roleIds)、part 3 pages attachedFiles、part 4 chat reactions[] user。

🤖 Generated with [Claude Code](https://claude.com/claude-code)