### PR TITLE
Fix emojis: /api/emojis list の url originalUrl fallback + roleIds (#1556 part 2/4)

### DIFF
--- a/internal/api/emojis/handler.go
+++ b/internal/api/emojis/handler.go
@@ -30,13 +30,25 @@ func (h *Handler) Emojis(c echo.Context) error {
 
 	result := make([]map[string]any, 0, len(emojis))
 	for _, e := range emojis {
+		// url は upstream packSimple と同じく publicUrl || originalUrl で、
+		// publicUrl 空 (remote emoji 等) のとき originalUrl に fallback する
+		// (#1556)。EmojiSimple.url は required non-null。
+		url := e.PublicURL
+		if url == "" {
+			url = e.OriginalURL
+		}
 		item := map[string]any{
 			"name":        e.Name,
 			"category":    e.Category,
 			"aliases":     e.Aliases,
-			"url":         e.PublicURL,
+			"url":         url,
 			"localOnly":   e.LocalOnly,
 			"isSensitive": e.IsSensitive,
+		}
+		// roleIdsThatCanBeUsedThisEmojiAsReaction は length>0 のときだけ emit
+		// (upstream packSimple、#1556)。reaction-role gating UI が使う。
+		if len(e.RoleIDsThatCanBeUsedThisEmojiAsReaction) > 0 {
+			item["roleIdsThatCanBeUsedThisEmojiAsReaction"] = []string(e.RoleIDsThatCanBeUsedThisEmojiAsReaction)
 		}
 		result = append(result, item)
 	}

--- a/internal/api/emojis/handler_test.go
+++ b/internal/api/emojis/handler_test.go
@@ -70,6 +70,47 @@ func TestEmojis_WithLocalEmojis(t *testing.T) {
 	shapetest.Assert(t, "EmojiSimple", emoji) // L3 (#1286)
 }
 
+// #1556 url は publicUrl 空のとき originalUrl に fallback、roleIds は length>0 の
+// ときだけ emit する (upstream packSimple)。
+func TestEmojis_URLFallbackAndRoleIds(t *testing.T) {
+	h, repo := setup()
+	// publicUrl 空 → originalUrl に fallback。roleIds 付き。
+	repo.Emojis["a@"] = &model.Emoji{
+		Name:                                    "a",
+		PublicURL:                               "",
+		OriginalURL:                             "https://example.com/emoji/a-orig.png",
+		Aliases:                                 []string{},
+		RoleIDsThatCanBeUsedThisEmojiAsReaction: []string{"role1", "role2"},
+	}
+	// roleIds 空 → field 省略。
+	repo.Emojis["b@"] = &model.Emoji{
+		Name:      "b",
+		PublicURL: "https://example.com/emoji/b.png",
+		Aliases:   []string{},
+	}
+
+	rec := doPost(h)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	arr := body["emojis"].([]any)
+	byName := map[string]map[string]any{}
+	for _, e := range arr {
+		m := e.(map[string]any)
+		byName[m["name"].(string)] = m
+	}
+
+	a := byName["a"]
+	assert.Equal(t, "https://example.com/emoji/a-orig.png", a["url"], "publicUrl 空 → originalUrl fallback")
+	roleIds, ok := a["roleIdsThatCanBeUsedThisEmojiAsReaction"].([]any)
+	require.True(t, ok, "roleIds が length>0 のとき emit される")
+	assert.Len(t, roleIds, 2)
+	shapetest.Assert(t, "EmojiSimple", a)
+
+	b := byName["b"]
+	_, hasRole := b["roleIdsThatCanBeUsedThisEmojiAsReaction"]
+	assert.False(t, hasRole, "roleIds 空のとき省略される")
+}
+
 // failingEmojiRepo always fails on ListLocal.
 type failingEmojiRepo struct {
 	*testutil.MockEmojiRepository


### PR DESCRIPTION
## Summary

Misskey TS 互換性監査 (#1556) の EmojiSimple (`/api/emojis` list) の 2 件を解消する。#1556 の part 2/4。singular (`/api/emoji`) は既に `entity.PackEmojiDetailed` 経由で対応済だったが、list は ad-hoc map で 2 点が欠けていた。

## 主な変更点

- **url の originalUrl fallback**: upstream `packSimple` と同じく `publicUrl || originalUrl` で、`publicUrl` が空 (remote emoji 等) のとき `originalUrl` に fallback する。`EmojiSimple.url` は required non-null なので、空 publicUrl のままだと必須フィールドが空になっていた。
- **roleIdsThatCanBeUsedThisEmojiAsReaction**: length>0 のときだけ emit する (upstream `packSimple`、reaction-role gating UI 用)。

`localOnly` / `isSensitive` の presence は監査対象外かつ schema optional なので現状の always-present を維持する。

## テスト

- `internal/api/emojis/handler_test.go`: `TestEmojis_URLFallbackAndRoleIds` (publicUrl 空 → originalUrl fallback、roleIds は length>0 で emit / 空で省略)
- 対象パッケージ coverage: emojis 100%
- `make fmt` / `go vet ./...` / `go test ./...` 全 pass

## 関連

#1556 (part 2/4)。残り: part 3 pages attachedFiles、part 4 chat reactions[] user。

🤖 Generated with [Claude Code](https://claude.com/claude-code)