### PR TITLE
Fix chat: room message の reactions に user (UserLite) を含める (#1556 part 3/3)

### DIFF
--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -371,7 +371,67 @@ func (h *Handler) packMessageDetailed(m *model.ChatMessage, meID string) map[str
 		// 旧 chat 実装ではこの key で判定していた残存 client がある。
 		result["room"] = h.packRoomDetailed(m.ToRoom, meID)
 	}
+	// room message の reactions は full/room schema で user (UserLite) を含む
+	// (upstream packMessageForRoom、#1556)。1on1 lite は user を持たないので
+	// base の {reaction} のまま。room 判定は ToRoomID 列で行う (ToRoom の eager
+	// load 有無に依らない)。
+	//
+	// 既知の差分: upstream は messages/show・search・history で full schema
+	// (packedChatMessageSchema) を使い、1on1 message でも reactions[].user を
+	// 含める。mk-go は全 endpoint が単一の packMessageDetailed を通り、room
+	// だけ user を付けるため、これらの endpoint で 1on1 message を返すと user が
+	// 欠ける。1on1 は参加者が 2 人で reactor が自明なため実害は小さく、room
+	// (多人数) の reactor 表示を優先して本 PR では room のみ対応する。
+	if m.ToRoomID != nil {
+		result["reactions"] = h.packRoomReactions(m)
+	}
 	return result
+}
+
+// packRoomReactions builds room-message reactions as {user, reaction} by
+// resolving the stored "<userId>/<reaction>" form to a UserLite (#1556)。
+// full/room schema は reactions[].user を required non-null とするため、user を
+// 解決できた reaction だけ emit する (= 削除済 user の reaction は drop して、
+// user 欠落で client が crash しないよう保証)。userRepo 未配線 (test / early
+// boot) は base の {reaction} に degrade する。
+func (h *Handler) packRoomReactions(m *model.ChatMessage) []map[string]any {
+	if h.userRepo == nil {
+		return packChatReactions(m.Reactions)
+	}
+	type parsed struct{ userID, reaction string }
+	items := make([]parsed, 0, len(m.Reactions))
+	idSet := make(map[string]struct{}, len(m.Reactions))
+	for _, r := range m.Reactions {
+		uid, reaction := "", r
+		if i := strings.Index(r, "/"); i >= 0 {
+			uid, reaction = r[:i], r[i+1:]
+		}
+		items = append(items, parsed{uid, reaction})
+		if uid != "" {
+			idSet[uid] = struct{}{}
+		}
+	}
+	userByID := make(map[string]*model.User, len(idSet))
+	if len(idSet) > 0 {
+		ids := make([]string, 0, len(idSet))
+		for id := range idSet {
+			ids = append(ids, id)
+		}
+		if users, err := h.userRepo.FindManyByIDs(ids); err == nil {
+			for _, u := range users {
+				userByID[u.ID] = u
+			}
+		}
+	}
+	out := make([]map[string]any, 0, len(items))
+	for _, it := range items {
+		u, ok := userByID[it.userID]
+		if !ok {
+			continue // user 未解決 (削除済等) の reaction は drop
+		}
+		out = append(out, map[string]any{"user": packUser(u), "reaction": it.reaction})
+	}
+	return out
 }
 
 // packUser produces the UserLite shape consumed by FE chat components.

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -1365,3 +1365,57 @@ func TestAttachedChatMessages_NoFileRepoReturnsEmpty(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "[]\n", rec.Body.String())
 }
+
+// #1556 room message の reactions は {user, reaction} を含む (full/room schema)。
+// user を解決できない reaction (削除済 user 等) は drop して user 欠落を防ぐ。
+func TestPackMessageDetailed_RoomReactionsIncludeUser(t *testing.T) {
+	h, _ := newTestHandler()
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	h.SetUserRepo(userRepo)
+
+	roomID := "room1"
+	m := &model.ChatMessage{ID: "m1", FromUserID: "u2", ToRoomID: &roomID,
+		Reactions: []string{"u1/👍", "ghost/😀"}}
+	out := h.packMessageDetailed(m, "viewer")
+
+	reactions, ok := out["reactions"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, reactions, 1, "u1 は解決され、ghost (未解決) は drop")
+	assert.Equal(t, "👍", reactions[0]["reaction"])
+	user, ok := reactions[0]["user"].(map[string]any)
+	require.True(t, ok, "room reaction は user (UserLite) を含む")
+	assert.Equal(t, "u1", user["id"])
+}
+
+// 1on1 (lite) message の reactions は user を含まない。
+func TestPackMessageDetailed_1on1ReactionsOmitUser(t *testing.T) {
+	h, _ := newTestHandler()
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	h.SetUserRepo(userRepo)
+
+	toUser := "u3"
+	m := &model.ChatMessage{ID: "m1", FromUserID: "u2", ToUserID: &toUser,
+		Reactions: []string{"u1/👍"}}
+	out := h.packMessageDetailed(m, "viewer")
+
+	reactions, ok := out["reactions"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, reactions, 1)
+	assert.Equal(t, "👍", reactions[0]["reaction"])
+	_, hasUser := reactions[0]["user"]
+	assert.False(t, hasUser, "1on1 lite reactions は user を省略する")
+}
+
+// userRepo 未配線の room message は base の {reaction} に degrade する (crash しない)。
+func TestPackMessageDetailed_RoomReactionsNoUserRepoDegrades(t *testing.T) {
+	h, _ := newTestHandler() // SetUserRepo を呼ばない
+	roomID := "room1"
+	m := &model.ChatMessage{ID: "m1", FromUserID: "u2", ToRoomID: &roomID,
+		Reactions: []string{"u1/👍"}}
+	out := h.packMessageDetailed(m, "viewer")
+	reactions := out["reactions"].([]map[string]any)
+	require.Len(t, reactions, 1)
+	assert.Equal(t, "👍", reactions[0]["reaction"])
+}


### PR DESCRIPTION
## Summary

Misskey TS 互換性監査 (#1556: entity:misc packers) の chat reactions parity を解消する。#1556 の最終 part。

upstream の room/full ChatMessage schema (`packedChatMessageSchema` / `packedChatMessageLiteForRoomSchema`) は `reactions[].user` を required non-null とする。mk-go は reactions を `"<userId>/<reaction>"` 形式で保存しているが `packChatReactions` は `{reaction}` のみで user を捨てていた。

## 主な変更点

- room message (`m.ToRoomID != nil`) のとき `packMessageDetailed` が reactions を `packRoomReactions` で `{user, reaction}` に上書きする。stored userId を `FindManyByIDs` で batch 解決し、解決できた reaction だけ emit する (削除済 user の reaction は drop して user 欠落で client が crash しないよう保証、upstream の `reactions.filter(r => r.user != null)` と同じ)。
- userRepo 未配線 (test/early-boot) は base の `{reaction}` に degrade。1on1 lite は user を持たない (`packedChatMessageLiteFor1on1Schema`) ので変更しない。
- chat は cherrypick-lineage + misskey_dart 互換のため shape 変更を最小化。room reactions への user 追加は misskey_dart にとって無害な extra field (既存の user 欠落より悪化しない)。

### 既知の差分 (コメント明記)

upstream は messages/show・search・history で full schema を使い 1on1 message にも `reactions[].user` を含めるが、mk-go は単一の `packMessageDetailed` を通すため room のみ対応する。1on1 は参加者 2 人で reactor が自明なため実害が小さく、room (多人数) の reactor 表示を優先した。

## テスト

- `internal/api/chat/handler_test.go`: room reactions が `{user, reaction}` を含む (未解決 user は drop)、1on1 は user 省略、userRepo 未配線 degrade
- 対象パッケージ coverage: chat 93.2%
- `make fmt` / `go vet ./...` / `go test ./...` 全 pass

## 関連

Closes #1556。

#1556 の項目別結果:
- channels isMuting/pinnedNotes (M) / app isAuthorized (M, #1656) / notifications grouped (L, #1559) / clips favoritedCount (L) → 既に解消済 (stale)
- following / i/favorites createdAt ms-ISO (L) → part 1 (#1660)
- emojis list url fallback + roleIds (M/L) → part 2 (#1661)
- chat reactions[] user (M) → 本 PR
- pages attachedFiles (L) → drive-file 解決基盤を要するため follow-up #1662 に切り出し (eyeCatchingImage と併せて対応)

🤖 Generated with [Claude Code](https://claude.com/claude-code)