### PR TITLE
Fix Page packer: attachedFiles + eyeCatchingImage の drive-file 解決 (#1662)

### DIFF
--- a/internal/api/pages/handler.go
+++ b/internal/api/pages/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
@@ -44,6 +45,16 @@ type Handler struct {
 	idGen               id.Generator
 	mainStreamPublisher MainStreamPublisher
 	userSource          UserBundleSource
+	// driveFileRepo は page content の image block / eyeCatchingImageId から
+	// drive file を解決して attachedFiles / eyeCatchingImage を埋めるのに使う
+	// (#1662)。未配線なら両 field は PackPage の default (空配列 / null)。
+	driveFileRepo repository.DriveFileRepository
+}
+
+// SetDriveFileRepo wires the drive file repo used to resolve a page's
+// attachedFiles (image-block files) and eyeCatchingImage (#1662)。
+func (h *Handler) SetDriveFileRepo(r repository.DriveFileRepository) {
+	h.driveFileRepo = r
 }
 
 // NewHandler creates a new pages Handler. idGen is required so that
@@ -179,7 +190,7 @@ func (h *Handler) Show(c echo.Context) error {
 		liked := h.svc.HasLiked(user.ID, p.ID)
 		isLikedPtr = &liked
 	}
-	return c.JSON(http.StatusOK, h.pageToMapWithOwner(p, owner, nil, isLikedPtr))
+	return c.JSON(http.StatusOK, h.pageToMapWithOwner(p, owner, isLikedPtr))
 }
 
 // UpdateRequest is the request body for pages/update.
@@ -486,7 +497,7 @@ func (h *Handler) pagesToList(rows []*model.Page, ownerLookup func(userID string
 		if owner == nil {
 			continue
 		}
-		out = append(out, h.pageToMapWithOwner(p, owner, nil, nil))
+		out = append(out, h.pageToMapWithOwner(p, owner, nil))
 	}
 	return out
 }
@@ -507,11 +518,17 @@ func (h *Handler) pageToMap(p *model.Page) map[string]any {
 // optional `eyeCatchingImage` / `isLiked`. Upstream PageEntityService.pack
 // always emits `user`; mk-go previously omitted it which silently broke the
 // frontend list views (#1134).
-func (h *Handler) pageToMapWithOwner(p *model.Page, owner *model.User, eyeCatchingImage map[string]any, isLiked *bool) map[string]any {
+func (h *Handler) pageToMapWithOwner(p *model.Page, owner *model.User, isLiked *bool) map[string]any {
+	// content の image block / eyeCatchingImageId から drive file を解決する
+	// (#1662)。driveFileRepo 未配線なら entity 側が (nil,nil) を返し default 維持。
+	// list 経路 (i/pages, featured) では page ごとに drive lookup が走る (N+1)
+	// が、page list は通常小さいので許容する。
+	attachedFiles, eyeCatchingImage := entity.ResolvePageDriveFiles(p, h.driveFileRepo, h.idGen)
 	return entity.PackPageWithContext(p, entity.PackPageContext{
 		IDGen:            h.idGen,
 		Owner:            owner,
 		EyeCatchingImage: eyeCatchingImage,
+		AttachedFiles:    attachedFiles,
 		IsLiked:          isLiked,
 	})
 }

--- a/internal/api/pages/handler_test.go
+++ b/internal/api/pages/handler_test.go
@@ -811,3 +811,71 @@ func TestPagePush_UserSourceError_NoEmit(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 	assert.Empty(t, pub.calls)
 }
+
+// #1662 page content の image block から attachedFiles を、eyeCatchingImageId から
+// eyeCatchingImage を解決する。attachedFiles は page owner-scope。
+func TestShow_ResolvesAttachedFilesAndEyeCatchingImage(t *testing.T) {
+	h, repo, _ := newHandler(t)
+	idGen, _ := id.NewGenerator("aidx")
+	pageID := idGen.Generate(time.Now())
+	// content: image block (f1, owner alice) + section children に image block
+	// (f2, owner alice) + 他人 file (f3, owner bob → 除外) を含む。
+	content := `[
+		{"type":"image","fileId":"f1"},
+		{"type":"text","text":"hi"},
+		{"type":"section","children":[{"type":"image","fileId":"f2"},{"type":"image","fileId":"f3"}]}
+	]`
+	eyeID := "eye1"
+	repo.Pages[pageID] = &model.Page{
+		ID: pageID, UserID: "alice", Name: "alpha", Visibility: model.PageVisibilityPublic,
+		Content: []byte(content), EyeCatchingImageID: &eyeID,
+	}
+
+	driveRepo := testutil.NewMockDriveFileRepository()
+	alice, bob := "alice", "bob"
+	driveRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &alice, Name: "a.png", Type: "image/png"}
+	driveRepo.Files["f2"] = &model.DriveFile{ID: "f2", UserID: &alice, Name: "b.png", Type: "image/png"}
+	driveRepo.Files["f3"] = &model.DriveFile{ID: "f3", UserID: &bob, Name: "c.png", Type: "image/png"} // owner mismatch
+	driveRepo.Files["eye1"] = &model.DriveFile{ID: "eye1", UserID: &alice, Name: "eye.png", Type: "image/png"}
+	h.SetDriveFileRepo(driveRepo)
+	h.SetUserSource(&stubUserSource{bundle: &coreuser.UserWithProfile{User: &model.User{ID: "alice", Username: "alice", UsernameLower: "alice"}}})
+
+	c, rec := newReq(t, `{"pageId":"`+pageID+`"}`)
+	require.NoError(t, h.Show(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var row map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &row))
+
+	attached, ok := row["attachedFiles"].([]any)
+	require.True(t, ok)
+	// f1 + f2 (alice owned)、content 順。f3 (bob) は owner mismatch で除外。
+	require.Len(t, attached, 2)
+	assert.Equal(t, "f1", attached[0].(map[string]any)["id"])
+	assert.Equal(t, "f2", attached[1].(map[string]any)["id"])
+
+	eye, ok := row["eyeCatchingImage"].(map[string]any)
+	require.True(t, ok, "eyeCatchingImage が解決される")
+	assert.Equal(t, "eye1", eye["id"])
+}
+
+// driveFileRepo 未配線なら attachedFiles は空配列 / eyeCatchingImage は null (default 維持)。
+func TestShow_NoDriveRepoKeepsDefaults(t *testing.T) {
+	h, repo, _ := newHandler(t)
+	idGen, _ := id.NewGenerator("aidx")
+	pageID := idGen.Generate(time.Now())
+	eyeID := "eye1"
+	repo.Pages[pageID] = &model.Page{
+		ID: pageID, UserID: "alice", Name: "alpha", Visibility: model.PageVisibilityPublic,
+		Content: []byte(`[{"type":"image","fileId":"f1"}]`), EyeCatchingImageID: &eyeID,
+	}
+	h.SetUserSource(&stubUserSource{bundle: &coreuser.UserWithProfile{User: &model.User{ID: "alice", Username: "alice", UsernameLower: "alice"}}})
+
+	c, rec := newReq(t, `{"pageId":"`+pageID+`"}`)
+	require.NoError(t, h.Show(c))
+	var row map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &row))
+	attached, ok := row["attachedFiles"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, attached, "未配線なら空配列")
+	assert.Nil(t, row["eyeCatchingImage"], "未配線なら null")
+}

--- a/internal/api/users/content_lists.go
+++ b/internal/api/users/content_lists.go
@@ -255,9 +255,15 @@ func (h *Handler) Pages(c echo.Context) error {
 	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, p := range rows {
+		// content の image block / eyeCatchingImageId から drive file を解決する
+		// (#1662)。driveFileRepo 未配線なら default ([] / null)。page list なので
+		// per-page lookup (N+1) だが list は小さい前提で許容する。
+		attachedFiles, eyeCatchingImage := entity.ResolvePageDriveFiles(p, h.driveFileRepo, h.idGen)
 		out = append(out, entity.PackPageWithContext(p, entity.PackPageContext{
-			IDGen: h.idGen,
-			Owner: owner.User,
+			IDGen:            h.idGen,
+			Owner:            owner.User,
+			EyeCatchingImage: eyeCatchingImage,
+			AttachedFiles:    attachedFiles,
 		}))
 	}
 	return c.JSON(http.StatusOK, out)

--- a/internal/api/users/content_lists_test.go
+++ b/internal/api/users/content_lists_test.go
@@ -196,3 +196,34 @@ func TestPages_HidesNonPublic(t *testing.T) {
 	require.True(t, ok, "page entity must include user field")
 	assert.Equal(t, "owner", user["username"])
 }
+
+// #1662 users/pages も page content の image block / eyeCatchingImageId から
+// drive file を解決する (i/pages / featured と同じ packer 経路)。
+func TestPages_ResolvesDriveFiles(t *testing.T) {
+	h, userRepo := newTestHandler(t)
+	userRepo.Users["owner"] = &model.User{ID: "owner", Username: "owner", UsernameLower: "owner"}
+	repo := testutil.NewMockPageRepository()
+	eyeID := "eye1"
+	require.NoError(t, repo.Create(&model.Page{
+		ID: "p1", UserID: "owner", Visibility: model.PageVisibilityPublic,
+		Content: []byte(`[{"type":"image","fileId":"f1"}]`), EyeCatchingImageID: &eyeID,
+	}))
+	h.SetPageRepo(repo)
+	driveRepo := testutil.NewMockDriveFileRepository()
+	owner := "owner"
+	driveRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &owner, Name: "a.png", Type: "image/png"}
+	driveRepo.Files["eye1"] = &model.DriveFile{ID: "eye1", UserID: &owner, Name: "e.png", Type: "image/png"}
+	h.SetDriveFileRepo(driveRepo)
+
+	rec := postStub(h.Pages, `{"userId":"owner"}`, nil)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	attached, ok := rows[0]["attachedFiles"].([]any)
+	require.True(t, ok)
+	require.Len(t, attached, 1)
+	assert.Equal(t, "f1", attached[0].(map[string]any)["id"])
+	eye, ok := rows[0]["eyeCatchingImage"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "eye1", eye["id"])
+}

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -71,6 +71,15 @@ type Handler struct {
 	// 判定し、remote user / 非 public reactions の閲覧制限を bypass するため
 	// に使う (upstream の iAmModerator 経路)。
 	moderatorChecker ModeratorChecker
+	// driveFileRepo は users/pages で page の attachedFiles / eyeCatchingImage を
+	// drive file から解決するのに使う (#1662)。未配線なら両 field は default。
+	driveFileRepo repository.DriveFileRepository
+}
+
+// SetDriveFileRepo wires the drive file repo used by users/pages to resolve a
+// page's attachedFiles / eyeCatchingImage (#1662)。
+func (h *Handler) SetDriveFileRepo(r repository.DriveFileRepository) {
+	h.driveFileRepo = r
 }
 
 // RemoteStatsFetcher abstracts the federation.RemoteStatsFetcher so wiring is

--- a/internal/entity/page.go
+++ b/internal/entity/page.go
@@ -73,11 +73,16 @@ type PackPageContext struct {
 	// when their lookup misses (= upstream packMany semantics), otherwise
 	// MkPagePreview crashes on the next `page.user.username` access.
 	Owner *model.User
-	// EyeCatchingImage is the pre-packed Drive file when Page.EyeCatchingImageID
-	// is set. nil means "either no image or the file lookup missed"; both
-	// render the same in MkPagePreview (the `v-if="page.eyeCatchingImage"`
-	// guard simply hides the block).
-	EyeCatchingImage map[string]any
+	// EyeCatchingImage is the packed Drive file when Page.EyeCatchingImageID
+	// is set (entity.DriveFileEntity or nil). nil means "either no image or the
+	// file lookup missed"; both render the same in MkPagePreview (the
+	// `v-if="page.eyeCatchingImage"` guard simply hides the block)。#1662 で
+	// handler が実 drive file を解決して渡せるようにした。
+	EyeCatchingImage any
+	// AttachedFiles are the packed Drive files referenced by image blocks in
+	// the page content (#1662)。nil leaves PackPage's default empty array; a
+	// non-nil slice (possibly empty) overrides it.
+	AttachedFiles []any
 	// IsLiked is the viewer's like state. nil omits the field (upstream
 	// `pages/show` returns undefined when there is no logged-in viewer).
 	IsLiked *bool
@@ -103,10 +108,101 @@ func PackPageWithContext(p *model.Page, ctx PackPageContext) map[string]any {
 	if ctx.EyeCatchingImage != nil {
 		out["eyeCatchingImage"] = ctx.EyeCatchingImage
 	}
+	// attachedFiles は content の image block から解決した drive file 群 (#1662)。
+	// nil なら PackPage の default 空配列を維持する。
+	if ctx.AttachedFiles != nil {
+		out["attachedFiles"] = ctx.AttachedFiles
+	}
 	if ctx.IsLiked != nil {
 		out["isLiked"] = *ctx.IsLiked
 	}
 	return out
+}
+
+// PageDriveFileLookup is the narrow drive-file repository view used to resolve
+// a page's attachedFiles / eyeCatchingImage (#1662)。repository.DriveFileRepository
+// が構造的に満たすので、entity は repository に依存しない。
+type PageDriveFileLookup interface {
+	FindByIDs(ids []string) ([]*model.DriveFile, error)
+	FindByID(id string) (*model.DriveFile, error)
+}
+
+// CollectPageImageFileIDs walks the page content blocks (jsonb) recursively and
+// returns the fileId of every `type==image` block in document order (upstream
+// PageEntityService の collectFile)。children を持つ block は再帰する。不正
+// JSON / 空は nil。
+func CollectPageImageFileIDs(content []byte) []string {
+	var blocks []any
+	if len(content) == 0 || json.Unmarshal(content, &blocks) != nil {
+		return nil
+	}
+	var ids []string
+	var walk func(xs []any)
+	walk = func(xs []any) {
+		for _, x := range xs {
+			m, ok := x.(map[string]any)
+			if !ok {
+				continue
+			}
+			if t, _ := m["type"].(string); t == "image" {
+				if fid, _ := m["fileId"].(string); fid != "" {
+					ids = append(ids, fid)
+				}
+			}
+			if ch, ok := m["children"].([]any); ok {
+				walk(ch)
+			}
+		}
+	}
+	walk(blocks)
+	return ids
+}
+
+// ResolvePageDriveFiles resolves a page's attachedFiles (drive files referenced
+// by image blocks in page.content, page owner-scope) and eyeCatchingImage
+// (#1662、upstream PageEntityService.pack)。lookup nil / p nil なら (nil, nil) を
+// 返し、呼び出し元は PackPage の default (空配列 / null) を維持する。
+//
+// attachedFiles は content (block) 順を保ち image block ごとに pack する
+// (upstream は block 単位で push するため同一 file が複数 block にあれば重複)。
+// owner-scope は upstream findOneBy({id, userId: page.userId}) と一致。
+// eyeCatchingImage は owner-scope 無しで id から pack する (upstream 同様)。
+func ResolvePageDriveFiles(p *model.Page, lookup PageDriveFileLookup, idGen id.Generator) ([]any, any) {
+	if lookup == nil || p == nil {
+		return nil, nil
+	}
+	attached := []any{}
+	if ids := CollectPageImageFileIDs(p.Content); len(ids) > 0 {
+		uniq := make([]string, 0, len(ids))
+		seen := make(map[string]struct{}, len(ids))
+		for _, fid := range ids {
+			if _, dup := seen[fid]; dup {
+				continue
+			}
+			seen[fid] = struct{}{}
+			uniq = append(uniq, fid)
+		}
+		byID := make(map[string]*model.DriveFile, len(uniq))
+		if files, err := lookup.FindByIDs(uniq); err == nil {
+			for _, f := range files {
+				if f.UserID != nil && *f.UserID == p.UserID {
+					byID[f.ID] = f
+				}
+			}
+		}
+		for _, fid := range ids {
+			if f, ok := byID[fid]; ok {
+				attached = append(attached, PackDriveFile(f, idGen))
+			}
+		}
+	}
+	var eyeCatchingImage any
+	if p.EyeCatchingImageID != nil {
+		if f, err := lookup.FindByID(*p.EyeCatchingImageID); err == nil && f != nil {
+			eyeCatchingImage = PackDriveFile(f, idGen)
+		}
+	}
+	return attached, eyeCatchingImage
 }
 
 // rawJSONBytes returns the raw JSON bytes as json.RawMessage so JSON encoders

--- a/internal/entity/page_test.go
+++ b/internal/entity/page_test.go
@@ -133,3 +133,63 @@ func TestPackPageWithContext_OmitsAbsentOptionals(t *testing.T) {
 func TestPackPageWithContext_NilPage(t *testing.T) {
 	assert.Nil(t, PackPageWithContext(nil, PackPageContext{}))
 }
+
+// #1662 CollectPageImageFileIDs は image block の fileId を document 順 (children
+// 再帰込み) で返す。
+func TestCollectPageImageFileIDs(t *testing.T) {
+	content := []byte(`[
+		{"type":"image","fileId":"a"},
+		{"type":"text"},
+		{"type":"section","children":[{"type":"image","fileId":"b"},{"type":"section","children":[{"type":"image","fileId":"c"}]}]},
+		{"type":"image"}
+	]`)
+	assert.Equal(t, []string{"a", "b", "c"}, CollectPageImageFileIDs(content))
+	assert.Nil(t, CollectPageImageFileIDs([]byte(`not json`)))
+	assert.Nil(t, CollectPageImageFileIDs(nil))
+}
+
+// stubPageDriveLookup is a minimal PageDriveFileLookup for ResolvePageDriveFiles.
+type stubPageDriveLookup struct{ files map[string]*model.DriveFile }
+
+func (s stubPageDriveLookup) FindByIDs(ids []string) ([]*model.DriveFile, error) {
+	out := make([]*model.DriveFile, 0, len(ids))
+	for _, id := range ids {
+		if f, ok := s.files[id]; ok {
+			out = append(out, f)
+		}
+	}
+	return out, nil
+}
+
+func (s stubPageDriveLookup) FindByID(id string) (*model.DriveFile, error) {
+	if f, ok := s.files[id]; ok {
+		return f, nil
+	}
+	return nil, assert.AnError
+}
+
+// #1662 ResolvePageDriveFiles は owner-scope の image-block file を解決し、
+// eyeCatchingImage を id から pack する。lookup nil は (nil, nil)。
+func TestResolvePageDriveFiles(t *testing.T) {
+	idGen := newTestIDGen(t)
+	alice, bob := "alice", "bob"
+	lookup := stubPageDriveLookup{files: map[string]*model.DriveFile{
+		"f1":  {ID: "f1", UserID: &alice, Name: "a.png", Type: "image/png"},
+		"f2":  {ID: "f2", UserID: &bob, Name: "b.png", Type: "image/png"}, // owner mismatch
+		"eye": {ID: "eye", UserID: &alice, Name: "e.png", Type: "image/png"},
+	}}
+	eyeID := "eye"
+	p := &model.Page{ID: "p1", UserID: "alice", EyeCatchingImageID: &eyeID,
+		Content: []byte(`[{"type":"image","fileId":"f1"},{"type":"image","fileId":"f2"}]`)}
+
+	attached, eye := ResolvePageDriveFiles(p, lookup, idGen)
+	require.Len(t, attached, 1, "owner alice の f1 のみ。bob の f2 は除外")
+	assert.Equal(t, "f1", attached[0].(DriveFileEntity).ID)
+	require.NotNil(t, eye)
+	assert.Equal(t, "eye", eye.(DriveFileEntity).ID)
+
+	// lookup nil → (nil, nil) で default 維持。
+	a2, e2 := ResolvePageDriveFiles(p, nil, idGen)
+	assert.Nil(t, a2)
+	assert.Nil(t, e2)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1286,6 +1286,8 @@ func (s *Server) setupRoutes() {
 	usersHandler.SetFlashRepo(flashRepo)
 	usersHandler.SetGalleryRepo(repository.NewGalleryRepository(s.db))
 	usersHandler.SetPageRepo(pageRepo)
+	// users/pages の page も attachedFiles / eyeCatchingImage を解決する (#1662)。
+	usersHandler.SetDriveFileRepo(driveFileRepo)
 	usersHandler.SetNoteFieldResolver(noteFieldResolver)
 	usersHandler.SetUserRepo(userRepo)
 	usersHandler.SetNoteReactionRepo(reactionRepo)
@@ -1770,6 +1772,9 @@ func (s *Server) setupRoutes() {
 
 	// Pages endpoints (Phase 4.5)
 	pagesHandler := pages.NewHandler(pageService, idGen)
+	// page content の image block / eyeCatchingImageId から drive file を解決して
+	// attachedFiles / eyeCatchingImage を埋める (#1662)。
+	pagesHandler.SetDriveFileRepo(driveFileRepo)
 	api.POST("/pages/create", pagesHandler.Create, middleware.RequireAuth(), middleware.RequireScope("write:pages"))
 	api.POST("/pages/show", pagesHandler.Show)
 	api.POST("/pages/update", pagesHandler.Update, middleware.RequireAuth(), middleware.RequireScope("write:pages"))


### PR DESCRIPTION
## Summary

#1556 (entity:misc packers) から follow-up として切り出した Page packer の drive-file 解決を実装する (upstream `PageEntityService.pack`)。従来 `attachedFiles` は常に `[]`、`eyeCatchingImage` は常に `null` だった。

## 主な変更点

- **attachedFiles**: `page.content` を再帰 walk して `type==image` block の fileId を document 順に集め (`entity.CollectPageImageFileIDs`)、page owner-scope (`findOneBy{id,userId}`) で解決して pack する。content 順を保ち、同一 file が複数 block にあれば重複する (upstream の per-block push と一致)。
- **eyeCatchingImage**: `page.eyeCatchingImageId` から owner-scope 無しで pack する (upstream 同様)。
- 解決ロジックを `entity.ResolvePageDriveFiles` (narrow `PageDriveFileLookup` interface で repository 非依存) に集約し、pages handler (pages/show, i/pages, featured) と users handler (**users/pages**) の両 page-list 経路で共用する。`driveFileRepo` 未配線なら `(nil, nil)` で `PackPage` の default (`[]` / `null`) を維持。

`users/pages` は別ハンドラ (users.Handler) だが同じ packer を共有する page-list 経路のため、レビュー指摘を受けて併せて対応した。

## 注意・scope

- list 経路は per-page の drive lookup (N+1) になるが、page list は通常小さいので許容 (コメント明記)。
- Create/Update の write response と pinnedPage embed (`/api/i`, `/api/users/show`) は従来どおり default (`[]` / `null`) のまま (scope 外、client は Show で再取得)。

## テスト

- `internal/entity/page_test.go`: `CollectPageImageFileIDs` (document 順 / 再帰 / 不正 JSON)、`ResolvePageDriveFiles` (owner-scope filter / eyeCatchingImage / lookup nil)
- `internal/api/pages/handler_test.go`: pages/show が attachedFiles (owner-scope, 他人 file 除外) + eyeCatchingImage を解決、未配線 degrade
- `internal/api/users/content_lists_test.go`: users/pages も drive file を解決
- 対象パッケージ coverage: entity 97.0% / pages 97.1% / users 維持
- `make fmt` / `go vet ./...` / `go test ./...` 全 pass

## 関連

Closes #1662 (#1556 から切り出した follow-up)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)