### PR TITLE
Fix i/authorized-apps: App entity shape + pagination (#1555 part1)

### DIFF
--- a/internal/api/i/apps.go
+++ b/internal/api/i/apps.go
@@ -98,31 +98,63 @@ func formatNullableTime(t *time.Time, layout string) any {
 }
 
 // AuthorizedApps handles POST /api/i/authorized-apps.
-// 本家 Misskey の実装に合わせて、自分に紐づく access_token を返す。
-// name / description / iconUrl / permission / lastUsedAt を含む。
+//
+// upstream authorized-apps.ts は `appId IS NOT NULL` の access_token を
+// limit/offset/sort 付きで引き、各 token を appEntityService.pack(token.appId,
+// me, {detail:true}) で **App entity** に変換して返す。旧 mk-go 実装は
+// access_token 自身の shape ({id=token.id, description, iconUrl, lastUsedAt
+// など}) を返しており、本家 res schema ({id=app.id, name, callbackUrl,
+// permission, isAuthorized}) と非互換だった (#1555)。
+//
+// isAuthorized は upstream で accessTokensRepository.countBy({appId, userId})>0。
+// ここで列挙している token 自体が該当 (appId, userId) ペアの存在を保証するので
+// 常に true。requireCredential なので me は必ず存在する。
 func (h *Handler) AuthorizedApps(c echo.Context) error {
 	if h.accessTokenRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
 	u := middleware.GetUser(c)
-	tokens, err := h.accessTokenRepo.ListByUserID(u.ID)
+	var req struct {
+		Limit  *int   `json:"limit"`
+		Offset int    `json:"offset"`
+		Sort   string `json:"sort"`
+	}
+	_ = c.Bind(&req)
+	// limit: default 10, clamp 1..100 (authorized-apps.ts paramDef)。
+	limit := 10
+	if req.Limit != nil {
+		limit = *req.Limit
+	}
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	offset := req.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	// sort enum ['desc','asc'] default 'desc' (= id DESC)。'asc' のみ昇順。
+	sortAsc := req.Sort == "asc"
+	tokens, err := h.accessTokenRepo.ListAuthorizedApps(u.ID, limit, offset, sortAsc)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
 	out := make([]map[string]any, 0, len(tokens))
 	for _, t := range tokens {
-		entry := map[string]any{
-			"id":          t.ID,
-			"name":        t.Name,
-			"description": t.Description,
-			"iconUrl":     t.IconURL,
-			"permission":  []string(t.Permission),
-			"lastUsedAt":  t.LastUsedAt,
+		// appId NOT NULL filter 済だが、app 行が削除済なら Preload が nil を返す。
+		// upstream は findOneByOrFail で reject するが、mk-go は graceful に skip。
+		if t.App == nil {
+			continue
 		}
-		if ct, err := h.idGen.ParseTime(t.ID); err == nil {
-			entry["createdAt"] = ct.UTC().Format("2006-01-02T15:04:05.000Z")
-		}
-		out = append(out, entry)
+		out = append(out, map[string]any{
+			"id":           t.App.ID,
+			"name":         t.App.Name,
+			"callbackUrl":  t.App.CallbackURL,
+			"permission":   []string(t.App.Permission),
+			"isAuthorized": true,
+		})
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/i/apps_test.go
+++ b/internal/api/i/apps_test.go
@@ -114,25 +114,89 @@ func TestRevokeToken(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, postExtra(h.RevokeToken, `{}`, stubUser).Code)
 }
 
-// --- P4-6 (#166): i/authorized-apps ---
+// --- P4-6 (#166) / #1555: i/authorized-apps は App entity shape を返す ---
 
-func TestAuthorizedApps_ReturnsOwnedTokens(t *testing.T) {
+// authorized-apps は upstream の App entity ({id=app.id, name, callbackUrl,
+// permission, isAuthorized}) を返す。appId NULL の raw/miauth token と他人の
+// token は除外される (#1555)。
+func TestAuthorizedApps_ReturnsAppEntities(t *testing.T) {
 	h, _ := newExtraHandler(t)
 	tokens := testutil.NewMockAccessTokenRepository()
 	idGen, _ := id.NewGenerator("aidx")
+
+	appID := "app1"
+	cb := "https://app.example/callback"
+	tokens.SetApp(&model.App{
+		ID:          appID,
+		Name:        "Misskey IDE",
+		CallbackURL: &cb,
+		Permission:  []string{"read:account", "write:notes"},
+	})
 	t1ID := idGen.Generate(time.Now())
-	name1 := "app one"
-	tokens.Tokens["h1"] = &model.AccessToken{ID: t1ID, Hash: "h1", UserID: stubUser.ID, Name: &name1}
-	tokens.Tokens["h2"] = &model.AccessToken{ID: "other-user-token", Hash: "h2", UserID: "other"}
+	tokens.Tokens["h1"] = &model.AccessToken{ID: t1ID, Hash: "h1", UserID: stubUser.ID, AppID: &appID}
+	// appId NULL の raw token は除外される。
+	tokens.Tokens["h2"] = &model.AccessToken{ID: idGen.Generate(time.Now()), Hash: "h2", UserID: stubUser.ID}
+	// 別ユーザーの token も除外。
+	tokens.Tokens["h3"] = &model.AccessToken{ID: "other-token", Hash: "h3", UserID: "other", AppID: &appID}
 	h.SetAccessTokenRepo(tokens)
 
 	rec := postExtra(h.AuthorizedApps, `{}`, stubUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	var got []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
-	// 自分のトークンだけ返る
 	require.Len(t, got, 1)
-	assert.Equal(t, t1ID, got[0]["id"])
+	entry := got[0]
+	// id は app.id (token.id ではない)。
+	assert.Equal(t, appID, entry["id"])
+	assert.Equal(t, "Misskey IDE", entry["name"])
+	assert.Equal(t, cb, entry["callbackUrl"])
+	assert.Equal(t, true, entry["isAuthorized"])
+	perm, _ := entry["permission"].([]any)
+	require.Len(t, perm, 2)
+	assert.Equal(t, "read:account", perm[0])
+	// token 専用 field (description/iconUrl/lastUsedAt) は含まない。
+	_, hasDesc := entry["description"]
+	assert.False(t, hasDesc)
+}
+
+// limit / offset / sort=asc が effect する。
+func TestAuthorizedApps_Pagination(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	tokens := testutil.NewMockAccessTokenRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	a1, a2, a3 := "a1", "a2", "a3"
+	for _, a := range []string{a1, a2, a3} {
+		tokens.SetApp(&model.App{ID: a, Name: a})
+	}
+	t1 := idGen.Generate(time.Now())
+	t2 := idGen.Generate(time.Now().Add(time.Second))
+	t3 := idGen.Generate(time.Now().Add(2 * time.Second))
+	tokens.Tokens["h1"] = &model.AccessToken{ID: t1, Hash: "h1", UserID: stubUser.ID, AppID: &a1}
+	tokens.Tokens["h2"] = &model.AccessToken{ID: t2, Hash: "h2", UserID: stubUser.ID, AppID: &a2}
+	tokens.Tokens["h3"] = &model.AccessToken{ID: t3, Hash: "h3", UserID: stubUser.ID, AppID: &a3}
+	h.SetAccessTokenRepo(tokens)
+
+	// limit=2, sort=asc (id 昇順) → t1(a1), t2(a2)。
+	rec := postExtra(h.AuthorizedApps, `{"limit":2,"sort":"asc"}`, stubUser)
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 2)
+	assert.Equal(t, a1, got[0]["id"])
+	assert.Equal(t, a2, got[1]["id"])
+
+	// offset=2, sort=asc → t3(a3) のみ。
+	rec = postExtra(h.AuthorizedApps, `{"sort":"asc","offset":2}`, stubUser)
+	got = nil
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, a3, got[0]["id"])
+
+	// default sort=desc → id 降順 (t3 が先頭)。
+	rec = postExtra(h.AuthorizedApps, `{}`, stubUser)
+	got = nil
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 3)
+	assert.Equal(t, a3, got[0]["id"])
 }
 
 // --- P4-6 (#166): i/revoke-token ---

--- a/internal/repository/access_token.go
+++ b/internal/repository/access_token.go
@@ -21,6 +21,12 @@ type AccessTokenRepository interface {
 	FindByHashOrToken(hash, rawToken string) (*model.AccessToken, error)
 	FindByID(id string) (*model.AccessToken, error)
 	ListByUserID(userID string) ([]*model.AccessToken, error)
+	// ListAuthorizedApps は /i/authorized-apps 用。upstream は
+	// accessTokensRepository.find({where:{userId, appId: Not(IsNull())}, take,
+	// skip, order:{id}}) で「app に紐づく token のみ」を limit/offset/sort 付きで
+	// 返す (authorized-apps.ts)。App を Preload して呼び出し側が App entity を
+	// 組み立てられるようにする。sortAsc=false で id DESC (= sort 'desc' / default)。
+	ListAuthorizedApps(userID string, limit, offset int, sortAsc bool) ([]*model.AccessToken, error)
 	// ListByUserIDPreloadApp は /i/apps 用に App を JOIN し、sort で
 	// 順序を制御して返す。sort 値 (Misskey TS 互換):
 	//   "+createdAt" → token.id DESC (新しい順)
@@ -73,6 +79,29 @@ func (r *accessTokenRepository) FindByID(id string) (*model.AccessToken, error) 
 func (r *accessTokenRepository) ListByUserID(userID string) ([]*model.AccessToken, error) {
 	var tokens []*model.AccessToken
 	if err := r.db.Where(`"userId" = ?`, userID).Order(`"id" DESC`).Find(&tokens).Error; err != nil {
+		return nil, err
+	}
+	return tokens, nil
+}
+
+// ListAuthorizedApps は /i/authorized-apps 用。appId IS NOT NULL で raw token /
+// miauth (appId NULL) を除外し、limit/offset/sort 付きで返す。Preload("App") で
+// app entity を組み立てられるようにする。
+func (r *accessTokenRepository) ListAuthorizedApps(userID string, limit, offset int, sortAsc bool) ([]*model.AccessToken, error) {
+	order := `"id" DESC`
+	if sortAsc {
+		order = `"id" ASC`
+	}
+	q := r.db.
+		Where(`"userId" = ? AND "appId" IS NOT NULL`, userID).
+		Preload("App").
+		Order(order).
+		Limit(limit)
+	if offset > 0 {
+		q = q.Offset(offset)
+	}
+	var tokens []*model.AccessToken
+	if err := q.Find(&tokens).Error; err != nil {
 		return nil, err
 	}
 	return tokens, nil

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -2575,6 +2575,38 @@ func (m *MockAccessTokenRepository) ListByUserID(userID string) ([]*model.Access
 	return out, nil
 }
 
+// ListAuthorizedApps は実 repo の appId IS NOT NULL filter + Preload("App") +
+// id sort (asc/desc) + limit/offset を再現する。
+func (m *MockAccessTokenRepository) ListAuthorizedApps(userID string, limit, offset int, sortAsc bool) ([]*model.AccessToken, error) {
+	out := make([]*model.AccessToken, 0)
+	for _, t := range m.Tokens {
+		if t.UserID != userID || t.AppID == nil {
+			continue
+		}
+		c := *t
+		if app, ok := m.Apps[*c.AppID]; ok {
+			c.App = app
+		}
+		out = append(out, &c)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if sortAsc {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].ID > out[j].ID
+	})
+	if offset > 0 {
+		if offset >= len(out) {
+			return []*model.AccessToken{}, nil
+		}
+		out = out[offset:]
+	}
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
 // ListByUserIDPreloadApp は実 repo の Preload("App") + sort 順を再現する。
 // sort 値は Misskey TS 互換 (+/-createdAt, +/-lastUsedAt, default は id ASC)。
 func (m *MockAccessTokenRepository) ListByUserIDPreloadApp(userID, sort string) ([]*model.AccessToken, error) {


### PR DESCRIPTION
## Summary

#1555 (i/* part1 parity) のうち authorized-apps の 2 項目 (HIGH + MEDIUM)。

`/api/i/authorized-apps` は upstream では `appId IS NOT NULL` の access_token を limit/offset/sort 付きで引き、各 token を `appEntityService.pack(token.appId, me, {detail:true})` で **App entity** に変換して返す (authorized-apps.ts + AppEntityService.ts)。旧 mk-go 実装は access_token 自身の shape を返しており、本家 res schema と非互換だった。

## 主な変更点

- **[HIGH] レスポンス shape を App entity に修正**: 旧 `{id=token.id, name, description, iconUrl, permission, lastUsedAt, createdAt}` → 本家 `{id=app.id, name, callbackUrl, permission, isAuthorized}`。`id` が app.id になり、`callbackUrl` / `isAuthorized` を追加、token 専用 field を除去。`isAuthorized` は列挙元 token が `(appId, userId)` ペアの存在を保証するため常に `true` (upstream `countBy>0` と一致)。
- **[MEDIUM] limit/offset/sort + appId filter**: `limit` (default 10, 1..100) / `offset` (default 0) / `sort` (`'desc'`/`'asc'`, default `'desc'`) を bind。`appId IS NOT NULL` で raw token / miauth (appId NULL) を除外。
- repository に `ListAuthorizedApps(userID, limit, offset, sortAsc)` を追加し mock も追従。

## テスト

- `TestAuthorizedApps_ReturnsAppEntities`: App entity shape (id=app.id, callbackUrl, isAuthorized:true)、appId NULL token / 他人 token の除外、token 専用 field の非出力
- `TestAuthorizedApps_Pagination`: limit / offset / sort=asc / default desc
- entitycompat drift gates / `go vet` / 既存テスト全 pass

## 関連

#1555 (i/* part1) の 2 項目。残りの項目は別 PR で対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)