### PR TITLE
Fix i/gallery packer: files (DriveFile 解決) + isLiked (#1555 part2)

### DIFF
--- a/internal/api/i/gallery.go
+++ b/internal/api/i/gallery.go
@@ -79,6 +79,7 @@ func (h *Handler) GalleryLikes(c echo.Context) error {
 		postByID[p.ID] = p
 	}
 	out := make([]map[string]any, 0, len(likes))
+	liked := true // この経路の post は viewer が like 済 (= isLiked true)。
 	for _, l := range likes {
 		// upstream Misskey TS は post が削除済の like row を Promise.all
 		// + pack の null フィルタで弾く。frontend の MkGalleryPostPreview
@@ -89,15 +90,42 @@ func (h *Handler) GalleryLikes(c echo.Context) error {
 		}
 		out = append(out, map[string]any{
 			"id":   l.ID,
-			"post": packGalleryPost(p, h.idGen),
+			"post": packGalleryPost(p, h.idGen, h.resolveGalleryFiles(p.FileIDs), &liked),
 		})
 	}
 	return c.JSON(http.StatusOK, out)
 }
 
+// resolveGalleryFiles resolves a gallery post's fileIds into packed DriveFile
+// entities in fileIds order (upstream driveFileEntityService.packManyByIds)。
+// driveFileRepo 未配線 / fileIds 空 / lookup miss は空配列で degrade する。
+// gallery post / file は公開前提なので owner-scope filter はしない (upstream 同様)。
+func (h *Handler) resolveGalleryFiles(fileIDs []string) []any {
+	files := []any{}
+	if h.driveFileRepo == nil || len(fileIDs) == 0 {
+		return files
+	}
+	found, err := h.driveFileRepo.FindByIDs([]string(fileIDs))
+	if err != nil {
+		return files
+	}
+	byID := make(map[string]*model.DriveFile, len(found))
+	for _, f := range found {
+		byID[f.ID] = f
+	}
+	for _, fid := range fileIDs {
+		if f, ok := byID[fid]; ok {
+			files = append(files, entity.PackDriveFile(f, h.idGen))
+		}
+	}
+	return files
+}
+
 // packGalleryPost は upstream の GalleryPost shape (createdAt / user 含む)
-// に揃えてレスポンス用の map を返す。
-func packGalleryPost(p *model.GalleryPost, idGen id.Generator) map[string]any {
+// に揃えてレスポンス用の map を返す。files は呼び出し側が resolveGalleryFiles
+// で解決した DriveFile entity 群、isLiked は viewer の like 状態 (nil で省略、
+// upstream は me==null 時に undefined)。
+func packGalleryPost(p *model.GalleryPost, idGen id.Generator, files []any, isLiked *bool) map[string]any {
 	const tsFormat = "2006-01-02T15:04:05.000Z"
 	createdAt := ""
 	if idGen != nil {
@@ -115,6 +143,9 @@ func packGalleryPost(p *model.GalleryPost, idGen id.Generator) map[string]any {
 	if tags == nil {
 		tags = []string{}
 	}
+	if files == nil {
+		files = []any{}
+	}
 	resp := map[string]any{
 		"id":          p.ID,
 		"createdAt":   createdAt,
@@ -123,10 +154,13 @@ func packGalleryPost(p *model.GalleryPost, idGen id.Generator) map[string]any {
 		"description": p.Description,
 		"userId":      p.UserID,
 		"fileIds":     fileIDs,
-		"files":       []any{},
+		"files":       files,
 		"isSensitive": p.IsSensitive,
 		"likedCount":  p.LikedCount,
 		"tags":        tags,
+	}
+	if isLiked != nil {
+		resp["isLiked"] = *isLiked
 	}
 	if p.User != nil {
 		resp["user"] = entity.PackUserLite(p.User)
@@ -154,7 +188,13 @@ func (h *Handler) GalleryPosts(c echo.Context) error {
 		if p.User == nil {
 			p.User = u
 		}
-		out = append(out, packGalleryPost(p, h.idGen))
+		// isLiked は viewer が自分の post を like しているか (upstream
+		// galleryLikesRepository.exists)。list は小さい前提で per-post lookup。
+		liked := false
+		if ok, err := h.galleryRepo.ExistsLike(u.ID, p.ID); err == nil {
+			liked = ok
+		}
+		out = append(out, packGalleryPost(p, h.idGen, h.resolveGalleryFiles(p.FileIDs), &liked))
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/i/gallery_test.go
+++ b/internal/api/i/gallery_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,6 +29,14 @@ func (s *stubGalleryRepo) ListLikesByUser(_, _, _ string, _, _ int) ([]*model.Ga
 }
 func (s *stubGalleryRepo) FindPostsByIDs(_ []string) ([]*model.GalleryPost, error) {
 	return s.posts, s.err
+}
+func (s *stubGalleryRepo) ExistsLike(_, postID string) (bool, error) {
+	for _, l := range s.likes {
+		if l.PostID == postID {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func TestGalleryLikes(t *testing.T) {
@@ -55,7 +64,38 @@ func TestGalleryPosts_WithRepo(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	require.Len(t, got, 1)
 	assert.Equal(t, postID, got[0]["id"])
+	// 認証 viewer なので isLiked は present (like していないので false)。
+	assert.Equal(t, false, got[0]["isLiked"])
 	shapetest.Assert(t, "GalleryPost", got[0]) // L3 (#1322)
+}
+
+// #1555 i/gallery/posts は fileIds から DriveFile を解決し、自分が like 済の
+// post には isLiked=true を返す。
+func TestGalleryPosts_ResolvesFilesAndIsLiked(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	idGen, _ := id.NewGenerator("aidx")
+	postID := idGen.Generate(time.Now())
+	h.SetGalleryRepo(&stubGalleryRepo{
+		posts: []*model.GalleryPost{{ID: postID, Title: "t", UserID: stubUser.ID, FileIDs: []string{"f1"}}},
+		// stub.ExistsLike は likes に postID があれば true を返す。
+		likes: []*model.GalleryLike{{ID: "l1", PostID: postID, UserID: stubUser.ID}},
+	})
+	driveRepo := testutil.NewMockDriveFileRepository()
+	owner := stubUser.ID
+	driveRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &owner, Name: "a.png", Type: "image/png"}
+	h.SetDriveFileRepo(driveRepo)
+
+	rec := postExtra(h.GalleryPosts, `{}`, stubUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 1)
+	files, ok := got[0]["files"].([]any)
+	require.True(t, ok)
+	require.Len(t, files, 1)
+	assert.Equal(t, "f1", files[0].(map[string]any)["id"])
+	assert.Equal(t, true, got[0]["isLiked"])
+	shapetest.Assert(t, "GalleryPost", got[0])
 }
 
 func TestGalleryLikes_WithRepo(t *testing.T) {

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -459,6 +459,8 @@ type GalleryRepository interface {
 	ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.GalleryPost, error)
 	ListLikesByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.GalleryLike, error)
 	FindPostsByIDs(ids []string) ([]*model.GalleryPost, error)
+	// ExistsLike は GalleryPost.isLiked 解決用 (#1555)。
+	ExistsLike(userID, postID string) (bool, error)
 }
 
 // SetAccessTokenRepo wires the access_token repo for i/authorized-apps and

--- a/internal/api/users/content_lists.go
+++ b/internal/api/users/content_lists.go
@@ -181,6 +181,8 @@ func (h *Handler) GalleryPosts(c echo.Context) error {
 	// galleryRepo.ListByUser が Preload("User") を行うので g.User を読んで
 	// user (UserLite) を embed できる。i/gallery/posts と同 shape。
 	const tsFormat = "2006-01-02T15:04:05.000Z"
+	// 認証 viewer がいれば isLiked を解決する (upstream は me==null で undefined)。
+	viewer := middleware.GetUser(c)
 	out := make([]map[string]any, 0, len(rows))
 	for _, g := range rows {
 		createdAt := ""
@@ -198,7 +200,15 @@ func (h *Handler) GalleryPosts(c echo.Context) error {
 			"tags":        []string(g.Tags),
 			"isSensitive": g.IsSensitive,
 			"likedCount":  g.LikedCount,
-			"files":       []any{},
+			// fileIds から DriveFile を解決する (#1555、i/gallery/posts と同じ)。
+			"files": h.resolveGalleryFiles(g.FileIDs),
+		}
+		if viewer != nil {
+			liked := false
+			if ok, err := h.galleryRepo.ExistsLike(viewer.ID, g.ID); err == nil {
+				liked = ok
+			}
+			entry["isLiked"] = liked
 		}
 		if g.User != nil {
 			entry["user"] = entity.PackUserLite(g.User)
@@ -206,6 +216,30 @@ func (h *Handler) GalleryPosts(c echo.Context) error {
 		out = append(out, entry)
 	}
 	return c.JSON(http.StatusOK, out)
+}
+
+// resolveGalleryFiles resolves gallery fileIds into packed DriveFile entities
+// in fileIds order (upstream driveFileEntityService.packManyByIds)。
+// driveFileRepo 未配線 / 空 / miss は空配列で degrade。
+func (h *Handler) resolveGalleryFiles(fileIDs []string) []any {
+	files := []any{}
+	if h.driveFileRepo == nil || len(fileIDs) == 0 {
+		return files
+	}
+	found, err := h.driveFileRepo.FindByIDs(fileIDs)
+	if err != nil {
+		return files
+	}
+	byID := make(map[string]*model.DriveFile, len(found))
+	for _, f := range found {
+		byID[f.ID] = f
+	}
+	for _, fid := range fileIDs {
+		if f, ok := byID[fid]; ok {
+			files = append(files, entity.PackDriveFile(f, h.idGen))
+		}
+	}
+	return files
 }
 
 // Pages handles POST /api/users/pages.

--- a/internal/api/users/content_lists_test.go
+++ b/internal/api/users/content_lists_test.go
@@ -31,6 +31,9 @@ func (s *stubGalleryRepo) ListLikesByUser(_, _, _ string, _, _ int) ([]*model.Ga
 func (s *stubGalleryRepo) FindPostsByIDs(_ []string) ([]*model.GalleryPost, error) {
 	return nil, nil
 }
+func (s *stubGalleryRepo) ExistsLike(_, _ string) (bool, error) {
+	return false, nil
+}
 
 // --- Clips ---
 
@@ -164,6 +167,31 @@ func TestGalleryPosts_ReturnsAll(t *testing.T) {
 	var rows []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
 	assert.Len(t, rows, 2)
+}
+
+// #1555 users/gallery/posts も fileIds から DriveFile を解決する
+// (i/gallery/posts と同じ)。未認証 viewer なので isLiked は省略される。
+func TestGalleryPosts_ResolvesFiles(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.SetGalleryRepo(&stubGalleryRepo{posts: []*model.GalleryPost{
+		{ID: "g1", UserID: "owner", Title: "t1", FileIDs: []string{"f1"}},
+	}})
+	driveRepo := testutil.NewMockDriveFileRepository()
+	owner := "owner"
+	driveRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &owner, Name: "a.png", Type: "image/png"}
+	h.SetDriveFileRepo(driveRepo)
+
+	rec := postStub(h.GalleryPosts, `{"userId":"owner"}`, nil)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	files, ok := rows[0]["files"].([]any)
+	require.True(t, ok)
+	require.Len(t, files, 1)
+	assert.Equal(t, "f1", files[0].(map[string]any)["id"])
+	// 未認証 viewer なので isLiked は出ない。
+	_, hasLiked := rows[0]["isLiked"]
+	assert.False(t, hasLiked)
 }
 
 // --- Pages ---

--- a/internal/repository/gallery.go
+++ b/internal/repository/gallery.go
@@ -17,6 +17,9 @@ type GalleryRepository interface {
 	// FindPostsByIDs returns the posts whose id is in ids. Used by
 	// i/gallery/likes to embed the full GalleryPost in each like row.
 	FindPostsByIDs(ids []string) ([]*model.GalleryPost, error)
+	// ExistsLike reports whether userID has liked postID. GalleryPost.isLiked
+	// 用 (upstream galleryLikesRepository.exists({postId, userId}))。
+	ExistsLike(userID, postID string) (bool, error)
 }
 
 type galleryRepository struct {
@@ -60,6 +63,16 @@ func (r *galleryRepository) ListByUser(userID, sinceID, untilID string, limit, o
 		return nil, err
 	}
 	return posts, nil
+}
+
+func (r *galleryRepository) ExistsLike(userID, postID string) (bool, error) {
+	var count int64
+	if err := r.db.Model(&model.GalleryLike{}).
+		Where(`"userId" = ? AND "postId" = ?`, userID, postID).
+		Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }
 
 func (r *galleryRepository) FindPostsByIDs(ids []string) ([]*model.GalleryPost, error) {

--- a/internal/repository/gallery_test.go
+++ b/internal/repository/gallery_test.go
@@ -72,3 +72,47 @@ func TestGalleryRepository_EmptyList(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, likes)
 }
+
+func TestGalleryRepository_ExistsLike(t *testing.T) {
+	repo := NewGalleryRepository(testDB)
+	seedUser(t, "gex_u1")
+	require.NoError(t, testDB.Create(&model.GalleryPost{ID: "gex_p1", UserID: "gex_u1", Title: "t", UpdatedAt: time.Now()}).Error)
+	t.Cleanup(func() {
+		testDB.Exec(`DELETE FROM "gallery_like" WHERE "userId" = ?`, "gex_u1")
+		testDB.Exec(`DELETE FROM "gallery_post" WHERE id = ?`, "gex_p1")
+	})
+
+	// like 未作成 → false
+	ok, err := repo.ExistsLike("gex_u1", "gex_p1")
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	require.NoError(t, testDB.Create(&model.GalleryLike{ID: "gex_l1", UserID: "gex_u1", PostID: "gex_p1"}).Error)
+
+	// like 済 → true
+	ok, err = repo.ExistsLike("gex_u1", "gex_p1")
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	// 別 user / 別 post は false
+	ok, err = repo.ExistsLike("gex_other", "gex_p1")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestGalleryRepository_FindPostsByIDs(t *testing.T) {
+	repo := NewGalleryRepository(testDB)
+	seedUser(t, "gf_u1")
+	require.NoError(t, testDB.Create(&model.GalleryPost{ID: "gf_p1", UserID: "gf_u1", Title: "t1", UpdatedAt: time.Now()}).Error)
+	require.NoError(t, testDB.Create(&model.GalleryPost{ID: "gf_p2", UserID: "gf_u1", Title: "t2", UpdatedAt: time.Now()}).Error)
+	t.Cleanup(func() { testDB.Exec(`DELETE FROM "gallery_post" WHERE "userId" = ?`, "gf_u1") })
+
+	// 空 ids は nil を返す (早期 return)。
+	posts, err := repo.FindPostsByIDs(nil)
+	require.NoError(t, err)
+	assert.Empty(t, posts)
+
+	posts, err = repo.FindPostsByIDs([]string{"gf_p1", "gf_p2", "gf_missing"})
+	require.NoError(t, err)
+	assert.Len(t, posts, 2)
+}


### PR DESCRIPTION
## Summary

#1555 (i/* part1 parity) のうち GalleryPost packer の 2 項目 (MEDIUM×2)。

upstream `GalleryPostEntityService.pack` は `files = driveFileEntityService.packManyByIds(post.fileIds)`、`isLiked = galleryLikesRepository.exists({postId, userId: meId})` (me!=null 時) を返すが、mk-go の `packGalleryPost` は `files:[]` 固定 + `isLiked` 欠落だった。

## 主な変更点

- **[MEDIUM] files の DriveFile 解決**: `resolveGalleryFiles` で `fileIds` を fileIds 順に DriveFile entity へ解決する (upstream `packManyByIds` 同様、owner-scope なし: gallery post / file は公開前提)。`driveFileRepo` 未配線 / lookup miss は空配列で degrade。
- **[MEDIUM] isLiked**: `i/gallery/likes` は post が viewer の like list 由来なので `isLiked=true` 固定 (冗長な per-row query を回避)。`i/gallery/posts` は `GalleryRepository.ExistsLike(userID, postID)` で per-post 解決。両 endpoint は認証必須なので常に present。
- **users/gallery/posts** も同じ files 解決 + isLiked (viewer present 時) を追加 (同 shape の page-list analog。users.Handler は driveFileRepo / galleryRepo 配線済)。upstream は `me==null` で isLiked を omit するので、未認証 viewer では省略。

## テスト

- `i/gallery/posts`: files 解決 + isLiked=true (like 済) / false (未like)、L3 `shapetest.Assert("GalleryPost")`
- `users/gallery/posts`: files 解決 + 未認証 viewer で isLiked 省略
- `repository`: `ExistsLike` (like 有無 / 別user・別post) + `FindPostsByIDs` の real-DB テストを追加 (パッケージ coverage 90.2%→90.4%)
- `go vet ./...` / entitycompat drift gates / 全テスト pass

## 関連

#1555 (i/* part1) の 2 項目。

🤖 Generated with [Claude Code](https://claude.com/claude-code)