### PR TITLE
Fix i/import-*: 同期 file 検証 (EMPTY/TOO_BIG) + import-following withReplies (#1555 part3)

### DIFF
--- a/internal/api/i/transfer_handler.go
+++ b/internal/api/i/transfer_handler.go
@@ -69,13 +69,56 @@ func importNoSuchFileID(importType string) string {
 	}
 }
 
+// importMaxFileSize is upstream の通常 import file 上限 (64KB)。account-move 中
+// (movedAt が直近 2h 以内) は 32MB まで緩和されるが、mk-go は import-* に
+// prohibitMoved gate を効かせる方針 (#1555) かつ move-in 経路は未実装のため、
+// 共通の 64KB で扱う。これより大きい file は上流が move 中だけ許可する稀な
+// ケースなので、保守的に弾く (= 上流が許可するものを誤って通すことはない)。
+const importMaxFileSize = 64 * 1024
+
+// importEmptyFileID maps an import type to upstream's per-endpoint emptyFile
+// error UUID (#1555)。
+func importEmptyFileID(importType string) string {
+	switch importType {
+	case transfer.ImportBlocking:
+		return "6f3a4dcc-f060-a707-4950-806fbdbe60d6"
+	case transfer.ImportMuting:
+		return "d2f12af1-e7b4-feac-86a3-519548f2728e"
+	case transfer.ImportUserLists:
+		return "99efe367-ce6e-4d44-93f8-5fae7b040356"
+	case transfer.ImportAntennas:
+		return "7f60115d-8d93-4b0f-bd0e-3815dcbb389f"
+	default: // ImportFollowing
+		return "31a1b42c-06f7-42ae-8a38-a661c5c9f691"
+	}
+}
+
+// importTooBigFileID maps an import type to upstream's per-endpoint tooBigFile
+// error UUID。import-antennas は upstream に tooBigFile check が無いため ""
+// (= size 上限 check を skip)。
+func importTooBigFileID(importType string) string {
+	switch importType {
+	case transfer.ImportBlocking:
+		return "b7fbf0b1-aeef-3b21-29ef-fadd4cb72ccf"
+	case transfer.ImportMuting:
+		return "9b4ada6d-d7f7-0472-0713-4f558bd1ec9c"
+	case transfer.ImportUserLists:
+		return "ae6e7a22-971b-4b52-b2be-fc0b9b121fe9"
+	case transfer.ImportAntennas:
+		return "" // upstream import-antennas は tooBigFile を持たない
+	default: // ImportFollowing
+		return "dee9d4ed-ad07-43ed-8b34-b2856398bc60"
+	}
+}
+
 // importHandler enqueues an import job using a DriveFile uploaded by the
 // user. フロントは fileId を渡してくる。本家互換。
 func (h *Handler) importHandler(importType string) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		u := middleware.GetUser(c)
 		var req struct {
-			FileID string `json:"fileId"`
+			FileID      string `json:"fileId"`
+			WithReplies *bool  `json:"withReplies"`
 		}
 		if err := c.Bind(&req); err != nil || req.FileID == "" {
 			return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "fileId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
@@ -93,13 +136,30 @@ func (h *Handler) importHandler(importType string) echo.HandlerFunc {
 		if err != nil || file == nil || file.UserID == nil || *file.UserID != u.ID {
 			return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_FILE", "No such file.", importNoSuchFileID(importType)))
 		}
+		// 同期 file 検証 (upstream は handler 内で実施)。空 file は EMPTY_FILE、
+		// 上限超過は TOO_BIG_FILE (import-antennas は upstream に tooBigFile が
+		// 無いので skip)。enqueue 前に弾くことで無駄な job 投入を避ける (#1555)。
+		if file.Size == 0 {
+			return c.JSON(http.StatusBadRequest, apierr.Error("EMPTY_FILE", "That file is empty.", importEmptyFileID(importType)))
+		}
+		if tooBigID := importTooBigFileID(importType); tooBigID != "" && file.Size > importMaxFileSize {
+			return c.JSON(http.StatusBadRequest, apierr.Error("TOO_BIG_FILE", "That file is too big.", tooBigID))
+		}
 		if h.transferEnqueuer == nil {
 			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Transfer queue not configured.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 		}
+		// withReplies は import-following のみが使う job-level fallback (CSV row が
+		// per-line withReplies を省略したときの default、upstream
+		// `withReplies ?? job.data.withReplies`)。他 type では Importer 側で無視。
+		withReplies := false
+		if req.WithReplies != nil {
+			withReplies = *req.WithReplies
+		}
 		if err := h.transferEnqueuer.EnqueueImport(queue.ImportPayload{
-			UserID: u.ID,
-			Type:   importType,
-			FileID: req.FileID,
+			UserID:      u.ID,
+			Type:        importType,
+			FileID:      req.FileID,
+			WithReplies: withReplies,
 		}); err != nil {
 			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Failed to enqueue import.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 		}

--- a/internal/api/i/transfer_handler_test.go
+++ b/internal/api/i/transfer_handler_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // stubTransferEnqueuer records calls and optionally returns an error.
@@ -57,7 +58,8 @@ func newTransferHandlerWithDrive() (*Handler, *stubTransferEnqueuer, *testutil.M
 	h.SetTransferEnqueuer(enq)
 	driveRepo := testutil.NewMockDriveFileRepository()
 	uid := ownerID
-	driveRepo.Files[ownedFileID] = &model.DriveFile{ID: ownedFileID, UserID: &uid}
+	// Size > 0 でないと EMPTY_FILE で弾かれる (#1555)。happy path 用に非空にする。
+	driveRepo.Files[ownedFileID] = &model.DriveFile{ID: ownedFileID, UserID: &uid, Size: 16}
 	h.SetDriveFileRepo(driveRepo)
 	return h, enq, driveRepo
 }
@@ -160,7 +162,7 @@ func TestImport_NoEnqueuer(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	driveRepo := testutil.NewMockDriveFileRepository()
 	uid := ownerID
-	driveRepo.Files[ownedFileID] = &model.DriveFile{ID: ownedFileID, UserID: &uid}
+	driveRepo.Files[ownedFileID] = &model.DriveFile{ID: ownedFileID, UserID: &uid, Size: 16}
 	h.SetDriveFileRepo(driveRepo)
 	rec := post(h.ImportFollowing, `{"fileId":"f1"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
@@ -251,4 +253,73 @@ func TestImport_OwnedFileAccepted(t *testing.T) {
 	assert.Len(t, enq.importCalls, 1)
 	assert.Equal(t, ownedFileID, enq.importCalls[0].FileID)
 	assert.Equal(t, ownerID, enq.importCalls[0].UserID)
+}
+
+// 空 file (size==0) は EMPTY_FILE で弾かれ、enqueue されない (#1555)。
+// 全 import endpoint で per-endpoint UUID を確認する。
+func TestImport_EmptyFileRejected(t *testing.T) {
+	for name, makeFn := range map[string]func(*Handler) func(c echo.Context) error{
+		"following":  func(h *Handler) func(c echo.Context) error { return h.ImportFollowing },
+		"blocking":   func(h *Handler) func(c echo.Context) error { return h.ImportBlocking },
+		"muting":     func(h *Handler) func(c echo.Context) error { return h.ImportMuting },
+		"user-lists": func(h *Handler) func(c echo.Context) error { return h.ImportUserLists },
+		"antennas":   func(h *Handler) func(c echo.Context) error { return h.ImportAntennas },
+	} {
+		t.Run(name, func(t *testing.T) {
+			h, enq, driveRepo := newTransferHandlerWithDrive()
+			uid := ownerID
+			driveRepo.Files["empty"] = &model.DriveFile{ID: "empty", UserID: &uid, Size: 0}
+			rec := post(makeFn(h), `{"fileId":"empty"}`, &model.User{ID: ownerID})
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			assert.Contains(t, rec.Body.String(), "EMPTY_FILE")
+			wantID := map[string]string{
+				"following":  "31a1b42c-06f7-42ae-8a38-a661c5c9f691",
+				"blocking":   "6f3a4dcc-f060-a707-4950-806fbdbe60d6",
+				"muting":     "d2f12af1-e7b4-feac-86a3-519548f2728e",
+				"user-lists": "99efe367-ce6e-4d44-93f8-5fae7b040356",
+				"antennas":   "7f60115d-8d93-4b0f-bd0e-3815dcbb389f",
+			}[name]
+			assert.Contains(t, rec.Body.String(), wantID)
+			assert.Empty(t, enq.importCalls)
+		})
+	}
+}
+
+// 64KB 超の file は TOO_BIG_FILE で弾かれる (import-antennas を除く)。
+func TestImport_TooBigFileRejected(t *testing.T) {
+	for name, makeFn := range map[string]func(*Handler) func(c echo.Context) error{
+		"following":  func(h *Handler) func(c echo.Context) error { return h.ImportFollowing },
+		"blocking":   func(h *Handler) func(c echo.Context) error { return h.ImportBlocking },
+		"muting":     func(h *Handler) func(c echo.Context) error { return h.ImportMuting },
+		"user-lists": func(h *Handler) func(c echo.Context) error { return h.ImportUserLists },
+	} {
+		t.Run(name, func(t *testing.T) {
+			h, enq, driveRepo := newTransferHandlerWithDrive()
+			uid := ownerID
+			driveRepo.Files["big"] = &model.DriveFile{ID: "big", UserID: &uid, Size: 64*1024 + 1}
+			rec := post(makeFn(h), `{"fileId":"big"}`, &model.User{ID: ownerID})
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			assert.Contains(t, rec.Body.String(), "TOO_BIG_FILE")
+			assert.Empty(t, enq.importCalls)
+		})
+	}
+}
+
+// import-antennas は upstream に tooBigFile が無いので 64KB 超でも通る。
+func TestImport_Antennas_NoTooBigCheck(t *testing.T) {
+	h, enq, driveRepo := newTransferHandlerWithDrive()
+	uid := ownerID
+	driveRepo.Files["big"] = &model.DriveFile{ID: "big", UserID: &uid, Size: 64*1024 + 1}
+	rec := post(h.ImportAntennas, `{"fileId":"big"}`, &model.User{ID: ownerID})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Len(t, enq.importCalls, 1)
+}
+
+// import-following の job-level withReplies が ImportPayload に伝わる (#1555)。
+func TestImport_Following_JobWithReplies(t *testing.T) {
+	h, enq, _ := newTransferHandlerWithDrive()
+	rec := post(h.ImportFollowing, `{"fileId":"f1","withReplies":true}`, &model.User{ID: ownerID})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	require.Len(t, enq.importCalls, 1)
+	assert.True(t, enq.importCalls[0].WithReplies)
 }

--- a/internal/core/transfer/import_csv.go
+++ b/internal/core/transfer/import_csv.go
@@ -27,14 +27,19 @@ import (
 // Applied/Skipped 集計が per-pair 非同期化では「enqueue 数」しか数えられず
 // 不正確になるため (#1563 review)。queue surface (TaskTypeFollow /
 // EnqueueFollowBulk) は用意済みなので、集計を再設計する場合はそちらへ移行する。
-func (i *Importer) importFollowing(user *model.User, body []byte) (*ImportResult, error) {
+func (i *Importer) importFollowing(user *model.User, body []byte, jobWithReplies bool) (*ImportResult, error) {
 	if i.deps.Following == nil {
 		return nil, fmt.Errorf("following service not configured")
 	}
 	lines := scanCSV(body)
 	res := &ImportResult{Total: len(lines)}
 	for _, line := range lines {
-		acctStr, opts := parseFollowingCSVLine(line)
+		acctStr, opts, withRepliesSet := parseFollowingCSVLine(line)
+		// CSV row が withReplies を省略していたら job-level の値を fallback に
+		// 使う (upstream `withReplies ?? job.data.withReplies`)。
+		if !withRepliesSet {
+			opts.WithReplies = jobWithReplies
+		}
 		target, err := i.resolveTargetUser(acctStr)
 		if err != nil || target == nil {
 			res.Skipped++
@@ -56,14 +61,18 @@ func (i *Importer) importFollowing(user *model.User, body []byte) (*ImportResult
 }
 
 // parseFollowingCSVLine splits a CSV row into its acct field and any optional
-// `key=value` fields, returning the acct and a populated FollowOptions.
+// `key=value` fields, returning the acct, a populated FollowOptions, and
+// whether the row carried an explicit `withReplies` field. The presence flag
+// lets the caller fall back to the job-level withReplies when the row omits it
+// (upstream `line[1] ? line[1] === 'true' : job.data.withReplies`)。
 //
 // 不正な field (= `=` を含まない trailing fragment や未知の key) は silently
 // skip する (= upstream の `switch (key)` で default なしの挙動と一致)。
-func parseFollowingCSVLine(line string) (string, FollowOptions) {
+func parseFollowingCSVLine(line string) (string, FollowOptions, bool) {
 	parts := strings.Split(line, ",")
 	acct := strings.TrimSpace(parts[0])
 	var opts FollowOptions
+	withRepliesSet := false
 	for _, kv := range parts[1:] {
 		k, v, ok := strings.Cut(strings.TrimSpace(kv), "=")
 		if !ok {
@@ -74,9 +83,10 @@ func parseFollowingCSVLine(line string) (string, FollowOptions) {
 			// upstream Misskey TS の `value === 'true'` と同 semantics: 文字列
 			// "true" 以外は (空文字 / "false" / "invalid" 等) すべて false。
 			opts.WithReplies = v == "true"
+			withRepliesSet = true
 		}
 	}
-	return acct, opts
+	return acct, opts, withRepliesSet
 }
 
 // importBlocking parses `acct` lines and applies a block per entry.

--- a/internal/core/transfer/import_csv_internal_test.go
+++ b/internal/core/transfer/import_csv_internal_test.go
@@ -18,38 +18,46 @@ func TestParseFollowingCSVLine(t *testing.T) {
 		line    string
 		acct    string
 		options FollowOptions
+		// set は withReplies field が row に明示されていたか (job-level fallback
+		// 判定用)。
+		set bool
 	}{
 		{
 			name:    "acct only",
 			line:    "@bob@host.example",
 			acct:    "@bob@host.example",
 			options: FollowOptions{WithReplies: false},
+			set:     false,
 		},
 		{
 			name:    "withReplies=true",
 			line:    "@bob@host.example,withReplies=true",
 			acct:    "@bob@host.example",
 			options: FollowOptions{WithReplies: true},
+			set:     true,
 		},
 		{
 			name:    "withReplies=false",
 			line:    "@bob@host.example,withReplies=false",
 			acct:    "@bob@host.example",
 			options: FollowOptions{WithReplies: false},
+			set:     true,
 		},
 		{
 			name: "withReplies=invalid falls back to false",
 			// loose parsing: "true" 以外はすべて false (upstream の
-			// `value === 'true'` と同 semantics)。
+			// `value === 'true'` と同 semantics)。key は present 扱い。
 			line:    "@bob@host.example,withReplies=yes",
 			acct:    "@bob@host.example",
 			options: FollowOptions{WithReplies: false},
+			set:     true,
 		},
 		{
 			name:    "unknown key is silently ignored",
 			line:    "@bob@host.example,silent=true",
 			acct:    "@bob@host.example",
 			options: FollowOptions{WithReplies: false},
+			set:     false,
 		},
 		{
 			name: "malformed key=value fragment (no =) silently skipped",
@@ -58,21 +66,24 @@ func TestParseFollowingCSVLine(t *testing.T) {
 			line:    "@bob@host.example,bareToken,withReplies=true",
 			acct:    "@bob@host.example",
 			options: FollowOptions{WithReplies: true},
+			set:     true,
 		},
 		{
 			name:    "leading/trailing spaces stripped",
 			line:    "  @bob@host.example  ,  withReplies=true  ",
 			acct:    "@bob@host.example",
 			options: FollowOptions{WithReplies: true},
+			set:     true,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			acct, opts := parseFollowingCSVLine(tc.line)
+			acct, opts, set := parseFollowingCSVLine(tc.line)
 			assert.Equal(t, tc.acct, acct)
 			assert.Equal(t, tc.options, opts)
+			assert.Equal(t, tc.set, set)
 		})
 	}
 }

--- a/internal/core/transfer/import_test.go
+++ b/internal/core/transfer/import_test.go
@@ -184,6 +184,31 @@ func TestImport_Following_DefaultsWithRepliesFalseWhenOmitted(t *testing.T) {
 	assert.False(t, fs.lastOpts.WithReplies, "missing withReplies field should default to false")
 }
 
+// #1555: CSV row が withReplies を省略したとき、job-level の値が fallback
+// として使われる (upstream `withReplies ?? job.data.withReplies`)。
+func TestImport_Following_JobWithRepliesFallback(t *testing.T) {
+	deps, user, fs, _, _, _ := newImporterDeps(t, []byte("bob\n"))
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportFollowing, "fid",
+		transfer.WithFollowReplies(true))
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Applied)
+	require.Len(t, fs.calls, 1)
+	assert.True(t, fs.lastOpts.WithReplies, "omitted per-line withReplies should fall back to job-level true")
+}
+
+// #1555: per-line の withReplies が明示されていれば job-level より優先される。
+func TestImport_Following_PerLineOverridesJob(t *testing.T) {
+	deps, user, fs, _, _, _ := newImporterDeps(t, []byte("bob,withReplies=false\n"))
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportFollowing, "fid",
+		transfer.WithFollowReplies(true))
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Applied)
+	require.Len(t, fs.calls, 1)
+	assert.False(t, fs.lastOpts.WithReplies, "explicit per-line withReplies=false must override job-level true")
+}
+
 func TestImport_Following_SkipsUnknown(t *testing.T) {
 	deps, user, fs, _, _, _ := newImporterDeps(t, []byte("ghost\nbob\n"))
 	imp := transfer.NewImporter(deps)

--- a/internal/core/transfer/importer.go
+++ b/internal/core/transfer/importer.go
@@ -76,10 +76,31 @@ type ImportResult struct {
 	Skipped int
 }
 
+// importConfig carries per-call options threaded through Import via functional
+// options. Currently only the import-following job-level withReplies fallback.
+type importConfig struct {
+	withReplies bool
+}
+
+// ImportOption configures a single Import call (functional-options pattern so
+// existing callers need no signature change)。
+type ImportOption func(*importConfig)
+
+// WithFollowReplies sets the import-following job-level withReplies fallback
+// used when a CSV row omits its per-line withReplies field (upstream
+// `withReplies ?? job.data.withReplies`)。他 import type では無視される。
+func WithFollowReplies(v bool) ImportOption {
+	return func(c *importConfig) { c.withReplies = v }
+}
+
 // Import reads the DriveFile referenced by fileID and dispatches the content
 // to the handler matching importType. Errors per-item are logged and counted
 // as Skipped so that a single malformed entry does not abort the batch.
-func (i *Importer) Import(ctx context.Context, userID, importType, fileID string) (*ImportResult, error) {
+func (i *Importer) Import(ctx context.Context, userID, importType, fileID string, opts ...ImportOption) (*ImportResult, error) {
+	var cfg importConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
 	user, err := i.deps.UserRepo.FindByID(userID)
 	if err != nil {
 		return nil, fmt.Errorf("find user: %w", err)
@@ -95,7 +116,7 @@ func (i *Importer) Import(ctx context.Context, userID, importType, fileID string
 	var result *ImportResult
 	switch importType {
 	case ImportFollowing:
-		result, err = i.importFollowing(user, body)
+		result, err = i.importFollowing(user, body, cfg.withReplies)
 	case ImportBlocking:
 		result, err = i.importBlocking(user, body)
 	case ImportMuting:

--- a/internal/queue/processors/transfer.go
+++ b/internal/queue/processors/transfer.go
@@ -64,7 +64,7 @@ func (p *ImportProcessor) Handle(ctx context.Context, t driver.Task) error {
 	if payload.UserID == "" || payload.Type == "" || payload.FileID == "" {
 		return fmt.Errorf("import payload missing fields: %w", driver.SkipRetry)
 	}
-	if _, err := p.importer.Import(ctx, payload.UserID, payload.Type, payload.FileID); err != nil {
+	if _, err := p.importer.Import(ctx, payload.UserID, payload.Type, payload.FileID, transfer.WithFollowReplies(payload.WithReplies)); err != nil {
 		if errors.Is(err, transfer.ErrUnsupportedType) {
 			return fmt.Errorf("%w: %w", err, driver.SkipRetry)
 		}

--- a/internal/queue/tasks.go
+++ b/internal/queue/tasks.go
@@ -200,6 +200,10 @@ type ImportPayload struct {
 	UserID string `json:"userId"`
 	Type   string `json:"type"` // following, blocking, muting, user-lists, antennas
 	FileID string `json:"fileId"`
+	// WithReplies は import-following の job-level fallback。CSV row が per-line
+	// withReplies を省略したときの default に使う (upstream
+	// `withReplies ?? job.data.withReplies`)。他 type では無視される。
+	WithReplies bool `json:"withReplies,omitempty"`
 }
 
 // NewImportTask creates a driver.Task for data import.


### PR DESCRIPTION
## Summary

#1555 (i/* part1 parity) のうち import 系の 3 項目 (HIGH partial + MEDIUM×2)。

upstream の各 import endpoint は handler 内で同期的に drive file を検証する (EMPTY_FILE / TOO_BIG_FILE) が、mk-go は ownership 検証 (#1555 で実装済) のみで enqueue していた。また import-following の job-level `withReplies` param が無視されていた。

## 主な変更点

- **[HIGH partial] 同期 file size 検証**: importHandler の ownership check 後に `EMPTY_FILE` (size==0) / `TOO_BIG_FILE` (size>64KB) を per-endpoint UUID で検証 (following/blocking/muting/user-lists)。`import-antennas` は upstream に `tooBigFile` が無いので size 上限 check を skip (EMPTY_FILE は持つ)。UUID は upstream import-*.ts および `golden_error_ids.json` と完全一致。
- **32MB 緩和の扱い**: upstream は account-move 中 (movedAt 2h 以内) のみ 32MB に緩和するが、mk-go は import-* に prohibitMoved gate を効かせる方針 + move-in 経路未実装のため一律 64KB。stricter 方向なので上流が許可するものを誤って通すことはない。
- **[MEDIUM] import-following の job-level withReplies**: `withReplies` param を bind → `ImportPayload.WithReplies`。Importer に variadic `ImportOption` (`WithFollowReplies`) を追加。CSV row が per-line `withReplies` を省略したときの fallback として使う (upstream `withReplies ?? job.data.withReplies`)。per-line 明示時はそちらが優先。

## scope 外 (別 issue #1667)

import-antennas の `TOO_MANY_ANTENNAS` / `NO_SUCH_USER` は handler 同期での file download+parse + roleService 配線が要るため #1667 に切り出した。

## テスト

- `transfer_handler_test`: 全 endpoint の EMPTY_FILE (per-endpoint UUID)、following/blocking/muting/user-lists の TOO_BIG_FILE、antennas は 64KB 超でも通る、import-following の job-level withReplies 伝播
- `core/transfer`: job-level withReplies fallback / per-line override、parseFollowingCSVLine の present 判定
- 既存 import test の happy-path mock を `Size: 16` に修正 (EMPTY 化回避)
- entitycompat drift gates / `go vet ./...` / 全テスト pass

## 関連

#1555 (i/* part1) の 3 項目。`TOO_MANY_ANTENNAS`/`NO_SUCH_USER` は #1667 へ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)