### PR TITLE
Fix i/2fa parity: issuer / TOTP window / meUpdated / update-key (#1555 part5)

### DIFF
--- a/internal/api/i/handler_2fa.go
+++ b/internal/api/i/handler_2fa.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
@@ -61,7 +62,10 @@ func (h *Handler) TwoFARegister(c echo.Context) error {
 		return c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "78d6c839-20c9-4c66-b90a-fc0542168b48"))
 	}
 
-	secret, uri, err := twofactor.GenerateSecret("Misskey", user.Username)
+	// issuer は upstream (register.ts) が config.host (instance hostname) を使う。
+	// authenticator アプリのラベルとレスポンスの issuer field を一致させる (#1555)。
+	issuer := h.twoFAIssuer()
+	secret, uri, err := twofactor.GenerateSecret(issuer, user.Username)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
@@ -81,8 +85,20 @@ func (h *Handler) TwoFARegister(c echo.Context) error {
 		"url":    uri,
 		"secret": secret,
 		"label":  user.Username,
-		"issuer": "Misskey",
+		"issuer": issuer,
 	})
+}
+
+// twoFAIssuer returns the TOTP issuer (instance hostname) derived from the
+// configured server URL, matching upstream's config.host (register.ts)。
+// serverURL 未配線 / parse 失敗時は "Misskey" にフォールバックする。
+func (h *Handler) twoFAIssuer() string {
+	if h.serverURL != "" {
+		if u, err := url.Parse(h.serverURL); err == nil && u.Host != "" {
+			return u.Host
+		}
+	}
+	return "Misskey"
 }
 
 // TwoFADone handles POST /api/i/2fa/done.
@@ -105,9 +121,10 @@ func (h *Handler) TwoFADone(c echo.Context) error {
 	// ValidateWithReplay は同一コードの replay を refuse する (RFC 6238 §5.2)。
 	// temp secret は確認後すぐ permanent secret に昇格されるため strictly
 	// 必要ではないが、3 経路で挙動を揃える方が監査・テスト時の予測可能性が
-	// 高い。副作用: TwoFADone 成功直後 (~30s 以内) に同じ code で signin を
-	// 試みると replay として 403 になる (permanent secret に同 value で昇格
-	// するため Redis slot に hit する)。次の TOTP step に進めば解消する。
+	// 高い。副作用: TwoFADone 成功直後 (replay guard TTL = TOTP acceptance
+	// window 内) に同じ code で signin を試みると replay として 403 になる
+	// (permanent secret に同 value で昇格するため Redis slot に hit する)。
+	// 次の TOTP step に進めば解消する。
 	if !twofactor.ValidateWithReplay(c.Request().Context(), h.totpReplayGuard, user.ID, req.Token, *profile.TwoFactorTempSecret) {
 		return c.JSON(http.StatusForbidden, apierr.InvalidToken())
 	}
@@ -126,6 +143,10 @@ func (h *Handler) TwoFADone(c echo.Context) error {
 		"twoFactorEnabled":      true,
 		"twoFactorBackupSecret": pq.StringArray(backupCodes),
 	})
+
+	// upstream (done.ts) は 2FA 有効化後に meUpdated を publish して UI を更新する
+	// (twoFactorEnabled の反映)。key 系 handler と挙動を揃える (#1555)。
+	h.publishMeUpdated(user.ID)
 
 	return c.JSON(http.StatusOK, map[string]any{
 		"backupCodes": backupCodes,
@@ -166,6 +187,9 @@ func (h *Handler) TwoFAUnregister(c echo.Context) error {
 		"twoFactorEnabled":      false,
 		"twoFactorBackupSecret": pq.StringArray(nil),
 	})
+
+	// upstream (unregister.ts) は 2FA 解除後に meUpdated を publish する (#1555)。
+	h.publishMeUpdated(user.ID)
 
 	return c.NoContent(http.StatusNoContent)
 }
@@ -463,6 +487,16 @@ func (h *Handler) TwoFAUpdateKey(c echo.Context) error {
 	user, _, ok := h.requireWebAuthn(c, req.Password, "932c904e-9460-45b7-9ce6-7ed33be7eb2c")
 	if !ok {
 		return nil
+	}
+	// upstream (update-key.ts) は key not-found (NO_SUCH_KEY) と not-owned
+	// (ACCESS_DENIED) を区別する。UpdateName は両者を ErrRecordNotFound に
+	// 畳むため、先に FindByID して所有権を判定する (#1555)。
+	key, err := h.securityKeyRepo.FindByID(req.CredentialID)
+	if err != nil || key == nil {
+		return c.JSON(http.StatusNotFound, apierr.NoSuchKey())
+	}
+	if key.UserID != user.ID {
+		return c.JSON(http.StatusForbidden, apierr.AccessDenied())
 	}
 	if err := h.securityKeyRepo.UpdateName(req.CredentialID, user.ID, req.Name); err != nil {
 		return c.JSON(http.StatusNotFound, apierr.NoSuchKey())

--- a/internal/api/i/handler_2fa_flow_test.go
+++ b/internal/api/i/handler_2fa_flow_test.go
@@ -41,6 +41,21 @@ func TestTwoFARegister_Success(t *testing.T) {
 	require.NotNil(t, profile.TwoFactorTempSecret)
 }
 
+// #1555 issuer は instance host (config.host) を使う (upstream register.ts)。
+// serverURL 配線時は host を返し、otpauth URL にも埋め込まれる。
+func TestTwoFARegister_IssuerFromHost(t *testing.T) {
+	h, repo := newExtraHandler(t)
+	h.SetServerURL("https://misskey.example")
+	user := setupUserWithPassword(repo, "u1", "pass")
+	rec := postExtra(h.TwoFARegister, `{"password":"pass"}`, user)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "misskey.example", resp["issuer"])
+	// otpauth URL の issuer param にも host が埋まる。
+	assert.Contains(t, resp["url"], "misskey.example")
+}
+
 func TestTwoFARegister_WrongPassword(t *testing.T) {
 	h, repo := newExtraHandler(t)
 	user := setupUserWithPassword(repo, "u1", "correct")
@@ -120,6 +135,50 @@ func TestTwoFADone_Success(t *testing.T) {
 	assert.Equal(t, secret, *profile.TwoFactorSecret)
 	assert.Nil(t, profile.TwoFactorTempSecret)
 	assert.Len(t, profile.TwoFactorBackupSecret, 5)
+}
+
+// #1555 TwoFADone は 2FA 有効化後に meUpdated を publish する (upstream done.ts)。
+func TestTwoFADone_PublishesMeUpdated(t *testing.T) {
+	h, repo := newExtraHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	pub := &stubIMainStreamPublisher{}
+	h.SetMainStreamPublisher(pub)
+
+	rec := postExtra(h.TwoFARegister, `{"password":"pass"}`, user)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	token, err := totp.GenerateCode(resp["secret"].(string), time.Now())
+	require.NoError(t, err)
+
+	rec2 := postExtra(h.TwoFADone, `{"token":"`+token+`"}`, user)
+	require.Equal(t, http.StatusOK, rec2.Code)
+	requireMeUpdated(t, pub, "u1")
+}
+
+// #1555 TwoFAUnregister は 2FA 解除後に meUpdated を publish する
+// (upstream unregister.ts)。
+func TestTwoFAUnregister_PublishesMeUpdated(t *testing.T) {
+	h, repo := newExtraHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	pub := &stubIMainStreamPublisher{}
+	h.SetMainStreamPublisher(pub)
+
+	rec := postExtra(h.TwoFAUnregister, `{"password":"pass"}`, user)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	requireMeUpdated(t, pub, "u1")
+}
+
+// requireMeUpdated asserts the publisher captured at least one meUpdated event
+// for userID。
+func requireMeUpdated(t *testing.T, pub *stubIMainStreamPublisher, userID string) {
+	t.Helper()
+	for _, c := range pub.calls {
+		if c.eventType == "meUpdated" && c.userID == userID {
+			return
+		}
+	}
+	t.Fatalf("expected a meUpdated event for %s, got %d events", userID, len(pub.calls))
 }
 
 func TestTwoFADone_NoTempSecret(t *testing.T) {

--- a/internal/api/i/handler_webauthn_test.go
+++ b/internal/api/i/handler_webauthn_test.go
@@ -420,6 +420,23 @@ func TestTwoFAUpdateKey_Success(t *testing.T) {
 	assert.Equal(t, "renamed", skRepo.keys["key1"].Name)
 }
 
+// #1555 他人所有の key を更新しようとすると ACCESS_DENIED (NO_SUCH_KEY ではない)。
+// upstream update-key.ts は key==null を noSuchKey、key.userId!==me.id を
+// accessDenied で区別する。
+func TestTwoFAUpdateKey_AccessDenied(t *testing.T) {
+	h, repo, skRepo := newWebAuthnHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	// key は別ユーザー (u2) 所有。
+	require.NoError(t, skRepo.Create(&model.UserSecurityKey{
+		ID: "key1", UserID: "u2", Name: "old", PublicKey: "pk",
+	}))
+	rec := postExtra(h.TwoFAUpdateKey, `{"password":"pass","credentialId":"key1","name":"x"}`, user)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "ACCESS_DENIED")
+	// 名前は変更されない。
+	assert.Equal(t, "old", skRepo.keys["key1"].Name)
+}
+
 // --- TwoFAPasswordLess ---
 //
 // upstream Misskey TS は paramDef を `{value: boolean}` で password を

--- a/internal/core/twofactor/replay.go
+++ b/internal/core/twofactor/replay.go
@@ -16,9 +16,9 @@ import (
 // attempt of the OTP after the successful validation has been issued
 // for the first OTP". Upstream Misskey TS (UserAuthService) does not
 // implement this protection, so an attacker who observes a 6-digit code
-// (phishing, shoulder surfing, MITM proxy) can replay it up to ~90s
-// later — long enough to open multiple sessions or to chain into other
-// 2FA-gated endpoints (i/2fa/done, key registration, etc.).
+// (phishing, shoulder surfing, MITM proxy) can replay it within the code's
+// acceptance window — long enough to open multiple sessions or to chain into
+// other 2FA-gated endpoints (i/2fa/done, key registration, etc.).
 //
 // mk-go ships this as an independent hardening on top of the drop-in
 // compatible schema: no new tables, no new error codes, just a Redis
@@ -31,12 +31,15 @@ type ReplayGuard interface {
 	MarkUsed(ctx context.Context, userID, code string) (bool, error)
 }
 
-// defaultReplayTTL covers the full acceptance window of a TOTP code
-// under pquerna/otp defaults (Period=30s, Skew=1 → ±1 step = up to 90s
-// from the moment the code becomes valid). We pad to 120s so that even
-// when the first acceptance happens at the very end of the window, the
-// guard entry survives for any conceivable retry inside the window.
-const defaultReplayTTL = 120 * time.Second
+// defaultReplayTTL covers the full acceptance window of a TOTP code under
+// our validation settings (Period=30s, Skew=totpSkew). A code generated for
+// step T stays structurally valid across [T-skew, T+skew] = (2*skew+1) steps,
+// so the guard entry must survive at least that long after the first
+// acceptance — otherwise the code could be replayed during the residual
+// validity once the entry expires. We pad by one extra step for clock jitter.
+// 旧実装は Skew=1 前提の 120s 固定だったが、#1555 で Skew=5 に広げたため
+// totpSkew から導出して lockstep を保つ (Skew=5 → 11 steps = 330s + 30s pad)。
+const defaultReplayTTL = time.Duration(2*totpSkew+2) * 30 * time.Second
 
 // RedisReplayGuard implements ReplayGuard on top of go-redis. Keys are
 // per-user and per-code; collisions across users are impossible because
@@ -48,7 +51,8 @@ type RedisReplayGuard struct {
 	// guard without configuring anything else.
 	KeyPrefix string
 	// TTL is the lifetime of each replay record. When zero, defaults to
-	// 120 seconds (= TOTP acceptance window with safety margin).
+	// defaultReplayTTL (= TOTP acceptance window for the configured Skew,
+	// with a one-step safety margin).
 	TTL time.Duration
 }
 
@@ -77,6 +81,7 @@ func (g *RedisReplayGuard) MarkUsed(ctx context.Context, userID, code string) (b
 	}
 	ttl := g.TTL
 	if ttl <= 0 {
+		// 未設定時は TOTP acceptance window をカバーする default を使う。
 		ttl = defaultReplayTTL
 	}
 	key := fmt.Sprintf("%s:%s:%s", prefix, userID, code)

--- a/internal/core/twofactor/totp_service.go
+++ b/internal/core/twofactor/totp_service.go
@@ -6,10 +6,17 @@ import (
 	"encoding/base64"
 	"fmt"
 	"image/png"
+	"time"
 
 	"github.com/pquerna/otp"
 	"github.com/pquerna/otp/totp"
 )
+
+// totpSkew は許容する前後ステップ数。upstream Misskey は OTPAuth.TOTP.validate
+// を window:5 で呼ぶ (UserAuthService.ts / 2fa/done.ts) ため、pquerna の
+// デフォルト Skew=1 (±30s) ではなく ±5 ステップ (±150s) に合わせる。これにより
+// 端末の時計ずれが大きい環境でも upstream と同じコードを受理できる (#1555)。
+const totpSkew = 5
 
 // qrImageSize は frontend MkPoll 系コンポーネントが想定する QR コード画像
 // の 1 辺ピクセル数。Misskey TS upstream の `QRCode.toDataURL(url)` は
@@ -54,7 +61,14 @@ func QRDataURL(uri string) (string, error) {
 	return "data:image/png;base64," + base64.StdEncoding.EncodeToString(buf.Bytes()), nil
 }
 
-// Validate checks if a TOTP code is valid for the given secret.
+// Validate checks if a TOTP code is valid for the given secret. The acceptance
+// window matches upstream Misskey (window:5 = ±5 steps ≈ ±150s)。
 func Validate(code, secret string) bool {
-	return totp.Validate(code, secret)
+	ok, err := totp.ValidateCustom(code, secret, time.Now().UTC(), totp.ValidateOpts{
+		Period:    30,
+		Skew:      totpSkew,
+		Digits:    otp.DigitsSix,
+		Algorithm: otp.AlgorithmSHA1,
+	})
+	return err == nil && ok
 }

--- a/internal/core/twofactor/totp_service_test.go
+++ b/internal/core/twofactor/totp_service_test.go
@@ -34,6 +34,22 @@ func TestValidate_WrongCode(t *testing.T) {
 	assert.False(t, Validate("000000", secret))
 }
 
+// #1555 acceptance window は upstream (window:5 ≈ ±150s) に合わせる。
+// 旧 Skew=1 (±30s) では落ちる ±120s ずれのコードを受理できることを確認する。
+func TestValidate_WideWindow(t *testing.T) {
+	secret, _, err := GenerateSecret("Misskey", "testuser")
+	require.NoError(t, err)
+	// 120秒前 (4 steps) のコード。Skew=1 では拒否、Skew=5 では受理。
+	code, err := totp.GenerateCode(secret, time.Now().Add(-120*time.Second))
+	require.NoError(t, err)
+	assert.True(t, Validate(code, secret), "code within ±150s window must be accepted")
+
+	// 窓外 (300秒前 = 10 steps) は拒否される。
+	farCode, err := totp.GenerateCode(secret, time.Now().Add(-300*time.Second))
+	require.NoError(t, err)
+	assert.False(t, Validate(farCode, secret), "code far outside the window must be rejected")
+}
+
 func TestValidate_EmptySecret(t *testing.T) {
 	assert.False(t, Validate("123456", ""))
 }


### PR DESCRIPTION
## Summary

#1555 (i/* part1 parity) のうち i/2fa 系の 4 項目 (MEDIUM + LOW×3)。

## 主な変更点

- **[MEDIUM] 2fa/register の issuer**: `GenerateSecret` / response の `issuer` を hardcode `"Misskey"` から instance host (upstream `config.host` 相当 = serverURL の Host) に変更。authenticator アプリのラベルと response が instance を反映するようになる。serverURL 未配線時は `"Misskey"` にフォールバック。
- **[LOW] TOTP acceptance window**: `Validate` を `totp.Validate` (Skew=1, ±30s) から `ValidateCustom(Skew=5, ±150s)` に変更。upstream の `OTPAuth ... window:5` (UserAuthService / 2fa/done.ts) と一致させ、端末の時計ずれに寛容にする。
- **[LOW] meUpdated**: `TwoFADone` / `TwoFAUnregister` 後に `publishMeUpdated` を呼び、`twoFactorEnabled` の変更を main stream 経由で UI に反映する (key 系 handler と挙動を揃える)。
- **[LOW] 2fa/update-key**: key not-found (`NO_SUCH_KEY`) と not-owned (`ACCESS_DENIED`) を `FindByID` + ownership check で区別する。従来は両者を `NO_SUCH_KEY` に畳んでいた。UUID は upstream / golden と一致。

## security (レビュー指摘の追加修正)

TOTP window を Skew=5 に広げたことで code の構造的有効期間が ~330s に伸び、replay guard の TTL が 120s 固定のままだと guard entry 失効後に同一 code を replay できる回帰が生じる。`defaultReplayTTL` を `totpSkew` から導出 (`(2*totpSkew+2)*30s = 360s`) して acceptance window 全体をカバーするよう修正した。

## テスト

- `twofactor`: `Validate` が ±120s ずれの code を受理、±300s は拒否
- `i/2fa`: register が serverURL から host issuer を返す、Done / Unregister が meUpdated を publish、update-key が他人 key で `ACCESS_DENIED`
- `go vet ./...` 全体 / entitycompat drift gates / 全テスト pass

## 関連

#1555 (i/* part1) の 4 項目。

🤖 Generated with [Claude Code](https://claude.com/claude-code)