### PR TITLE
Fix i/claim-achievement, i/import-*: prohibitMoved gate 配線 (#1555 part6)

### DIFF
--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1458,19 +1458,19 @@ func (s *Server) setupRoutes() {
 	// i/import-* の canImport* role policy gate は #1020 で追加。policy=false
 	// の user (default 全 false) は 403 ROLE_PERMISSION_DENIED を返す。
 	api.POST("/i/import-following", iHandler.ImportFollowing,
-		middleware.RequireAuth(),
+		middleware.RequireAuth(), middleware.RequireNotMoved(),
 		middleware.RequireRolePolicy(roleService, corerole.PolicyCanImportFollowing), middleware.RequireSecure())
 	api.POST("/i/import-blocking", iHandler.ImportBlocking,
-		middleware.RequireAuth(),
+		middleware.RequireAuth(), middleware.RequireNotMoved(),
 		middleware.RequireRolePolicy(roleService, corerole.PolicyCanImportBlocking), middleware.RequireSecure())
 	api.POST("/i/import-muting", iHandler.ImportMuting,
-		middleware.RequireAuth(),
+		middleware.RequireAuth(), middleware.RequireNotMoved(),
 		middleware.RequireRolePolicy(roleService, corerole.PolicyCanImportMuting), middleware.RequireSecure())
 	api.POST("/i/import-user-lists", iHandler.ImportUserLists,
-		middleware.RequireAuth(),
+		middleware.RequireAuth(), middleware.RequireNotMoved(),
 		middleware.RequireRolePolicy(roleService, corerole.PolicyCanImportUserLists), middleware.RequireSecure())
 	api.POST("/i/import-antennas", iHandler.ImportAntennas,
-		middleware.RequireAuth(),
+		middleware.RequireAuth(), middleware.RequireNotMoved(),
 		middleware.RequireRolePolicy(roleService, corerole.PolicyCanImportAntennas), middleware.RequireSecure())
 
 	// i/webhooks/* — Webhook管理 (実データ)
@@ -1504,7 +1504,9 @@ func (s *Server) setupRoutes() {
 	api.POST("/notifications/test-notification", notificationsHandler.TestNotification, middleware.RequireAuth(), middleware.RequireScope("write:notifications"))
 
 	// i/* ハンドラ
-	api.POST("/i/claim-achievement", iHandler.ClaimAchievement, middleware.RequireAuth(), middleware.RequireScope("write:account"))
+	// claim-achievement / import-* は upstream で prohibitMoved:true (移行済
+	// アカウントは YOUR_ACCOUNT_MOVED 403)。RequireNotMoved を配線する (#1555)。
+	api.POST("/i/claim-achievement", iHandler.ClaimAchievement, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:account"))
 	api.POST("/i/apps", iHandler.Apps, middleware.RequireAuth(), middleware.RequireSecure())
 	api.POST("/i/authorized-apps", iHandler.AuthorizedApps, middleware.RequireAuth(), middleware.RequireSecure())
 	api.POST("/i/signin-history", iHandler.SigninHistory, middleware.RequireAuth(), middleware.RequireSecure())


### PR DESCRIPTION
## Summary

#1555 (i/* part1 parity) の最終項目 (MEDIUM)。upstream の `i/claim-achievement` と `i/import-*` (following/blocking/muting/user-lists/antennas) は `prohibitMoved: true` を持ち、移行済みアカウント (`movedToUri` セット済) を `YOUR_ACCOUNT_MOVED` (403) で弾く。mk-go は `RequireNotMoved()` middleware を持つが、これら 6 endpoint には未配線だった。

## 主な変更点

- `i/claim-achievement` と `i/import-following` / `i/import-blocking` / `i/import-muting` / `i/import-user-lists` / `i/import-antennas` の router 配線に、`RequireAuth()` の直後 `RequireNotMoved()` を追加。
- `export-*` は upstream でも `prohibitMoved` を持たない (移行済みでも自データ export は許可) ため対象外。
- `YOUR_ACCOUNT_MOVED` は `RequireNotMoved` middleware が emit する (handler ではない) ため errorid drift gate (handler scan) には影響しない。`RequireNotMoved` 自体は既存の unit test でカバー済。

## scope 外 (follow-up #1671)

横断調査の結果、upstream の `prohibitMoved:true` endpoint は全体で **59本** あり、mk-go は大半が未配線 (notes/create, drive, channels, chat, flash, gallery, pages, mute, users/lists, i/move, i/pin 等)。本 PR は #1555 の scope (claim-achievement / import-*) のみに留め、残りの全配線は #1671 に切り出した。

## テスト

- `RequireNotMoved` middleware は `internal/server/middleware/auth_test.go` でカバー済 (移行済みで `YOUR_ACCOUNT_MOVED` 403)。router 配線層は server パッケージ (CI coverage 0% 例外、e2e/drop-in で検証)。
- `go build ./...` / `go vet ./...` / 全テスト pass。

## 関連

Closes #1555 (i/* part1 の全 real 項目を part1-6 で解消)。残課題は #1667 (import-antennas TOO_MANY_ANTENNAS) / #1671 (prohibitMoved 全配線)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)