### PR TITLE
Fix i/import-antennas: 同期 TOO_MANY_ANTENNAS enforce (#1667)

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -113,6 +113,13 @@ type Handler struct {
 	// 他人 / 不在 / system file (userId NULL) は NO_SUCH_FILE で弾く。未配線時は
 	// fail-closed (= 常に NO_SUCH_FILE) にして cross-user file read を防ぐ。
 	driveFileRepo repository.DriveFileRepository
+	// importDriveReader は i/import-antennas で file content を同期 download して
+	// antenna 件数を数え TOO_MANY_ANTENNAS を enforce するために使う (#1667)。
+	// 未配線時は limit check を skip して worker に委ねる (degrade)。
+	importDriveReader ImportFileReader
+	// antennaCounter は i/import-antennas の TOO_MANY_ANTENNAS 判定で現 antenna
+	// 件数を数えるのに使う (#1667)。未配線時は limit check を skip する。
+	antennaCounter AntennaCounter
 }
 
 // TokenInvalidator は i/regenerate-token / i/change-password 等の sensitive

--- a/internal/api/i/transfer_handler.go
+++ b/internal/api/i/transfer_handler.go
@@ -1,15 +1,39 @@
 package i
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/transfer"
+	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
+
+// ImportFileReader reads a drive file's content synchronously. Satisfied by
+// transfer.RepoBackedDriveReader。i/import-antennas が件数 enforce のために
+// content を読むのに使う (#1667)。entity が core/transfer に依存しないよう
+// narrow interface で受ける。
+type ImportFileReader interface {
+	Fetch(fileID string) (*model.DriveFile, []byte, error)
+}
+
+// AntennaCounter returns the number of antennas owned by a user. Satisfied by
+// repository.AntennaRepository (#1667)。
+type AntennaCounter interface {
+	CountByUser(userID string) (int64, error)
+}
+
+// SetImportDriveReader wires the synchronous drive content reader used by
+// i/import-antennas to count antennas before enqueue (#1667)。
+func (h *Handler) SetImportDriveReader(r ImportFileReader) { h.importDriveReader = r }
+
+// SetAntennaCounter wires the antenna counter used by i/import-antennas to
+// enforce TOO_MANY_ANTENNAS (#1667)。
+func (h *Handler) SetAntennaCounter(c AntennaCounter) { h.antennaCounter = c }
 
 // TransferEnqueuer is the subset of queue.Enqueuer needed to schedule
 // export/import jobs. 小さいインターフェースにすることで i/Handler のテスト
@@ -120,39 +144,57 @@ func importTooBigFileID(importType string) string {
 	}
 }
 
+// validateImportRequest validates the fileId param, file ownership, and size
+// for an import-* endpoint. On any failure it writes the error response and
+// returns ok=false (callers then `return nil`, mirroring requireWebAuthn)。
+// 成功時は認証 user / 解決済 DriveFile / job-level withReplies を返す。
+//
+// upstream Misskey の import-* は driveFilesRepository.findOneBy({id, userId:
+// me.id}) で所有 file のみ許可し、他人 / 不在 / system file (userId NULL) は
+// NO_SUCH_FILE で弾く。所有権検証を欠くと cross-user file read が成立するため
+// driveFileRepo 未配線時は fail-closed (#1555)。空 file は EMPTY_FILE、上限超過は
+// TOO_BIG_FILE (import-antennas は upstream に tooBigFile が無いので skip)。
+func (h *Handler) validateImportRequest(c echo.Context, importType string) (*model.User, *model.DriveFile, bool, bool) {
+	u := middleware.GetUser(c)
+	var req struct {
+		FileID      string `json:"fileId"`
+		WithReplies *bool  `json:"withReplies"`
+	}
+	if err := c.Bind(&req); err != nil || req.FileID == "" {
+		_ = c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "fileId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+		return nil, nil, false, false
+	}
+	if h.driveFileRepo == nil {
+		_ = c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_FILE", "No such file.", importNoSuchFileID(importType)))
+		return nil, nil, false, false
+	}
+	file, err := h.driveFileRepo.FindByID(req.FileID)
+	if err != nil || file == nil || file.UserID == nil || *file.UserID != u.ID {
+		_ = c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_FILE", "No such file.", importNoSuchFileID(importType)))
+		return nil, nil, false, false
+	}
+	if file.Size == 0 {
+		_ = c.JSON(http.StatusBadRequest, apierr.Error("EMPTY_FILE", "That file is empty.", importEmptyFileID(importType)))
+		return nil, nil, false, false
+	}
+	if tooBigID := importTooBigFileID(importType); tooBigID != "" && file.Size > importMaxFileSize {
+		_ = c.JSON(http.StatusBadRequest, apierr.Error("TOO_BIG_FILE", "That file is too big.", tooBigID))
+		return nil, nil, false, false
+	}
+	withReplies := false
+	if req.WithReplies != nil {
+		withReplies = *req.WithReplies
+	}
+	return u, file, withReplies, true
+}
+
 // importHandler enqueues an import job using a DriveFile uploaded by the
 // user. フロントは fileId を渡してくる。本家互換。
 func (h *Handler) importHandler(importType string) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		u := middleware.GetUser(c)
-		var req struct {
-			FileID      string `json:"fileId"`
-			WithReplies *bool  `json:"withReplies"`
-		}
-		if err := c.Bind(&req); err != nil || req.FileID == "" {
-			return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "fileId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
-		}
-		// upstream Misskey の import-* は driveFilesRepository.findOneBy({id,
-		// userId: me.id}) で「リクエスト元 user 所有の file」のみ許可し、
-		// 他人 / 不在 / system file (userId NULL) は NO_SUCH_FILE で弾く
-		// (import-following.ts:71-73 ほか)。所有権検証を欠くと任意の認証 user が
-		// 他人の drive file を import 経路に流し込めるため fail-closed にする
-		// (#1555)。NO_SUCH_FILE の UUID は upstream import 系と一致させる。
-		if h.driveFileRepo == nil {
-			return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_FILE", "No such file.", importNoSuchFileID(importType)))
-		}
-		file, err := h.driveFileRepo.FindByID(req.FileID)
-		if err != nil || file == nil || file.UserID == nil || *file.UserID != u.ID {
-			return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_FILE", "No such file.", importNoSuchFileID(importType)))
-		}
-		// 同期 file 検証 (upstream は handler 内で実施)。空 file は EMPTY_FILE、
-		// 上限超過は TOO_BIG_FILE (import-antennas は upstream に tooBigFile が
-		// 無いので skip)。enqueue 前に弾くことで無駄な job 投入を避ける (#1555)。
-		if file.Size == 0 {
-			return c.JSON(http.StatusBadRequest, apierr.Error("EMPTY_FILE", "That file is empty.", importEmptyFileID(importType)))
-		}
-		if tooBigID := importTooBigFileID(importType); tooBigID != "" && file.Size > importMaxFileSize {
-			return c.JSON(http.StatusBadRequest, apierr.Error("TOO_BIG_FILE", "That file is too big.", tooBigID))
+		u, file, withReplies, ok := h.validateImportRequest(c, importType)
+		if !ok {
+			return nil
 		}
 		if h.transferEnqueuer == nil {
 			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Transfer queue not configured.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
@@ -160,20 +202,46 @@ func (h *Handler) importHandler(importType string) echo.HandlerFunc {
 		// withReplies は import-following のみが使う job-level fallback (CSV row が
 		// per-line withReplies を省略したときの default、upstream
 		// `withReplies ?? job.data.withReplies`)。他 type では Importer 側で無視。
-		withReplies := false
-		if req.WithReplies != nil {
-			withReplies = *req.WithReplies
-		}
 		if err := h.transferEnqueuer.EnqueueImport(queue.ImportPayload{
 			UserID:      u.ID,
 			Type:        importType,
-			FileID:      req.FileID,
+			FileID:      file.ID,
 			WithReplies: withReplies,
 		}); err != nil {
 			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Failed to enqueue import.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 		}
 		return c.NoContent(http.StatusNoContent)
 	}
+}
+
+// antennaImportWouldExceedLimit reports whether importing the antennas in file
+// would push the user at/over their antennaLimit, mirroring upstream
+// import-antennas.ts (`currentAntennasCount + antennas.length >= antennaLimit`)。
+// 依存 (driveReader / antennaCounter / roleProvider) 未配線、content download
+// 失敗、JSON parse 失敗、count 失敗時はいずれも false を返し、limit check を
+// skip して worker に委ねる (degrade)。所有権 / EMPTY は呼び出し前に検証済み。
+func (h *Handler) antennaImportWouldExceedLimit(userID, fileID string) bool {
+	if h.importDriveReader == nil || h.antennaCounter == nil || h.roleProvider == nil {
+		return false
+	}
+	limit, ok := h.roleProvider.GetUserPolicies(userID)["antennaLimit"].(int)
+	if !ok || limit < 0 {
+		return false
+	}
+	_, body, err := h.importDriveReader.Fetch(fileID)
+	if err != nil {
+		return false
+	}
+	// 件数のみ必要なので各 entry は raw のまま len を取る。
+	var entries []json.RawMessage
+	if json.Unmarshal(body, &entries) != nil {
+		return false
+	}
+	current, err := h.antennaCounter.CountByUser(userID)
+	if err != nil {
+		return false
+	}
+	return current+int64(len(entries)) >= int64(limit)
 }
 
 // Export handler factory methods — one per endpoint for router binding.
@@ -215,6 +283,32 @@ func (h *Handler) ImportMuting(c echo.Context) error {
 func (h *Handler) ImportUserLists(c echo.Context) error {
 	return h.importHandler(transfer.ImportUserLists)(c)
 }
+
+// ImportAntennas は他の import-* と異なり、upstream import-antennas.ts に倣って
+// enqueue 前に同期で TOO_MANY_ANTENNAS を enforce する (#1667)。upstream は
+// file を download+parse して antenna 件数を数え、現件数 + import 件数 >=
+// antennaLimit なら弾く。
+//
+// なお upstream の NO_SUCH_USER (usersRepository.exists 失敗) は防御的 check で、
+// mk-go では RequireAuth が user を load 済みのため到達不能。dead code を避けて
+// 実装しない (golden には id があるが emit しないのは drift gate 上問題ない)。
 func (h *Handler) ImportAntennas(c echo.Context) error {
-	return h.importHandler(transfer.ImportAntennas)(c)
+	u, file, _, ok := h.validateImportRequest(c, transfer.ImportAntennas)
+	if !ok {
+		return nil
+	}
+	if h.antennaImportWouldExceedLimit(u.ID, file.ID) {
+		return c.JSON(http.StatusBadRequest, apierr.Error("TOO_MANY_ANTENNAS", "You cannot create antenna any more.", "600917d4-a4cb-4cc5-8ba8-7ac8ea3c7779"))
+	}
+	if h.transferEnqueuer == nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Transfer queue not configured.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	if err := h.transferEnqueuer.EnqueueImport(queue.ImportPayload{
+		UserID: u.ID,
+		Type:   transfer.ImportAntennas,
+		FileID: file.ID,
+	}); err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Failed to enqueue import.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/i/transfer_handler_test.go
+++ b/internal/api/i/transfer_handler_test.go
@@ -6,12 +6,32 @@ import (
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/core/transfer"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// stubImportFileReader returns canned drive content for i/import-antennas
+// limit enforcement tests (#1667)。
+type stubImportFileReader struct {
+	body []byte
+	err  error
+}
+
+func (s *stubImportFileReader) Fetch(_ string) (*model.DriveFile, []byte, error) {
+	return nil, s.body, s.err
+}
+
+// stubAntennaCounter returns a canned current antenna count (#1667)。
+type stubAntennaCounter struct {
+	count int64
+	err   error
+}
+
+func (s *stubAntennaCounter) CountByUser(_ string) (int64, error) { return s.count, s.err }
 
 // stubTransferEnqueuer records calls and optionally returns an error.
 type stubTransferEnqueuer struct {
@@ -324,6 +344,49 @@ func TestImport_Antennas_NoTooBigCheck(t *testing.T) {
 	rec := post(h.ImportAntennas, `{"fileId":"big"}`, &model.User{ID: ownerID})
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 	assert.Len(t, enq.importCalls, 1)
+}
+
+// #1667 現 antenna 件数 + import 件数 >= antennaLimit なら TOO_MANY_ANTENNAS
+// (upstream import-antennas.ts、import-antennas 固有 UUID)。
+func TestImportAntennas_TooMany(t *testing.T) {
+	h, enq, driveRepo := newTransferHandlerWithDrive()
+	uid := ownerID
+	driveRepo.Files["ant"] = &model.DriveFile{ID: "ant", UserID: &uid, Size: 100}
+	h.SetImportDriveReader(&stubImportFileReader{body: []byte(`[{"name":"a"},{"name":"b"}]`)})
+	h.SetAntennaCounter(&stubAntennaCounter{count: 4})
+	h.SetRoleProvider(&stubRoleProvider{policies: map[string]any{"antennaLimit": 5}})
+	// 現 4 + import 2 = 6 >= 5 → TOO_MANY_ANTENNAS。
+	rec := post(h.ImportAntennas, `{"fileId":"ant"}`, &model.User{ID: ownerID})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "TOO_MANY_ANTENNAS")
+	assert.Contains(t, rec.Body.String(), "600917d4-a4cb-4cc5-8ba8-7ac8ea3c7779")
+	assert.Empty(t, enq.importCalls)
+}
+
+// 上限未満なら enqueue される。
+func TestImportAntennas_UnderLimit(t *testing.T) {
+	h, enq, driveRepo := newTransferHandlerWithDrive()
+	uid := ownerID
+	driveRepo.Files["ant"] = &model.DriveFile{ID: "ant", UserID: &uid, Size: 100}
+	h.SetImportDriveReader(&stubImportFileReader{body: []byte(`[{"name":"a"}]`)})
+	h.SetAntennaCounter(&stubAntennaCounter{count: 1})
+	h.SetRoleProvider(&stubRoleProvider{policies: map[string]any{"antennaLimit": 5}})
+	// 現 1 + import 1 = 2 < 5 → enqueue。
+	rec := post(h.ImportAntennas, `{"fileId":"ant"}`, &model.User{ID: ownerID})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	require.Len(t, enq.importCalls, 1)
+	assert.Equal(t, transfer.ImportAntennas, enq.importCalls[0].Type)
+}
+
+// 依存 (driveReader / antennaCounter / roleProvider) 未配線時は limit check を
+// skip して enqueue する (degrade、worker に委ねる)。
+func TestImportAntennas_NoDepsDegrades(t *testing.T) {
+	h, enq, driveRepo := newTransferHandlerWithDrive()
+	uid := ownerID
+	driveRepo.Files["ant"] = &model.DriveFile{ID: "ant", UserID: &uid, Size: 100}
+	rec := post(h.ImportAntennas, `{"fileId":"ant"}`, &model.User{ID: ownerID})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	require.Len(t, enq.importCalls, 1)
 }
 
 // import-following の job-level withReplies が ImportPayload に伝わる (#1555)。

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1359,6 +1359,9 @@ func (s *Server) setupRoutes() {
 	// i/import-* の fileId 所有権検証 (#1555)。未配線だと fail-closed
 	// (NO_SUCH_FILE) になるため production では必ず wire する。
 	iHandler.SetDriveFileRepo(driveFileRepo)
+	// i/import-antennas の TOO_MANY_ANTENNAS 同期 enforce 用 (#1667)。
+	iHandler.SetImportDriveReader(driveReader)
+	iHandler.SetAntennaCounter(antennaRepo)
 	// P4-6 (#166): i/authorized-apps, i/revoke-token, i/gallery/*, i/page-likes
 	iHandler.SetAccessTokenRepo(repository.NewAccessTokenRepository(s.db))
 	iHandler.SetGalleryRepo(repository.NewGalleryRepository(s.db))


### PR DESCRIPTION
## Summary

#1555 part3 (#1668) から切り出した follow-up。upstream `import-antennas.ts` は handler 内で file を download+parse して antenna 件数を数え、`currentAntennasCount + antennas.length >= antennaLimit` なら `TOO_MANY_ANTENNAS` を同期で返す。mk-go は fileId 検証のみで enqueue しており、この limit gate が無かった。

## 主な変更点

- **validateImportRequest helper を抽出**: fileId bind / ownership (NO_SUCH_FILE) / EMPTY_FILE / TOO_BIG_FILE 検証を共通化。`importHandler` (following/blocking/muting/user-lists) はこれを使う thin wrapper に。`return nil`-after-write は既存 `requireWebAuthn` と同じ idiom。
- **ImportAntennas を専用 handler に分離**: `validateImportRequest` → `antennaImportWouldExceedLimit` → enqueue。
- **antennaImportWouldExceedLimit**: `importDriveReader.Fetch` で content を download → `[]json.RawMessage` で array length を取得 → `roleProvider.GetUserPolicies()["antennaLimit"]` と `antennaCounter.CountByUser` で `current + len >= limit` を評価 (upstream と byte-for-byte 一致、`>=`)。`TOO_MANY_ANTENNAS` は **import-antennas 固有 UUID** `600917d4-...` (antennas/create の `faf47050` とは別、golden と一致)。
- **degrade**: 依存 (driveReader / antennaCounter / roleProvider) 未配線、download/parse/count 失敗時は limit check を skip して worker に委ねる (fail-open。limit は防御的 cap であり security gate ではない)。ownership 検証後にのみ Fetch するので他人 file の content は読まない。
- router で `SetImportDriveReader(driveReader)` / `SetAntennaCounter(antennaRepo)` を配線。

## scope 外 (既知差分)

upstream の `NO_SUCH_USER` (`usersRepository.exists`) は防御的 check で、mk-go では `RequireAuth` が user を load 済みのため到達不能。dead code を避けて未実装とした (golden に id はあるが emit しないのは errorid drift gate 上問題ない)。

## テスト

- `TestImportAntennas_TooMany`: 現 4 + import 2 = 6 >= 5 → `TOO_MANY_ANTENNAS` (固有 UUID 検証)、enqueue されない
- `TestImportAntennas_UnderLimit`: 1 + 1 = 2 < 5 → enqueue
- `TestImportAntennas_NoDepsDegrades`: 依存未配線で limit skip → enqueue
- 既存 import test (validateImportRequest 抽出後の following/blocking/muting/user-lists の回帰なし) / entitycompat drift gates / `go vet ./...` / 全テスト pass

## 関連

Closes #1667 (#1555 part3 から切り出し)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)