### PR TITLE
Fix notes/clips: 空配列スタブを実装 (#1554 part1)

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -53,8 +53,14 @@ type Handler struct {
 	driveFolderRepo   repository.DriveFolderRepository
 	userRepo          repository.UserRepository
 	userListRepo      repository.UserListRepository
-	moderatorChecker  ModeratorChecker
-	bufReader         entity.BufferedReactionsReader
+	// clipRepo / clipNoteRepo / clipFavoriteRepo は notes/clips で「この note を
+	// 含む public clip」を Clip entity として返すのに使う (#1554)。未配線時は
+	// 空配列 fallback (旧 stub 互換)。
+	clipRepo         repository.ClipRepository
+	clipNoteRepo     repository.ClipNoteRepository
+	clipFavoriteRepo repository.ClipFavoriteRepository
+	moderatorChecker ModeratorChecker
+	bufReader        entity.BufferedReactionsReader
 	// ugcVisibility controls what unauthenticated visitors can see.
 	// "all" (default), "local", "none"
 	ugcVisibility string

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -278,9 +278,67 @@ func (h *Handler) SearchByTag(c echo.Context) error {
 	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))
 }
 
+// SetClipRepos wires the clip repos used by notes/clips (#1554)。未配線時は
+// 旧 stub 同様に空配列を返す。
+func (h *Handler) SetClipRepos(clip repository.ClipRepository, clipNote repository.ClipNoteRepository, clipFavorite repository.ClipFavoriteRepository) {
+	h.clipRepo = clip
+	h.clipNoteRepo = clipNote
+	h.clipFavoriteRepo = clipFavorite
+}
+
 // Clips handles POST /api/notes/clips.
+//
+// upstream notes/clips.ts: getNote で note 存在確認 (無ければ NO_SUCH_NOTE) →
+// clipNotesRepository.findBy({noteId}) で note を含む clip を引き →
+// clipsRepository.findBy({id IN, isPublic:true}) → clipEntityService.packMany。
+// owner / 他人を問わず「その note を含む public clip」を返す (#1554)。
 func (h *Handler) Clips(c echo.Context) error {
-	return c.JSON(http.StatusOK, []any{})
+	var req struct {
+		NoteID string `json:"noteId"`
+	}
+	if err := c.Bind(&req); err != nil || req.NoteID == "" {
+		return apierr.JSONInvalidParam(c)
+	}
+	// clip repo 未配線時は旧 stub 互換で空配列。
+	if h.clipRepo == nil || h.clipNoteRepo == nil {
+		return c.JSON(http.StatusOK, []any{})
+	}
+	// note 存在確認 (upstream getterService.getNote)。可視性は問わず存在のみ。
+	if _, err := h.noteRepo.FindByID(req.NoteID); err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "47db1a1c-b0af-458d-8fb4-986e4efafe1e"))
+	}
+	clipIDs, err := h.clipNoteRepo.ListClipIDsByNote(req.NoteID)
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
+	clips, err := h.clipRepo.ListPublicByIDs(clipIDs)
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
+	viewer := middleware.GetUser(c)
+	out := make([]map[string]any, 0, len(clips))
+	for _, cl := range clips {
+		// owner は clip ごとに異なりうる (note は複数 user の clip に入りうる)。
+		var owner *model.User
+		if h.userRepo != nil {
+			owner, _ = h.userRepo.FindByID(cl.UserID)
+		}
+		// favoritedCount は常時、isFavorited は認証 viewer のみ、notesCount は
+		// owner 閲覧時のみ (#1562、upstream ClipEntityService.pack)。
+		extras := entity.ClipExtras{ShowNotesCount: viewer != nil && viewer.ID == cl.UserID}
+		if h.clipFavoriteRepo != nil {
+			if n, err := h.clipFavoriteRepo.CountByClip(cl.ID); err == nil {
+				extras.FavoritedCount = n
+			}
+			if viewer != nil {
+				if ok, err := h.clipFavoriteRepo.Exists(viewer.ID, cl.ID); err == nil {
+					extras.IsFavorited = &ok
+				}
+			}
+		}
+		out = append(out, entity.PackClip(cl, h.idGen, owner, extras))
+	}
+	return c.JSON(http.StatusOK, out)
 }
 
 // Translate handles POST /api/notes/translate.

--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -6,10 +6,12 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	corenote "github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/core/translate"
+	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -54,6 +56,67 @@ func postExtra(h func(echo.Context) error, body string, user *model.User) *httpt
 	}
 	_ = h(c)
 	return rec
+}
+
+// --- Clips (#1554) ---
+
+// notes/clips は note を含む public clip を Clip entity で返す。private clip と
+// 他人 clip(非public)は除外、public なら他人の clip も含む。
+func TestClips_ReturnsPublicClips(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	// clip ID は createdAt 復元のため valid aidx である必要がある。
+	idGen, _ := id.NewGenerator("aidx")
+	c1 := idGen.Generate(time.Now())
+	c2 := idGen.Generate(time.Now())
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic}
+	clipRepo := testutil.NewMockClipRepository()
+	clipRepo.Clips[c1] = &model.Clip{ID: c1, UserID: "u2", Name: "pub", IsPublic: true}
+	clipRepo.Clips[c2] = &model.Clip{ID: c2, UserID: "u1", Name: "priv", IsPublic: false}
+	clipNoteRepo := testutil.NewMockClipNoteRepository()
+	clipNoteRepo.Entries["e1"] = &model.ClipNote{ID: "e1", ClipID: c1, NoteID: "n1"}
+	clipNoteRepo.Entries["e2"] = &model.ClipNote{ID: "e2", ClipID: c2, NoteID: "n1"}
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["u2"] = &model.User{ID: "u2", Username: "u2", UsernameLower: "u2"}
+	h.SetUserRepo(userRepo)
+	h.SetClipRepos(clipRepo, clipNoteRepo, testutil.NewMockClipFavoriteRepository())
+
+	rec := postExtra(h.Clips, `{"noteId":"n1"}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	// public clip c1 のみ (private c2 は除外)。
+	require.Len(t, got, 1)
+	assert.Equal(t, c1, got[0]["id"])
+	assert.Equal(t, true, got[0]["isPublic"])
+	user, ok := got[0]["user"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "u2", user["username"])
+	shapetest.Assert(t, "Clip", got[0])
+}
+
+// note が存在しなければ NO_SUCH_NOTE (clips 固有 UUID 47db1a1c)。
+func TestClips_NoSuchNote(t *testing.T) {
+	h, _, _ := newExtraHandler(t)
+	h.SetClipRepos(testutil.NewMockClipRepository(), testutil.NewMockClipNoteRepository(), testutil.NewMockClipFavoriteRepository())
+	rec := postExtra(h.Clips, `{"noteId":"ghost"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_NOTE")
+	assert.Contains(t, rec.Body.String(), "47db1a1c-b0af-458d-8fb4-986e4efafe1e")
+}
+
+// clip repo 未配線時は旧 stub 互換で空配列。
+func TestClips_NoRepoDegrades(t *testing.T) {
+	h, _, _ := newExtraHandler(t)
+	rec := postExtra(h.Clips, `{"noteId":"n1"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "[]\n", rec.Body.String())
+}
+
+func TestClips_InvalidParam(t *testing.T) {
+	h, _, _ := newExtraHandler(t)
+	h.SetClipRepos(testutil.NewMockClipRepository(), testutil.NewMockClipNoteRepository(), testutil.NewMockClipFavoriteRepository())
+	rec := postExtra(h.Clips, `{}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 // --- Favorites ---

--- a/internal/repository/clip.go
+++ b/internal/repository/clip.go
@@ -21,6 +21,10 @@ type ClipRepository interface {
 	// users/clips when the viewer is not the owner so LIMIT applies to the
 	// already-filtered set. Same cursor semantics as ListByUser.
 	ListPublicByUser(userID string, sinceID, untilID string, limit, offset int) ([]*model.Clip, error)
+	// ListPublicByIDs returns the public clips whose id is in ids (any owner).
+	// notes/clips が「note を含む public clip」を引くのに使う (upstream
+	// clipsRepository.findBy({id: In(...), isPublic: true}))。
+	ListPublicByIDs(ids []string) ([]*model.Clip, error)
 	IncrementCount(clipID, column string, delta int) error
 }
 
@@ -43,6 +47,17 @@ func (r *clipRepository) FindByID(id string) (*model.Clip, error) {
 		return nil, err
 	}
 	return &c, nil
+}
+
+func (r *clipRepository) ListPublicByIDs(ids []string) ([]*model.Clip, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var clips []*model.Clip
+	if err := r.db.Where(`"id" IN ? AND "isPublic" = ?`, ids, true).Find(&clips).Error; err != nil {
+		return nil, err
+	}
+	return clips, nil
 }
 
 func (r *clipRepository) UpdateFields(clipID string, fields map[string]any) error {

--- a/internal/repository/clip_note.go
+++ b/internal/repository/clip_note.go
@@ -25,6 +25,10 @@ type ClipNoteRepository interface {
 	// CountByClip returns the number of notes in the given clip. Used by
 	// noteEachClipsLimit policy gate (#1029 PR-1 follow-up).
 	CountByClip(clipID string) (int64, error)
+	// ListClipIDsByNote returns the distinct clipIds that contain noteID,
+	// across all clips/owners. notes/clips が「この note を含む public clip」を
+	// 引くのに使う (upstream clipNotesRepository.findBy({noteId}))。
+	ListClipIDsByNote(noteID string) ([]string, error)
 }
 
 type clipNoteRepository struct {
@@ -61,6 +65,17 @@ func (r *clipNoteRepository) CountByClip(clipID string) (int64, error) {
 		return 0, err
 	}
 	return count, nil
+}
+
+func (r *clipNoteRepository) ListClipIDsByNote(noteID string) ([]string, error) {
+	var ids []string
+	if err := r.db.Model(&model.ClipNote{}).
+		Where(`"noteId" = ?`, noteID).
+		Distinct(`"clipId"`).
+		Pluck(`"clipId"`, &ids).Error; err != nil {
+		return nil, err
+	}
+	return ids, nil
 }
 
 // ListByClip returns the entries for a clip with since/until pagination on

--- a/internal/repository/clip_note_test.go
+++ b/internal/repository/clip_note_test.go
@@ -53,6 +53,47 @@ func TestClipNoteRepository_LifeCycle(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// #1554 ListClipIDsByNote は note を含む clip の distinct clipId を返す。
+func TestClipNoteRepository_ListClipIDsByNote(t *testing.T) {
+	clipRepo := NewClipRepository(testDB)
+	repo := NewClipNoteRepository(testDB)
+	noteRepo := NewNoteRepository(testDB)
+	user := insertTestUser(t, "u_cnlist", "cnlistuser")
+	defer cleanupUser(t, user.ID)
+
+	c1 := newTestClip("clp_cnl_1", user.ID, "c1")
+	c2 := newTestClip("clp_cnl_2", user.ID, "c2")
+	require.NoError(t, clipRepo.Create(c1))
+	require.NoError(t, clipRepo.Create(c2))
+	defer cleanupClip(t, c1.ID)
+	defer cleanupClip(t, c2.ID)
+
+	n := &model.Note{ID: "n_cnl_1", UserID: user.ID, Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}"))}
+	other := &model.Note{ID: "n_cnl_2", UserID: user.ID, Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}"))}
+	require.NoError(t, noteRepo.Create(n))
+	require.NoError(t, noteRepo.Create(other))
+	defer cleanupNote(t, n.ID)
+	defer cleanupNote(t, other.ID)
+
+	// n は c1 と c2 の両方に、other は c1 のみに含める。
+	for _, cn := range []*model.ClipNote{
+		{ID: "cn_l1", ClipID: c1.ID, NoteID: n.ID},
+		{ID: "cn_l2", ClipID: c2.ID, NoteID: n.ID},
+		{ID: "cn_l3", ClipID: c1.ID, NoteID: other.ID},
+	} {
+		require.NoError(t, repo.Create(cn))
+		defer testDB.Exec(`DELETE FROM "clip_note" WHERE id = ?`, cn.ID)
+	}
+
+	ids, err := repo.ListClipIDsByNote(n.ID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{c1.ID, c2.ID}, ids)
+
+	ids, err = repo.ListClipIDsByNote("n_cnl_nonexistent")
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+}
+
 func TestClipNoteRepository_FindByPair_NotFound(t *testing.T) {
 	repo := NewClipNoteRepository(testDB)
 	_, err := repo.FindByPair("nope", "nope")

--- a/internal/repository/clip_test.go
+++ b/internal/repository/clip_test.go
@@ -37,6 +37,33 @@ func TestClipRepository_CreateAndFindByID(t *testing.T) {
 	assert.Equal(t, "alpha clip", got.Name)
 }
 
+// #1554 ListPublicByIDs は ids のうち isPublic=true の clip のみ返す。
+func TestClipRepository_ListPublicByIDs(t *testing.T) {
+	repo := NewClipRepository(testDB)
+	user := insertTestUser(t, "u_clp_pub", "clippubuser")
+	defer cleanupUser(t, user.ID)
+
+	pub := newTestClip("clp_pub_1", user.ID, "public")
+	pub.IsPublic = true
+	priv := newTestClip("clp_pub_2", user.ID, "private")
+	priv.IsPublic = false
+	require.NoError(t, repo.Create(pub))
+	require.NoError(t, repo.Create(priv))
+	defer cleanupClip(t, pub.ID)
+	defer cleanupClip(t, priv.ID)
+
+	// 空 ids は nil。
+	got, err := repo.ListPublicByIDs(nil)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+
+	// public のみ返る (private は除外)。
+	got, err = repo.ListPublicByIDs([]string{pub.ID, priv.ID, "clp_missing"})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, pub.ID, got[0].ID)
+}
+
 func TestClipRepository_FindByID_NotFound(t *testing.T) {
 	repo := NewClipRepository(testDB)
 	_, err := repo.FindByID("missing")

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1196,6 +1196,8 @@ func (s *Server) setupRoutes() {
 	notesHandler.SetUserRepo(userRepo)
 	notesHandler.SetModeratorChecker(roleService) // #1538: moderator note delete
 	notesHandler.SetUserListRepo(userListRepo)
+	notesHandler.SetClipRepos(clipRepo, clipNoteRepo, clipFavoriteRepo) // #1554: notes/clips
+
 	notehide.SetFollowingRepo(followingRepo)
 	// LocalTimeline / GlobalTimeline / HybridTimeline で ltlAvailable /
 	// gtlAvailable role policy を gate するために配線 (#1026)。匿名 viewer に

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -3388,6 +3388,21 @@ func (m *MockClipRepository) ListPublicByUser(userID, sinceID, untilID string, l
 	return paginateClips(rows, sinceID, untilID, limit, offset), nil
 }
 
+// ListPublicByIDs returns the public clips whose id is in ids (any owner).
+func (m *MockClipRepository) ListPublicByIDs(ids []string) ([]*model.Clip, error) {
+	want := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		want[id] = struct{}{}
+	}
+	var rows []*model.Clip
+	for _, c := range m.Clips {
+		if _, ok := want[c.ID]; ok && c.IsPublic {
+			rows = append(rows, c)
+		}
+	}
+	return rows, nil
+}
+
 // paginateClips applies the same ordering / limit / cursor-vs-offset rules as
 // the real clipRepository so mock-based tests exercise the upstream
 // makePaginationQuery semantics. ASC ordering kicks in when sinceID is set
@@ -3494,6 +3509,21 @@ func (m *MockClipNoteRepository) CountByClip(clipID string) (int64, error) {
 		}
 	}
 	return count, nil
+}
+
+// ListClipIDsByNote returns the distinct clipIds containing noteID.
+func (m *MockClipNoteRepository) ListClipIDsByNote(noteID string) ([]string, error) {
+	seen := make(map[string]struct{})
+	var ids []string
+	for _, cn := range m.Entries {
+		if cn.NoteID == noteID {
+			if _, dup := seen[cn.ClipID]; !dup {
+				seen[cn.ClipID] = struct{}{}
+				ids = append(ids, cn.ClipID)
+			}
+		}
+	}
+	return ids, nil
 }
 
 func (m *MockClipNoteRepository) ListByClip(clipID string, untilID, sinceID string, limit int) ([]*model.ClipNote, error) {


### PR DESCRIPTION
## Summary

#1554 (notes/* timeline+list parity) の HIGH 項目。`POST /api/notes/clips` は upstream では noteId を受け取り、その note を含む `isPublic=true` な Clip を Clip entity 配列で返すが、mk-go は noteId を一切見ず常に `[]` を返す stub だった (note 存在確認も Clip 解決もしない)。

## 主な変更点

- **repository**: `ClipNoteRepository.ListClipIDsByNote(noteID)` (note を含む clip の distinct clipId) と `ClipRepository.ListPublicByIDs(ids)` (id IN + isPublic=true) を追加。
- **handler**: noteId bind → `noteRepo.FindByID` で存在確認 (無ければ `NO_SUCH_NOTE` `47db1a1c-...`、clips 固有 UUID) → `ListClipIDsByNote` → `ListPublicByIDs` → 各 clip を `PackClip`。owner は clip ごとに解決 (note は複数 user の clip に入りうる)。`ClipExtras` は favoritedCount 常時 / isFavorited は viewer 有時 / notesCount は owner 閲覧時のみ (upstream `ClipEntityService.pack` と一致)。clip repo 未配線時は `[]` fallback (旧 stub 互換)。

## 設計

- 可視性: upstream `getNote` 同様 note の**存在のみ**確認し可視性 gate しない。返すのは public clip のみなので private note の所在が漏れることはない。
- NO_SUCH_NOTE は notes/clips 固有 UUID `47db1a1c-...` (generic `24fcbfc6` ではない、golden と一致)。

## テスト

- handler: public clip のみ返す (private / 他人非public 除外、他人 public は含む)、NO_SUCH_NOTE (固有 UUID)、未配線 degrade、INVALID_PARAM、L3 `shapetest.Assert("Clip")`
- repository: `ListPublicByIDs` (isPublic filter / 空 ids) + `ListClipIDsByNote` (distinct / 他 note 混在除外) の real-DB テスト
- `go vet ./...` 全体 / entitycompat drift gates / 全テスト pass

## 関連

#1554 (notes/* timeline+list) の HIGH 1 項目。残りは別 PR / follow-up で対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)