### PR TITLE
Fix notes timeline error parity: STL_DISABLED + BOTH_WITH_REPLIES (#1554 part2)

### DIFF
--- a/internal/api/apierr/echo.go
+++ b/internal/api/apierr/echo.go
@@ -58,6 +58,11 @@ func JSONLtlDisabled(c echo.Context) error {
 	return c.JSON(http.StatusForbidden, LtlDisabled())
 }
 
+// JSONStlDisabled writes a 403 STL_DISABLED response (notes/hybrid-timeline)。
+func JSONStlDisabled(c echo.Context) error {
+	return c.JSON(http.StatusForbidden, StlDisabled())
+}
+
 // JSONGtlDisabled writes a 403 GTL_DISABLED response. 詳細は GtlDisabled の doc。
 func JSONGtlDisabled(c echo.Context) error {
 	return c.JSON(http.StatusForbidden, GtlDisabled())

--- a/internal/api/apierr/echo_test.go
+++ b/internal/api/apierr/echo_test.go
@@ -115,6 +115,14 @@ func TestJSONLtlDisabled(t *testing.T) {
 	assert.Equal(t, UUIDLtlDisabled, errObj["id"])
 }
 
+func TestJSONStlDisabled(t *testing.T) {
+	code, body := invoke(t, JSONStlDisabled)
+	assert.Equal(t, http.StatusForbidden, code)
+	errObj := body["error"].(map[string]any)
+	assert.Equal(t, "STL_DISABLED", errObj["code"])
+	assert.Equal(t, UUIDStlDisabled, errObj["id"])
+}
+
 func TestJSONGtlDisabled(t *testing.T) {
 	code, body := invoke(t, JSONGtlDisabled)
 	assert.Equal(t, http.StatusForbidden, code)

--- a/internal/api/apierr/errors.go
+++ b/internal/api/apierr/errors.go
@@ -103,8 +103,12 @@ const (
 
 	// UUIDLtlDisabled は upstream `notes/local-timeline` の `ltlDisabled` UUID。
 	// `ltlAvailable` role policy が false のときに 403 で reject する (#1026)。
-	// hybrid-timeline からも同 UUID で reject する upstream 仕様。
 	UUIDLtlDisabled = "45a6eb02-7695-4393-b023-dd3be9aaaefd"
+	// UUIDStlDisabled は upstream `notes/hybrid-timeline` の `stlDisabled` UUID。
+	// hybrid-timeline は ltlAvailable policy で gate するが、エラーコードは
+	// STL_DISABLED (Social TimeLine) で local-timeline の LTL_DISABLED とは別
+	// (#1554)。
+	UUIDStlDisabled = "620763f4-f621-4533-ab33-0577a1a3c342"
 	// UUIDGtlDisabled は upstream `notes/global-timeline` の `gtlDisabled` UUID。
 	// `gtlAvailable` role policy が false のときに 403 で reject する (#1026)。
 	UUIDGtlDisabled = "0332fc13-6ab2-4427-ae80-a9fadffd1a6b"
@@ -347,6 +351,12 @@ func RestrictedByRole() map[string]any {
 	return Error("RESTRICTED_BY_ROLE",
 		"This feature is restricted by your role.",
 		UUIDRestrictedByRole)
+}
+
+// StlDisabled returns a 403 STL_DISABLED error response (upstream
+// notes/hybrid-timeline の stlDisabled、#1554)。
+func StlDisabled() map[string]any {
+	return Error("STL_DISABLED", "Hybrid timeline has been disabled.", UUIDStlDisabled)
 }
 
 // LtlDisabled returns a 403 LTL_DISABLED error response. upstream

--- a/internal/api/apierr/errors_test.go
+++ b/internal/api/apierr/errors_test.go
@@ -191,6 +191,14 @@ func TestLtlDisabled(t *testing.T) {
 	assert.Equal(t, "Local timeline has been disabled.", errObj["message"])
 }
 
+func TestStlDisabled(t *testing.T) {
+	result := StlDisabled()
+	errObj := result["error"].(map[string]any)
+	assert.Equal(t, "STL_DISABLED", errObj["code"])
+	assert.Equal(t, UUIDStlDisabled, errObj["id"])
+	assert.Equal(t, "Hybrid timeline has been disabled.", errObj["message"])
+}
+
 // #1026: upstream notes/global-timeline.ts の gtlDisabled と一致を seal。
 func TestGtlDisabled(t *testing.T) {
 	result := GtlDisabled()

--- a/internal/api/notes/timeline_handler.go
+++ b/internal/api/notes/timeline_handler.go
@@ -140,8 +140,10 @@ func (h *Handler) GlobalTimeline(c echo.Context) error {
 func (h *Handler) HybridTimeline(c echo.Context) error {
 	// upstream: hybrid-timeline は ltlAvailable で gate する (gtl ではなく
 	// ltl 側 policy を見るのは「ローカルタイムライン + social の hybrid」だから)。
+	// ただしエラーコードは STL_DISABLED (Social TimeLine) で local の LTL_DISABLED
+	// とは別 UUID を返す (#1554、upstream hybrid-timeline.ts stlDisabled)。
 	if !h.timelineAvailable(c, policyKeyLtlAvailable) {
-		return apierr.JSONLtlDisabled(c)
+		return apierr.JSONStlDisabled(c)
 	}
 	return h.serveTimeline(c, "hybrid", func(viewer *model.User, req TimelineRequest) ([]*model.Note, error) {
 		f := timeline.TimelineFilter{
@@ -229,6 +231,18 @@ func (h *Handler) serveTimeline(
 		return apierr.JSONInvalidParam(c)
 	}
 	req.normalize()
+
+	// upstream local/hybrid-timeline は withReplies && withFiles 同時指定を
+	// BOTH_WITH_REPLIES_AND_WITH_FILES で弾く (endpoint 固有 UUID、#1554)。
+	// timeline(home)/global は upstream に該当エラーが無いので対象外。
+	if req.WithReplies != nil && *req.WithReplies && req.WithFiles {
+		switch kind {
+		case "local":
+			return c.JSON(http.StatusBadRequest, apierr.Error("BOTH_WITH_REPLIES_AND_WITH_FILES", "Specifying both withReplies and withFiles is not supported", "dd9c8400-1cb5-4eef-8a31-200c5f933793"))
+		case "hybrid":
+			return c.JSON(http.StatusBadRequest, apierr.Error("BOTH_WITH_REPLIES_AND_WITH_FILES", "Specifying both withReplies and withFiles is not supported", "dfaa3eb7-8002-4cb7-bcc4-1095df46656f"))
+		}
+	}
 
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。旧実装は
 	// idGen.Generate(time) で完全 ID (= time prefix + random nodeID + counter)

--- a/internal/api/notes/timeline_handler_test.go
+++ b/internal/api/notes/timeline_handler_test.go
@@ -262,7 +262,43 @@ func TestHybridTimeline_LtlDisabledRejects(t *testing.T) {
 	setAuthUser(c, &model.User{ID: "alice"})
 	require.NoError(t, h.HybridTimeline(c))
 	assert.Equal(t, http.StatusForbidden, rec.Code, "hybrid は ltlAvailable で gate")
-	assert.Contains(t, rec.Body.String(), "LTL_DISABLED")
+	// gate は ltlAvailable だが error code は STL_DISABLED (#1554)。
+	assert.Contains(t, rec.Body.String(), "STL_DISABLED")
+	assert.Contains(t, rec.Body.String(), "620763f4-f621-4533-ab33-0577a1a3c342")
+}
+
+// #1554 local-timeline は withReplies && withFiles 同時指定を
+// BOTH_WITH_REPLIES_AND_WITH_FILES (local 固有 UUID) で弾く。
+func TestLocalTimeline_BothWithRepliesAndWithFiles(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	h := newTimelineHandler(t, noteRepo, newFailingTimelineService(t))
+	c, rec := newJSONRequest(t, "/api/notes/local-timeline", `{"withReplies":true,"withFiles":true}`)
+	require.NoError(t, h.LocalTimeline(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "BOTH_WITH_REPLIES_AND_WITH_FILES")
+	assert.Contains(t, rec.Body.String(), "dd9c8400-1cb5-4eef-8a31-200c5f933793")
+}
+
+// #1554 hybrid-timeline も同様 (hybrid 固有 UUID)。
+func TestHybridTimeline_BothWithRepliesAndWithFiles(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	h := newTimelineHandler(t, noteRepo, newFailingTimelineService(t))
+	c, rec := newJSONRequest(t, "/api/notes/hybrid-timeline", `{"withReplies":true,"withFiles":true}`)
+	setAuthUser(c, &model.User{ID: "alice"})
+	require.NoError(t, h.HybridTimeline(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "BOTH_WITH_REPLIES_AND_WITH_FILES")
+	assert.Contains(t, rec.Body.String(), "dfaa3eb7-8002-4cb7-bcc4-1095df46656f")
+}
+
+// withReplies のみ / withFiles のみは通る (両方同時のときだけ弾く)。
+func TestLocalTimeline_WithRepliesOnlyOK(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	h := newTimelineHandler(t, noteRepo, newFailingTimelineService(t))
+	c, rec := newJSONRequest(t, "/api/notes/local-timeline", `{"withReplies":true}`)
+	require.NoError(t, h.LocalTimeline(c))
+	// BOTH guard は通り、後段の failing service で 500 (= guard で弾かれていない)。
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
 // policyProvider 未配線時は gate を skip する (= 旧挙動互換 / test fixture)。


### PR DESCRIPTION
## Summary

#1554 (notes/* timeline+list parity) の timeline エラー 2 項目 (HIGH + MEDIUM)。

## 主な変更点

- **[HIGH] hybrid-timeline の無効時エラーコード**: hybrid-timeline は `ltlAvailable` policy で gate するが、無効時の error code は upstream で `STL_DISABLED` (Social TimeLine、`620763f4-...`) であり local-timeline の `LTL_DISABLED` (`45a6eb02-...`) とは**別**。mk-go は両方 `LTL_DISABLED` を返していたため hybrid を `STL_DISABLED` に修正。`apierr.StlDisabled` / `JSONStlDisabled` / `UUIDStlDisabled` を追加。
- **[MEDIUM] BOTH_WITH_REPLIES_AND_WITH_FILES**: local/hybrid-timeline は `withReplies && withFiles` 同時指定を `BOTH_WITH_REPLIES_AND_WITH_FILES` (local `dd9c8400-...` / hybrid `dfaa3eb7-...`、endpoint 固有 UUID) で弾く upstream guard が欠落していた。`serveTimeline` に kind 別 guard を追加。`timeline`(home)/`global` は upstream に該当エラーが無いので対象外。

UUID / message は upstream `local/hybrid-timeline.ts` および `golden_error_ids.json` と一致。`STL_DISABLED` は `HybridTimeline` route method で emit するため errorid drift gate の検証対象 (green)。

## テスト

- hybrid disabled → `STL_DISABLED`/`620763f4`、local disabled → `LTL_DISABLED` (据え置き)
- local/hybrid の `withReplies && withFiles` → `BOTH_WITH_REPLIES_AND_WITH_FILES` (per-endpoint UUID)、withReplies のみは通る
- apierr: `StlDisabled` / `JSONStlDisabled` の table test 追加
- entitycompat drift gates / `go vet ./...` / 全テスト pass

## 関連

#1554 (notes/* timeline+list) の 2 項目。

🤖 Generated with [Claude Code](https://claude.com/claude-code)