### PR TITLE
Fix notes/children,replies,renotes: block/mute/instance-mute filter (#1554 part3)

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -48,11 +48,15 @@ type Handler struct {
 	channelMutingRepo repository.ChannelMutingRepository
 	mutingRepo        repository.MutingRepository
 	renoteMutingRepo  repository.RenoteMutingRepository
-	instanceRepo      repository.InstanceRepository
-	emojiRepo         repository.EmojiRepository
-	driveFolderRepo   repository.DriveFolderRepository
-	userRepo          repository.UserRepository
-	userListRepo      repository.UserListRepository
+	// blockingRepo は notes/children・replies・renotes の list 応答で被block /
+	// mute / instance-mute filter を適用するのに使う (#1554、upstream
+	// generateBaseNoteFilteringQuery 相当)。未配線時は filter skip。
+	blockingRepo    repository.BlockingRepository
+	instanceRepo    repository.InstanceRepository
+	emojiRepo       repository.EmojiRepository
+	driveFolderRepo repository.DriveFolderRepository
+	userRepo        repository.UserRepository
+	userListRepo    repository.UserListRepository
 	// clipRepo / clipNoteRepo / clipFavoriteRepo は notes/clips で「この note を
 	// 含む public clip」を Clip entity として返すのに使う (#1554)。未配線時は
 	// 空配列 fallback (旧 stub 互換)。
@@ -137,6 +141,12 @@ func (h *Handler) SetMutingRepo(r repository.MutingRepository) {
 // upstream Misskey TS の generateMutedUserRelatedRenotesQuery と同 semantics。
 func (h *Handler) SetRenoteMutingRepo(r repository.RenoteMutingRepository) {
 	h.renoteMutingRepo = r
+}
+
+// SetBlockingRepo attaches a BlockingRepository so notes/children・replies・
+// renotes can exclude notes authored by users who block the viewer (#1554)。
+func (h *Handler) SetBlockingRepo(r repository.BlockingRepository) {
+	h.blockingRepo = r
 }
 
 // SetTranslator attaches a DeepL translator for /api/notes/translate.
@@ -592,7 +602,34 @@ func (h *Handler) serveList(c echo.Context, noSuchNoteID string, fn func(*model.
 		}
 		return apierr.JSONInternalError(c)
 	}
+	// upstream children/replies/renotes は generateBaseNoteFilteringQuery で
+	// 被block / mute / instance-mute を除外する (#1554)。QueryService は
+	// 可視性しか見ないため、antennas/roles と同じ post-fetch filter をここで
+	// 適用する (blocked-host / suspended は別 follow-up)。
+	notes, err = h.applyMuteBlock(viewer, notes)
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
 	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))
+}
+
+// applyMuteBlock filters out notes the viewer should not see per the mute/block
+// dimensions of upstream generateBaseNoteFilteringQuery: muted-user / 被block /
+// muted-instance (note/reply/renote の author いずれか一致で除外)。
+// channel-mute は upstream の generateBaseNoteFilteringQuery には含まれず
+// timeline 系のみで適用されるため、ここでは channelMutingRepo に nil を渡して
+// 適用しない (children/replies/renotes parity、#1554)。blocked-host / suspended
+// は別 follow-up。blockingRepo 未配線 / viewer nil なら no-op。fail-closed:
+// lookup / filter エラーは呼び出し側で 500 にする。
+func (h *Handler) applyMuteBlock(viewer *model.User, notes []*model.Note) ([]*model.Note, error) {
+	if viewer == nil || h.blockingRepo == nil {
+		return notes, nil
+	}
+	sets, err := notesfilter.LoadMuteBlockSets(viewer, h.mutingRepo, h.blockingRepo, nil, h.userRepo)
+	if err != nil {
+		return nil, err
+	}
+	return notesfilter.ApplyMuteBlockChannel(notes, sets, h.noteRepo)
 }
 
 // SearchRequest is the request body for notes/search.

--- a/internal/api/notes/handler_query_test.go
+++ b/internal/api/notes/handler_query_test.go
@@ -81,6 +81,65 @@ func TestRenotes_OK(t *testing.T) {
 	shapetest.Assert(t, "Note", resp[0]) // L3 (#1316)
 }
 
+// #1554 renotes は viewer を block している author の note を除外する
+// (upstream generateBaseNoteFilteringQuery 相当)。
+func TestRenotes_FiltersBlockingAuthor(t *testing.T) {
+	h, repo := newQueryHandler(t)
+	parent := seedPublicNote(repo, "parent")
+	pid := parent.ID
+	// blocker が parent を renote。blocker は viewer(alice) を block している。
+	r := seedPublicNote(repo, "r1")
+	r.UserID = "blocker"
+	r.RenoteID = &pid
+	r.User = &model.User{ID: "blocker", Username: "blocker", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+
+	mutingRepo := testutil.NewMockMutingRepository()
+	blockingRepo := testutil.NewMockBlockingRepository()
+	blockingRepo.Blockings["b1"] = &model.Blocking{ID: "b1", BlockerID: "blocker", BlockeeID: "alice"}
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice", UsernameLower: "alice"}
+	h.SetMutingRepo(mutingRepo)
+	h.SetBlockingRepo(blockingRepo)
+	h.SetUserRepo(userRepo)
+
+	c, rec := newJSONRequest(t, "/api/notes/renotes", `{"noteId":"parent"}`)
+	setAuthUser(c, &model.User{ID: "alice"})
+	require.NoError(t, h.Renotes(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	// blocker の renote は除外される。
+	assert.Empty(t, resp)
+}
+
+// #1554 replies は viewer が mute した author の note を除外する。
+func TestReplies_FiltersMutedAuthor(t *testing.T) {
+	h, repo := newQueryHandler(t)
+	parent := seedPublicNote(repo, "parent")
+	pid := parent.ID
+	reply := seedPublicNote(repo, "rep1")
+	reply.UserID = "muted"
+	reply.ReplyID = &pid
+	reply.User = &model.User{ID: "muted", Username: "muted", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+
+	mutingRepo := testutil.NewMockMutingRepository()
+	mutingRepo.Mutings["m1"] = &model.Muting{ID: "m1", MuterID: "alice", MuteeID: "muted"}
+	blockingRepo := testutil.NewMockBlockingRepository()
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice", UsernameLower: "alice"}
+	h.SetMutingRepo(mutingRepo)
+	h.SetBlockingRepo(blockingRepo)
+	h.SetUserRepo(userRepo)
+
+	c, rec := newJSONRequest(t, "/api/notes/replies", `{"noteId":"parent"}`)
+	setAuthUser(c, &model.User{ID: "alice"})
+	require.NoError(t, h.Replies(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Empty(t, resp)
+}
+
 func TestRenotes_NotFound(t *testing.T) {
 	h, _ := newQueryHandler(t)
 	c, rec := newJSONRequest(t, "/api/notes/renotes", `{"noteId":"ghost"}`)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1189,6 +1189,7 @@ func (s *Server) setupRoutes() {
 	// filter (#903)。未配線だと renote-mute は read 時に効かず、frontend
 	// で消えるべき renote が表示され続ける。production では必ず wire する。
 	notesHandler.SetRenoteMutingRepo(renoteMutingRepo)
+	notesHandler.SetBlockingRepo(blockingRepo) // #1554: children/replies/renotes mute/block filter
 	notesHandler.SetInstanceRepo(instanceRepo)
 	notesHandler.SetEmojiRepo(emojiRepo)
 	notesHandler.SetReactionReader(reactionCountWriter)


### PR DESCRIPTION
## Summary

#1554 (notes/* timeline+list parity) の MEDIUM 1 項目。upstream の `notes/children` / `notes/replies` / `notes/renotes` は `generateVisibilityQuery + generateBaseNoteFilteringQuery` で被block / mute / instance-mute を除外するが、mk-go の `QueryService` は可視性しか見ず、handler の `packMany` も word-mute のみだったため、mute/block した相手の返信・引用・renote が漏れていた。

## 主な変更点

- notes `Handler` に `blockingRepo` + `SetBlockingRepo` を追加。
- `serveList` (Children/Replies/Renotes 共用) で fetch 後・packMany 前に `applyMuteBlock` を適用。antennas/roles/users と同じ `LoadMuteBlockSets` + `ApplyMuteBlockChannel` (muted-user / 被block / instance-mute、note/reply/renote の author いずれか一致で除外) を post-fetch filter する。
- **channel-mute は対象外**: upstream の `generateBaseNoteFilteringQuery` には channel 次元が無く、channel-mute は timeline 系のみで適用される。strict parity のため `channelMutingRepo` に `nil` を渡して適用しない (レビュー指摘)。
- viewer nil (匿名) / blockingRepo 未配線時は no-op、lookup/filter エラーは 500 (fail-closed)。

## scope 外 (既存 list-endpoint パターンと共通)

`blocked-host` (admin meta.blockedHosts) と `suspended-user` は notesfilter に未実装で、antennas/roles/users でも未適用。timeline 系の base-filtering follow-up と合わせて別途対応する。

## テスト

- renotes: viewer を block している author の renote が除外される
- replies: viewer が mute した author の reply が除外される
- 既存 `TestRenotes_OK` (filter 未配線) は非回帰
- `go vet ./...` / entitycompat drift gates / 全テスト pass

## 関連

#1554 (notes/* timeline+list) の 1 項目。

🤖 Generated with [Claude Code](https://claude.com/claude-code)