### PR TITLE
Fix notes/mentions: following param + block/mute/thread-mute filter (#1554 part4)

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -632,6 +632,20 @@ func (h *Handler) applyMuteBlock(viewer *model.User, notes []*model.Note) ([]*mo
 	return notesfilter.ApplyMuteBlockChannel(notes, sets, h.noteRepo)
 }
 
+// applyThreadMute drops notes belonging to a thread the viewer has muted
+// (upstream generateMutedNoteThreadQuery、#1554)。threadMutingRepo 未配線 /
+// viewer nil なら no-op。fail-closed: lookup エラーは呼び出し側で 500 にする。
+func (h *Handler) applyThreadMute(viewer *model.User, notes []*model.Note) ([]*model.Note, error) {
+	if viewer == nil || h.threadMutingRepo == nil {
+		return notes, nil
+	}
+	ids, err := h.threadMutingRepo.ListMutedThreadIDs(viewer.ID)
+	if err != nil {
+		return nil, err
+	}
+	return notesfilter.ApplyThreadMute(notes, ids), nil
+}
+
 // SearchRequest is the request body for notes/search.
 //
 // Misskey 本家と互換のフィールド構成。`sinceDate` / `untilDate` (unix milli)

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -149,6 +149,7 @@ func (h *Handler) Mentions(c echo.Context) error {
 		SinceDate  *int64 `json:"sinceDate"`
 		UntilDate  *int64 `json:"untilDate"`
 		Visibility string `json:"visibility"`
+		Following  bool   `json:"following"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
@@ -161,7 +162,19 @@ func (h *Handler) Mentions(c echo.Context) error {
 	// note.visibility = <値> で exact-match し、未指定は全種別を返す。旧実装は
 	// post-fetch で specified / 非specified に振り分けていたため、ページ内が片方の
 	// 種別で埋まると limit 未満になる under-fill が起きていた。
-	notes, err := h.noteRepo.ListMentions(user.ID, req.Visibility, req.Limit, sinceID, untilID)
+	// following=true のとき followee + 自分の note のみに絞る (upstream
+	// mentions.ts following param、#1554)。
+	notes, err := h.noteRepo.ListMentions(user.ID, req.Visibility, req.Following, req.Limit, sinceID, untilID)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	// upstream mentions は generateBaseNoteFilteringQuery + generateMutedNoteThreadQuery
+	// で被block / mute / instance-mute / thread-mute を除外する (#1554)。
+	notes, err = h.applyMuteBlock(user, notes)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	notes, err = h.applyThreadMute(user, notes)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}

--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -363,6 +363,35 @@ func TestMentions_InvalidJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// #1554 mentions は viewer が mute した author の note を除外する。
+func TestMentions_FiltersMutedAuthor(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	noteRepo.Notes["mm1"] = &model.Note{ID: "mm1", UserID: "muted", Visibility: "public", Mentions: []string{"u1"}, User: &model.User{ID: "muted"}}
+	mutingRepo := testutil.NewMockMutingRepository()
+	mutingRepo.Mutings["mx"] = &model.Muting{ID: "mx", MuterID: "u1", MuteeID: "muted"}
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "u1", UsernameLower: "u1"}
+	h.SetMutingRepo(mutingRepo)
+	h.SetBlockingRepo(testutil.NewMockBlockingRepository())
+	h.SetUserRepo(userRepo)
+
+	ids := mentionIDs(t, postExtra(h.Mentions, `{}`, &model.User{ID: "u1"}))
+	assert.False(t, ids["mm1"], "mute した author の mention note は除外される")
+}
+
+// #1554 mentions は muted thread の note を除外する (generateMutedNoteThreadQuery)。
+func TestMentions_FiltersThreadMute(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	thread := "rootthread"
+	noteRepo.Notes["mt1"] = &model.Note{ID: "mt1", UserID: "author", Visibility: "public", Mentions: []string{"u1"}, ThreadID: &thread, User: &model.User{ID: "author"}}
+	tmRepo := testutil.NewMockNoteThreadMutingRepository()
+	require.NoError(t, tmRepo.Create(&model.NoteThreadMuting{UserID: "u1", ThreadID: thread}))
+	h.SetThreadMutingRepo(tmRepo)
+
+	ids := mentionIDs(t, postExtra(h.Mentions, `{}`, &model.User{ID: "u1"}))
+	assert.False(t, ids["mt1"], "muted thread の mention note は除外される")
+}
+
 func mentionIDs(t *testing.T, rec *httptest.ResponseRecorder) map[string]bool {
 	t.Helper()
 	require.Equal(t, http.StatusOK, rec.Code)
@@ -993,7 +1022,7 @@ func TestUnrenote_DeleteError(t *testing.T) {
 
 type failingMentionsRepo struct{ *testutil.MockNoteRepository }
 
-func (f *failingMentionsRepo) ListMentions(_, _ string, _ int, _, _ string) ([]*model.Note, error) {
+func (f *failingMentionsRepo) ListMentions(_, _ string, _ bool, _ int, _, _ string) ([]*model.Note, error) {
 	return nil, testutil.ErrNotFound
 }
 

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -866,7 +866,7 @@ func (f *failingNoteRepo) ListFeaturedByUser(_, _, _ string, _ int) ([]*model.No
 func (f *failingNoteRepo) FindRenoteByUser(_, _ string) (*model.Note, error) {
 	return nil, testutil.ErrNotFound
 }
-func (f *failingNoteRepo) ListMentions(_, _ string, _ int, _, _ string) ([]*model.Note, error) {
+func (f *failingNoteRepo) ListMentions(_, _ string, _ bool, _ int, _, _ string) ([]*model.Note, error) {
 	return nil, nil
 }
 func (f *failingNoteRepo) SearchByTag(_, _ string, _ int, _, _ string) ([]*model.Note, error) {

--- a/internal/core/notesfilter/threadmute.go
+++ b/internal/core/notesfilter/threadmute.go
@@ -1,0 +1,36 @@
+package notesfilter
+
+import "github.com/shiroha-a/mk/internal/model"
+
+// ApplyThreadMute drops notes belonging to a thread the viewer has muted,
+// mirroring upstream QueryService.generateMutedNoteThreadQuery (#1554)。
+//
+// upstream は `note.id NOT IN (mutedThreadIds)` かつ
+// `(note.threadId IS NULL OR note.threadId NOT IN (mutedThreadIds))` で絞る。
+// すなわち note.id が muted thread の root であるか、note.threadId が muted
+// thread であれば除外する。mutedThreadIDs が空なら no-op。
+func ApplyThreadMute(notes []*model.Note, mutedThreadIDs []string) []*model.Note {
+	if len(notes) == 0 || len(mutedThreadIDs) == 0 {
+		return notes
+	}
+	muted := make(map[string]struct{}, len(mutedThreadIDs))
+	for _, id := range mutedThreadIDs {
+		muted[id] = struct{}{}
+	}
+	out := make([]*model.Note, 0, len(notes))
+	for _, n := range notes {
+		if n == nil {
+			continue
+		}
+		if _, ok := muted[n.ID]; ok {
+			continue
+		}
+		if n.ThreadID != nil {
+			if _, ok := muted[*n.ThreadID]; ok {
+				continue
+			}
+		}
+		out = append(out, n)
+	}
+	return out
+}

--- a/internal/core/notesfilter/threadmute_test.go
+++ b/internal/core/notesfilter/threadmute_test.go
@@ -1,0 +1,43 @@
+package notesfilter
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func strptr(s string) *string { return &s }
+
+func TestApplyThreadMute_EmptyListIsNoop(t *testing.T) {
+	notes := []*model.Note{{ID: "n1"}}
+	assert.Len(t, ApplyThreadMute(notes, nil), 1)
+}
+
+func TestApplyThreadMute_DropsByRootID(t *testing.T) {
+	// note.id がそのまま muted thread root のケース。
+	notes := []*model.Note{{ID: "root"}, {ID: "other"}}
+	out := ApplyThreadMute(notes, []string{"root"})
+	assert.Len(t, out, 1)
+	assert.Equal(t, "other", out[0].ID)
+}
+
+func TestApplyThreadMute_DropsByThreadID(t *testing.T) {
+	// reply note の threadId が muted thread のケース。
+	notes := []*model.Note{
+		{ID: "reply1", ThreadID: strptr("root")},
+		{ID: "reply2", ThreadID: strptr("elsewhere")},
+		{ID: "noThread"},
+	}
+	out := ApplyThreadMute(notes, []string{"root"})
+	assert.Len(t, out, 2)
+	assert.Equal(t, "reply2", out[0].ID)
+	assert.Equal(t, "noThread", out[1].ID)
+}
+
+func TestApplyThreadMute_NilNoteSkipped(t *testing.T) {
+	notes := []*model.Note{nil, {ID: "n1"}}
+	out := ApplyThreadMute(notes, []string{"x"})
+	assert.Len(t, out, 1)
+	assert.Equal(t, "n1", out[0].ID)
+}

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -131,8 +131,9 @@ type NoteRepository interface {
 	// visibility が空でなければ note.visibility = visibility の exact-match で
 	// 絞る (upstream TS notes/mentions と同じ; 空は全種別)。振り分けを LIMIT 前に
 	// SQL で行うことで handler の post-fetch 振り分けによる under-fill を解消する
-	// (#1451)。
-	ListMentions(userID, visibility string, limit int, sinceID, untilID string) ([]*model.Note, error)
+	// (#1451)。following=true のとき note.userId が viewer の followee または
+	// viewer 自身に限定する (upstream mentions.ts following param、#1554)。
+	ListMentions(userID, visibility string, following bool, limit int, sinceID, untilID string) ([]*model.Note, error)
 	// SearchByTag returns notes carrying tag that viewerID is allowed to see.
 	// viewerID 空文字は匿名 (public/home のみ)。discovery 系の tag 検索は
 	// ID 既知公開 (notes/show) doctrine の対象外なので、core/note.CanSeeNote と
@@ -730,7 +731,7 @@ func (r *noteRepository) FindRenoteByUser(userID, renoteID string) (*model.Note,
 	return &note, nil
 }
 
-func (r *noteRepository) ListMentions(userID, visibility string, limit int, sinceID, untilID string) ([]*model.Note, error) {
+func (r *noteRepository) ListMentions(userID, visibility string, following bool, limit int, sinceID, untilID string) ([]*model.Note, error) {
 	if limit <= 0 {
 		limit = 10
 	}
@@ -763,6 +764,12 @@ func (r *noteRepository) ListMentions(userID, visibility string, limit int, sinc
 	// 未知の値は単に 0 件になる (TS と同じ挙動)。
 	if visibility != "" {
 		q = q.Where(`"visibility" = ?`, visibility)
+	}
+	// following=true: note.userId が viewer の followee または viewer 自身に限定
+	// (upstream mentions.ts:84-87)。subquery は ListHomeTimeline と同じ following
+	// テーブル参照。
+	if following {
+		q = q.Where(`("userId" IN (SELECT "followeeId" FROM "following" WHERE "followerId" = ?) OR "userId" = ?)`, userID, userID)
 	}
 	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
 	if sinceID != "" {

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -1824,18 +1824,59 @@ func TestNoteRepository_ListMentions(t *testing.T) {
 	require.NoError(t, testDB.Create(n).Error)
 	defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, n.ID)
 
-	notes, err := repo.ListMentions(mentionee.ID, "", 10, "", "")
+	notes, err := repo.ListMentions(mentionee.ID, "", false, 10, "", "")
 	require.NoError(t, err)
 	assert.NotEmpty(t, notes)
 
 	// with cursors
-	notes, err = repo.ListMentions(mentionee.ID, "", 10, "", "zzz")
+	notes, err = repo.ListMentions(mentionee.ID, "", false, 10, "", "zzz")
 	require.NoError(t, err)
 	assert.NotEmpty(t, notes)
 
-	notes, err = repo.ListMentions(mentionee.ID, "", 10, "000", "")
+	notes, err = repo.ListMentions(mentionee.ID, "", false, 10, "000", "")
 	require.NoError(t, err)
 	assert.NotEmpty(t, notes)
+}
+
+// #1554 following=true は note.userId が viewer の followee または viewer 自身に
+// 限定する (upstream mentions.ts following param)。
+func TestNoteRepository_ListMentions_Following(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	viewer := insertTestUser(t, "lmf_v", "lmfviewer")
+	followed := insertTestUser(t, "lmf_f", "lmffollowed")
+	stranger := insertTestUser(t, "lmf_s", "lmfstranger")
+	defer cleanupUser(t, viewer.ID)
+	defer cleanupUser(t, followed.ID)
+	defer cleanupUser(t, stranger.ID)
+	// viewer は followed を follow する。
+	require.NoError(t, testDB.Create(&model.Following{ID: "lmf_fl1", FollowerID: viewer.ID, FolloweeID: followed.ID}).Error)
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, "lmf_fl1")
+
+	// followed / stranger / viewer 自身が viewer を mention する 3 note。
+	for _, n := range []*model.Note{
+		{ID: "lmf_nf", UserID: followed.ID, Visibility: "public", Mentions: []string{viewer.ID}},
+		{ID: "lmf_ns", UserID: stranger.ID, Visibility: "public", Mentions: []string{viewer.ID}},
+		{ID: "lmf_nself", UserID: viewer.ID, Visibility: "public", Mentions: []string{viewer.ID}},
+	} {
+		require.NoError(t, testDB.Create(n).Error)
+		defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, n.ID)
+	}
+
+	// following=false は全件 (3)。
+	all, err := repo.ListMentions(viewer.ID, "", false, 50, "", "")
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+
+	// following=true は followed + 自分の note のみ (stranger 除外)。
+	followingOnly, err := repo.ListMentions(viewer.ID, "", true, 50, "", "")
+	require.NoError(t, err)
+	ids := make(map[string]bool)
+	for _, n := range followingOnly {
+		ids[n.ID] = true
+	}
+	assert.True(t, ids["lmf_nf"], "followee の note は含まれる")
+	assert.True(t, ids["lmf_nself"], "自分の note は含まれる")
+	assert.False(t, ids["lmf_ns"], "非フォローの stranger の note は除外される")
 }
 
 // TestNoteRepository_ListMentions_VisibilityPushDown は #1441 を検証する。
@@ -1875,7 +1916,7 @@ func TestNoteRepository_ListMentions_VisibilityPushDown(t *testing.T) {
 	}
 
 	// follow なし / visibleUserIds 非対象 -> public のみ (followers/specified は隠れる)。
-	out, err := repo.ListMentions(victim.ID, "", 50, "", "")
+	out, err := repo.ListMentions(victim.ID, "", false, 50, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_lm_pub"}, idsOf(out))
 
@@ -1883,20 +1924,20 @@ func TestNoteRepository_ListMentions_VisibilityPushDown(t *testing.T) {
 	f := &model.Following{ID: "fl_lm_1", FollowerID: victim.ID, FolloweeID: author.ID}
 	require.NoError(t, followingRepo.Create(f))
 	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, f.ID)
-	out, err = repo.ListMentions(victim.ID, "", 50, "", "")
+	out, err = repo.ListMentions(victim.ID, "", false, 50, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_lm_fol", "n_lm_pub"}, idsOf(out))
 
 	// specified の visibleUserIds に victim を含めると specified も見える。
 	require.NoError(t, repo.UpdateFields("n_lm_spec", map[string]any{"visibleUserIds": pq.StringArray{victim.ID}}))
-	out, err = repo.ListMentions(victim.ID, "", 50, "", "")
+	out, err = repo.ListMentions(victim.ID, "", false, 50, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_lm_fol", "n_lm_pub", "n_lm_spec"}, idsOf(out))
 }
 
 func TestNoteRepository_ListMentions_DefaultLimit(t *testing.T) {
 	repo := NewNoteRepository(testDB)
-	notes, err := repo.ListMentions("nobody", "", 0, "", "")
+	notes, err := repo.ListMentions("nobody", "", false, 0, "", "")
 	require.NoError(t, err)
 	assert.Empty(t, notes)
 }
@@ -1905,7 +1946,7 @@ func TestNoteRepository_ListMentions_Error(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	repo := NewNoteRepository(testDB.WithContext(ctx))
-	_, err := repo.ListMentions("x", "", 10, "", "")
+	_, err := repo.ListMentions("x", "", false, 10, "", "")
 	assert.Error(t, err)
 }
 
@@ -1940,7 +1981,7 @@ func TestNoteRepository_ListMentions_VisibilityFilter(t *testing.T) {
 	}
 
 	// public のみ limit=5 -> public が 5 件きっちり (specified がスロットを食わない)。
-	pub, err := repo.ListMentions(me.ID, "public", 5, "", "")
+	pub, err := repo.ListMentions(me.ID, "public", false, 5, "", "")
 	require.NoError(t, err)
 	require.Len(t, pub, 5, "public 指定で under-fill しない")
 	for _, n := range pub {
@@ -1948,7 +1989,7 @@ func TestNoteRepository_ListMentions_VisibilityFilter(t *testing.T) {
 	}
 
 	// specified のみ limit=5 -> specified が 5 件。
-	spec, err := repo.ListMentions(me.ID, "specified", 5, "", "")
+	spec, err := repo.ListMentions(me.ID, "specified", false, 5, "", "")
 	require.NoError(t, err)
 	require.Len(t, spec, 5, "specified 指定で under-fill しない")
 	for _, n := range spec {
@@ -1956,7 +1997,7 @@ func TestNoteRepository_ListMentions_VisibilityFilter(t *testing.T) {
 	}
 
 	// 未指定 (default) -> 全種別 (TS 一致): public + specified の両方が出る。
-	all, err := repo.ListMentions(me.ID, "", 100, "", "")
+	all, err := repo.ListMentions(me.ID, "", false, 100, "", "")
 	require.NoError(t, err)
 	assert.Len(t, all, 10, "default は全種別を返す")
 }
@@ -2001,19 +2042,19 @@ func TestNoteRepository_ListMentions_VisibleUserIDsOnly(t *testing.T) {
 
 	// recipient (default = 全種別): visibleUserIds 由来 / mentions+visibleUserIds
 	// 両方とも 1 行ずつ。OR は単一行 boolean なので重複しない。
-	out, err := repo.ListMentions(recipient.ID, "", 50, "", "")
+	out, err := repo.ListMentions(recipient.ID, "", false, 50, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, 1, countOf(out, "n_vu_dm"), "@mention の無い specified DM が visibleUserIds 経由で出る")
 	assert.Equal(t, 1, countOf(out, "n_vu_both"), "mentions と visibleUserIds 両方に入っても重複行は出ない")
 
 	// recipient (Direct タブ = visibility=specified): 同じく両方出る。
-	out, err = repo.ListMentions(recipient.ID, "specified", 50, "", "")
+	out, err = repo.ListMentions(recipient.ID, "specified", false, 50, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, 1, countOf(out, "n_vu_dm"), "Direct タブでも visibleUserIds-only DM が出る")
 	assert.Equal(t, 1, countOf(out, "n_vu_both"))
 
 	// stranger: 宛先でも mention 対象でもないので何も出ない (#1441 gate 整合)。
-	out, err = repo.ListMentions(stranger.ID, "", 50, "", "")
+	out, err = repo.ListMentions(stranger.ID, "", false, 50, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, 0, countOf(out, "n_vu_dm"))
 	assert.Equal(t, 0, countOf(out, "n_vu_both"))

--- a/internal/repository/note_thread_muting.go
+++ b/internal/repository/note_thread_muting.go
@@ -10,6 +10,9 @@ type NoteThreadMutingRepository interface {
 	Create(m *model.NoteThreadMuting) error
 	Delete(userID, threadID string) error
 	Exists(userID, threadID string) (bool, error)
+	// ListMutedThreadIDs returns the threadIds the user has muted. read 経路の
+	// thread-mute filter (upstream generateMutedNoteThreadQuery) 用 (#1554)。
+	ListMutedThreadIDs(userID string) ([]string, error)
 }
 
 type noteThreadMutingRepository struct {
@@ -35,4 +38,17 @@ func (r *noteThreadMutingRepository) Exists(userID, threadID string) (bool, erro
 	err := r.db.Model(&model.NoteThreadMuting{}).
 		Where(`"userId" = ? AND "threadId" = ?`, userID, threadID).Count(&count).Error
 	return count > 0, err
+}
+
+func (r *noteThreadMutingRepository) ListMutedThreadIDs(userID string) ([]string, error) {
+	if userID == "" {
+		return nil, nil
+	}
+	var ids []string
+	if err := r.db.Model(&model.NoteThreadMuting{}).
+		Where(`"userId" = ?`, userID).
+		Pluck(`"threadId"`, &ids).Error; err != nil {
+		return nil, err
+	}
+	return ids, nil
 }

--- a/internal/repository/note_thread_muting_test.go
+++ b/internal/repository/note_thread_muting_test.go
@@ -25,3 +25,25 @@ func TestNoteThreadMutingRepository_CRUD(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, ok)
 }
+
+// #1554 ListMutedThreadIDs は user の muted threadId のみ返す。
+func TestNoteThreadMutingRepository_ListMutedThreadIDs(t *testing.T) {
+	repo := NewNoteThreadMutingRepository(testDB)
+	seedUser(t, "ntml_u1")
+	seedUser(t, "ntml_u2")
+	t.Cleanup(func() {
+		testDB.Exec(`DELETE FROM "note_thread_muting" WHERE "userId" IN (?, ?)`, "ntml_u1", "ntml_u2")
+	})
+	require.NoError(t, repo.Create(&model.NoteThreadMuting{ID: "ntml_1", UserID: "ntml_u1", ThreadID: "t1"}))
+	require.NoError(t, repo.Create(&model.NoteThreadMuting{ID: "ntml_2", UserID: "ntml_u1", ThreadID: "t2"}))
+	require.NoError(t, repo.Create(&model.NoteThreadMuting{ID: "ntml_3", UserID: "ntml_u2", ThreadID: "t3"}))
+
+	ids, err := repo.ListMutedThreadIDs("ntml_u1")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"t1", "t2"}, ids)
+
+	// 空 userID は nil。
+	ids, err = repo.ListMutedThreadIDs("")
+	require.NoError(t, err)
+	assert.Nil(t, ids)
+}

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1210,7 +1210,11 @@ func (m *MockNoteRepository) FindRenoteByUser(userID, renoteID string) (*model.N
 	return nil, ErrNotFound
 }
 
-func (m *MockNoteRepository) ListMentions(userID, visibility string, limit int, sinceID, untilID string) ([]*model.Note, error) {
+// ListMentions accepts the `following` flag for signature parity but does not
+// filter on it: the mock has no following graph, so the followee restriction
+// is exercised by the real-DB repository test instead (#1554)。
+func (m *MockNoteRepository) ListMentions(userID, visibility string, following bool, limit int, sinceID, untilID string) ([]*model.Note, error) {
+	_ = following
 	if limit <= 0 {
 		limit = 10
 	}
@@ -6840,6 +6844,16 @@ func (m *MockNoteThreadMutingRepository) Delete(userID, threadID string) error {
 func (m *MockNoteThreadMutingRepository) Exists(userID, threadID string) (bool, error) {
 	_, ok := m.Mutings[userID+":"+threadID]
 	return ok, nil
+}
+
+func (m *MockNoteThreadMutingRepository) ListMutedThreadIDs(userID string) ([]string, error) {
+	var ids []string
+	for _, mut := range m.Mutings {
+		if mut.UserID == userID {
+			ids = append(ids, mut.ThreadID)
+		}
+	}
+	return ids, nil
 }
 
 // MockUsedUsernameRepository is a test double for repository.UsedUsernameRepository.


### PR DESCRIPTION
## Summary

#1554 (notes/* timeline+list parity) の mentions 2 項目 (MEDIUM×2)。upstream `notes/mentions` は `following` param で followee+自分に絞り、`generateBaseNoteFilteringQuery` + `generateMutedNoteThreadQuery` で被block / mute / instance-mute / thread-mute を除外するが、mk-go はいずれも未対応だった。

## 主な変更点

- **[MEDIUM] following param**: `ListMentions` に `following bool` を追加。true で `note.userId IN (SELECT followeeId FROM following WHERE followerId=viewer) OR note.userId = viewer` を AND (upstream mentions.ts:84-87)。handler が `req.following` を bind して渡す。
- **[MEDIUM] block/mute/instance-mute filter**: handler が `applyMuteBlock` (#1677 で追加した被block / mute / instance-mute) を packMany 前に適用。channel-mute は upstream mentions の base-filtering に無いので適用しない。
- **thread-mute filter**: `NoteThreadMutingRepository.ListMutedThreadIDs` を追加、`notesfilter.ApplyThreadMute` (`note.id ∈ muted OR note.threadId ∈ muted` で除外、upstream `generateMutedNoteThreadQuery` の De Morgan 等価) を追加し handler で適用。

`blocked-host` (admin meta) / `suspended` は notesfilter 未実装で別 follow-up。

## テスト

- repository: `ListMentions(following=true)` で followee+自分のみ (stranger 除外) の real-DB test、`ListMutedThreadIDs` の real-DB test
- notesfilter: `ApplyThreadMute` (root id / threadId / 空 / nil)
- handler: mute author 除外、muted thread 除外
- `go vet ./...` / drift gates / 全テスト pass

## 関連

#1554 (notes/* timeline+list) の 2 項目。

🤖 Generated with [Claude Code](https://claude.com/claude-code)