### PR TITLE
Fix notes/search-by-tag: reply/renote/poll/withFiles param + block/mute filter (#1554 part5)

### DIFF
--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -251,6 +251,10 @@ func (h *Handler) SearchByTag(c echo.Context) error {
 		UntilID   string     `json:"untilId"`
 		SinceDate *int64     `json:"sinceDate"`
 		UntilDate *int64     `json:"untilDate"`
+		Reply     *bool      `json:"reply"`
+		Renote    *bool      `json:"renote"`
+		Poll      *bool      `json:"poll"`
+		WithFiles bool       `json:"withFiles"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "tag is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
@@ -279,7 +283,9 @@ func (h *Handler) SearchByTag(c echo.Context) error {
 	if viewer != nil {
 		viewerID = viewer.ID
 	}
-	notes, err := h.noteRepo.SearchByTag(req.Tag, viewerID, req.Limit, sinceID, untilID)
+	// reply/renote/poll/withFiles で絞る (upstream search-by-tag.ts、#1554)。
+	filter := model.NoteSearchTagFilter{Reply: req.Reply, Renote: req.Renote, Poll: req.Poll, WithFiles: req.WithFiles}
+	notes, err := h.noteRepo.SearchByTag(req.Tag, viewerID, req.Limit, sinceID, untilID, filter)
 	if err != nil {
 		// tag 検索失敗は従来どおり空配列で返す (TS 互換) が、visibility
 		// push-down 追加で SQL エラーも黙殺されうるため診断用に 1 行残す。
@@ -287,6 +293,12 @@ func (h *Handler) SearchByTag(c echo.Context) error {
 		// Warn ではなく Debug に留める (#1446 review)。
 		slog.Debug("notes/search-by-tag: SearchByTag failed", "tag", req.Tag, "err", err)
 		return c.JSON(http.StatusOK, []entity.NoteEntity{})
+	}
+	// upstream search-by-tag は generateBaseNoteFilteringQuery で被block / mute /
+	// instance-mute を除外する (#1554)。block/mute は post-fetch で適用する。
+	notes, err = h.applyMuteBlock(viewer, notes)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))
 }

--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -637,6 +637,39 @@ func TestSearchByTag_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// #1554 search-by-tag の reply filter: reply=true は reply note のみ返す。
+func TestSearchByTag_ReplyFilter(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	parent := "p1"
+	noteRepo.Notes["plain"] = &model.Note{ID: "plain", UserID: "u1", Tags: []string{"t"}, Visibility: "public", User: &model.User{ID: "u1"}}
+	noteRepo.Notes["rep"] = &model.Note{ID: "rep", UserID: "u1", Tags: []string{"t"}, Visibility: "public", ReplyID: &parent, User: &model.User{ID: "u1"}}
+	rec := postExtra(h.SearchByTag, `{"tag":"t","reply":true}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "rep", resp[0]["id"])
+}
+
+// #1554 search-by-tag は viewer が mute した author の note を除外する。
+func TestSearchByTag_FiltersMutedAuthor(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	noteRepo.Notes["mn"] = &model.Note{ID: "mn", UserID: "muted", Tags: []string{"t"}, Visibility: "public", User: &model.User{ID: "muted"}}
+	mutingRepo := testutil.NewMockMutingRepository()
+	mutingRepo.Mutings["m1"] = &model.Muting{ID: "m1", MuterID: "viewer", MuteeID: "muted"}
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["viewer"] = &model.User{ID: "viewer", Username: "viewer", UsernameLower: "viewer"}
+	h.SetMutingRepo(mutingRepo)
+	h.SetBlockingRepo(testutil.NewMockBlockingRepository())
+	h.SetUserRepo(userRepo)
+
+	rec := postExtra(h.SearchByTag, `{"tag":"t"}`, &model.User{ID: "viewer"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Empty(t, resp, "mute した author の note は除外される")
+}
+
 func TestSearchByTag_QueryArray(t *testing.T) {
 	h, noteRepo, _ := newExtraHandler(t)
 	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Tags: []string{"go"}, Visibility: "public", User: &model.User{ID: "u1"}}
@@ -724,7 +757,7 @@ func TestSearchByTag_SpecifiedTargetAndAuthorSee(t *testing.T) {
 
 type failingSearchByTagRepo struct{ *testutil.MockNoteRepository }
 
-func (f *failingSearchByTagRepo) SearchByTag(_, _ string, _ int, _, _ string) ([]*model.Note, error) {
+func (f *failingSearchByTagRepo) SearchByTag(_, _ string, _ int, _, _ string, _ model.NoteSearchTagFilter) ([]*model.Note, error) {
 	return nil, testutil.ErrNotFound
 }
 

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -869,7 +869,7 @@ func (f *failingNoteRepo) FindRenoteByUser(_, _ string) (*model.Note, error) {
 func (f *failingNoteRepo) ListMentions(_, _ string, _ bool, _ int, _, _ string) ([]*model.Note, error) {
 	return nil, nil
 }
-func (f *failingNoteRepo) SearchByTag(_, _ string, _ int, _, _ string) ([]*model.Note, error) {
+func (f *failingNoteRepo) SearchByTag(_, _ string, _ int, _, _ string, _ model.NoteSearchTagFilter) ([]*model.Note, error) {
 	return nil, nil
 }
 func (f *failingNoteRepo) ListByFileID(_, _, _ string, _ int) ([]*model.Note, error) {

--- a/internal/model/note_search_filter.go
+++ b/internal/model/note_search_filter.go
@@ -1,0 +1,12 @@
+package model
+
+// NoteSearchTagFilter carries the optional reply/renote/poll/withFiles filters
+// for the SearchByTag repository query (upstream notes/search-by-tag.ts、#1554)。
+// Reply/Renote/Poll は nil で無条件、non-nil で IS (NOT) NULL / hasPoll = <bool>。
+// WithFiles=true で fileIds != '{}' (添付ありのみ)。
+type NoteSearchTagFilter struct {
+	Reply     *bool
+	Renote    *bool
+	Poll      *bool
+	WithFiles bool
+}

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -137,8 +137,9 @@ type NoteRepository interface {
 	// SearchByTag returns notes carrying tag that viewerID is allowed to see.
 	// viewerID 空文字は匿名 (public/home のみ)。discovery 系の tag 検索は
 	// ID 既知公開 (notes/show) doctrine の対象外なので、core/note.CanSeeNote と
-	// 同じ可視性条件を LIMIT 前に SQL で絞る (#1439)。
-	SearchByTag(tag, viewerID string, limit int, sinceID, untilID string) ([]*model.Note, error)
+	// 同じ可視性条件を LIMIT 前に SQL で絞る (#1439)。filter で reply/renote/poll/
+	// withFiles を絞る (upstream search-by-tag.ts、#1554)。
+	SearchByTag(tag, viewerID string, limit int, sinceID, untilID string, filter model.NoteSearchTagFilter) ([]*model.Note, error)
 	// ListByFileID returns notes whose fileIds array contains fileID, with
 	// cursor (sinceID/untilID) pagination matching upstream Misskey's
 	// makePaginationQuery. limit <= 0 defaults to 10.
@@ -785,7 +786,7 @@ func (r *noteRepository) ListMentions(userID, visibility string, following bool,
 	return notes, nil
 }
 
-func (r *noteRepository) SearchByTag(tag, viewerID string, limit int, sinceID, untilID string) ([]*model.Note, error) {
+func (r *noteRepository) SearchByTag(tag, viewerID string, limit int, sinceID, untilID string, filter model.NoteSearchTagFilter) ([]*model.Note, error) {
 	if limit <= 0 {
 		limit = 10
 	}
@@ -794,6 +795,27 @@ func (r *noteRepository) SearchByTag(tag, viewerID string, limit int, sinceID, u
 	// visibility push-down: core/note.CanSeeNote と同じ条件を LIMIT 前に絞る。
 	// ListByUserIDFiltered / clip の ListByClipVisible と同じ可視性定義 (#1439)。
 	q = applyViewerVisibility(q, viewerID)
+	// reply/renote/poll/withFiles filter (upstream search-by-tag.ts:124-150、#1554)。
+	if filter.Reply != nil {
+		if *filter.Reply {
+			q = q.Where(`"replyId" IS NOT NULL`)
+		} else {
+			q = q.Where(`"replyId" IS NULL`)
+		}
+	}
+	if filter.Renote != nil {
+		if *filter.Renote {
+			q = q.Where(`"renoteId" IS NOT NULL`)
+		} else {
+			q = q.Where(`"renoteId" IS NULL`)
+		}
+	}
+	if filter.Poll != nil {
+		q = q.Where(`"hasPoll" = ?`, *filter.Poll)
+	}
+	if filter.WithFiles {
+		q = q.Where(`"fileIds" != '{}'`)
+	}
 	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
 	if sinceID != "" {
 		q = q.Where("id > ?", sinceID)

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -2069,30 +2069,74 @@ func TestNoteRepository_SearchByTag(t *testing.T) {
 	require.NoError(t, testDB.Create(n).Error)
 	defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, n.ID)
 
-	notes, err := repo.SearchByTag("golang", "", 10, "", "")
+	notes, err := repo.SearchByTag("golang", "", 10, "", "", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	assert.NotEmpty(t, notes)
 
-	notes, err = repo.SearchByTag("nonexistent", "", 10, "", "")
+	notes, err = repo.SearchByTag("nonexistent", "", 10, "", "", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	assert.Empty(t, notes)
 
 	// default limit
-	notes, err = repo.SearchByTag("golang", "", 0, "", "")
+	notes, err = repo.SearchByTag("golang", "", 0, "", "", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	assert.NotEmpty(t, notes)
 
 	// with cursors
-	notes, err = repo.SearchByTag("golang", "", 10, "000", "zzz")
+	notes, err = repo.SearchByTag("golang", "", 10, "000", "zzz", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	assert.NotEmpty(t, notes)
+}
+
+// #1554 SearchByTag の reply/renote/poll/withFiles filter。
+func TestNoteRepository_SearchByTag_Filters(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	user := insertTestUser(t, "sbtf_u", "sbtfuser")
+	defer cleanupUser(t, user.ID)
+	// reply の ReplyID は FK_note_replyId 制約があるため既存 note (plain) を指す。
+	parent := "sbtf_plain"
+	bt := func(v bool) *bool { return &v }
+
+	plain := &model.Note{ID: "sbtf_plain", UserID: user.ID, Visibility: "public", Tags: []string{"sbtf"}}
+	reply := &model.Note{ID: "sbtf_reply", UserID: user.ID, Visibility: "public", Tags: []string{"sbtf"}, ReplyID: &parent}
+	pollFile := &model.Note{ID: "sbtf_pf", UserID: user.ID, Visibility: "public", Tags: []string{"sbtf"}, HasPoll: true, FileIDs: []string{"f1"}}
+	for _, n := range []*model.Note{plain, reply, pollFile} {
+		require.NoError(t, testDB.Create(n).Error)
+		defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, n.ID)
+	}
+
+	collect := func(f model.NoteSearchTagFilter) map[string]bool {
+		out, err := repo.SearchByTag("sbtf", "", 50, "", "", f)
+		require.NoError(t, err)
+		ids := map[string]bool{}
+		for _, n := range out {
+			ids[n.ID] = true
+		}
+		return ids
+	}
+
+	ids := collect(model.NoteSearchTagFilter{Reply: bt(true)})
+	assert.True(t, ids["sbtf_reply"])
+	assert.False(t, ids["sbtf_plain"])
+
+	ids = collect(model.NoteSearchTagFilter{Reply: bt(false)})
+	assert.False(t, ids["sbtf_reply"])
+	assert.True(t, ids["sbtf_plain"])
+
+	ids = collect(model.NoteSearchTagFilter{Poll: bt(true)})
+	assert.True(t, ids["sbtf_pf"])
+	assert.False(t, ids["sbtf_plain"])
+
+	ids = collect(model.NoteSearchTagFilter{WithFiles: true})
+	assert.True(t, ids["sbtf_pf"])
+	assert.False(t, ids["sbtf_plain"])
 }
 
 func TestNoteRepository_SearchByTag_Error(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	repo := NewNoteRepository(testDB.WithContext(ctx))
-	_, err := repo.SearchByTag("x", "", 10, "", "")
+	_, err := repo.SearchByTag("x", "", 10, "", "", model.NoteSearchTagFilter{})
 	assert.Error(t, err)
 }
 
@@ -2137,26 +2181,26 @@ func TestNoteRepository_SearchByTag_VisibilityPushDown(t *testing.T) {
 	}
 
 	// 匿名 / stranger は public のみ。
-	out, err := repo.SearchByTag("sbttag", "", 50, "", "")
+	out, err := repo.SearchByTag("sbttag", "", 50, "", "", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_sbt_pub"}, idsOf(out))
 
-	out, err = repo.SearchByTag("sbttag", stranger.ID, 50, "", "")
+	out, err = repo.SearchByTag("sbttag", stranger.ID, 50, "", "", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_sbt_pub"}, idsOf(out))
 
 	// follower は public + followers。
-	out, err = repo.SearchByTag("sbttag", follower.ID, 50, "", "")
+	out, err = repo.SearchByTag("sbttag", follower.ID, 50, "", "", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_sbt_fol", "n_sbt_pub"}, idsOf(out))
 
 	// visibleUserIds 対象は public + specified。
-	out, err = repo.SearchByTag("sbttag", allowed.ID, 50, "", "")
+	out, err = repo.SearchByTag("sbttag", allowed.ID, 50, "", "", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_sbt_pub", "n_sbt_spec"}, idsOf(out))
 
 	// author 本人は全 visibility。
-	out, err = repo.SearchByTag("sbttag", author.ID, 50, "", "")
+	out, err = repo.SearchByTag("sbttag", author.ID, 50, "", "", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_sbt_fol", "n_sbt_pub", "n_sbt_spec"}, idsOf(out))
 }
@@ -2872,14 +2916,14 @@ func TestNoteRepository_SinceIDFlipsOrderASC(t *testing.T) {
 	}
 
 	// sinceID単独指定: ASC順 (古い→新しい)。asc_n_a より大なので b, c が返る想定。
-	notes, err := repo.SearchByTag("ascflip", "", 10, "asc_n_a", "")
+	notes, err := repo.SearchByTag("ascflip", "", 10, "asc_n_a", "", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	require.Len(t, notes, 2)
 	assert.Equal(t, "asc_n_b", notes[0].ID)
 	assert.Equal(t, "asc_n_c", notes[1].ID)
 
 	// untilID単独指定: DESC順 (既存挙動)。asc_n_c より小なので b, a が返る。
-	notes, err = repo.SearchByTag("ascflip", "", 10, "", "asc_n_c")
+	notes, err = repo.SearchByTag("ascflip", "", 10, "", "asc_n_c", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	require.Len(t, notes, 2)
 	assert.Equal(t, "asc_n_b", notes[0].ID)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1246,12 +1246,25 @@ func (m *MockNoteRepository) ListMentions(userID, visibility string, following b
 	}, untilID, sinceID, limit), nil
 }
 
-func (m *MockNoteRepository) SearchByTag(tag, viewerID string, limit int, sinceID, untilID string) ([]*model.Note, error) {
+func (m *MockNoteRepository) SearchByTag(tag, viewerID string, limit int, sinceID, untilID string, filter model.NoteSearchTagFilter) ([]*model.Note, error) {
 	if limit <= 0 {
 		limit = 10
 	}
 	return m.listFiltered(func(n *model.Note) bool {
 		if !m.canViewerSeeNote(viewerID, n) {
+			return false
+		}
+		// reply/renote/poll/withFiles filter (#1554)。
+		if filter.Reply != nil && (n.ReplyID != nil) != *filter.Reply {
+			return false
+		}
+		if filter.Renote != nil && (n.RenoteID != nil) != *filter.Renote {
+			return false
+		}
+		if filter.Poll != nil && n.HasPoll != *filter.Poll {
+			return false
+		}
+		if filter.WithFiles && len(n.FileIDs) == 0 {
 			return false
 		}
 		for _, t := range n.Tags {


### PR DESCRIPTION
## Summary

#1554 (notes/* timeline+list parity) の search-by-tag 2 項目 (MEDIUM + LOW)。upstream `notes/search-by-tag` は reply/renote/poll/withFiles param で絞り、`generateVisibilityQuery + generateBaseNoteFilteringQuery` で被block / mute / instance-mute を除外するが、mk-go はいずれも未対応だった。

## 主な変更点

- **[MEDIUM] reply/renote/poll/withFiles param**: `model.NoteSearchTagFilter` を追加し `SearchByTag` に filter param を追加。reply/renote → `replyId`/`renoteId IS (NOT) NULL` (nil=無条件)、poll → `hasPoll = <bool>`、withFiles → `fileIds != '{}'` (upstream search-by-tag.ts:124-150)。handler が 4 param を bind。
- **[LOW] block/mute filter**: handler が `applyMuteBlock` (#1677 で追加した被block / mute / instance-mute) を packMany 前に適用。channel-mute は upstream base-filtering に無いので非適用。

## scope 外 (follow-up)

- query (`string[][]` の OR of AND 複合 tag 検索) は最初の1タグのみ使う既存挙動を据え置き。完全な AND/OR 交差は別 follow-up (#1554 の MEDIUM 項目、heavy)。
- blocked-host / suspended は notesfilter 未実装で別 follow-up。

## テスト

- repository: `SearchByTag` の reply(true/false)/poll/withFiles filter real-DB test
- handler: reply filter (reply note のみ)、mute author 除外
- `go vet ./...` / drift gates / 全テスト pass

## 関連

#1554 (notes/* timeline+list) の 2 項目。

🤖 Generated with [Claude Code](https://claude.com/claude-code)