### PR TITLE
Fix notes/conversation offset + notes/search viewer-visibility (#1554 part6)

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -727,6 +727,7 @@ func (h *Handler) State(c echo.Context) error {
 type ConversationRequest struct {
 	NoteID string `json:"noteId"`
 	Limit  int    `json:"limit"`
+	Offset int    `json:"offset"`
 }
 
 // Conversation handles POST /api/notes/conversation.
@@ -736,9 +737,12 @@ func (h *Handler) Conversation(c echo.Context) error {
 		return apierr.JSONInvalidParam(c)
 	}
 	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
+	if req.Offset < 0 {
+		req.Offset = 0
+	}
 
 	viewer := middleware.GetUser(c)
-	notes, err := h.queryService.Conversation(viewer, req.NoteID, req.Limit)
+	notes, err := h.queryService.Conversation(viewer, req.NoteID, req.Limit, req.Offset)
 	if err != nil {
 		// 現状QueryService.ConversationはErrNoteNotFound以外を返さない
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "e1035875-9551-45ec-afa8-1ded1fcb53c8"))

--- a/internal/core/note/note_query_service.go
+++ b/internal/core/note/note_query_service.go
@@ -137,7 +137,7 @@ func (s *QueryService) ListChildren(viewer *model.User, noteID, untilID, sinceID
 // Conversation walks up the reply chain from the given noteID and returns
 // up to `limit` ancestors, ordered from oldest to newest. The starting note
 // itself is NOT included. Notes the viewer cannot see terminate the walk.
-func (s *QueryService) Conversation(viewer *model.User, noteID string, limit int) ([]*model.Note, error) {
+func (s *QueryService) Conversation(viewer *model.User, noteID string, limit, offset int) ([]*model.Note, error) {
 	start, err := s.Show(viewer, noteID)
 	if err != nil {
 		return nil, err
@@ -145,11 +145,17 @@ func (s *QueryService) Conversation(viewer *model.User, noteID string, limit int
 	if limit <= 0 {
 		limit = 10
 	}
+	if offset < 0 {
+		offset = 0
+	}
 
 	var ancestors []*model.Note
 	current := start
-	// 親をたどる。深さ制限はlimit回。サイクル回避のため訪問済みも記録する。
+	// 親をたどる。offset 件分の近い親を skip してから limit 件収集する
+	// (upstream conversation.ts: i を increment し i > offset のみ push、
+	// conversation.length == limit で停止)。サイクル回避のため訪問済みも記録。
 	visited := map[string]struct{}{current.ID: {}}
+	i := 0
 	for len(ancestors) < limit {
 		if current.ReplyID == nil {
 			break
@@ -166,7 +172,11 @@ func (s *QueryService) Conversation(viewer *model.User, noteID string, limit int
 			break
 		}
 		visited[parentID] = struct{}{}
-		ancestors = append(ancestors, parent)
+		i++
+		// 最初の offset 件 (note に近い親) は skip する。
+		if i > offset {
+			ancestors = append(ancestors, parent)
+		}
 		current = parent
 	}
 	// 古い順 (最深の親を先頭) に並び替える

--- a/internal/core/note/note_query_service_test.go
+++ b/internal/core/note/note_query_service_test.go
@@ -253,7 +253,7 @@ func TestQueryService_Conversation_Empty(t *testing.T) {
 	svc, noteRepo, _ := newQueryService(t)
 	noteRepo.Notes["root"] = &model.Note{ID: "root", UserID: "a", Visibility: model.NoteVisibilityPublic}
 
-	out, err := svc.Conversation(nil, "root", 10)
+	out, err := svc.Conversation(nil, "root", 10, 0)
 	require.NoError(t, err)
 	assert.Empty(t, out)
 }
@@ -266,7 +266,7 @@ func TestQueryService_Conversation_Walks(t *testing.T) {
 	pID := "p"
 	noteRepo.Notes["c"] = &model.Note{ID: "c", UserID: "a", Visibility: model.NoteVisibilityPublic, ReplyID: &pID}
 
-	out, err := svc.Conversation(nil, "c", 10)
+	out, err := svc.Conversation(nil, "c", 10, 0)
 	require.NoError(t, err)
 	require.Len(t, out, 2)
 	// 古い順 (祖先が先頭)
@@ -280,7 +280,7 @@ func TestQueryService_Conversation_DefaultLimit(t *testing.T) {
 	rootID := "root"
 	noteRepo.Notes["c"] = &model.Note{ID: "c", UserID: "a", Visibility: model.NoteVisibilityPublic, ReplyID: &rootID}
 
-	out, err := svc.Conversation(nil, "c", 0)
+	out, err := svc.Conversation(nil, "c", 0, 0)
 	require.NoError(t, err)
 	assert.Len(t, out, 1)
 }
@@ -296,12 +296,38 @@ func TestQueryService_Conversation_LimitRespected(t *testing.T) {
 	cID := "c"
 	noteRepo.Notes["d"] = &model.Note{ID: "d", UserID: "u", Visibility: model.NoteVisibilityPublic, ReplyID: &cID}
 
-	out, err := svc.Conversation(nil, "d", 2)
+	out, err := svc.Conversation(nil, "d", 2, 0)
 	require.NoError(t, err)
 	require.Len(t, out, 2)
 	// 直近の親2件: c, b. 古い順なのでb, c
 	assert.Equal(t, "b", out[0].ID)
 	assert.Equal(t, "c", out[1].ID)
+}
+
+// #1554 offset は note に近い親を skip する (upstream conversation.ts:72-74)。
+func TestQueryService_Conversation_Offset(t *testing.T) {
+	svc, noteRepo, _ := newQueryService(t)
+	// d -> c -> b -> a (d が leaf)。親チェーンは c(最近), b, a(最古)。
+	noteRepo.Notes["a"] = &model.Note{ID: "a", UserID: "u", Visibility: model.NoteVisibilityPublic}
+	aID := "a"
+	noteRepo.Notes["b"] = &model.Note{ID: "b", UserID: "u", Visibility: model.NoteVisibilityPublic, ReplyID: &aID}
+	bID := "b"
+	noteRepo.Notes["c"] = &model.Note{ID: "c", UserID: "u", Visibility: model.NoteVisibilityPublic, ReplyID: &bID}
+	cID := "c"
+	noteRepo.Notes["d"] = &model.Note{ID: "d", UserID: "u", Visibility: model.NoteVisibilityPublic, ReplyID: &cID}
+
+	// offset=1: 最近の親 c を skip → b, a を収集。古い順で a, b。
+	out, err := svc.Conversation(nil, "d", 10, 1)
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	assert.Equal(t, "a", out[0].ID)
+	assert.Equal(t, "b", out[1].ID)
+
+	// offset=1 + limit=1: c skip → b のみ。
+	out, err = svc.Conversation(nil, "d", 1, 1)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, "b", out[0].ID)
 }
 
 func TestQueryService_Conversation_HiddenAncestorTerminates(t *testing.T) {
@@ -310,7 +336,7 @@ func TestQueryService_Conversation_HiddenAncestorTerminates(t *testing.T) {
 	secretID := "secret"
 	noteRepo.Notes["leaf"] = &model.Note{ID: "leaf", UserID: "viewer", Visibility: model.NoteVisibilityPublic, ReplyID: &secretID}
 
-	out, err := svc.Conversation(&model.User{ID: "viewer"}, "leaf", 10)
+	out, err := svc.Conversation(&model.User{ID: "viewer"}, "leaf", 10, 0)
 	require.NoError(t, err)
 	// 親は閲覧不可なのでチェーンが切れる
 	assert.Empty(t, out)
@@ -318,7 +344,7 @@ func TestQueryService_Conversation_HiddenAncestorTerminates(t *testing.T) {
 
 func TestQueryService_Conversation_StartMissing(t *testing.T) {
 	svc, _, _ := newQueryService(t)
-	_, err := svc.Conversation(nil, "ghost", 10)
+	_, err := svc.Conversation(nil, "ghost", 10, 0)
 	require.ErrorIs(t, err, note.ErrNoteNotFound)
 }
 
@@ -328,7 +354,7 @@ func TestQueryService_Conversation_CycleSafe(t *testing.T) {
 	aID := "a"
 	noteRepo.Notes["a"] = &model.Note{ID: "a", UserID: "u", Visibility: model.NoteVisibilityPublic, ReplyID: &aID}
 
-	out, err := svc.Conversation(nil, "a", 10)
+	out, err := svc.Conversation(nil, "a", 10, 0)
 	require.NoError(t, err)
 	assert.Empty(t, out)
 }
@@ -339,7 +365,7 @@ func TestQueryService_Conversation_ParentMissingTerminates(t *testing.T) {
 	ghostID := "ghost"
 	noteRepo.Notes["leaf"] = &model.Note{ID: "leaf", UserID: "u", Visibility: model.NoteVisibilityPublic, ReplyID: &ghostID}
 
-	out, err := svc.Conversation(nil, "leaf", 10)
+	out, err := svc.Conversation(nil, "leaf", 10, 0)
 	require.NoError(t, err)
 	assert.Empty(t, out)
 }

--- a/internal/core/search/sqllike_provider.go
+++ b/internal/core/search/sqllike_provider.go
@@ -55,6 +55,12 @@ func (p *SQLLikeProvider) SearchNote(viewer *model.User, query string, opts Sear
 	if limit <= 0 {
 		limit = 10
 	}
+	// viewer 自身の followers/specified/visibleUserIds note も検索対象に含める
+	// よう viewerID を渡す (#1554)。匿名は空文字 → public/home のみ。
+	viewerID := ""
+	if viewer != nil {
+		viewerID = viewer.ID
+	}
 	rows, err := p.noteRepo.SearchByFilter(model.NoteSearchFilter{
 		Query:     query,
 		UserID:    opts.UserID,
@@ -63,6 +69,7 @@ func (p *SQLLikeProvider) SearchNote(viewer *model.User, query string, opts Sear
 		UntilID:   page.UntilID,
 		SinceID:   page.SinceID,
 		Limit:     limit,
+		ViewerID:  viewerID,
 		Pgroonga:  p.pgroonga,
 	})
 	if err != nil {

--- a/internal/model/note.go
+++ b/internal/model/note.go
@@ -79,6 +79,11 @@ type NoteSearchFilter struct {
 	UntilID   string
 	SinceID   string
 	Limit     int
+	// ViewerID is the searching user's id for visibility push-down. 空文字は
+	// 匿名 (public/home のみ)。非空なら viewer 自身の followers/specified/
+	// visibleUserIds note も検索対象に含める (upstream SearchService の
+	// generateVisibilityQuery、#1554)。
+	ViewerID string
 	// Pgroonga, when true, switches the WHERE clause from ILIKE to the
 	// PGroonga `&@~` full-text match operator. Mirrors upstream Misskey TS
 	// SearchService.searchNoteByLike, which swaps the predicate when

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -485,8 +485,9 @@ func (r *noteRepository) ListChildrenOf(noteID, viewerID, untilID, sinceID strin
 // SearchByFilter returns notes matching the filter criteria.
 // 検索バックエンド (core/search.SQLLikeProvider) から呼ばれる。
 // When f.Pgroonga is true the predicate uses the PGroonga `&@~` full-text
-// operator; otherwise it falls back to ILIKE substring match. Visibility is
-// always limited to public/home.
+// operator; otherwise it falls back to ILIKE substring match. Visibility は
+// f.ViewerID 視点で push-down する (空は public/home のみ、非空なら viewer 自身の
+// followers/specified/visibleUserIds note も含む、#1554)。
 func (r *noteRepository) SearchByFilter(f model.NoteSearchFilter) ([]*model.Note, error) {
 	var notes []*model.Note
 	q := preloadNoteRelations(r.db)
@@ -497,10 +498,11 @@ func (r *noteRepository) SearchByFilter(f model.NoteSearchFilter) ([]*model.Note
 	} else {
 		q = q.Where("text ILIKE ?", "%"+f.Query+"%")
 	}
-	q = q.Where("visibility IN ?", []string{
-		string(model.NoteVisibilityPublic),
-		string(model.NoteVisibilityHome),
-	})
+	// visibility push-down: viewer 視点の可視性で絞る (upstream SearchService の
+	// generateVisibilityQuery、#1554)。ViewerID 空は匿名 (public/home のみ)、
+	// 非空なら viewer 自身の followers/specified/visibleUserIds note も含む。
+	// core/note.CanSeeNote と同条件 (mentions / search-by-tag と同じ helper)。
+	q = applyViewerVisibility(q, f.ViewerID)
 	if f.UserID != "" {
 		q = q.Where("\"userId\" = ?", f.UserID)
 	}

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -1220,11 +1220,17 @@ func TestNoteRepository_SearchByFilter(t *testing.T) {
 		defer cleanupNote(t, n.ID)
 	}
 
-	// 基本: 部分一致 + visibility フィルタ。followers (n_se_3) は除外。
+	// 基本: 部分一致 + visibility フィルタ。匿名 (ViewerID 空) は public/home のみ、
+	// followers (n_se_3) は除外。
 	out, err := repo.SearchByFilter(model.NoteSearchFilter{Query: "hello", Limit: 10})
 	require.NoError(t, err)
 	got := idsOf(out)
 	assert.ElementsMatch(t, []string{"n_se_1", "n_se_4", "n_se_5", "n_se_6"}, got)
+
+	// #1554 ViewerID = 著者本人なら自分の followers note (n_se_3) も検索できる。
+	out, err = repo.SearchByFilter(model.NoteSearchFilter{Query: "hello", ViewerID: localUser.ID, Limit: 10})
+	require.NoError(t, err)
+	assert.Contains(t, idsOf(out), "n_se_3", "viewer 自身の followers note は検索対象に含まれる")
 
 	// userId フィルタ
 	out, err = repo.SearchByFilter(model.NoteSearchFilter{Query: "hello", UserID: localUser.ID, Limit: 10})


### PR DESCRIPTION
## Summary

#1554 (notes/* timeline+list parity) の LOW 2 項目。

## 主な変更点

- **[LOW] notes/conversation の offset param**: `ConversationRequest` に `offset` を追加し、`QueryService.Conversation(viewer, noteID, limit, offset)` が note に近い親を `offset` 件 skip してから `limit` 件収集する (upstream conversation.ts:65-83 の `i > offset` push)。`offset=0` で従来挙動と同一。
- **[LOW] notes/search (SQL provider) の viewer-visibility**: `model.NoteSearchFilter` に `ViewerID` を追加し、`SearchByFilter` の hardcoded `visibility IN ('public','home')` を `applyViewerVisibility(f.ViewerID)` に置換。これで viewer 自身の followers / specified / visibleUserIds note も検索対象に含む (upstream `SearchService.generateVisibilityQuery` 相当、mentions/search-by-tag と同じ helper)。`SQLLikeProvider` が `viewer.ID` を渡す。匿名 (ViewerID 空) は従来どおり public/home のみで **regression なし**。

## scope 外

`notes/search` の `offset` param は upstream `searchNote` も無視する (paramDef にあるが sqlLike path に渡さない) ため未実装 = upstream の accept-and-ignore 挙動と一致。`home timeline のチャンネル note 包含` (LOW) は perf-critical な timeline DB path の変更 + channel_following 配線が要るため、timeline base-filtering follow-up に回す。

## テスト

- `QueryService.Conversation` offset (近親 skip + offset+limit 併用)
- `SearchByFilter` で viewer 自身の followers note が検索対象に含まれる real-DB test、匿名は public/home のみ (非回帰)
- `go vet ./...` / drift gates / 全テスト pass

## 関連

#1554 (notes/* timeline+list) の 2 項目。

🤖 Generated with [Claude Code](https://claude.com/claude-code)