### PR TITLE
Fix timeline base-filtering: 被block / reply著者mute / instance-mute (#1681 part1)

### DIFF
--- a/internal/api/notes/timeline_handler.go
+++ b/internal/api/notes/timeline_handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -91,6 +92,8 @@ func (h *Handler) Timeline(c echo.Context) error {
 			MutedChannelIDs:       h.loadMutedChannelIDs(viewer),
 			MutedUserIDs:          h.loadMutedUserIDs(viewer),
 			RenoteMutedUserIDs:    h.loadRenoteMutedUserIDs(viewer),
+			BlockerIDs:            h.loadBlockerIDs(viewer),
+			MutedInstances:        h.loadMutedInstances(viewer),
 		}
 		req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 		return h.timelineService.HomeTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
@@ -111,6 +114,8 @@ func (h *Handler) LocalTimeline(c echo.Context) error {
 			MutedChannelIDs:    h.loadMutedChannelIDs(viewer),
 			MutedUserIDs:       h.loadMutedUserIDs(viewer),
 			RenoteMutedUserIDs: h.loadRenoteMutedUserIDs(viewer),
+			BlockerIDs:         h.loadBlockerIDs(viewer),
+			MutedInstances:     h.loadMutedInstances(viewer),
 		}
 		req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 		return h.timelineService.LocalTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
@@ -130,6 +135,8 @@ func (h *Handler) GlobalTimeline(c echo.Context) error {
 			MutedChannelIDs:    h.loadMutedChannelIDs(viewer),
 			MutedUserIDs:       h.loadMutedUserIDs(viewer),
 			RenoteMutedUserIDs: h.loadRenoteMutedUserIDs(viewer),
+			BlockerIDs:         h.loadBlockerIDs(viewer),
+			MutedInstances:     h.loadMutedInstances(viewer),
 		}
 		req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 		return h.timelineService.GlobalTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
@@ -157,6 +164,8 @@ func (h *Handler) HybridTimeline(c echo.Context) error {
 			MutedChannelIDs:       h.loadMutedChannelIDs(viewer),
 			MutedUserIDs:          h.loadMutedUserIDs(viewer),
 			RenoteMutedUserIDs:    h.loadRenoteMutedUserIDs(viewer),
+			BlockerIDs:            h.loadBlockerIDs(viewer),
+			MutedInstances:        h.loadMutedInstances(viewer),
 		}
 		req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 		return h.timelineService.HybridTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
@@ -216,6 +225,46 @@ func (h *Handler) loadRenoteMutedUserIDs(viewer *model.User) []string {
 		return nil
 	}
 	return ids
+}
+
+// loadBlockerIDs returns the ids of users who block the viewer (被block、#1681)。
+// timeline で note/reply/renote の author が viewer を block していれば除外する
+// (upstream generateBlockedUserQueryForNotes)。
+func (h *Handler) loadBlockerIDs(viewer *model.User) []string {
+	if viewer == nil || h.blockingRepo == nil {
+		return nil
+	}
+	ids, err := h.blockingRepo.ListBlockerIDs(viewer.ID)
+	if err != nil {
+		slog.Warn("timeline: failed to load blockers", "userId", viewer.ID, "err", err)
+		return nil
+	}
+	return ids
+}
+
+// loadMutedInstances returns the viewer's muted instance hosts (lowercase、#1681)。
+// user_profile.mutedInstances (jsonb host 配列) を parse する。profile 不在 /
+// 破損 jsonb は空扱い (best-effort、timeline を閉塞させない)。
+func (h *Handler) loadMutedInstances(viewer *model.User) []string {
+	if viewer == nil || h.userRepo == nil {
+		return nil
+	}
+	profile, err := h.userRepo.FindProfileByUserID(viewer.ID)
+	if err != nil || profile == nil || len(profile.MutedInstances) == 0 {
+		return nil
+	}
+	var hosts []string
+	if err := json.Unmarshal(profile.MutedInstances, &hosts); err != nil {
+		slog.Warn("timeline: failed to parse muted instances", "userId", viewer.ID, "err", err)
+		return nil
+	}
+	out := make([]string, 0, len(hosts))
+	for _, host := range hosts {
+		if host != "" {
+			out = append(out, strings.ToLower(host))
+		}
+	}
+	return out
 }
 
 // serveTimeline factors out the common parsing and error handling for the four

--- a/internal/api/notes/timeline_handler_test.go
+++ b/internal/api/notes/timeline_handler_test.go
@@ -537,3 +537,32 @@ func TestTimeline_Cache_ByteIdenticalToNonCached(t *testing.T) {
 	assert.Equal(t, recNo.Body.String(), recYes.Body.String(),
 		"cache miss 経路 (marshal+改行) は c.JSON 経路と byte 一致")
 }
+
+// #1681 loadBlockerIDs / loadMutedInstances loader の coverage。
+func TestLoadBlockerIDs(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	h := newTimelineHandler(t, noteRepo, nil)
+	// nil viewer / 未配線 blockingRepo は nil。
+	assert.Nil(t, h.loadBlockerIDs(nil))
+	assert.Nil(t, h.loadBlockerIDs(&model.User{ID: "v"}))
+	blk := testutil.NewMockBlockingRepository()
+	blk.Blockings["b1"] = &model.Blocking{ID: "b1", BlockerID: "blocker", BlockeeID: "v"}
+	h.SetBlockingRepo(blk)
+	assert.Equal(t, []string{"blocker"}, h.loadBlockerIDs(&model.User{ID: "v"}))
+}
+
+func TestLoadMutedInstances(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	h := newTimelineHandler(t, noteRepo, nil)
+	// nil viewer / 未配線 userRepo は nil。
+	assert.Nil(t, h.loadMutedInstances(nil))
+	assert.Nil(t, h.loadMutedInstances(&model.User{ID: "v"}))
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Profiles["v"] = &model.UserProfile{UserID: "v", MutedInstances: datatypes.JSON([]byte(`["Bad.Example","good.tld"]`))}
+	userRepo.Profiles["empty"] = &model.UserProfile{UserID: "empty"}
+	h.SetUserRepo(userRepo)
+	// 大文字 host は lowercase 化される。
+	assert.ElementsMatch(t, []string{"bad.example", "good.tld"}, h.loadMutedInstances(&model.User{ID: "v"}))
+	// 空 mutedInstances は nil。
+	assert.Nil(t, h.loadMutedInstances(&model.User{ID: "empty"}))
+}

--- a/internal/core/timeline/timeline_filter.go
+++ b/internal/core/timeline/timeline_filter.go
@@ -1,6 +1,29 @@
 package timeline
 
-import "github.com/shiroha-a/mk/internal/model"
+import (
+	"strings"
+
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// idInSet reports whether the (nilable) id is present in set.
+func idInSet(set map[string]struct{}, id *string) bool {
+	if id == nil {
+		return false
+	}
+	_, ok := set[*id]
+	return ok
+}
+
+// hostInSet reports whether the (nilable) host (case-insensitive) is in set.
+// set のキーは lowercase 前提。
+func hostInSet(set map[string]struct{}, host *string) bool {
+	if host == nil {
+		return false
+	}
+	_, ok := set[strings.ToLower(*host)]
+	return ok
+}
 
 // TimelineFilter holds filtering options for timeline queries.
 // *bool フィールドは nil のときデフォルト値として扱う。
@@ -30,6 +53,13 @@ type TimelineFilter struct {
 	//   - pure renote (= text なし / file なし / renoteId あり) のみ skip
 	// upstream Misskey TS の generateMutedUserRelatedRenotesQuery と同 semantics。
 	RenoteMutedUserIDs []string
+	// BlockerIDs は viewer を block している user の id (被block、#1681)。
+	// note/reply/renote のいずれかの author が含まれる note を除外する
+	// (upstream generateBlockedUserQueryForNotes)。
+	BlockerIDs []string
+	// MutedInstances は viewer が mute した instance host (#1681、lowercase)。
+	// note/reply/renote のいずれかの author host が一致する note を除外する。
+	MutedInstances []string
 }
 
 // boolDefault returns *b if non-nil, else def.
@@ -85,6 +115,25 @@ func ApplyFilter(notes []*model.Note, viewerID string, f TimelineFilter) []*mode
 		}
 	}
 
+	// 被block (#1681): viewer を block している user が note/reply/renote の
+	// author なら除外。
+	var blockers map[string]struct{}
+	if len(f.BlockerIDs) > 0 {
+		blockers = make(map[string]struct{}, len(f.BlockerIDs))
+		for _, id := range f.BlockerIDs {
+			blockers[id] = struct{}{}
+		}
+	}
+	// instance-mute (#1681): viewer が mute した instance の note/reply/renote
+	// author host を除外。host は lowercase で突合する。
+	var mutedInstances map[string]struct{}
+	if len(f.MutedInstances) > 0 {
+		mutedInstances = make(map[string]struct{}, len(f.MutedInstances))
+		for _, h := range f.MutedInstances {
+			mutedInstances[strings.ToLower(h)] = struct{}{}
+		}
+	}
+
 	out := make([]*model.Note, 0, len(notes))
 	for _, n := range notes {
 		if f.WithFiles && len(n.FileIDs) == 0 {
@@ -98,9 +147,9 @@ func ApplyFilter(notes []*model.Note, viewerID string, f TimelineFilter) []*mode
 				continue
 			}
 		}
-		// user mute filter: 投稿者が muted user なら除外。renote の場合は
-		// renote 元 user も check する (= upstream Misskey TS の muting JOIN
-		// と同 semantics、#874)。
+		// user mute filter: 投稿者が muted user なら除外。renote / reply の
+		// author も check する (= upstream generateMutedUserQueryForNotes は
+		// note/reply/renote の 3 author を見る、#874 / reply は #1681 で追加)。
 		if mutedUsers != nil {
 			if _, muted := mutedUsers[n.UserID]; muted {
 				continue
@@ -110,6 +159,21 @@ func ApplyFilter(notes []*model.Note, viewerID string, f TimelineFilter) []*mode
 					continue
 				}
 			}
+			if n.ReplyUserID != nil {
+				if _, muted := mutedUsers[*n.ReplyUserID]; muted {
+					continue
+				}
+			}
+		}
+		// 被block (#1681): note/reply/renote のいずれかの author が viewer を
+		// block していれば除外。
+		if blockers != nil && (idInSet(blockers, &n.UserID) || idInSet(blockers, n.ReplyUserID) || idInSet(blockers, n.RenoteUserID)) {
+			continue
+		}
+		// instance-mute (#1681): note/reply/renote のいずれかの author host が
+		// muted instance なら除外。
+		if mutedInstances != nil && (hostInSet(mutedInstances, n.UserHost) || hostInSet(mutedInstances, n.ReplyUserHost) || hostInSet(mutedInstances, n.RenoteUserHost)) {
+			continue
 		}
 		// renote-mute filter: 投稿者が renote-muted で **かつ** pure renote
 		// の場合のみ除外する (= upstream の generateMutedUserRelatedRenotesQuery

--- a/internal/core/timeline/timeline_filter_test.go
+++ b/internal/core/timeline/timeline_filter_test.go
@@ -47,6 +47,59 @@ func TestIsPureRenote(t *testing.T) {
 	assert.False(t, isPureRenote(makeNote("4", withRenote, withFiles)))
 }
 
+func withReplyUser(uid string) func(*model.Note) {
+	return func(n *model.Note) { n.ReplyID = strPtr("rp1"); n.ReplyUserID = strPtr(uid) }
+}
+func withHost(host string) func(*model.Note) {
+	return func(n *model.Note) { n.UserHost = strPtr(host) }
+}
+
+// #1681 被block: note/reply/renote のいずれかの author が viewer を block して
+// いれば除外。
+func TestApplyFilter_Blocker(t *testing.T) {
+	notes := []*model.Note{
+		makeNote("a", withUser("blocker")),                   // note author が blocker
+		makeNote("b", withReplyUser("blocker")),              // reply 先が blocker
+		makeNote("c", withRenote, withRenoteUser("blocker")), // renote 元が blocker
+		makeNote("ok", withUser("friend")),
+	}
+	out := ApplyFilter(notes, "viewer", TimelineFilter{BlockerIDs: []string{"blocker"}})
+	assert.Len(t, out, 1)
+	assert.Equal(t, "ok", out[0].ID)
+}
+
+// #1681 reply著者mute: reply 先が muted user なら除外 (mutedUsers が reply
+// author も見る)。
+func TestApplyFilter_MutedReplyAuthor(t *testing.T) {
+	notes := []*model.Note{
+		makeNote("a", withReplyUser("muted")),
+		makeNote("ok", withReplyUser("other")),
+	}
+	out := ApplyFilter(notes, "viewer", TimelineFilter{MutedUserIDs: []string{"muted"}})
+	assert.Len(t, out, 1)
+	assert.Equal(t, "ok", out[0].ID)
+}
+
+// #1681 instance-mute: note/reply/renote のいずれかの author host が muted
+// instance なら除外。case-insensitive。
+func TestApplyFilter_MutedInstance(t *testing.T) {
+	notes := []*model.Note{
+		makeNote("a", withHost("Bad.Example")), // 大文字混じり host
+		makeNote("b", func(n *model.Note) { n.ReplyUserHost = strPtr("bad.example") }),
+		makeNote("local"), // host nil = local、常に通す
+		makeNote("ok", withHost("good.example")),
+	}
+	out := ApplyFilter(notes, "viewer", TimelineFilter{MutedInstances: []string{"bad.example"}})
+	ids := map[string]bool{}
+	for _, n := range out {
+		ids[n.ID] = true
+	}
+	assert.False(t, ids["a"])
+	assert.False(t, ids["b"])
+	assert.True(t, ids["local"])
+	assert.True(t, ids["ok"])
+}
+
 func TestApplyFilter_WithFiles(t *testing.T) {
 	notes := []*model.Note{
 		makeNote("1"),

--- a/internal/core/timeline/timeline_service.go
+++ b/internal/core/timeline/timeline_service.go
@@ -218,6 +218,10 @@ func toDBFilter(f TimelineFilter, viewerID string) model.TimelineDBFilter {
 		// renote-mute も同様に subquery 経路を使う (#903)。pure renote 条件
 		// は applyTimelineFilter 側で組み立てる。
 		UseRenoteMutingSubquery: viewerID != "",
+		// 被block / instance-mute は loader で取得した literal list を両経路に
+		// 渡す (#1681)。anon viewer では空。
+		BlockerIDs:     f.BlockerIDs,
+		MutedInstances: f.MutedInstances,
 	}
 }
 

--- a/internal/model/timeline_filter.go
+++ b/internal/model/timeline_filter.go
@@ -34,4 +34,14 @@ type TimelineDBFilter struct {
 	// note は通す。upstream Misskey TS の
 	// generateMutedUserRelatedRenotesQuery と同 semantics。
 	UseRenoteMutingSubquery bool
+	// BlockerIDs は viewer を block している user の id 一覧 (被block、#1681)。
+	// note/reply/renote のいずれかの author が含まれる note を除外する
+	// (upstream generateBlockedUserQueryForNotes)。viewer 単位で件数が少ない
+	// (= 自分を block している相手) ため literal NOT IN で十分。
+	BlockerIDs []string
+	// MutedInstances は viewer が mute した instance host の一覧 (#1681)。
+	// note/reply/renote のいずれかの author host が含まれる note を除外する
+	// (upstream generateMutedUserQueryForNotes の mutedInstances 分岐)。host は
+	// lowercase 前提 (AP canonical)。
+	MutedInstances []string
 }

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -925,13 +925,42 @@ func applyTimelineFilter(q *gorm.DB, f model.TimelineDBFilter) *gorm.DB {
 		notExistsForCol := func(col string) string {
 			return `NOT EXISTS (SELECT 1 FROM "muting" m WHERE m."muterId" = ? AND m."muteeId" = ` + col + ` AND (m."expiresAt" IS NULL OR m."expiresAt" > NOW()))`
 		}
+		// note/renote/reply のいずれかの author が active mute なら除外
+		// (upstream generateMutedUserQueryForNotes は 3 author すべて見る、#1681)。
+		// reply著者mute は #1681 で追加 (旧実装は userId + renoteUserId のみ)。
 		q = q.Where(
-			notExistsForCol(`"note"."userId"`)+` AND ("renoteUserId" IS NULL OR `+notExistsForCol(`"note"."renoteUserId"`)+`)`,
-			f.ViewerID, f.ViewerID,
+			notExistsForCol(`"note"."userId"`)+
+				` AND ("renoteUserId" IS NULL OR `+notExistsForCol(`"note"."renoteUserId"`)+`)`+
+				` AND ("replyUserId" IS NULL OR `+notExistsForCol(`"note"."replyUserId"`)+`)`,
+			f.ViewerID, f.ViewerID, f.ViewerID,
 		)
 	} else if len(f.MutedUserIDs) > 0 {
 		// "userId" は JOIN 併用時の曖昧性回避のため "note". で修飾 (#1498)。
-		q = q.Where(`"note"."userId" NOT IN ? AND ("renoteUserId" IS NULL OR "renoteUserId" NOT IN ?)`, f.MutedUserIDs, f.MutedUserIDs)
+		// reply著者も check (#1681、upstream parity)。
+		q = q.Where(
+			`"note"."userId" NOT IN ? AND ("renoteUserId" IS NULL OR "renoteUserId" NOT IN ?) AND ("replyUserId" IS NULL OR "replyUserId" NOT IN ?)`,
+			f.MutedUserIDs, f.MutedUserIDs, f.MutedUserIDs,
+		)
+	}
+	// blocked-by filter (#1681): viewer を block している user が note/reply/renote
+	// のいずれかの author なら除外 (upstream generateBlockedUserQueryForNotes)。
+	if len(f.BlockerIDs) > 0 {
+		q = q.Where(
+			`"note"."userId" NOT IN ? AND ("replyUserId" IS NULL OR "replyUserId" NOT IN ?) AND ("renoteUserId" IS NULL OR "renoteUserId" NOT IN ?)`,
+			f.BlockerIDs, f.BlockerIDs, f.BlockerIDs,
+		)
+	}
+	// instance-mute filter (#1681): viewer が mute した instance の note/reply/
+	// renote author を除外 (upstream generateMutedUserQueryForNotes の
+	// mutedInstances 分岐)。local user (host NULL) は常に通す。host は lowercase 前提。
+	if len(f.MutedInstances) > 0 {
+		// host は LOWER() で突合する。Redis path (hostInSet) が note host を
+		// ToLower するため、SQL も case-insensitive にして 2 経路の結果を一致
+		// させる (#1681 review)。MutedInstances は loader で lowercase 済。
+		q = q.Where(
+			`("note"."userHost" IS NULL OR LOWER("userHost") NOT IN ?) AND ("replyUserHost" IS NULL OR LOWER("replyUserHost") NOT IN ?) AND ("renoteUserHost" IS NULL OR LOWER("renoteUserHost") NOT IN ?)`,
+			f.MutedInstances, f.MutedInstances, f.MutedInstances,
+		)
 	}
 	// renote-mute filter (#903): 投稿者が renote-muted で **かつ** pure
 	// renote の note のみ除外する。投稿者の plain note / quote renote は

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -90,6 +90,65 @@ func TestNoteRepository_ListHomeTimeline_MutedChannelFilter(t *testing.T) {
 	// 返ってしまう。ここでは他ユーザーがいないので fan-out テストは省略。
 }
 
+// #1681 applyTimelineFilter の被block / reply著者mute / instance-mute を
+// ListHomeTimeline (SQL push-down) で検証する。
+func TestNoteRepository_ListHomeTimeline_BaseFilters(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	viewer := insertTestUser(t, "u_bf_v", "bfviewer")
+	author := insertTestUser(t, "u_bf_a", "bfauthor")
+	blocker := insertTestUser(t, "u_bf_b", "bfblocker")
+	muted := insertTestUser(t, "u_bf_m", "bfmuted")
+	defer cleanupUser(t, viewer.ID)
+	defer cleanupUser(t, author.ID)
+	defer cleanupUser(t, blocker.ID)
+	defer cleanupUser(t, muted.ID)
+
+	// viewer は author / blocker / muted をフォロー (home timeline 対象)。
+	for i, fid := range []string{author.ID, blocker.ID, muted.ID} {
+		flid := "flw_bf_" + string(rune('a'+i))
+		require.NoError(t, testDB.Exec(`INSERT INTO "following" (id, "followerId", "followeeId") VALUES (?, ?, ?)`, flid, viewer.ID, fid).Error)
+		defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, flid)
+	}
+
+	txt := "hi"
+	mkNote := func(n *model.Note) *model.Note {
+		n.Text = &txt
+		n.Visibility = model.NoteVisibilityPublic
+		n.Reactions = datatypes.JSON([]byte("{}"))
+		require.NoError(t, repo.Create(n))
+		t.Cleanup(func() { cleanupNote(t, n.ID) })
+		return n
+	}
+	plain := mkNote(&model.Note{ID: "n_bf_plain", UserID: author.ID})
+	byBlocker := mkNote(&model.Note{ID: "n_bf_blk", UserID: blocker.ID})
+	replyToMuted := mkNote(&model.Note{ID: "n_bf_rep", UserID: author.ID, ReplyID: strPtr2("n_bf_plain"), ReplyUserID: &muted.ID})
+	remoteHost := "bad.example"
+	fromBadInstance := mkNote(&model.Note{ID: "n_bf_inst", UserID: author.ID, UserHost: &remoteHost})
+	// 大文字混じり host も LOWER() 突合で除外されること (#1681 review)。
+	upperHost := "Bad.Example"
+	fromUpperInstance := mkNote(&model.Note{ID: "n_bf_inst_up", UserID: author.ID, UserHost: &upperHost})
+
+	filter := model.TimelineDBFilter{
+		ViewerID:       viewer.ID,
+		BlockerIDs:     []string{blocker.ID},
+		MutedInstances: []string{"bad.example"},
+		MutedUserIDs:   []string{muted.ID}, // literal path で reply著者mute を検証
+	}
+	rows, err := repo.ListHomeTimeline(viewer.ID, 50, "", "", filter)
+	require.NoError(t, err)
+	ids := map[string]bool{}
+	for _, n := range rows {
+		ids[n.ID] = true
+	}
+	assert.True(t, ids[plain.ID], "通常 note は含まれる")
+	assert.False(t, ids[byBlocker.ID], "被block author の note は除外")
+	assert.False(t, ids[replyToMuted.ID], "muted user 宛 reply は除外")
+	assert.False(t, ids[fromBadInstance.ID], "muted instance の note は除外")
+	assert.False(t, ids[fromUpperInstance.ID], "大文字 host も LOWER() で除外")
+}
+
+func strPtr2(s string) *string { return &s }
+
 // TestNoteRepository_ListHomeTimeline_WithRepliesFalse_SelfThreadOnly は #1047
 // で導入された upstream 互換の reply filter semantics を SQL 層で直接検証する。
 //


### PR DESCRIPTION
## Summary

#1681 (timeline base-note-filtering) の中核。home/local/global/hybrid の 4 timeline に upstream `generateBaseNoteFilteringQuery` 相当の filter を **SQL push-down + Redis in-memory 両経路**で追加する。これまで timeline は user-mute (note/renote author) / renote-mute / channel-mute のみで、被block・reply著者mute・instance-mute が漏れていた。

## 主な変更点

- **被block** (`generateBlockedUserQueryForNotes`): viewer を block している user が note/reply/renote のいずれかの author なら除外。`blockingRepo.ListBlockerIDs` の小集合 literal NOT IN。
- **reply著者mute**: 既存 muting filter (note/renote author のみ) を `replyUserId` にも拡張 (upstream `generateMutedUserQueryForNotes` は 3 author すべて見る)。subquery / literal / Redis 全経路。
- **instance-mute** (`mutedInstances` 分岐): viewer の `user_profile.mutedInstances` の host を持つ note/reply/renote author を除外。SQL は `LOWER()` で case-insensitive 突合 (Redis path の `ToLower` と一致させ 2 経路の結果を揃える、レビュー指摘)。
- `TimelineDBFilter` / `TimelineFilter` に `BlockerIDs` / `MutedInstances` を追加、`toDBFilter` で両経路に伝搬、handler に `loadBlockerIDs` / `loadMutedInstances` loader を追加し 4 timeline filter に配線。anon viewer (local/global) は空 filter で no-op。

## perf

被block / instance-mute は小集合の literal `NOT IN`、reply著者mute は既存 muting subquery への correlation 追加のみで**新規 JOIN は無し**。hot path への影響を最小化。本番投入前に bench harness (`tests/bench/`) で p95 を確認することを推奨。

## scope 外 (#1681 の別 PR)

`suspended-user` (Redis path で denormalized flag が無く要検討) / `blocked-host` (metaRepo + subdomain) / `user-list-timeline` / `home channels` / `withReplies nil` は後続 PR で対応。

## テスト

- `ApplyFilter` (Redis): 被block (3 author)、reply著者mute、instance-mute (case-insensitive / local 通過)
- `repository` (SQL real-DB): `ListHomeTimeline` で被block / reply著者mute / instance-mute (大文字 host 含む) を除外
- `go vet ./...` / drift gates / 全テスト pass

## 関連

#1681 (timeline base-note-filtering) の part1。

🤖 Generated with [Claude Code](https://claude.com/claude-code)