### PR TITLE
Fix user-list-timeline: base-note-filtering 適用 (#1681 part2)

### DIFF
--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -224,13 +224,22 @@ func (h *Handler) UserListTimeline(c echo.Context) error {
 	// renote/file 系 param は他 timeline と同じ filter で SQL push-down する
 	// (#1498)。WithReplies は per-member (membership.withReplies, #1496) で別途
 	// 処理されるため filter には積まない。
+	// upstream user-list-timeline.ts:188-201 は generateBaseNoteFilteringQuery +
+	// generateMutedUserRenotesQueryForNotes + mutedChannelIds を適用するため、
+	// 他 timeline と同じ base-filter (user-mute / renote-mute / 被block /
+	// instance-mute / channel-mute) を積む (#1681)。
 	filter := model.TimelineDBFilter{
-		ViewerID:              me.ID,
-		WithFiles:             req.WithFiles,
-		WithRenotes:           req.WithRenotes,
-		IncludeMyRenotes:      req.IncludeMyRenotes,
-		IncludeRenotedMyNotes: req.IncludeRenotedMyNotes,
-		IncludeLocalRenotes:   req.IncludeLocalRenotes,
+		ViewerID:                me.ID,
+		WithFiles:               req.WithFiles,
+		WithRenotes:             req.WithRenotes,
+		IncludeMyRenotes:        req.IncludeMyRenotes,
+		IncludeRenotedMyNotes:   req.IncludeRenotedMyNotes,
+		IncludeLocalRenotes:     req.IncludeLocalRenotes,
+		UseMutingSubquery:       true,
+		UseRenoteMutingSubquery: true,
+		MutedChannelIDs:         h.loadMutedChannelIDs(me),
+		BlockerIDs:              h.loadBlockerIDs(me),
+		MutedInstances:          h.loadMutedInstances(me),
 	}
 	notes, err := h.noteRepo.ListByUserList(req.ListID, req.Limit, sinceID, untilID, filter)
 	if err != nil {

--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -481,21 +481,23 @@ func TestMentions_SpecifiedVisibleUserIDsOnly(t *testing.T) {
 // --- UserListTimeline ---
 
 func TestUserListTimeline_Success(t *testing.T) {
-	h, noteRepo, _ := newExtraHandler(t)
+	// #1681 で UserListTimeline が UseMutingSubquery を立てるようになり、bare
+	// mock の ListByUserList は muting subquery を未実装で panic する。可視性 /
+	// filter の実 SQL は repository test で覆うので、ここでは push-down を行わない
+	// userListNotesRepo fake で「handler が repo の返り値をそのまま pack する」
+	// 経路だけを検証する。
+	n1 := &model.Note{ID: "n1", UserID: "member1", Visibility: "public", User: &model.User{ID: "member1"}}
+	noteRepo := &userListNotesRepo{MockNoteRepository: testutil.NewMockNoteRepository(), rows: []*model.Note{n1}}
+	pollRepo := testutil.NewMockPollRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	querySvc := corenote.NewQueryService(noteRepo, testutil.NewMockFollowingRepository())
+	h := NewHandler(noteRepo, corenote.NewCreateService(noteRepo, pollRepo, idGen, nil), corenote.NewDeleteService(noteRepo), querySvc, nil, nil, nil, nil, idGen)
 	listRepo := testutil.NewMockUserListRepository()
 	listRepo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "u1", Name: "my list"}
 	h.SetUserListRepo(listRepo)
-	// リストメンバーのノートを用意 + mock ListByUserList の membership map を seed
-	// (#1491 audit 指摘 1 で mock parity を持たせたので、membership 経由で
-	// filter される。これが無いと mock は空を返し、本 test の body assert が
-	// 落ちる)。
-	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "member1", Visibility: "public", User: &model.User{ID: "member1"}}
-	noteRepo.UserListMembers["l1"] = []*model.UserListMembership{{UserListID: "l1", UserID: "member1"}}
 
 	rec := postExtra(h.UserListTimeline, `{"listId":"l1"}`, &model.User{ID: "u1"})
 	require.Equal(t, http.StatusOK, rec.Code)
-	// #1491 audit 指摘 6: body shape / id を明示 fix。push-down で空 / 別 id を
-	// 返すような regression を取り漏らさないようにする。
 	var resp []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	require.Len(t, resp, 1)
@@ -592,14 +594,22 @@ func TestUserListTimeline_PassesFilterToRepo(t *testing.T) {
 	assert.False(t, *noteRepo.gotFilter.IncludeRenotedMyNotes, "includeRenotedMyNotes=false が filter に渡る")
 	require.NotNil(t, noteRepo.gotFilter.IncludeLocalRenotes)
 	assert.False(t, *noteRepo.gotFilter.IncludeLocalRenotes, "includeLocalRenotes=false が filter に渡る")
+	// #1681: base-filter (user-mute / renote-mute subquery) が user-list-timeline
+	// でも立つことを確認。
+	assert.True(t, noteRepo.gotFilter.UseMutingSubquery, "UseMutingSubquery が立つ (#1681)")
+	assert.True(t, noteRepo.gotFilter.UseRenoteMutingSubquery, "UseRenoteMutingSubquery が立つ (#1681)")
 	// post-fetch filter は無いので repo の返り値がそのまま返る。
 	require.Len(t, out, 1)
 	assert.Equal(t, "ul_pub", out[0]["id"])
 }
 
 func TestUserListTimeline_WithoutUserListRepo(t *testing.T) {
-	// userListRepoがnilの場合は所有権チェックをスキップしてDBクエリに進む
-	h, _, _ := newExtraHandler(t)
+	// userListRepo が nil の場合は所有権チェックをスキップして DB クエリに進む。
+	// #1681 で muting subquery が立つため bare mock は panic する → push-down を
+	// 行わない userListNotesRepo fake を使う。
+	noteRepo := &userListNotesRepo{MockNoteRepository: testutil.NewMockNoteRepository(), rows: nil}
+	idGen, _ := id.NewGenerator("aidx")
+	h := NewHandler(noteRepo, nil, nil, nil, nil, nil, nil, nil, idGen)
 	rec := postExtra(h.UserListTimeline, `{"listId":"l1"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusOK, rec.Code)
 }

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -1138,8 +1138,10 @@ func (r *noteRepository) ListByUserList(listID string, limit int, sinceID, until
 	// withRenotes / includeMyRenotes / includeRenotedMyNotes / includeLocalRenotes
 	// / withFiles を他 timeline と同じ SQL で適用する (#1498, upstream getFromDb と
 	// 一致)。WithReplies は上の per-member 経路 (#1496) で処理済みなので filter には
-	// 積まない (nil = applyTimelineFilter は skip)。muting は user-list-timeline では
-	// 対象外なので filter に積まない。
+	// 積まない (nil = applyTimelineFilter は skip)。
+	// base-filter (user-mute / renote-mute / 被block / instance-mute / channel-mute)
+	// は handler が filter に積むので applyTimelineFilter がここで適用する
+	// (#1681、upstream user-list-timeline の generateBaseNoteFilteringQuery 相当)。
 	q = applyTimelineFilter(q, filter)
 	var notes []*model.Note
 	if err := q.Order(paginationOrder(sinceID, untilID, `"note"."id"`)).Limit(limit).Find(&notes).Error; err != nil {

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -1757,6 +1757,49 @@ func TestNoteRepository_ListByUserList_WithReplies(t *testing.T) {
 // includeMyRenotes / includeRenotedMyNotes / includeLocalRenotes / withFiles) が
 // applyTimelineFilter で適用されることを実 SQL で覆う。pure renote と quote renote
 // (text あり) を区別し、quote は常に残ることも確認する。
+// #1681 user-list-timeline にも base-filter (被block / instance-mute) が効く。
+func TestNoteRepository_ListByUserList_BaseFilters(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	viewer := insertTestUser(t, "ulbf_v", "ulbfV")
+	member := insertTestUser(t, "ulbf_m", "ulbfM")
+	blocker := insertTestUser(t, "ulbf_b", "ulbfB")
+	defer cleanupUser(t, viewer.ID)
+	defer cleanupUser(t, member.ID)
+	defer cleanupUser(t, blocker.ID)
+
+	listID := "ulbf_list"
+	require.NoError(t, testDB.Create(&model.UserList{ID: listID, UserID: viewer.ID, Name: "l"}).Error)
+	defer testDB.Exec(`DELETE FROM "user_list" WHERE id = ?`, listID)
+	for i, mem := range []string{member.ID, blocker.ID} {
+		mid := fmt.Sprintf("ulbf_mem_%d", i)
+		require.NoError(t, testDB.Create(&model.UserListMembership{ID: mid, UserListID: listID, UserID: mem}).Error)
+		defer testDB.Exec(`DELETE FROM "user_list_membership" WHERE id = ?`, mid)
+	}
+
+	plain := &model.Note{ID: "ulbf_plain", UserID: member.ID, Visibility: "public"}
+	byBlocker := &model.Note{ID: "ulbf_blk", UserID: blocker.ID, Visibility: "public"}
+	badHost := "bad.example"
+	fromBad := &model.Note{ID: "ulbf_inst", UserID: member.ID, Visibility: "public", UserHost: &badHost}
+	for _, n := range []*model.Note{plain, byBlocker, fromBad} {
+		require.NoError(t, testDB.Create(n).Error)
+		defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, n.ID)
+	}
+
+	got, err := repo.ListByUserList(listID, 50, "", "", model.TimelineDBFilter{
+		ViewerID:       viewer.ID,
+		BlockerIDs:     []string{blocker.ID},
+		MutedInstances: []string{"bad.example"},
+	})
+	require.NoError(t, err)
+	ids := map[string]bool{}
+	for _, n := range got {
+		ids[n.ID] = true
+	}
+	assert.True(t, ids["ulbf_plain"], "通常 member の note は含まれる")
+	assert.False(t, ids["ulbf_blk"], "被block member の note は除外")
+	assert.False(t, ids["ulbf_inst"], "muted instance の note は除外")
+}
+
 func TestNoteRepository_ListByUserList_RenoteFilters(t *testing.T) {
 	repo := NewNoteRepository(testDB)
 	viewer := insertTestUser(t, "ulr_v", "ulrV") // list owner かつ member


### PR DESCRIPTION
## Summary

#1681 (timeline base-note-filtering) の part2。upstream `user-list-timeline.ts:188-201` は `generateBaseNoteFilteringQuery` + `generateMutedUserRenotesQueryForNotes` + `mutedChannelIds` を適用するが、mk-go の `UserListTimeline` は filter に muting/block/instance/channel を積んでおらず「対象外」だった。

## 主な変更点

- `UserListTimeline` handler が `TimelineDBFilter` に `UseMutingSubquery` / `UseRenoteMutingSubquery` / `MutedChannelIDs` / `BlockerIDs` / `MutedInstances` を積むよう変更。`ListByUserList` は既に `applyTimelineFilter` を呼ぶ (#1684 で全 dim 実装済) ため **SQL 変更は不要**で、他 timeline と同じ base-filter (user-mute incl reply著者 / renote-mute / 被block / instance-mute / channel-mute) が効く。
- mock の `ListByUserList` は muting subquery を未実装で panic する設計のため、影響を受ける handler test (`Success` / `WithoutUserListRepo`) を push-down 非依存の `userListNotesRepo` fake 経由に切り替え。`PassesFilterToRepo` に `UseMutingSubquery` / `UseRenoteMutingSubquery` の forward 検証を追加。

## テスト

- `repository` real-DB: `ListByUserList` で被block member / muted instance の note が除外される (JOIN context で SQL が正しく効くことを確認)
- handler: filter forward 検証 + fake 経路の pack 検証
- `go vet ./...` / 全テスト pass

## scope 外 (#1681 残)

`home channels` (followed-channel note 包含) と `suspended-user` (Redis path で denormalized flag 無く要検討) は別 PR / follow-up。`withReplies nil` は #1047 の fanout 設計 (Redis pass-through / DB fallback は明示時のみ) が意図的なため非変更。

## 関連

#1681 (timeline base-note-filtering) の part2。

🤖 Generated with [Claude Code](https://claude.com/claude-code)