### PR TITLE
Fix notes/featured: 被block / mute / instance-mute filter (#1682)

### DIFF
--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -116,7 +116,15 @@ func (h *Handler) Featured(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, middleware.GetUser(c)))
+	// upstream featured.ts:99-107 は me の mute / 被block を isUserRelated で除外する
+	// (#1682)。users/featured-notes (#1547) と同じく被block / mute / instance-mute を
+	// post-fetch で除外する。blocked-host / suspended は別 follow-up。
+	viewer := middleware.GetUser(c)
+	notes, err = h.applyMuteBlock(viewer, notes)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))
 }
 
 // Unrenote handles POST /api/notes/unrenote.

--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -301,6 +301,26 @@ func TestFeatured_InvalidJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// #1682 notes/featured は viewer が mute / 被block した author の note を除外する
+// (upstream featured.ts:99-107 の isUserRelated)。
+func TestFeatured_FiltersMutedAuthor(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	noteRepo.Notes["fn"] = &model.Note{ID: "fn", UserID: "muted", Visibility: "public", User: &model.User{ID: "muted"}}
+	mutingRepo := testutil.NewMockMutingRepository()
+	mutingRepo.Mutings["m1"] = &model.Muting{ID: "m1", MuterID: "viewer", MuteeID: "muted"}
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["viewer"] = &model.User{ID: "viewer", Username: "viewer", UsernameLower: "viewer"}
+	h.SetMutingRepo(mutingRepo)
+	h.SetBlockingRepo(testutil.NewMockBlockingRepository())
+	h.SetUserRepo(userRepo)
+
+	rec := postExtra(h.Featured, `{}`, &model.User{ID: "viewer"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Empty(t, resp, "mute した author の featured note は除外される")
+}
+
 // channelId 指定時は当該チャンネルに属するノートだけが返ること (#489)。
 // handler が channelId を bind せずに repo に渡し忘れると、ハイライト
 // タブで他チャンネル / グローバルのノートが混入する。


### PR DESCRIPTION
## Summary

#1682 (notes/featured ランキング + filter) のうち **filter** 部分。upstream `featured.ts:99-107` は me の mute / 被block を `isUserRelated` で featured 結果から除外するが、mk-go の `notes/featured` は packMany するだけで filter が無かった (`users/featured-notes` は #1547 で対応済)。

## 主な変更点

- `notes/featured` handler に `applyMuteBlock` (被block / mute / instance-mute、#1677 で追加した helper) を packMany 前に適用。`users/featured-notes` (#1547) と同じ post-fetch filter pattern。匿名 viewer は no-op。

## scope 外 (分割)

- **engagement ランキング** (reaction + renote を Redis sorted set + 時間窓/decay で集計) は大型 feature のため #1687 に切り出した。現状の `(renoteCount + repliesCount) DESC` SQL ranking は機能的近似として維持。
- `blocked-host` (admin meta) / `suspended` は別 follow-up (timeline 側 #1686 と共通の cross-cutting gap)。

## テスト

- `notes/featured`: viewer が mute した author の featured note が除外される
- 既存 `TestFeatured_Success` (匿名 viewer、no-op) 非回帰
- `go vet ./...` / 全テスト pass

## 関連

#1682 (filter 部分)。ranking は #1687。

🤖 Generated with [Claude Code](https://claude.com/claude-code)