### PR TITLE
Fix notes/search-by-tag: query を OR-of-AND 複合タグ検索に対応 (#1683)

### DIFF
--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -257,8 +257,9 @@ func (h *Handler) UserListTimeline(c echo.Context) error {
 }
 
 // SearchByTag handles POST /api/notes/search-by-tag.
-// TS互換: tag (string) または query (string[][] — AND/OR組み合わせ) を受け付ける。
-// query の完全なAND/OR交差はサポートせず、最初に見つかったタグで検索する。
+// TS互換: tag (string) または query (string[][] — 外側 OR・内側 AND の複合タグ
+// 検索) を受け付ける (#1683、upstream search-by-tag.ts)。tag が指定されれば
+// 単一タグ、無ければ query を OR-of-AND で検索する。
 func (h *Handler) SearchByTag(c echo.Context) error {
 	var req struct {
 		Tag       string     `json:"tag"`
@@ -276,16 +277,25 @@ func (h *Handler) SearchByTag(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "tag is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	// query 配列から tag を抽出 (tag が空の場合のフォールバック)
-	if req.Tag == "" && len(req.Query) > 0 {
+	// tag / query を tagGroups ([][]string、外側 OR・内側 AND) に正規化する。
+	// upstream: 'tag' があれば単一タグ、無ければ query をそのまま使う。
+	var tagGroups [][]string
+	if req.Tag != "" {
+		tagGroups = [][]string{{req.Tag}}
+	} else {
 		for _, inner := range req.Query {
-			if len(inner) > 0 && inner[0] != "" {
-				req.Tag = inner[0]
-				break
+			g := make([]string, 0, len(inner))
+			for _, t := range inner {
+				if t != "" {
+					g = append(g, t)
+				}
+			}
+			if len(g) > 0 {
+				tagGroups = append(tagGroups, g)
 			}
 		}
 	}
-	if req.Tag == "" {
+	if len(tagGroups) == 0 {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "tag is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
@@ -302,7 +312,7 @@ func (h *Handler) SearchByTag(c echo.Context) error {
 	}
 	// reply/renote/poll/withFiles で絞る (upstream search-by-tag.ts、#1554)。
 	filter := model.NoteSearchTagFilter{Reply: req.Reply, Renote: req.Renote, Poll: req.Poll, WithFiles: req.WithFiles}
-	notes, err := h.noteRepo.SearchByTag(req.Tag, viewerID, req.Limit, sinceID, untilID, filter)
+	notes, err := h.noteRepo.SearchByTag(tagGroups, viewerID, req.Limit, sinceID, untilID, filter)
 	if err != nil {
 		// tag 検索失敗は従来どおり空配列で返す (TS 互換) が、visibility
 		// push-down 追加で SQL エラーも黙殺されうるため診断用に 1 行残す。

--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -700,19 +700,27 @@ func TestSearchByTag_FiltersMutedAuthor(t *testing.T) {
 	assert.Empty(t, resp, "mute した author の note は除外される")
 }
 
-func TestSearchByTag_QueryArray(t *testing.T) {
+// #1683 query は外側 OR・内側 AND の複合タグ検索。
+func TestSearchByTag_QueryOrOfAnd(t *testing.T) {
 	h, noteRepo, _ := newExtraHandler(t)
-	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Tags: []string{"go"}, Visibility: "public", User: &model.User{ID: "u1"}}
-	// query の最初の要素がタグとして使われる
+	// goAndRust は go+rust 両方、webOnly は web、goOnly は go のみ。
+	noteRepo.Notes["goAndRust"] = &model.Note{ID: "goAndRust", UserID: "u1", Tags: []string{"go", "rust"}, Visibility: "public", User: &model.User{ID: "u1"}}
+	noteRepo.Notes["webOnly"] = &model.Note{ID: "webOnly", UserID: "u1", Tags: []string{"web"}, Visibility: "public", User: &model.User{ID: "u1"}}
+	noteRepo.Notes["goOnly"] = &model.Note{ID: "goOnly", UserID: "u1", Tags: []string{"go"}, Visibility: "public", User: &model.User{ID: "u1"}}
+
+	// query [["go","rust"],["web"]] = (go AND rust) OR (web)。
+	// goAndRust (両方) と webOnly はヒット、goOnly (go だけ、rust 欠) は外れる。
 	rec := postExtra(h.SearchByTag, `{"query":[["go","rust"],["web"]]}`, nil)
 	require.Equal(t, http.StatusOK, rec.Code)
-	// #1491 audit 指摘 6: query 配列 parse の正しさを id 識別で fix。
-	// 旧 test は status のみ確認していて、tag が "rust"/"web" 等にズレても通って
-	// しまっていた。
 	var resp []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	require.Len(t, resp, 1)
-	assert.Equal(t, "n1", resp[0]["id"])
+	ids := map[string]bool{}
+	for _, n := range resp {
+		ids[n["id"].(string)] = true
+	}
+	assert.True(t, ids["goAndRust"], "go AND rust を満たす note はヒット")
+	assert.True(t, ids["webOnly"], "web group を満たす note はヒット")
+	assert.False(t, ids["goOnly"], "go だけ (rust 欠) は (go AND rust) を満たさず外れる")
 }
 
 func TestSearchByTag_QueryArrayEmpty(t *testing.T) {
@@ -787,7 +795,7 @@ func TestSearchByTag_SpecifiedTargetAndAuthorSee(t *testing.T) {
 
 type failingSearchByTagRepo struct{ *testutil.MockNoteRepository }
 
-func (f *failingSearchByTagRepo) SearchByTag(_, _ string, _ int, _, _ string, _ model.NoteSearchTagFilter) ([]*model.Note, error) {
+func (f *failingSearchByTagRepo) SearchByTag(_ [][]string, _ string, _ int, _, _ string, _ model.NoteSearchTagFilter) ([]*model.Note, error) {
 	return nil, testutil.ErrNotFound
 }
 

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -869,7 +869,7 @@ func (f *failingNoteRepo) FindRenoteByUser(_, _ string) (*model.Note, error) {
 func (f *failingNoteRepo) ListMentions(_, _ string, _ bool, _ int, _, _ string) ([]*model.Note, error) {
 	return nil, nil
 }
-func (f *failingNoteRepo) SearchByTag(_, _ string, _ int, _, _ string, _ model.NoteSearchTagFilter) ([]*model.Note, error) {
+func (f *failingNoteRepo) SearchByTag(_ [][]string, _ string, _ int, _, _ string, _ model.NoteSearchTagFilter) ([]*model.Note, error) {
 	return nil, nil
 }
 func (f *failingNoteRepo) ListByFileID(_, _, _ string, _ int) ([]*model.Note, error) {

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -138,8 +138,9 @@ type NoteRepository interface {
 	// viewerID 空文字は匿名 (public/home のみ)。discovery 系の tag 検索は
 	// ID 既知公開 (notes/show) doctrine の対象外なので、core/note.CanSeeNote と
 	// 同じ可視性条件を LIMIT 前に SQL で絞る (#1439)。filter で reply/renote/poll/
-	// withFiles を絞る (upstream search-by-tag.ts、#1554)。
-	SearchByTag(tag, viewerID string, limit int, sinceID, untilID string, filter model.NoteSearchTagFilter) ([]*model.Note, error)
+	// withFiles を絞る (upstream search-by-tag.ts、#1554)。tagGroups は外側 OR・
+	// 内側 AND の複合タグ検索 (string[][]、#1683)。単一タグは [][]string{{tag}}。
+	SearchByTag(tagGroups [][]string, viewerID string, limit int, sinceID, untilID string, filter model.NoteSearchTagFilter) ([]*model.Note, error)
 	// ListByFileID returns notes whose fileIds array contains fileID, with
 	// cursor (sinceID/untilID) pagination matching upstream Misskey's
 	// makePaginationQuery. limit <= 0 defaults to 10.
@@ -788,12 +789,41 @@ func (r *noteRepository) ListMentions(userID, visibility string, following bool,
 	return notes, nil
 }
 
-func (r *noteRepository) SearchByTag(tag, viewerID string, limit int, sinceID, untilID string, filter model.NoteSearchTagFilter) ([]*model.Note, error) {
+func (r *noteRepository) SearchByTag(tagGroups [][]string, viewerID string, limit int, sinceID, untilID string, filter model.NoteSearchTagFilter) ([]*model.Note, error) {
 	if limit <= 0 {
 		limit = 10
 	}
+	// tagGroups は upstream search-by-tag.ts の query (string[][]) と同じ
+	// 外側 OR・内側 AND の複合タグ検索 (#1683)。各 group は AND (= note.tags が
+	// group の全 tag を含む = `tags @> ARRAY[inner]`)、group 同士は OR。単一タグ
+	// 検索は [][]string{{tag}} を渡せばよい。空 tag は除外し、有効な group が
+	// 無ければ空結果を返す。
+	var conds []string
+	var args []any
+	for _, g := range tagGroups {
+		clean := make([]string, 0, len(g))
+		for _, t := range g {
+			if t != "" {
+				clean = append(clean, t)
+			}
+		}
+		if len(clean) == 0 {
+			continue
+		}
+		ph := make([]string, len(clean))
+		for i := range clean {
+			ph[i] = "?"
+		}
+		conds = append(conds, "tags @> ARRAY["+strings.Join(ph, ",")+"]::varchar[]")
+		for _, t := range clean {
+			args = append(args, t)
+		}
+	}
+	if len(conds) == 0 {
+		return []*model.Note{}, nil
+	}
 	q := preloadNoteRelations(r.db).
-		Where("tags @> ARRAY[?]::varchar[]", tag)
+		Where("("+strings.Join(conds, " OR ")+")", args...)
 	// visibility push-down: core/note.CanSeeNote と同じ条件を LIMIT 前に絞る。
 	// ListByUserIDFiltered / clip の ListByClipVisible と同じ可視性定義 (#1439)。
 	q = applyViewerVisibility(q, viewerID)

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -2177,23 +2177,54 @@ func TestNoteRepository_SearchByTag(t *testing.T) {
 	require.NoError(t, testDB.Create(n).Error)
 	defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, n.ID)
 
-	notes, err := repo.SearchByTag("golang", "", 10, "", "", model.NoteSearchTagFilter{})
+	notes, err := repo.SearchByTag([][]string{{"golang"}}, "", 10, "", "", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	assert.NotEmpty(t, notes)
 
-	notes, err = repo.SearchByTag("nonexistent", "", 10, "", "", model.NoteSearchTagFilter{})
+	notes, err = repo.SearchByTag([][]string{{"nonexistent"}}, "", 10, "", "", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	assert.Empty(t, notes)
 
 	// default limit
-	notes, err = repo.SearchByTag("golang", "", 0, "", "", model.NoteSearchTagFilter{})
+	notes, err = repo.SearchByTag([][]string{{"golang"}}, "", 0, "", "", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	assert.NotEmpty(t, notes)
 
 	// with cursors
-	notes, err = repo.SearchByTag("golang", "", 10, "000", "zzz", model.NoteSearchTagFilter{})
+	notes, err = repo.SearchByTag([][]string{{"golang"}}, "", 10, "000", "zzz", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	assert.NotEmpty(t, notes)
+}
+
+// #1683 query (外側OR・内側AND) の複合タグ検索を実 SQL で検証する。
+func TestNoteRepository_SearchByTag_OrOfAnd(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	user := insertTestUser(t, "tagq_u", "tagquser")
+	defer cleanupUser(t, user.ID)
+
+	goRust := &model.Note{ID: "tagq_gr", UserID: user.ID, Visibility: "public", Tags: []string{"go", "rust"}}
+	webOnly := &model.Note{ID: "tagq_web", UserID: user.ID, Visibility: "public", Tags: []string{"web"}}
+	goOnly := &model.Note{ID: "tagq_go", UserID: user.ID, Visibility: "public", Tags: []string{"go"}}
+	for _, n := range []*model.Note{goRust, webOnly, goOnly} {
+		require.NoError(t, testDB.Create(n).Error)
+		defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, n.ID)
+	}
+
+	// (go AND rust) OR (web)。
+	out, err := repo.SearchByTag([][]string{{"go", "rust"}, {"web"}}, "", 50, "", "", model.NoteSearchTagFilter{})
+	require.NoError(t, err)
+	ids := map[string]bool{}
+	for _, n := range out {
+		ids[n.ID] = true
+	}
+	assert.True(t, ids["tagq_gr"], "go AND rust はヒット")
+	assert.True(t, ids["tagq_web"], "web group はヒット")
+	assert.False(t, ids["tagq_go"], "go だけは (go AND rust) を満たさず外れる")
+
+	// 有効 group が無い (空) は空結果。
+	out, err = repo.SearchByTag([][]string{{""}}, "", 50, "", "", model.NoteSearchTagFilter{})
+	require.NoError(t, err)
+	assert.Empty(t, out)
 }
 
 // #1554 SearchByTag の reply/renote/poll/withFiles filter。
@@ -2214,7 +2245,7 @@ func TestNoteRepository_SearchByTag_Filters(t *testing.T) {
 	}
 
 	collect := func(f model.NoteSearchTagFilter) map[string]bool {
-		out, err := repo.SearchByTag("sbtf", "", 50, "", "", f)
+		out, err := repo.SearchByTag([][]string{{"sbtf"}}, "", 50, "", "", f)
 		require.NoError(t, err)
 		ids := map[string]bool{}
 		for _, n := range out {
@@ -2244,7 +2275,7 @@ func TestNoteRepository_SearchByTag_Error(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	repo := NewNoteRepository(testDB.WithContext(ctx))
-	_, err := repo.SearchByTag("x", "", 10, "", "", model.NoteSearchTagFilter{})
+	_, err := repo.SearchByTag([][]string{{"x"}}, "", 10, "", "", model.NoteSearchTagFilter{})
 	assert.Error(t, err)
 }
 
@@ -2289,26 +2320,26 @@ func TestNoteRepository_SearchByTag_VisibilityPushDown(t *testing.T) {
 	}
 
 	// 匿名 / stranger は public のみ。
-	out, err := repo.SearchByTag("sbttag", "", 50, "", "", model.NoteSearchTagFilter{})
+	out, err := repo.SearchByTag([][]string{{"sbttag"}}, "", 50, "", "", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_sbt_pub"}, idsOf(out))
 
-	out, err = repo.SearchByTag("sbttag", stranger.ID, 50, "", "", model.NoteSearchTagFilter{})
+	out, err = repo.SearchByTag([][]string{{"sbttag"}}, stranger.ID, 50, "", "", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_sbt_pub"}, idsOf(out))
 
 	// follower は public + followers。
-	out, err = repo.SearchByTag("sbttag", follower.ID, 50, "", "", model.NoteSearchTagFilter{})
+	out, err = repo.SearchByTag([][]string{{"sbttag"}}, follower.ID, 50, "", "", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_sbt_fol", "n_sbt_pub"}, idsOf(out))
 
 	// visibleUserIds 対象は public + specified。
-	out, err = repo.SearchByTag("sbttag", allowed.ID, 50, "", "", model.NoteSearchTagFilter{})
+	out, err = repo.SearchByTag([][]string{{"sbttag"}}, allowed.ID, 50, "", "", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_sbt_pub", "n_sbt_spec"}, idsOf(out))
 
 	// author 本人は全 visibility。
-	out, err = repo.SearchByTag("sbttag", author.ID, 50, "", "", model.NoteSearchTagFilter{})
+	out, err = repo.SearchByTag([][]string{{"sbttag"}}, author.ID, 50, "", "", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n_sbt_fol", "n_sbt_pub", "n_sbt_spec"}, idsOf(out))
 }
@@ -3024,14 +3055,14 @@ func TestNoteRepository_SinceIDFlipsOrderASC(t *testing.T) {
 	}
 
 	// sinceID単独指定: ASC順 (古い→新しい)。asc_n_a より大なので b, c が返る想定。
-	notes, err := repo.SearchByTag("ascflip", "", 10, "asc_n_a", "", model.NoteSearchTagFilter{})
+	notes, err := repo.SearchByTag([][]string{{"ascflip"}}, "", 10, "asc_n_a", "", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	require.Len(t, notes, 2)
 	assert.Equal(t, "asc_n_b", notes[0].ID)
 	assert.Equal(t, "asc_n_c", notes[1].ID)
 
 	// untilID単独指定: DESC順 (既存挙動)。asc_n_c より小なので b, a が返る。
-	notes, err = repo.SearchByTag("ascflip", "", 10, "", "asc_n_c", model.NoteSearchTagFilter{})
+	notes, err = repo.SearchByTag([][]string{{"ascflip"}}, "", 10, "", "asc_n_c", model.NoteSearchTagFilter{})
 	require.NoError(t, err)
 	require.Len(t, notes, 2)
 	assert.Equal(t, "asc_n_b", notes[0].ID)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1246,9 +1246,41 @@ func (m *MockNoteRepository) ListMentions(userID, visibility string, following b
 	}, untilID, sinceID, limit), nil
 }
 
-func (m *MockNoteRepository) SearchByTag(tag, viewerID string, limit int, sinceID, untilID string, filter model.NoteSearchTagFilter) ([]*model.Note, error) {
+func (m *MockNoteRepository) SearchByTag(tagGroups [][]string, viewerID string, limit int, sinceID, untilID string, filter model.NoteSearchTagFilter) ([]*model.Note, error) {
 	if limit <= 0 {
 		limit = 10
+	}
+	// 空 tag を除いた有効 group のみ。有効 group が無ければ空。
+	groups := make([][]string, 0, len(tagGroups))
+	for _, g := range tagGroups {
+		clean := make([]string, 0, len(g))
+		for _, t := range g {
+			if t != "" {
+				clean = append(clean, t)
+			}
+		}
+		if len(clean) > 0 {
+			groups = append(groups, clean)
+		}
+	}
+	if len(groups) == 0 {
+		return []*model.Note{}, nil
+	}
+	// note.tags が group の全 tag を含むか (AND)、いずれかの group を満たすか (OR)。
+	hasAll := func(n *model.Note, g []string) bool {
+		for _, want := range g {
+			found := false
+			for _, t := range n.Tags {
+				if t == want {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+		return true
 	}
 	return m.listFiltered(func(n *model.Note) bool {
 		if !m.canViewerSeeNote(viewerID, n) {
@@ -1267,8 +1299,8 @@ func (m *MockNoteRepository) SearchByTag(tag, viewerID string, limit int, sinceI
 		if filter.WithFiles && len(n.FileIDs) == 0 {
 			return false
 		}
-		for _, t := range n.Tags {
-			if t == tag {
+		for _, g := range groups {
+			if hasAll(n, g) {
 				return true
 			}
 		}


### PR DESCRIPTION
## Summary

#1683。upstream `search-by-tag.ts` の `query` (`string[][]`) は外側 OR・内側 AND の複合タグ検索だが、mk-go は最初の 1 タグだけ使う単一タグ検索に落としていた。

## 主な変更点

- `SearchByTag` の signature を `tag string` → `tagGroups [][]string` に変更。各 group は `tags @> ARRAY[inner...]::varchar[]` (内側 AND = note.tags が group の全 tag を含む)、group 同士を OR 連結 (外側 OR)。例: `[["go","rust"],["web"]]` = `(go AND rust) OR (web)`。空 tag 除外、有効 group 無しは空結果。単一タグは `[][]string{{tag}}`。
- handler: `tag` があれば単一、無ければ `query` を空除外して tagGroups に正規化 (upstream の `if ('tag' in ps)` 優先順位)。`len 0` で INVALID_PARAM。
- visibility push-down + reply/renote/poll/withFiles filter (#1554) は従来どおり。mock は `hasAll`(group の全 tag を含む)を OR で再現。interface / fake の signature 追従。

## テスト

- handler `TestSearchByTag_QueryOrOfAnd`: `[["go","rust"],["web"]]` で go+rust と web はヒット、go だけ (rust 欠) は外れる
- repository real-DB `TestNoteRepository_SearchByTag_OrOfAnd`: 同 OR-of-AND + 空 group → 空結果
- 既存単一タグ test 非回帰、`go vet ./...` / 全テスト pass

## 関連

Closes #1683。

🤖 Generated with [Claude Code](https://claude.com/claude-code)