### PR TITLE
Fix timeline: suspended-user の note を timeline から除外 (#1686)

### DIFF
--- a/internal/core/timeline/timeline_filter.go
+++ b/internal/core/timeline/timeline_filter.go
@@ -75,6 +75,13 @@ func isPureRenote(n *model.Note) bool {
 	return n.RenoteID != nil && n.Text == nil && len(n.FileIDs) == 0
 }
 
+// userSuspended reports whether the (nilable) preloaded user is suspended.
+// relation が未取得 (nil) なら suspended ではないものとして扱う (SQL 側の
+// `replyUser.id IS NULL` 分岐と同じく pass-through)。
+func userSuspended(u *model.User) bool {
+	return u != nil && u.IsSuspended
+}
+
 // ApplyFilter filters notes in-memory according to the given TimelineFilter.
 // viewerID is the currently authenticated user's ID (empty string if anonymous).
 func ApplyFilter(notes []*model.Note, viewerID string, f TimelineFilter) []*model.Note {
@@ -146,6 +153,16 @@ func ApplyFilter(notes []*model.Note, viewerID string, f TimelineFilter) []*mode
 			if _, muted := mutedChannels[*n.ChannelID]; muted {
 				continue
 			}
+		}
+		// suspended-user filter (#1686): note/reply/renote のいずれかの author が
+		// suspended なら除外する (upstream generateSuspendedUserQueryForNote)。
+		// FindManyByIDsWithUser が note/sub-note の User relation を配線するため、
+		// reply/renote 先の author suspended も判定できる。SQL 側の
+		// applyTimelineFilter にも同等の NOT EXISTS があり 2 経路で一致する。
+		if userSuspended(n.User) ||
+			(n.Reply != nil && userSuspended(n.Reply.User)) ||
+			(n.Renote != nil && userSuspended(n.Renote.User)) {
+			continue
 		}
 		// user mute filter: 投稿者が muted user なら除外。renote / reply の
 		// author も check する (= upstream generateMutedUserQueryForNotes は

--- a/internal/core/timeline/timeline_filter_test.go
+++ b/internal/core/timeline/timeline_filter_test.go
@@ -54,6 +54,44 @@ func withHost(host string) func(*model.Note) {
 	return func(n *model.Note) { n.UserHost = strPtr(host) }
 }
 
+// #1686 suspended: note/reply/renote のいずれかの author が suspended なら除外。
+// User relation は FindManyByIDsWithUser が配線する前提なのでテストでも seed する。
+func withAuthorSuspended(n *model.Note) {
+	n.User = &model.User{ID: n.UserID, IsSuspended: true}
+}
+func withReplyAuthorSuspended(n *model.Note) {
+	n.ReplyID = strPtr("rp1")
+	n.ReplyUserID = strPtr("suspended")
+	n.Reply = &model.Note{ID: "rp1", UserID: "suspended", User: &model.User{ID: "suspended", IsSuspended: true}}
+}
+func withRenoteAuthorSuspended(n *model.Note) {
+	n.RenoteID = strPtr("rn1")
+	n.RenoteUserID = strPtr("suspended")
+	n.Renote = &model.Note{ID: "rn1", UserID: "suspended", User: &model.User{ID: "suspended", IsSuspended: true}}
+}
+
+func TestApplyFilter_Suspended(t *testing.T) {
+	notes := []*model.Note{
+		makeNote("a", withAuthorSuspended),       // note author が suspended
+		makeNote("b", withReplyAuthorSuspended),  // reply 先 author が suspended
+		makeNote("c", withRenoteAuthorSuspended), // renote 元 author が suspended
+		// User relation が nil なら pass-through (suspended 不明扱い)
+		makeNote("nilrel"),
+		// 非 suspended author は通す
+		func() *model.Note {
+			n := makeNote("ok")
+			n.User = &model.User{ID: "author", IsSuspended: false}
+			return n
+		}(),
+	}
+	out := ApplyFilter(notes, "viewer", TimelineFilter{})
+	ids := make([]string, 0, len(out))
+	for _, n := range out {
+		ids = append(ids, n.ID)
+	}
+	assert.ElementsMatch(t, []string{"nilrel", "ok"}, ids)
+}
+
 // #1681 被block: note/reply/renote のいずれかの author が viewer を block して
 // いれば除外。
 func TestApplyFilter_Blocker(t *testing.T) {

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -1010,6 +1010,20 @@ func applyTimelineFilter(q *gorm.DB, f model.TimelineDBFilter) *gorm.DB {
 			f.ViewerID,
 		)
 	}
+	// suspended-user filter (#1686): note/reply/renote のいずれかの author が
+	// suspended なら除外する (upstream generateSuspendedUserQueryForNote)。
+	// timeline は viewer に依らず常に suspended user の note を隠すので無条件
+	// 適用。isSuspended は user table への NOT EXISTS で確認し bind parameter を
+	// 持たない。suspended user は post-suspension で fanout list に note ID が
+	// 残るため、Redis 経路の ApplyFilter にも対応する suspended check がある。
+	suspendedNotExists := func(col string) string {
+		return `NOT EXISTS (SELECT 1 FROM "user" su WHERE su."id" = ` + col + ` AND su."isSuspended" = true)`
+	}
+	q = q.Where(
+		suspendedNotExists(`"note"."userId"`) +
+			` AND ("replyUserId" IS NULL OR ` + suspendedNotExists(`"note"."replyUserId"`) + `)` +
+			` AND ("renoteUserId" IS NULL OR ` + suspendedNotExists(`"note"."renoteUserId"`) + `)`,
+	)
 	return q
 }
 

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -149,6 +149,52 @@ func TestNoteRepository_ListHomeTimeline_BaseFilters(t *testing.T) {
 
 func strPtr2(s string) *string { return &s }
 
+// TestNoteRepository_ListHomeTimeline_SuspendedFilter は #1686 の suspended-user
+// filter を SQL 層で検証する。note/reply/renote のいずれかの author が
+// suspended なら除外される (upstream generateSuspendedUserQueryForNote)。
+func TestNoteRepository_ListHomeTimeline_SuspendedFilter(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	viewer := insertTestUser(t, "u_sus_v", "susviewer")
+	normal := insertTestUser(t, "u_sus_n", "susnormal")
+	susp := insertTestUser(t, "u_sus_s", "suspended")
+	defer cleanupUser(t, viewer.ID)
+	defer cleanupUser(t, normal.ID)
+	defer cleanupUser(t, susp.ID)
+	require.NoError(t, testDB.Exec(`UPDATE "user" SET "isSuspended" = true WHERE id = ?`, susp.ID).Error)
+
+	// viewer は normal / susp をフォロー (home timeline 対象)。
+	for i, fid := range []string{normal.ID, susp.ID} {
+		flid := "flw_sus_" + string(rune('a'+i))
+		require.NoError(t, testDB.Exec(`INSERT INTO "following" (id, "followerId", "followeeId") VALUES (?, ?, ?)`, flid, viewer.ID, fid).Error)
+		defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, flid)
+	}
+
+	txt := "hi"
+	mkNote := func(n *model.Note) *model.Note {
+		n.Text = &txt
+		n.Visibility = model.NoteVisibilityPublic
+		n.Reactions = datatypes.JSON([]byte("{}"))
+		require.NoError(t, repo.Create(n))
+		t.Cleanup(func() { cleanupNote(t, n.ID) })
+		return n
+	}
+	plain := mkNote(&model.Note{ID: "n_sus_plain", UserID: normal.ID})
+	bySusp := mkNote(&model.Note{ID: "n_sus_own", UserID: susp.ID})
+	replyToSusp := mkNote(&model.Note{ID: "n_sus_rep", UserID: normal.ID, ReplyID: strPtr2("n_sus_own"), ReplyUserID: &susp.ID})
+	renoteOfSusp := mkNote(&model.Note{ID: "n_sus_rnt", UserID: normal.ID, RenoteID: strPtr2("n_sus_own"), RenoteUserID: &susp.ID})
+
+	rows, err := repo.ListHomeTimeline(viewer.ID, 50, "", "", model.TimelineDBFilter{ViewerID: viewer.ID})
+	require.NoError(t, err)
+	ids := map[string]bool{}
+	for _, n := range rows {
+		ids[n.ID] = true
+	}
+	assert.True(t, ids[plain.ID], "非 suspended author の note は含まれる")
+	assert.False(t, ids[bySusp.ID], "suspended author の note は除外")
+	assert.False(t, ids[replyToSusp.ID], "suspended user 宛 reply は除外")
+	assert.False(t, ids[renoteOfSusp.ID], "suspended user の renote/quote は除外")
+}
+
 // TestNoteRepository_ListHomeTimeline_WithRepliesFalse_SelfThreadOnly は #1047
 // で導入された upstream 互換の reply filter semantics を SQL 層で直接検証する。
 //


### PR DESCRIPTION
## Summary

#1686 のうち suspended-user filter を実装。upstream `generateSuspendedUserQueryForNote` 相当が mk-go の timeline 両経路 (SQL push-down / Redis fanout in-memory) に無く、suspend されたユーザーの note・suspend されたユーザー宛の reply・その renote が home/local/global/hybrid/user-list timeline に残っていた。

## 主な変更点

- **SQL** (`applyTimelineFilter`): note/reply/renote のいずれかの author が suspended なら除外する `NOT EXISTS (SELECT 1 FROM "user" su WHERE su."id" = <col> AND su."isSuspended" = true)` を無条件追加。timeline は viewer に依らず常に suspended を隠すため flag 化せず常時適用、bind parameter なし。`"note"."userId"` は user-list JOIN との曖昧性回避で修飾。
- **Redis 経路** (`ApplyFilter`): preload 済の `n.User` / `n.Reply.User` / `n.Renote.User` の `IsSuspended` を判定。`FindManyByIDsWithUser` が sub-note の User も配線するため reply/renote 先の suspended も検出でき SQL と一致。relation nil は pass-through (SQL の `id IS NULL` 分岐と同 semantics)。

## テスト

- `TestApplyFilter_Suspended` (in-memory): note/reply/renote author suspended の 3 ケース除外 + nil relation / 非 suspended は通過
- `TestNoteRepository_ListHomeTimeline_SuspendedFilter` (real-DB): 同 3 ケースを ListHomeTimeline で検証
- `internal/repository` / `internal/core/timeline` 全テスト + `go vet ./...` pass

## 関連

#1686 (timeline 系の follow-up)。home channels 包含は別 PR で対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)