### PR TITLE
Fix home timeline: follow 中 channel の note を含め、follow user の channel note を除外 (#1686)

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -46,8 +46,12 @@ type Handler struct {
 	noteReactionRepo  repository.NoteReactionRepository
 	channelRepo       repository.ChannelRepository
 	channelMutingRepo repository.ChannelMutingRepository
-	mutingRepo        repository.MutingRepository
-	renoteMutingRepo  repository.RenoteMutingRepository
+	// channelFollowingRepo は home timeline で follow 中 channel の note を
+	// 含めるため、viewer の followed channel id を引くのに使う (#1686)。
+	// 未配線時は home に followed channel note を含めない (= channelId IS NULL のみ)。
+	channelFollowingRepo repository.ChannelFollowingRepository
+	mutingRepo           repository.MutingRepository
+	renoteMutingRepo     repository.RenoteMutingRepository
 	// blockingRepo は notes/children・replies・renotes の list 応答で被block /
 	// mute / instance-mute filter を適用するのに使う (#1554、upstream
 	// generateBaseNoteFilteringQuery 相当)。未配線時は filter skip。
@@ -127,6 +131,12 @@ func (h *Handler) SetPolicyProvider(p TimelinePolicyProvider) {
 // can exclude notes posted to channels the viewer has muted.
 func (h *Handler) SetChannelMutingRepo(r repository.ChannelMutingRepository) {
 	h.channelMutingRepo = r
+}
+
+// SetChannelFollowingRepo attaches a ChannelFollowingRepository so the home
+// timeline includes notes from channels the viewer follows (#1686).
+func (h *Handler) SetChannelFollowingRepo(r repository.ChannelFollowingRepository) {
+	h.channelFollowingRepo = r
 }
 
 // SetMutingRepo attaches a MutingRepository so timeline handlers can exclude

--- a/internal/api/notes/timeline_handler.go
+++ b/internal/api/notes/timeline_handler.go
@@ -94,6 +94,7 @@ func (h *Handler) Timeline(c echo.Context) error {
 			RenoteMutedUserIDs:    h.loadRenoteMutedUserIDs(viewer),
 			BlockerIDs:            h.loadBlockerIDs(viewer),
 			MutedInstances:        h.loadMutedInstances(viewer),
+			FollowedChannelIDs:    h.loadFollowedChannelIDs(viewer),
 		}
 		req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 		return h.timelineService.HomeTimeline(c.Request().Context(), viewer, req.UntilID, req.SinceID, req.Limit, f)
@@ -193,6 +194,55 @@ func (h *Handler) loadMutedChannelIDs(viewer *model.User) []string {
 		ids = append(ids, m.ChannelID)
 	}
 	return ids
+}
+
+// loadFollowedChannelIDs returns the channel IDs the viewer follows, excluding
+// muted channels (#1686, upstream timeline.ts の followingChannelIds から
+// mutingChannelIds を除く分岐)。home timeline でのみ使い、空なら home は
+// channelId IS NULL の note のみ。anonymous viewer / repo 未配線 / 取得失敗時は
+// nil (best-effort、warning ログ)。
+func (h *Handler) loadFollowedChannelIDs(viewer *model.User) []string {
+	if viewer == nil || h.channelFollowingRepo == nil {
+		return nil
+	}
+	// 1 user の follow channel 数は通常少ないが、暴走防止に上限で打ち切る。
+	const pageSize = 100
+	const maxFollowedChannels = 500
+	var followed []string
+	for offset := 0; offset < maxFollowedChannels; offset += pageSize {
+		rows, err := h.channelFollowingRepo.ListFollowed(viewer.ID, "", "", pageSize, offset)
+		if err != nil {
+			slog.Warn("timeline: failed to load followed channels", "userId", viewer.ID, "err", err)
+			return nil
+		}
+		for _, f := range rows {
+			followed = append(followed, f.FolloweeID)
+		}
+		if len(rows) < pageSize {
+			break
+		}
+	}
+	if len(followed) == 0 {
+		return nil
+	}
+	muted := h.loadMutedChannelIDs(viewer)
+	if len(muted) == 0 {
+		return followed
+	}
+	mutedSet := make(map[string]struct{}, len(muted))
+	for _, id := range muted {
+		mutedSet[id] = struct{}{}
+	}
+	out := followed[:0]
+	for _, id := range followed {
+		if _, m := mutedSet[id]; !m {
+			out = append(out, id)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // loadMutedUserIDs returns userIDs that viewer has muted (active mutes only,

--- a/internal/api/notes/timeline_mute_test.go
+++ b/internal/api/notes/timeline_mute_test.go
@@ -74,3 +74,59 @@ func TestLoadRenoteMutedUserIDs_EmptyResultReturnsNil(t *testing.T) {
 	h.SetRenoteMutingRepo(repo)
 	assert.Nil(t, h.loadRenoteMutedUserIDs(&model.User{ID: "viewer"}))
 }
+
+// loadFollowedChannelIDs は viewer が follow している channel id を返し、mute
+// 済 channel を除外する (#1686)。
+func TestLoadFollowedChannelIDs(t *testing.T) {
+	h, _ := newTestHandler(t)
+	repo := testutil.NewMockChannelFollowingRepository()
+	repo.Followings["cf1"] = &model.ChannelFollowing{ID: "cf1", FollowerID: "viewer", FolloweeID: "ch-f1"}
+	repo.Followings["cf2"] = &model.ChannelFollowing{ID: "cf2", FollowerID: "viewer", FolloweeID: "ch-f2"}
+	repo.Followings["cf3"] = &model.ChannelFollowing{ID: "cf3", FollowerID: "other", FolloweeID: "ch-x"}
+	h.SetChannelFollowingRepo(repo)
+	// ch-f2 は mute されているので除外される。
+	muting := testutil.NewMockChannelMutingRepository()
+	require.NoError(t, muting.Create(&model.ChannelMuting{ID: "m1", UserID: "viewer", ChannelID: "ch-f2"}))
+	h.SetChannelMutingRepo(muting)
+
+	ids := h.loadFollowedChannelIDs(&model.User{ID: "viewer"})
+	assert.ElementsMatch(t, []string{"ch-f1"}, ids)
+}
+
+func TestLoadFollowedChannelIDs_NoMute(t *testing.T) {
+	h, _ := newTestHandler(t)
+	repo := testutil.NewMockChannelFollowingRepository()
+	repo.Followings["cf1"] = &model.ChannelFollowing{ID: "cf1", FollowerID: "viewer", FolloweeID: "ch-f1"}
+	repo.Followings["cf2"] = &model.ChannelFollowing{ID: "cf2", FollowerID: "viewer", FolloweeID: "ch-f2"}
+	h.SetChannelFollowingRepo(repo)
+	ids := h.loadFollowedChannelIDs(&model.User{ID: "viewer"})
+	assert.ElementsMatch(t, []string{"ch-f1", "ch-f2"}, ids)
+}
+
+func TestLoadFollowedChannelIDs_AllMutedReturnsNil(t *testing.T) {
+	h, _ := newTestHandler(t)
+	repo := testutil.NewMockChannelFollowingRepository()
+	repo.Followings["cf1"] = &model.ChannelFollowing{ID: "cf1", FollowerID: "viewer", FolloweeID: "ch-f1"}
+	h.SetChannelFollowingRepo(repo)
+	muting := testutil.NewMockChannelMutingRepository()
+	require.NoError(t, muting.Create(&model.ChannelMuting{ID: "m1", UserID: "viewer", ChannelID: "ch-f1"}))
+	h.SetChannelMutingRepo(muting)
+	assert.Nil(t, h.loadFollowedChannelIDs(&model.User{ID: "viewer"}))
+}
+
+func TestLoadFollowedChannelIDs_AnonymousReturnsNil(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.SetChannelFollowingRepo(testutil.NewMockChannelFollowingRepository())
+	assert.Nil(t, h.loadFollowedChannelIDs(nil))
+}
+
+func TestLoadFollowedChannelIDs_RepoUnsetReturnsNil(t *testing.T) {
+	h, _ := newTestHandler(t)
+	assert.Nil(t, h.loadFollowedChannelIDs(&model.User{ID: "viewer"}))
+}
+
+func TestLoadFollowedChannelIDs_EmptyResultReturnsNil(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.SetChannelFollowingRepo(testutil.NewMockChannelFollowingRepository())
+	assert.Nil(t, h.loadFollowedChannelIDs(&model.User{ID: "viewer"}))
+}

--- a/internal/core/timeline/fanout_hook.go
+++ b/internal/core/timeline/fanout_hook.go
@@ -63,15 +63,25 @@ type UserRolesLookup interface {
 	GetUserRoles(userID string) ([]*model.Role, error)
 }
 
+// ChannelFollowerLister abstracts cursor-paged "who follows this channel?" for
+// channel note home fanout (#1686). 循環依存回避のため narrow interface で受け
+// 取る (実装は repository.ChannelFollowingRepository)。channel note は author の
+// follower ではなく channel の follower の home へ push する (upstream pushToTl
+// の channelId 分岐)。
+type ChannelFollowerLister interface {
+	ListFollowerIDsPage(channelID, afterRowID string, limit int) (ids []string, nextCursor string, err error)
+}
+
 // FanoutHook implements note.TimelineFanoutHook by pushing newly-created notes
 // onto the appropriate Redis timelines (home/local/global/user).
 type FanoutHook struct {
-	fanout        *FanoutTimelineService
-	followingRepo repository.FollowingRepository
-	publisher     StreamingPublisher
-	limits        MetaCacheLimitsProvider
-	userListRepo  UserListMemberLookup
-	userRoles     UserRolesLookup
+	fanout              *FanoutTimelineService
+	followingRepo       repository.FollowingRepository
+	publisher           StreamingPublisher
+	limits              MetaCacheLimitsProvider
+	userListRepo        UserListMemberLookup
+	userRoles           UserRolesLookup
+	channelFollowerRepo ChannelFollowerLister
 }
 
 // NewFanoutHook constructs a FanoutHook.
@@ -97,6 +107,13 @@ func (h *FanoutHook) SetCacheLimitsProvider(p MetaCacheLimitsProvider) {
 // triggers push to userListTimeline:<listId> topics (#330).
 func (h *FanoutHook) SetUserListRepo(r UserListMemberLookup) {
 	h.userListRepo = r
+}
+
+// SetChannelFollowerRepo attaches a ChannelFollowerLister so that channel note
+// creation fans the note out to each channel-follower's home timeline (#1686).
+// Without it channel notes only reach the channel timeline / channel WS.
+func (h *FanoutHook) SetChannelFollowerRepo(r ChannelFollowerLister) {
+	h.channelFollowerRepo = r
 }
 
 // SetUserRolesLookup attaches a UserRolesLookup so that public note creation
@@ -127,32 +144,44 @@ func (h *FanoutHook) OnNoteCreated(n *model.Note, author *model.User) {
 	}
 	h.pushWithLimit(ctx, UserTimelineName(author.ID), n.ID, resolveCap(limits, userTimelineKind))
 
-	// 2. ホームタイムライン: 投稿者本人 + フォロワー全員
-	//    follower一覧の取得は1ページずつ繰り返し読みだす
+	// 2-5. channel note か否かで home/local/global/userList の配信先を分ける
+	//      (#1686, upstream NoteCreateService.pushToTl の channelId 分岐)。
 	homeCap := resolveCap(limits, HomeTimelineKind)
-	h.pushWithLimit(ctx, HomeTimelineName(author.ID), n.ID, homeCap)
-	h.publishNote("homeTimeline:"+author.ID, n, author)
-	if h.followingRepo != nil && shouldFanoutToFollowers(n) {
-		h.fanoutToFollowersAndStream(ctx, author.ID, n, author, homeCap)
-	}
+	if n.ChannelID != nil && *n.ChannelID != "" {
+		// channel note は author の follower ではなく channel の follower の home
+		// へ fanout する。LTL/GTL/userList へは出さない (channel note はこれらの
+		// timeline に乗らない = upstream 互換、LTL/GTL の DB query も channelId IS
+		// NULL で除外している)。channel WS への live publish は下記 step 6 が担う。
+		if h.channelFollowerRepo != nil {
+			h.fanoutToChannelFollowers(ctx, *n.ChannelID, n.ID, homeCap)
+		}
+	} else {
+		// 2. ホームタイムライン: 投稿者本人 + フォロワー全員
+		//    follower一覧の取得は1ページずつ繰り返し読みだす
+		h.pushWithLimit(ctx, HomeTimelineName(author.ID), n.ID, homeCap)
+		h.publishNote("homeTimeline:"+author.ID, n, author)
+		if h.followingRepo != nil && shouldFanoutToFollowers(n) {
+			h.fanoutToFollowersAndStream(ctx, author.ID, n, author, homeCap)
+		}
 
-	// 3. ローカルタイムライン: ローカル投稿でvisibility=publicのみ。
-	// home visibilityはフォロワー向けなのでLTLには出さない (本家と同じ挙動)。
-	if author.Host == nil && n.Visibility == model.NoteVisibilityPublic {
-		h.pushWithLimit(ctx, LocalTimeline, n.ID, MaxTimelineLength)
-		h.publishNote("localTimeline", n, author)
-	}
+		// 3. ローカルタイムライン: ローカル投稿でvisibility=publicのみ。
+		// home visibilityはフォロワー向けなのでLTLには出さない (本家と同じ挙動)。
+		if author.Host == nil && n.Visibility == model.NoteVisibilityPublic {
+			h.pushWithLimit(ctx, LocalTimeline, n.ID, MaxTimelineLength)
+			h.publishNote("localTimeline", n, author)
+		}
 
-	// 4. グローバルタイムライン: visibility=publicのみ
-	if n.Visibility == model.NoteVisibilityPublic {
-		h.pushWithLimit(ctx, GlobalTimeline, n.ID, MaxTimelineLength)
-		h.publishNote("globalTimeline", n, author)
-	}
+		// 4. グローバルタイムライン: visibility=publicのみ
+		if n.Visibility == model.NoteVisibilityPublic {
+			h.pushWithLimit(ctx, GlobalTimeline, n.ID, MaxTimelineLength)
+			h.publishNote("globalTimeline", n, author)
+		}
 
-	// 5. ユーザーリストタイムライン: 投稿者が属するリストへ配信
-	if h.userListRepo != nil && shouldFanoutToFollowers(n) {
-		listCap := resolveCap(limits, UserListTimelineKind)
-		h.fanoutToUserLists(ctx, n, author, listCap)
+		// 5. ユーザーリストタイムライン: 投稿者が属するリストへ配信
+		if h.userListRepo != nil && shouldFanoutToFollowers(n) {
+			listCap := resolveCap(limits, UserListTimelineKind)
+			h.fanoutToUserLists(ctx, n, author, listCap)
+		}
 	}
 
 	// 6. チャンネルタイムライン (Misskey channel): channel:<channelId> へ live
@@ -469,6 +498,62 @@ func (h *FanoutHook) fanoutToUserLists(ctx context.Context, n *model.Note, autho
 	}
 }
 
+// channelFollowerPageSize は channel follower fanout の cursor batch サイズ。
+// #320 の channel unread fanout (channel_service.go) と同値に揃える。
+const channelFollowerPageSize = 500
+
+// fanoutToChannelFollowers pushes a channel note ID onto every channel
+// follower's home timeline Redis list (#1686, upstream pushToTl の channelId
+// 分岐)。cursor-based pagination で全 follower を走査するため popular channel
+// でも O(followers / pageSize) 回のラウンドトリップで完了する。push 先は home
+// list のみ (live WS 配信は channel:<id> topic が担当するため home WS への
+// per-follower publish は行わない)。reply gating は適用しない (upstream の
+// channel 分岐も follower 全員へ push する)。
+func (h *FanoutHook) fanoutToChannelFollowers(ctx context.Context, channelID, noteID string, homeCap int) {
+	cursor := ""
+	for {
+		ids, next, err := h.channelFollowerRepo.ListFollowerIDsPage(channelID, cursor, channelFollowerPageSize)
+		if err != nil {
+			slog.Warn("fanoutToChannelFollowers: list channel followers failed", "err", err, "channel", channelID)
+			return
+		}
+		if len(ids) == 0 {
+			return
+		}
+		for _, fid := range ids {
+			h.pushWithLimit(ctx, HomeTimelineName(fid), noteID, homeCap)
+		}
+		if next == "" {
+			return
+		}
+		cursor = next
+	}
+}
+
+// removeFromChannelFollowerHomes removes a channel note ID from every channel
+// follower's home timeline list, mirroring fanoutToChannelFollowers for
+// OnNoteDeleted (#1686).
+func (h *FanoutHook) removeFromChannelFollowerHomes(ctx context.Context, channelID, noteID string) {
+	cursor := ""
+	for {
+		ids, next, err := h.channelFollowerRepo.ListFollowerIDsPage(channelID, cursor, channelFollowerPageSize)
+		if err != nil {
+			slog.Warn("removeFromChannelFollowerHomes: list channel followers failed", "err", err, "channel", channelID)
+			return
+		}
+		if len(ids) == 0 {
+			return
+		}
+		for _, fid := range ids {
+			h.removeBestEffort(ctx, HomeTimelineName(fid), noteID)
+		}
+		if next == "" {
+			return
+		}
+		cursor = next
+	}
+}
+
 // pushWithLimit wraps Push with error logging and an explicit cap.
 func (h *FanoutHook) pushWithLimit(ctx context.Context, name Name, id string, maxLen int) {
 	if err := h.fanout.Push(ctx, name, id, maxLen); err != nil {
@@ -490,25 +575,35 @@ func (h *FanoutHook) OnNoteDeleted(n *model.Note, author *model.User) {
 	// 1. ユーザータイムライン
 	h.removeBestEffort(ctx, UserTimelineName(author.ID), n.ID)
 
-	// 2. ホームタイムライン: 投稿者本人 + フォロワー全員
-	h.removeBestEffort(ctx, HomeTimelineName(author.ID), n.ID)
-	if h.followingRepo != nil && shouldFanoutToFollowers(n) {
-		h.removeFromFollowerHomes(ctx, author.ID, n.ID)
-	}
+	// 2-5. OnNoteCreated と対称に、channel note か否かで掃除先を分ける (#1686)。
+	if n.ChannelID != nil && *n.ChannelID != "" {
+		// channel note は channel follower の home にのみ push されているので
+		// そこから掃除する (author home / user-follower / LTL / GTL / userList
+		// には push していない)。
+		if h.channelFollowerRepo != nil {
+			h.removeFromChannelFollowerHomes(ctx, *n.ChannelID, n.ID)
+		}
+	} else {
+		// 2. ホームタイムライン: 投稿者本人 + フォロワー全員
+		h.removeBestEffort(ctx, HomeTimelineName(author.ID), n.ID)
+		if h.followingRepo != nil && shouldFanoutToFollowers(n) {
+			h.removeFromFollowerHomes(ctx, author.ID, n.ID)
+		}
 
-	// 3. ローカルタイムライン
-	if author.Host == nil && n.Visibility == model.NoteVisibilityPublic {
-		h.removeBestEffort(ctx, LocalTimeline, n.ID)
-	}
+		// 3. ローカルタイムライン
+		if author.Host == nil && n.Visibility == model.NoteVisibilityPublic {
+			h.removeBestEffort(ctx, LocalTimeline, n.ID)
+		}
 
-	// 4. グローバルタイムライン
-	if n.Visibility == model.NoteVisibilityPublic {
-		h.removeBestEffort(ctx, GlobalTimeline, n.ID)
-	}
+		// 4. グローバルタイムライン
+		if n.Visibility == model.NoteVisibilityPublic {
+			h.removeBestEffort(ctx, GlobalTimeline, n.ID)
+		}
 
-	// 5. ユーザーリストタイムライン
-	if h.userListRepo != nil && shouldFanoutToFollowers(n) {
-		h.removeFromUserLists(ctx, author.ID, n.ID)
+		// 5. ユーザーリストタイムライン
+		if h.userListRepo != nil && shouldFanoutToFollowers(n) {
+			h.removeFromUserLists(ctx, author.ID, n.ID)
+		}
 	}
 }
 

--- a/internal/core/timeline/fanout_hook_test.go
+++ b/internal/core/timeline/fanout_hook_test.go
@@ -121,6 +121,71 @@ func TestFanoutHook_FanoutsToFollowers(t *testing.T) {
 	}
 }
 
+// #1686: channel note は author の (user) follower ではなく channel の follower
+// の home へ fanout する。author home / LTL / GTL / user-follower home には乗せ
+// ない (upstream pushToTl の channelId 分岐)。
+func TestFanoutHook_ChannelNoteToChannelFollowers(t *testing.T) {
+	h, fanout, following := newTestHook(t)
+	ctx := context.Background()
+	// author は user-follower "uf" を持つが、channel note では uf の home に push
+	// されないことを確認する。
+	following.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "uf", FolloweeID: "author"}
+	chMock := testutil.NewMockChannelFollowingRepository()
+	chMock.Followings["cf1"] = &model.ChannelFollowing{ID: "cf1", FolloweeID: "ch1", FollowerID: "cf"}
+	h.SetChannelFollowerRepo(chMock)
+
+	noteID := idGen.Generate(time.Now())
+	ch := "ch1"
+	n := &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityPublic, ChannelID: &ch}
+	h.OnNoteCreated(n, &model.User{ID: "author"})
+
+	// channel follower "cf" の home に入る
+	out, err := fanout.Get(ctx, HomeTimelineName("cf"), "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{noteID}, out, "channel follower home should receive channel note")
+
+	// author home / user-follower home / LTL / GTL には入らない
+	for _, name := range []Name{
+		HomeTimelineName("author"),
+		HomeTimelineName("uf"),
+		LocalTimeline,
+		GlobalTimeline,
+	} {
+		out, err := fanout.Get(ctx, name, "", "", 10)
+		require.NoError(t, err)
+		assert.Empty(t, out, "channel note should NOT be in %q", name)
+	}
+
+	// user timeline (step 1) には引き続き入る (users/notes 互換、scope 外)。
+	out, err = fanout.Get(ctx, UserTimelineName("author"), "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{noteID}, out, "author user timeline still receives channel note")
+}
+
+// #1686: channel note の OnNoteDeleted は channel follower の home からのみ掃除
+// する (push と対称)。
+func TestFanoutHook_OnNoteDeleted_ChannelNote(t *testing.T) {
+	h, fanout, _ := newTestHook(t)
+	ctx := context.Background()
+	chMock := testutil.NewMockChannelFollowingRepository()
+	chMock.Followings["cf1"] = &model.ChannelFollowing{ID: "cf1", FolloweeID: "ch1", FollowerID: "cf"}
+	h.SetChannelFollowerRepo(chMock)
+
+	noteID := idGen.Generate(time.Now())
+	ch := "ch1"
+	n := &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityPublic, ChannelID: &ch}
+	h.OnNoteCreated(n, &model.User{ID: "author"})
+	// push 済を確認
+	out, err := fanout.Get(ctx, HomeTimelineName("cf"), "", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []string{noteID}, out)
+
+	h.OnNoteDeleted(n, &model.User{ID: "author"})
+	out, err = fanout.Get(ctx, HomeTimelineName("cf"), "", "", 10)
+	require.NoError(t, err)
+	assert.Empty(t, out, "channel follower home should be cleaned after delete")
+}
+
 // 他人宛 reply は WithReplies=true の follower にだけ push される (#1047)。
 // upstream Misskey TS の `following.withReplies` setting と互換にするため、
 // fanout 段階で per-follower flag を見て push を制御する。

--- a/internal/core/timeline/timeline_filter.go
+++ b/internal/core/timeline/timeline_filter.go
@@ -60,6 +60,12 @@ type TimelineFilter struct {
 	// MutedInstances は viewer が mute した instance host (#1681、lowercase)。
 	// note/reply/renote のいずれかの author host が一致する note を除外する。
 	MutedInstances []string
+	// FollowedChannelIDs は viewer がフォローしている channel の id (mute 済は
+	// 除く、#1686)。home timeline でのみ使う。in-memory ApplyFilter では参照
+	// しない (Redis の home list は fanout が channel-follower の home へ push
+	// するため既に正しい)。DB fallback の ListHomeTimeline が
+	// `channelId IN (...)` で followed channel の note を home に含める。
+	FollowedChannelIDs []string
 }
 
 // boolDefault returns *b if non-nil, else def.

--- a/internal/core/timeline/timeline_service.go
+++ b/internal/core/timeline/timeline_service.go
@@ -222,6 +222,9 @@ func toDBFilter(f TimelineFilter, viewerID string) model.TimelineDBFilter {
 		// 渡す (#1681)。anon viewer では空。
 		BlockerIDs:     f.BlockerIDs,
 		MutedInstances: f.MutedInstances,
+		// followed channel (mute 済除外) を home DB fallback に渡す (#1686)。
+		// home 以外の timeline では handler が空のまま渡す。
+		FollowedChannelIDs: f.FollowedChannelIDs,
 	}
 }
 

--- a/internal/core/timeline/todbfilter_mapping_test.go
+++ b/internal/core/timeline/todbfilter_mapping_test.go
@@ -30,6 +30,7 @@ func TestToDBFilter_AllFieldsMapped(t *testing.T) {
 		IncludeRenotedMyNotes: &includeRenotedMyNotes,
 		IncludeLocalRenotes:   &includeLocalRenotes,
 		MutedChannelIDs:       []string{"ch1", "ch2"},
+		FollowedChannelIDs:    []string{"chf1", "chf2"},
 	}
 
 	out := toDBFilter(in, "viewer1")
@@ -51,6 +52,7 @@ func TestToDBFilter_AllFieldsMapped(t *testing.T) {
 		assert.False(t, *out.IncludeLocalRenotes)
 	}
 	assert.Equal(t, []string{"ch1", "ch2"}, out.MutedChannelIDs)
+	assert.Equal(t, []string{"chf1", "chf2"}, out.FollowedChannelIDs)
 
 	// viewerID 有なら mute / renote-mute の両 subquery が有効化される。
 	assert.True(t, out.UseMutingSubquery)

--- a/internal/model/timeline_filter.go
+++ b/internal/model/timeline_filter.go
@@ -44,4 +44,10 @@ type TimelineDBFilter struct {
 	// (upstream generateMutedUserQueryForNotes の mutedInstances 分岐)。host は
 	// lowercase 前提 (AP canonical)。
 	MutedInstances []string
+	// FollowedChannelIDs は viewer がフォローしている channel の id 一覧
+	// (mute 済は除外、#1686)。ListHomeTimeline でのみ使う。空でなければ home に
+	// `channelId IN (...)` の followed channel note を含める (upstream
+	// timeline.ts の followingChannelIds 分岐)。空なら従来どおり channelId IS NULL
+	// の note のみ (= followed user の channel note は home から除外される)。
+	FollowedChannelIDs []string
 }

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -1029,10 +1029,28 @@ func applyTimelineFilter(q *gorm.DB, f model.TimelineDBFilter) *gorm.DB {
 
 // ListHomeTimeline returns notes by the user and users they follow.
 // DBフォールバック用。Redisが空のときに使う。
+//
+// channel note の扱い (#1686, upstream timeline.ts の followingChannelIds 分岐):
+//   - followed user の note は `channelId IS NULL` のものだけ home に出す
+//     (= followed user が channel に投稿しても、その channel を follow して
+//     いなければ home には出さない)。
+//   - filter.FollowedChannelIDs が非空なら、follow 中 channel の note を
+//     `channelId IN (...)` で追加で含める (mute 済 channel は handler 側で
+//     除外済)。
 func (r *noteRepository) ListHomeTimeline(userID string, limit int, sinceID, untilID string, filter model.TimelineDBFilter) ([]*model.Note, error) {
-	q := preloadNoteRelations(r.db).
-		Where(`("userId" = ? OR "userId" IN (SELECT "followeeId" FROM "following" WHERE "followerId" = ?)) AND "visibility" IN ('public','home','followers')`, userID, userID).
-		Order(paginationOrder(sinceID, untilID, `"id"`)).Limit(limit)
+	q := preloadNoteRelations(r.db)
+	if len(filter.FollowedChannelIDs) > 0 {
+		q = q.Where(
+			`(("userId" = ? OR "userId" IN (SELECT "followeeId" FROM "following" WHERE "followerId" = ?)) AND "channelId" IS NULL OR "channelId" IN ?) AND "visibility" IN ('public','home','followers')`,
+			userID, userID, filter.FollowedChannelIDs,
+		)
+	} else {
+		q = q.Where(
+			`("userId" = ? OR "userId" IN (SELECT "followeeId" FROM "following" WHERE "followerId" = ?)) AND "channelId" IS NULL AND "visibility" IN ('public','home','followers')`,
+			userID, userID,
+		)
+	}
+	q = q.Order(paginationOrder(sinceID, untilID, `"id"`)).Limit(limit)
 	if sinceID != "" {
 		q = q.Where(`"id" > ?`, sinceID)
 	}

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -72,9 +72,14 @@ func TestNoteRepository_ListHomeTimeline_MutedChannelFilter(t *testing.T) {
 	defer cleanupNote(t, inMuted.ID)
 	defer cleanupNote(t, inAllowed.ID)
 
+	// #1686: channel note は viewer が follow している channel のものだけ home
+	// に含まれる (follow user の channel note は除外)。両 channel を follow した
+	// 上で、muted channel の note は MutedChannelIDs 側で除外されることを検証する
+	// (= mute が channel-follow より優先)。
 	filter := model.TimelineDBFilter{
-		ViewerID:        viewer.ID,
-		MutedChannelIDs: []string{mutedCh.ID},
+		ViewerID:           viewer.ID,
+		MutedChannelIDs:    []string{mutedCh.ID},
+		FollowedChannelIDs: []string{mutedCh.ID, allowedCh.ID},
 	}
 	rows, err := repo.ListHomeTimeline(viewer.ID, 50, "", "", filter)
 	require.NoError(t, err)
@@ -84,10 +89,8 @@ func TestNoteRepository_ListHomeTimeline_MutedChannelFilter(t *testing.T) {
 		ids[n.ID] = true
 	}
 	assert.True(t, ids[plain.ID], "plain note must be included")
-	assert.True(t, ids[inAllowed.ID], "note in allowed channel must be included")
-	assert.False(t, ids[inMuted.ID], "note in muted channel must be excluded")
-	// OR 節のバグがあると、viewer が follow していない他ユーザーの note も
-	// 返ってしまう。ここでは他ユーザーがいないので fan-out テストは省略。
+	assert.True(t, ids[inAllowed.ID], "note in followed allowed channel must be included")
+	assert.False(t, ids[inMuted.ID], "note in muted channel must be excluded even when followed")
 }
 
 // #1681 applyTimelineFilter の被block / reply著者mute / instance-mute を
@@ -193,6 +196,65 @@ func TestNoteRepository_ListHomeTimeline_SuspendedFilter(t *testing.T) {
 	assert.False(t, ids[bySusp.ID], "suspended author の note は除外")
 	assert.False(t, ids[replyToSusp.ID], "suspended user 宛 reply は除外")
 	assert.False(t, ids[renoteOfSusp.ID], "suspended user の renote/quote は除外")
+}
+
+// TestNoteRepository_ListHomeTimeline_FollowedChannels は #1686 の home channel
+// 包含を検証する。follow 中 channel の note は home に含め、follow 中 user が
+// channel に投稿した note は (その channel を follow していない限り) home から
+// 除外される (upstream timeline.ts の followingChannelIds 分岐)。
+func TestNoteRepository_ListHomeTimeline_FollowedChannels(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	viewer := insertTestUser(t, "u_hc_v", "hcviewer")
+	fu := insertTestUser(t, "u_hc_fu", "hcfollowed")
+	x := insertTestUser(t, "u_hc_x", "hcother")
+	defer cleanupUser(t, viewer.ID)
+	defer cleanupUser(t, fu.ID)
+	defer cleanupUser(t, x.ID)
+
+	// viewer は fu のみ user-follow する。
+	require.NoError(t, testDB.Exec(`INSERT INTO "following" (id, "followerId", "followeeId") VALUES (?, ?, ?)`, "flw_hc", viewer.ID, fu.ID).Error)
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, "flw_hc")
+
+	txt := "hi"
+	chFollowed := "ch_followed"
+	chOther := "ch_other"
+	mkNote := func(id, uid string, channelID *string) *model.Note {
+		n := &model.Note{ID: id, UserID: uid, Text: &txt, Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}")), ChannelID: channelID}
+		require.NoError(t, repo.Create(n))
+		t.Cleanup(func() { cleanupNote(t, id) })
+		return n
+	}
+	plain := mkNote("n_hc_plain", fu.ID, nil)                   // followed user の通常 note
+	fuInOther := mkNote("n_hc_fuoth", fu.ID, &chOther)          // followed user の非follow channel note
+	inFollowed := mkNote("n_hc_inf", x.ID, &chFollowed)         // follow 中 channel の note (投稿者は未follow)
+	inOther := mkNote("n_hc_inoth", x.ID, &chOther)             // 非follow channel の note
+	ownInFollowed := mkNote("n_hc_own", viewer.ID, &chFollowed) // 自分の follow 中 channel note
+
+	collect := func(followed []string) map[string]bool {
+		rows, err := repo.ListHomeTimeline(viewer.ID, 50, "", "", model.TimelineDBFilter{ViewerID: viewer.ID, FollowedChannelIDs: followed})
+		require.NoError(t, err)
+		ids := map[string]bool{}
+		for _, n := range rows {
+			ids[n.ID] = true
+		}
+		return ids
+	}
+
+	// follow 中 channel あり: follow channel note は含む、follow user の channel
+	// note (非follow channel) は除外。
+	withCh := collect([]string{chFollowed})
+	assert.True(t, withCh[plain.ID], "通常 note は含まれる")
+	assert.False(t, withCh[fuInOther.ID], "follow user の非follow channel note は除外")
+	assert.True(t, withCh[inFollowed.ID], "follow 中 channel の note は含まれる")
+	assert.False(t, withCh[inOther.ID], "非follow channel の note は除外")
+	assert.True(t, withCh[ownInFollowed.ID], "自分の follow 中 channel note は含まれる")
+
+	// follow 中 channel なし: 全 channel note 除外、通常 note のみ。
+	noCh := collect(nil)
+	assert.True(t, noCh[plain.ID], "通常 note は含まれる")
+	assert.False(t, noCh[fuInOther.ID], "channel note は全除外")
+	assert.False(t, noCh[inFollowed.ID], "channel note は全除外")
+	assert.False(t, noCh[ownInFollowed.ID], "channel note は全除外")
 }
 
 // TestNoteRepository_ListHomeTimeline_WithRepliesFalse_SelfThreadOnly は #1047

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -251,6 +251,8 @@ func (s *Server) setupRoutes() {
 	timelineFanoutHook.SetCacheLimitsProvider(coretimeline.NewMetaRepoCacheLimits(metaRepo))
 	timelineFanoutHook.SetUserListRepo(userListRepo)
 	timelineFanoutHook.SetUserRolesLookup(roleService) // #1549: roleTimeline fanout
+	// #1686: channel note を channel follower の home timeline へ fanout する。
+	timelineFanoutHook.SetChannelFollowerRepo(channelFollowingRepo)
 	noteCreateService.SetFanoutHook(timelineFanoutHook)
 	// #379: Delete (inbound activity / local notes/delete どちらも) で
 	// Redis fanout timelines から note ID を LREM するための hook。
@@ -1181,6 +1183,8 @@ func (s *Server) setupRoutes() {
 	notesHandler.SetNoteReactionRepo(reactionRepo)
 	notesHandler.SetChannelRepo(channelRepo)
 	notesHandler.SetChannelMutingRepo(channelMutingRepo)
+	// home timeline で follow 中 channel の note を含める (#1686)。
+	notesHandler.SetChannelFollowingRepo(channelFollowingRepo)
 	// timeline endpoint で muted user の note を除外する filter (#874)。
 	// 未配線だと user mute は read 時に効かず、cache のみ DB 整合の状態
 	// になる security/UX regression が残る。production では必ず wire する。


### PR DESCRIPTION
## Summary

#1686 のうち home channel 包含を実装。upstream `NoteCreateService.pushToTl` / `timeline.ts` の channelId 分岐が mk-go に無く、以下 2 つの差異があった:

1. follow している channel の note が home timeline に出ない (gap)
2. follow user が channel に投稿すると、その channel を follow していなくても home に漏れる (leak)

fanout と DB fallback の両経路を upstream に揃える。

## 主な変更点

- **fanout** (`OnNoteCreated` / `OnNoteDeleted`): channel note は author の (user) follower ではなく **channel の follower** の home へ push する (`fanoutToChannelFollowers`、`ListFollowerIDsPage` の cursor 走査)。home/LTL/GTL/userList push は非 channel note のみの `else` 分岐へ移動 (LTL/GTL の DB query は元々 `channelId IS NULL` で除外しており、Redis push 側を揃えて整合させる)。`UserTimeline` push (step 1) と `channel:` live publish (step 6) は据え置き。
- **`ListHomeTimeline`**: follow user の note は `channelId IS NULL` のものだけ含め、`FollowedChannelIDs` 非空なら `channelId IN (...)` で follow 中 channel の note を追加。Redis hit 経路は fanout が channel-follower home に push するため `FollowedChannelIDs` 無しで正しく、DB fallback のみが使う非対称設計。
- **handler `loadFollowedChannelIDs`**: follow 中 channel を取得し mute 済を除外 (upstream の `followingChannelIds` - `mutingChannelIds`)。home filter にのみ set。
- `TimelineFilter` / `TimelineDBFilter` に `FollowedChannelIDs` 追加、`toDBFilter` で map、`router.go` で `SetChannelFollowerRepo` / `SetChannelFollowingRepo` 配線。

## 非対象 / 既知の挙動

- users/notes (UserTimeline) の channel note 扱いは scope 外 (step 1 据え置き)。
- 空文字 `channelId` (`""`、API 不正値) は fanout が非 channel 扱いで home に push・DB は `channelId IS NULL` で除外する非対称があるが、これは upstream (`if (note.channelId)` が `''` を falsy 扱い + DB は `channelId IS NULL`) と同一挙動。

## テスト

- fanout: `TestFanoutHook_ChannelNoteToChannelFollowers` (channel-follower home に push、author/user-follower/LTL/GTL には出ない)、`TestFanoutHook_OnNoteDeleted_ChannelNote` (削除で channel-follower home から掃除)
- repo real-DB: `TestNoteRepository_ListHomeTimeline_FollowedChannels` (follow channel 包含 / follow user の非follow channel note 除外 / 自分の follow channel note 包含 / follow channel 無しは全 channel note 除外)、既存 `...MutedChannelFilter` を mute>follow 優先検証に更新
- handler: `TestLoadFollowedChannelIDs` 系 (mute 除外 / anon / repo nil / 空)、`toDBFilter` mapping
- `internal/repository` / `internal/core/timeline` / `internal/api/notes` 全テスト + `go vet ./...` pass

## 関連

#1686 (suspended-user filter は #1690 で実装済)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)