### PR TITLE
featured.Service: engagement ランキングの Redis windowed ZSET 基盤 (#1687)

### DIFF
--- a/internal/core/featured/featured_service.go
+++ b/internal/core/featured/featured_service.go
@@ -1,0 +1,166 @@
+// Package featured implements the engagement ranking used by notes/featured,
+// users/featured-notes and channel featured. It is a faithful port of upstream
+// Misskey's FeaturedService: per-window Redis sorted sets (ZSET) keyed by a
+// time window, incremented on reaction / renote, read by merging the current
+// and previous window.
+package featured
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Ranking key prefixes (upstream FeaturedService の name 引数に対応)。
+const (
+	globalNotesRankingName    = "featuredGlobalNotesRanking"
+	inChannelNotesRankingName = "featuredInChannelNotesRanking" // ":<channelId>" を付ける
+	perUserNotesRankingName   = "featuredPerUserNotesRanking"   // ":<userId>" を付ける
+)
+
+// Ranking time windows (upstream の *_RANKING_WINDOW 定数に対応)。各 window ごと
+// に別 ZSET を持ち、古い window は TTL で失効する。
+const (
+	globalNotesRankingWindow  = 3 * 24 * time.Hour // 3日ごと
+	perUserNotesRankingWindow = 7 * 24 * time.Hour // 1週間ごと
+)
+
+// featuredEpoch は window 番号計算の基準時刻 (upstream featuredEpoc =
+// 2023-01-01T00:00:00Z)。window = floor((now - epoch) / windowRange)。
+var featuredEpoch = time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// Service maintains the engagement ranking ZSETs in Redis.
+type Service struct {
+	redis *redis.Client
+	// now is the clock used for window computation. テストで固定するため差し替え
+	// 可能にしてある (本番は time.Now)。
+	now func() time.Time
+}
+
+// NewService constructs a featured ranking Service backed by the given Redis
+// client.
+func NewService(r *redis.Client) *Service {
+	return &Service{redis: r, now: time.Now}
+}
+
+// currentWindow returns the window index for the given range at the current
+// time (upstream getCurrentWindow)。
+func (s *Service) currentWindow(windowRange time.Duration) int64 {
+	passed := s.now().Sub(featuredEpoch)
+	return int64(passed / windowRange)
+}
+
+func windowKey(name string, window int64) string {
+	return name + ":" + strconv.FormatInt(window, 10)
+}
+
+// updateRankingOf increments element's score in the current window ZSET and
+// (re)sets the window TTL only when it has none (upstream updateRankingOf:
+// ZINCRBY + EXPIRE NX)。TTL は windowRange*3 にして current/previous window が
+// 読めるだけの寿命を持たせる。
+func (s *Service) updateRankingOf(ctx context.Context, name string, windowRange time.Duration, element string, score float64) error {
+	key := windowKey(name, s.currentWindow(windowRange))
+	pipe := s.redis.TxPipeline()
+	pipe.ZIncrBy(ctx, key, score, element)
+	pipe.ExpireNX(ctx, key, windowRange*3)
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+// getRankingOf returns up to (threshold+1)*2 (deduped) element IDs from the
+// current and previous window, merged by averaging the score of elements that
+// appear in both windows (upstream getRankingOf)。返り値は current window 優先
+// の挿入順 (= スコア DESC の current → previous-only を後置)。呼び出し側が ID で
+// 並べ替えるため順序自体に強い意味は無いが upstream と揃える。
+func (s *Service) getRankingOf(ctx context.Context, name string, windowRange time.Duration, threshold int) ([]string, error) {
+	cur := s.currentWindow(windowRange)
+	prev := cur - 1
+	pipe := s.redis.Pipeline()
+	curCmd := pipe.ZRevRangeWithScores(ctx, windowKey(name, cur), 0, int64(threshold))
+	prevCmd := pipe.ZRevRangeWithScores(ctx, windowKey(name, prev), 0, int64(threshold))
+	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
+		return nil, err
+	}
+
+	ranking := make(map[string]float64)
+	order := make([]string, 0, len(curCmd.Val())+len(prevCmd.Val()))
+	for _, z := range curCmd.Val() {
+		id, ok := z.Member.(string)
+		if !ok {
+			continue
+		}
+		ranking[id] = z.Score
+		order = append(order, id)
+	}
+	for _, z := range prevCmd.Val() {
+		id, ok := z.Member.(string)
+		if !ok {
+			continue
+		}
+		if existing, dup := ranking[id]; dup {
+			ranking[id] = (existing + z.Score) / 2
+		} else {
+			ranking[id] = z.Score
+			order = append(order, id)
+		}
+	}
+	return order, nil
+}
+
+// removeFromRanking drops element from both the current and previous window
+// (upstream removeFromRanking)。note 削除時に呼ぶ。
+func (s *Service) removeFromRanking(ctx context.Context, name string, windowRange time.Duration, element string) error {
+	cur := s.currentWindow(windowRange)
+	pipe := s.redis.Pipeline()
+	pipe.ZRem(ctx, windowKey(name, cur), element)
+	pipe.ZRem(ctx, windowKey(name, cur-1), element)
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+// UpdateGlobalNotesRanking adds score to noteID in the global notes ranking.
+func (s *Service) UpdateGlobalNotesRanking(ctx context.Context, noteID string, score float64) error {
+	return s.updateRankingOf(ctx, globalNotesRankingName, globalNotesRankingWindow, noteID, score)
+}
+
+// UpdateInChannelNotesRanking adds score to noteID in channelID's ranking.
+func (s *Service) UpdateInChannelNotesRanking(ctx context.Context, channelID, noteID string, score float64) error {
+	return s.updateRankingOf(ctx, inChannelNotesRankingName+":"+channelID, globalNotesRankingWindow, noteID, score)
+}
+
+// UpdatePerUserNotesRanking adds score to noteID in userID's per-user ranking.
+func (s *Service) UpdatePerUserNotesRanking(ctx context.Context, userID, noteID string, score float64) error {
+	return s.updateRankingOf(ctx, perUserNotesRankingName+":"+userID, perUserNotesRankingWindow, noteID, score)
+}
+
+// GetGlobalNotesRanking returns the top-threshold global ranked note IDs.
+func (s *Service) GetGlobalNotesRanking(ctx context.Context, threshold int) ([]string, error) {
+	return s.getRankingOf(ctx, globalNotesRankingName, globalNotesRankingWindow, threshold)
+}
+
+// GetInChannelNotesRanking returns the top-threshold ranked note IDs in channelID.
+func (s *Service) GetInChannelNotesRanking(ctx context.Context, channelID string, threshold int) ([]string, error) {
+	return s.getRankingOf(ctx, inChannelNotesRankingName+":"+channelID, globalNotesRankingWindow, threshold)
+}
+
+// GetPerUserNotesRanking returns the top-threshold ranked note IDs by userID.
+func (s *Service) GetPerUserNotesRanking(ctx context.Context, userID string, threshold int) ([]string, error) {
+	return s.getRankingOf(ctx, perUserNotesRankingName+":"+userID, perUserNotesRankingWindow, threshold)
+}
+
+// RemoveGlobalNotesRanking removes noteID from the global ranking windows.
+func (s *Service) RemoveGlobalNotesRanking(ctx context.Context, noteID string) error {
+	return s.removeFromRanking(ctx, globalNotesRankingName, globalNotesRankingWindow, noteID)
+}
+
+// RemoveInChannelNotesRanking removes noteID from channelID's ranking windows.
+func (s *Service) RemoveInChannelNotesRanking(ctx context.Context, channelID, noteID string) error {
+	return s.removeFromRanking(ctx, inChannelNotesRankingName+":"+channelID, globalNotesRankingWindow, noteID)
+}
+
+// RemovePerUserNotesRanking removes noteID from userID's per-user ranking windows.
+func (s *Service) RemovePerUserNotesRanking(ctx context.Context, userID, noteID string) error {
+	return s.removeFromRanking(ctx, perUserNotesRankingName+":"+userID, perUserNotesRankingWindow, noteID)
+}

--- a/internal/core/featured/featured_service_test.go
+++ b/internal/core/featured/featured_service_test.go
@@ -1,0 +1,178 @@
+package featured
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testRedis *testutil.TestRedis
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	var err error
+	testRedis, err = testutil.SetupRedis(ctx)
+	if err != nil {
+		// Redis コンテナを起動できない環境では skip 扱いにする (CI は services で
+		// 起動済み、ローカルは testcontainers が起動する)。
+		os.Exit(0)
+	}
+	code := m.Run()
+	testRedis.Teardown(ctx)
+	os.Exit(code)
+}
+
+// newSvc returns a Service with a fixed clock so window indices are
+// deterministic across runs.
+func newSvc(t *testing.T, now time.Time) *Service {
+	t.Helper()
+	testRedis.FlushAll(context.Background())
+	s := NewService(testRedis.Client)
+	s.now = func() time.Time { return now }
+	return s
+}
+
+func TestService_UpdateAndGetGlobal(t *testing.T) {
+	ctx := context.Background()
+	now := featuredEpoch.Add(10 * globalNotesRankingWindow)
+	s := newSvc(t, now)
+
+	require.NoError(t, s.UpdateGlobalNotesRanking(ctx, "n_low", 1))
+	require.NoError(t, s.UpdateGlobalNotesRanking(ctx, "n_high", 1))
+	require.NoError(t, s.UpdateGlobalNotesRanking(ctx, "n_high", 5)) // n_high の累計 score = 6
+
+	ids, err := s.GetGlobalNotesRanking(ctx, 100)
+	require.NoError(t, err)
+	// score DESC 順 (current window のみ): n_high(6) → n_low(1)。
+	assert.Equal(t, []string{"n_high", "n_low"}, ids)
+}
+
+// 現在 window と前 window をまたいで取得し、両方に居る note の score が平均され
+// (= dedup されて 1 回だけ現れ)、前 window のみの note も含まれることを検証する。
+func TestService_WindowMerge(t *testing.T) {
+	ctx := context.Background()
+	w0 := featuredEpoch.Add(20 * globalNotesRankingWindow)
+	s := newSvc(t, w0)
+
+	// 前 window (W) に書き込む。
+	require.NoError(t, s.UpdateGlobalNotesRanking(ctx, "n_prevonly", 10))
+	require.NoError(t, s.UpdateGlobalNotesRanking(ctx, "n_shared", 4))
+
+	// clock を次 window (W+1) に進める。これで W が previous、W+1 が current。
+	s.now = func() time.Time { return w0.Add(globalNotesRankingWindow) }
+	require.NoError(t, s.UpdateGlobalNotesRanking(ctx, "n_curonly", 8))
+	require.NoError(t, s.UpdateGlobalNotesRanking(ctx, "n_shared", 6))
+
+	ids, err := s.GetGlobalNotesRanking(ctx, 100)
+	require.NoError(t, err)
+	// current(W+1) を score DESC で先に: n_curonly(8) → n_shared(6)。次に
+	// previous-only: n_prevonly。n_shared は両 window に居るので 1 回のみ。
+	assert.Equal(t, []string{"n_curonly", "n_shared", "n_prevonly"}, ids)
+}
+
+func TestService_Threshold(t *testing.T) {
+	ctx := context.Background()
+	s := newSvc(t, featuredEpoch.Add(5*globalNotesRankingWindow))
+	for i, id := range []string{"a", "b", "c", "d"} {
+		require.NoError(t, s.UpdateGlobalNotesRanking(ctx, id, float64(i+1)))
+	}
+	// threshold=1 なら ZRANGE 0..1 = 上位 2 件 (d=4, c=3)。
+	ids, err := s.GetGlobalNotesRanking(ctx, 1)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"d", "c"}, ids)
+}
+
+func TestService_Remove(t *testing.T) {
+	ctx := context.Background()
+	w0 := featuredEpoch.Add(30 * globalNotesRankingWindow)
+	s := newSvc(t, w0)
+	require.NoError(t, s.UpdateGlobalNotesRanking(ctx, "keep", 3))
+	require.NoError(t, s.UpdateGlobalNotesRanking(ctx, "gone", 5))
+	// 前 window にも gone を入れて、remove が両 window を掃除することを確認。
+	s.now = func() time.Time { return w0.Add(globalNotesRankingWindow) }
+	require.NoError(t, s.UpdateGlobalNotesRanking(ctx, "gone", 2))
+
+	require.NoError(t, s.RemoveGlobalNotesRanking(ctx, "gone"))
+	ids, err := s.GetGlobalNotesRanking(ctx, 100)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"keep"}, ids)
+}
+
+func TestService_InChannelAndPerUserAreSeparate(t *testing.T) {
+	ctx := context.Background()
+	now := featuredEpoch.Add(40 * globalNotesRankingWindow)
+	s := newSvc(t, now)
+
+	require.NoError(t, s.UpdateGlobalNotesRanking(ctx, "g1", 1))
+	require.NoError(t, s.UpdateInChannelNotesRanking(ctx, "ch1", "c1", 1))
+	require.NoError(t, s.UpdatePerUserNotesRanking(ctx, "u1", "p1", 1))
+
+	gids, err := s.GetGlobalNotesRanking(ctx, 100)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"g1"}, gids)
+
+	cids, err := s.GetInChannelNotesRanking(ctx, "ch1", 100)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"c1"}, cids)
+
+	pids, err := s.GetPerUserNotesRanking(ctx, "u1", 100)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"p1"}, pids)
+
+	// 別 channel / 別 user の ranking は空。
+	other, err := s.GetInChannelNotesRanking(ctx, "ch2", 100)
+	require.NoError(t, err)
+	assert.Empty(t, other)
+}
+
+func TestService_RemoveInChannelAndPerUser(t *testing.T) {
+	ctx := context.Background()
+	now := featuredEpoch.Add(41 * globalNotesRankingWindow)
+	s := newSvc(t, now)
+	require.NoError(t, s.UpdateInChannelNotesRanking(ctx, "ch1", "c1", 1))
+	require.NoError(t, s.UpdatePerUserNotesRanking(ctx, "u1", "p1", 1))
+	require.NoError(t, s.RemoveInChannelNotesRanking(ctx, "ch1", "c1"))
+	require.NoError(t, s.RemovePerUserNotesRanking(ctx, "u1", "p1"))
+
+	cids, err := s.GetInChannelNotesRanking(ctx, "ch1", 100)
+	require.NoError(t, err)
+	assert.Empty(t, cids)
+	pids, err := s.GetPerUserNotesRanking(ctx, "u1", 100)
+	require.NoError(t, err)
+	assert.Empty(t, pids)
+}
+
+func TestService_EmptyRanking(t *testing.T) {
+	ctx := context.Background()
+	s := newSvc(t, featuredEpoch.Add(50*globalNotesRankingWindow))
+	ids, err := s.GetGlobalNotesRanking(ctx, 100)
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+}
+
+// updateRankingOf は current window key に TTL (windowRange*3) を NX で設定する。
+func TestService_SetsTTL(t *testing.T) {
+	ctx := context.Background()
+	now := featuredEpoch.Add(60 * globalNotesRankingWindow)
+	s := newSvc(t, now)
+	require.NoError(t, s.UpdateGlobalNotesRanking(ctx, "n1", 1))
+
+	key := windowKey(globalNotesRankingName, s.currentWindow(globalNotesRankingWindow))
+	ttl, err := testRedis.Client.TTL(ctx, key).Result()
+	require.NoError(t, err)
+	assert.Greater(t, ttl, time.Duration(0))
+	assert.LessOrEqual(t, ttl, globalNotesRankingWindow*3)
+}
+
+// NewService は本番 clock (time.Now) を設定する。currentWindow が正の window を
+// 返す (= epoch より後) ことだけ確認する。
+func TestNewService_DefaultClock(t *testing.T) {
+	s := NewService(testRedis.Client)
+	require.NotNil(t, s.now)
+	assert.Positive(t, s.currentWindow(globalNotesRankingWindow))
+}


### PR DESCRIPTION
## Summary

#1687 (notes/featured の engagement ランキング) の基盤として、upstream `FeaturedService` の Go port を新設する。**本 PR は service 単体**で、reaction/renote hook と endpoint への配線は後続 PR で行う (hot path への影響を分離してレビューするため)。

## 主な変更点

`internal/core/featured/featured_service.go`:
- 時間窓ごとに別 ZSET (global = 3日 / per-user = 1週間) を持ち、`ZINCRBY` + `EXPIRE NX` (TTL = window×3) で更新。古い window は TTL で失効する。
- 取得は current + previous window を `ZREVRANGE ... WITHSCORES` して merge。両 window に居る要素は score を平均 (upstream `getRankingOf` と同じ decay 表現)。返り値は current 優先の挿入順 ID 列 (呼び出し側が ID 順に並べ替える前提)。
- `UpdateGlobalNotesRanking` / `UpdateInChannelNotesRanking` / `UpdatePerUserNotesRanking` と対応する `Get*` / `Remove*` を公開。
- clock を注入可能にして window 計算をテストで固定 (本番は `time.Now`)。

## テスト

- `TestService_UpdateAndGetGlobal` / `_Threshold` / `_WindowMerge` (current+previous の merge・平均・dedup) / `_Remove` (両 window 掃除) / `_InChannelAndPerUserAreSeparate` / `_RemoveInChannelAndPerUser` / `_EmptyRanking` / `_SetsTTL` / `_DefaultClock`
- testRedis (testcontainers) 上で実行、package coverage 93.9%、`go vet` pass

## 関連

#1687。後続 PR で reaction/renote 付与・note 削除の hook と notes/featured・users/featured-notes endpoint をこの service に接続する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)