### PR TITLE
featured ランキング: reaction/renote の engagement hook を配線 (#1687)

### DIFF
--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -2,8 +2,10 @@
 package note
 
 import (
+	"context"
 	"errors"
 	"log/slog"
+	"math/rand"
 	"regexp"
 	"strings"
 	"sync"
@@ -17,6 +19,13 @@ import (
 	"github.com/shiroha-a/mk/internal/misc/keyword"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// featured ランキング更新の sampling rate / note 年齢上限 (upstream
+// NoteCreateService.incRenoteCount と同値)。renote は score=5。
+const (
+	featuredSampleRate = 0.3
+	featuredMaxNoteAge = 3 * 24 * time.Hour
 )
 
 // Errors returned by NoteCreateService.
@@ -219,6 +228,27 @@ type CreateService struct {
 	metaRepo            repository.MetaRepository
 	channelRepo         repository.ChannelRepository
 	silencingProvider   SilencingProvider
+	featuredRanking     FeaturedRanking
+	// randFn は featured ランキング更新の 30% sampling 用。テストで固定する。
+	randFn func() float64
+}
+
+// FeaturedRanking abstracts the engagement ranking store (#1687). 循環依存回避の
+// ため narrow interface で受け取る (実装は core/featured.Service)。renote は
+// renote 対象 note の global / in-channel / per-user ranking を boost する。
+type FeaturedRanking interface {
+	UpdateGlobalNotesRanking(ctx context.Context, noteID string, score float64) error
+	UpdateInChannelNotesRanking(ctx context.Context, channelID, noteID string, score float64) error
+	UpdatePerUserNotesRanking(ctx context.Context, userID, noteID string, score float64) error
+}
+
+// SetFeaturedRanking wires the engagement ranking store so renotes boost the
+// renoted note's featured ranking (#1687). nil 注入時 (= 未配線 / test) は skip。
+func (s *CreateService) SetFeaturedRanking(r FeaturedRanking) {
+	s.featuredRanking = r
+	if s.randFn == nil {
+		s.randFn = rand.Float64
+	}
 }
 
 // SetUserRepo attaches a UserRepository for resolving mention usernames to IDs.
@@ -635,6 +665,12 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 	if renoteTarget != nil && isPureRenote(in) {
 		_ = s.noteRepo.IncrementCount(renoteTarget.ID, "renoteCount", 1)
 	}
+	// featured engagement ランキング更新 (#1687, upstream incRenoteCount 内)。
+	// renote (quote 含む) で、自身の note でなく、bot でない renoter の場合に
+	// renote 対象 note を boost する (upstream の incRenoteCount 呼び出し条件)。
+	if renoteTarget != nil && renoteTarget.UserID != in.User.ID && !in.User.IsBot {
+		s.updateFeaturedOnRenote(renoteTarget)
+	}
 
 	// 投票が指定されていればPollレコードを作成しnote.hasPollを更新
 	if in.Poll != nil && len(in.Poll.Choices) > 0 {
@@ -720,6 +756,35 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 	})
 
 	return finalNote, nil
+}
+
+// updateFeaturedOnRenote boosts the renoted target note's featured engagement
+// ranking (#1687, upstream NoteCreateService.incRenoteCount 内、score=5)。30%
+// sampling、target が 3日以内、の gate を通った場合のみ。channel note は
+// in-channel ranking、それ以外は public かつ local かつ非 reply のときに
+// global + per-user ranking を更新する。caller 側で self-renote / bot を除外済。
+func (s *CreateService) updateFeaturedOnRenote(target *model.Note) {
+	if s.featuredRanking == nil || s.randFn == nil {
+		return
+	}
+	if s.randFn() >= featuredSampleRate {
+		return
+	}
+	created, err := s.idGen.ParseTime(target.ID)
+	if err != nil || time.Since(created) >= featuredMaxNoteAge {
+		return
+	}
+	ctx := context.Background()
+	if target.ChannelID != nil && *target.ChannelID != "" {
+		if target.ReplyID == nil {
+			_ = s.featuredRanking.UpdateInChannelNotesRanking(ctx, *target.ChannelID, target.ID, 5)
+		}
+		return
+	}
+	if target.Visibility == model.NoteVisibilityPublic && target.UserHost == nil && target.ReplyID == nil {
+		_ = s.featuredRanking.UpdateGlobalNotesRanking(ctx, target.ID, 5)
+		_ = s.featuredRanking.UpdatePerUserNotesRanking(ctx, target.UserID, target.ID, 5)
+	}
 }
 
 // publishNoteMainEvents fans out `reply`, `renote`, and `mention` events to

--- a/internal/core/note/note_featured_test.go
+++ b/internal/core/note/note_featured_test.go
@@ -1,0 +1,113 @@
+package note
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeFeaturedRanking records the ranking updates issued by the renote hook.
+type fakeFeaturedRanking struct {
+	global  []string
+	inCh    map[string][]string
+	perUser map[string][]string
+}
+
+func newFakeRanking() *fakeFeaturedRanking {
+	return &fakeFeaturedRanking{inCh: map[string][]string{}, perUser: map[string][]string{}}
+}
+
+func (f *fakeFeaturedRanking) UpdateGlobalNotesRanking(_ context.Context, noteID string, _ float64) error {
+	f.global = append(f.global, noteID)
+	return nil
+}
+
+func (f *fakeFeaturedRanking) UpdateInChannelNotesRanking(_ context.Context, channelID, noteID string, _ float64) error {
+	f.inCh[channelID] = append(f.inCh[channelID], noteID)
+	return nil
+}
+
+func (f *fakeFeaturedRanking) UpdatePerUserNotesRanking(_ context.Context, userID, noteID string, _ float64) error {
+	f.perUser[userID] = append(f.perUser[userID], noteID)
+	return nil
+}
+
+func newCreateSvcWithRanking(t *testing.T, alwaysSample bool) (*CreateService, *testutil.MockNoteRepository, *fakeFeaturedRanking, id.Generator) {
+	t.Helper()
+	noteRepo := testutil.NewMockNoteRepository()
+	pollRepo := testutil.NewMockPollRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := NewCreateService(noteRepo, pollRepo, idGen, nil)
+	fake := newFakeRanking()
+	svc.SetFeaturedRanking(fake)
+	if alwaysSample {
+		svc.randFn = func() float64 { return 0 }
+	} else {
+		svc.randFn = func() float64 { return 1 }
+	}
+	return svc, noteRepo, fake, idGen
+}
+
+func TestUpdateFeaturedOnRenote_GlobalAndPerUser(t *testing.T) {
+	svc, noteRepo, fake, idGen := newCreateSvcWithRanking(t, true)
+	targetID := idGen.Generate(time.Now())
+	noteRepo.Notes[targetID] = &model.Note{ID: targetID, UserID: "author", Visibility: model.NoteVisibilityPublic}
+	_, err := svc.Create(CreateInput{User: &model.User{ID: "renoter"}, RenoteID: &targetID})
+	require.NoError(t, err)
+	assert.Equal(t, []string{targetID}, fake.global)
+	assert.Equal(t, []string{targetID}, fake.perUser["author"])
+	assert.Empty(t, fake.inCh)
+}
+
+func TestUpdateFeaturedOnRenote_Channel(t *testing.T) {
+	svc, noteRepo, fake, idGen := newCreateSvcWithRanking(t, true)
+	ch := "ch1"
+	targetID := idGen.Generate(time.Now())
+	noteRepo.Notes[targetID] = &model.Note{ID: targetID, UserID: "author", Visibility: model.NoteVisibilityPublic, ChannelID: &ch}
+	_, err := svc.Create(CreateInput{User: &model.User{ID: "renoter"}, RenoteID: &targetID, ChannelID: &ch})
+	require.NoError(t, err)
+	assert.Equal(t, []string{targetID}, fake.inCh["ch1"])
+	assert.Empty(t, fake.global)
+}
+
+func TestUpdateFeaturedOnRenote_SkipSelf(t *testing.T) {
+	svc, noteRepo, fake, idGen := newCreateSvcWithRanking(t, true)
+	targetID := idGen.Generate(time.Now())
+	noteRepo.Notes[targetID] = &model.Note{ID: targetID, UserID: "author", Visibility: model.NoteVisibilityPublic}
+	_, err := svc.Create(CreateInput{User: &model.User{ID: "author"}, RenoteID: &targetID})
+	require.NoError(t, err)
+	assert.Empty(t, fake.global)
+}
+
+func TestUpdateFeaturedOnRenote_SkipBot(t *testing.T) {
+	svc, noteRepo, fake, idGen := newCreateSvcWithRanking(t, true)
+	targetID := idGen.Generate(time.Now())
+	noteRepo.Notes[targetID] = &model.Note{ID: targetID, UserID: "author", Visibility: model.NoteVisibilityPublic}
+	_, err := svc.Create(CreateInput{User: &model.User{ID: "renoter", IsBot: true}, RenoteID: &targetID})
+	require.NoError(t, err)
+	assert.Empty(t, fake.global)
+}
+
+func TestUpdateFeaturedOnRenote_SkipOld(t *testing.T) {
+	svc, noteRepo, fake, idGen := newCreateSvcWithRanking(t, true)
+	targetID := idGen.Generate(time.Now().Add(-4 * 24 * time.Hour))
+	noteRepo.Notes[targetID] = &model.Note{ID: targetID, UserID: "author", Visibility: model.NoteVisibilityPublic}
+	_, err := svc.Create(CreateInput{User: &model.User{ID: "renoter"}, RenoteID: &targetID})
+	require.NoError(t, err)
+	assert.Empty(t, fake.global)
+}
+
+func TestUpdateFeaturedOnRenote_SkipNotSampled(t *testing.T) {
+	svc, noteRepo, fake, idGen := newCreateSvcWithRanking(t, false)
+	targetID := idGen.Generate(time.Now())
+	noteRepo.Notes[targetID] = &model.Note{ID: targetID, UserID: "author", Visibility: model.NoteVisibilityPublic}
+	_, err := svc.Create(CreateInput{User: &model.User{ID: "renoter"}, RenoteID: &targetID})
+	require.NoError(t, err)
+	assert.Empty(t, fake.global)
+}

--- a/internal/core/reaction/reaction_featured_test.go
+++ b/internal/core/reaction/reaction_featured_test.go
@@ -1,0 +1,134 @@
+package reaction
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeFeaturedRanking records the ranking updates issued by the reaction hook.
+type fakeFeaturedRanking struct {
+	global  []string
+	inCh    map[string][]string
+	perUser map[string][]string
+}
+
+func newFakeRanking() *fakeFeaturedRanking {
+	return &fakeFeaturedRanking{inCh: map[string][]string{}, perUser: map[string][]string{}}
+}
+
+func (f *fakeFeaturedRanking) UpdateGlobalNotesRanking(_ context.Context, noteID string, _ float64) error {
+	f.global = append(f.global, noteID)
+	return nil
+}
+
+func (f *fakeFeaturedRanking) UpdateInChannelNotesRanking(_ context.Context, channelID, noteID string, _ float64) error {
+	f.inCh[channelID] = append(f.inCh[channelID], noteID)
+	return nil
+}
+
+func (f *fakeFeaturedRanking) UpdatePerUserNotesRanking(_ context.Context, userID, noteID string, _ float64) error {
+	f.perUser[userID] = append(f.perUser[userID], noteID)
+	return nil
+}
+
+// newSvcWithRanking builds a reaction Service wired to a fake ranking with a
+// deterministic sampling decision (alwaysSample → randFn returns 0 < 0.3).
+func newSvcWithRanking(t *testing.T, alwaysSample bool) (*Service, *testutil.MockNoteRepository, *fakeFeaturedRanking, id.Generator) {
+	t.Helper()
+	noteRepo := testutil.NewMockNoteRepository()
+	reactRepo := testutil.NewMockNoteReactionRepository()
+	emojiRepo := testutil.NewMockEmojiRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := NewService(noteRepo, reactRepo, emojiRepo, followingRepo, idGen)
+	fake := newFakeRanking()
+	svc.SetFeaturedRanking(fake)
+	if alwaysSample {
+		svc.randFn = func() float64 { return 0 }
+	} else {
+		svc.randFn = func() float64 { return 1 }
+	}
+	return svc, noteRepo, fake, idGen
+}
+
+func TestUpdateFeaturedOnReaction_GlobalAndPerUser(t *testing.T) {
+	svc, noteRepo, fake, idGen := newSvcWithRanking(t, true)
+	noteID := idGen.Generate(time.Now())
+	noteRepo.Notes[noteID] = &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityPublic}
+	_, err := svc.Create(&model.User{ID: "viewer"}, noteID, "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{noteID}, fake.global)
+	assert.Equal(t, []string{noteID}, fake.perUser["author"])
+	assert.Empty(t, fake.inCh)
+}
+
+func TestUpdateFeaturedOnReaction_Channel(t *testing.T) {
+	svc, noteRepo, fake, idGen := newSvcWithRanking(t, true)
+	noteID := idGen.Generate(time.Now())
+	ch := "ch1"
+	noteRepo.Notes[noteID] = &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityPublic, ChannelID: &ch}
+	_, err := svc.Create(&model.User{ID: "viewer"}, noteID, "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{noteID}, fake.inCh["ch1"])
+	assert.Empty(t, fake.global)
+}
+
+func TestUpdateFeaturedOnReaction_SkipSelf(t *testing.T) {
+	svc, noteRepo, fake, idGen := newSvcWithRanking(t, true)
+	noteID := idGen.Generate(time.Now())
+	noteRepo.Notes[noteID] = &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityPublic}
+	_, err := svc.Create(&model.User{ID: "author"}, noteID, "")
+	require.NoError(t, err)
+	assert.Empty(t, fake.global)
+}
+
+func TestUpdateFeaturedOnReaction_SkipOldNote(t *testing.T) {
+	svc, noteRepo, fake, idGen := newSvcWithRanking(t, true)
+	noteID := idGen.Generate(time.Now().Add(-4 * 24 * time.Hour))
+	noteRepo.Notes[noteID] = &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityPublic}
+	_, err := svc.Create(&model.User{ID: "viewer"}, noteID, "")
+	require.NoError(t, err)
+	assert.Empty(t, fake.global)
+}
+
+func TestUpdateFeaturedOnReaction_SkipNotSampled(t *testing.T) {
+	svc, noteRepo, fake, idGen := newSvcWithRanking(t, false)
+	noteID := idGen.Generate(time.Now())
+	noteRepo.Notes[noteID] = &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityPublic}
+	_, err := svc.Create(&model.User{ID: "viewer"}, noteID, "")
+	require.NoError(t, err)
+	assert.Empty(t, fake.global)
+}
+
+// reply note は global ranking から除外される (upstream の replyId == null gate)。
+func TestUpdateFeaturedOnReaction_SkipReply(t *testing.T) {
+	svc, noteRepo, fake, idGen := newSvcWithRanking(t, true)
+	parentID := idGen.Generate(time.Now())
+	noteRepo.Notes[parentID] = &model.Note{ID: parentID, UserID: "author", Visibility: model.NoteVisibilityPublic}
+	noteID := idGen.Generate(time.Now())
+	noteRepo.Notes[noteID] = &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityPublic, ReplyID: &parentID}
+	_, err := svc.Create(&model.User{ID: "viewer"}, noteID, "")
+	require.NoError(t, err)
+	assert.Empty(t, fake.global)
+}
+
+// ranking 未配線時は hook が no-op (panic しない)。
+func TestUpdateFeaturedOnReaction_NoRankingNoop(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	reactRepo := testutil.NewMockNoteReactionRepository()
+	emojiRepo := testutil.NewMockEmojiRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := NewService(noteRepo, reactRepo, emojiRepo, followingRepo, idGen)
+	noteID := idGen.Generate(time.Now())
+	noteRepo.Notes[noteID] = &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityPublic}
+	_, err := svc.Create(&model.User{ID: "viewer"}, noteID, "")
+	require.NoError(t, err)
+}

--- a/internal/core/reaction/reaction_service.go
+++ b/internal/core/reaction/reaction_service.go
@@ -2,7 +2,9 @@
 package reaction
 
 import (
+	"context"
 	"errors"
+	"math/rand"
 	"regexp"
 	"slices"
 	"strings"
@@ -12,6 +14,13 @@ import (
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// featured ランキング更新の sampling rate / note 年齢上限 (upstream
+// ReactionService / NoteCreateService と同値)。reaction は score=1。
+const (
+	featuredSampleRate = 0.3
+	featuredMaxNoteAge = 3 * 24 * time.Hour
 )
 
 // FallbackReaction is the default reaction used when no reaction is provided.
@@ -150,6 +159,15 @@ type MediaSilenceChecker interface {
 	IsMediaSilenced(host string) bool
 }
 
+// FeaturedRanking abstracts the engagement ranking store (#1687). 循環依存回避の
+// ため narrow interface で受け取る (実装は core/featured.Service)。reaction は
+// 対象 note の global / in-channel / per-user ranking を更新する。
+type FeaturedRanking interface {
+	UpdateGlobalNotesRanking(ctx context.Context, noteID string, score float64) error
+	UpdateInChannelNotesRanking(ctx context.Context, channelID, noteID string, score float64) error
+	UpdatePerUserNotesRanking(ctx context.Context, userID, noteID string, score float64) error
+}
+
 type Service struct {
 	noteRepo         repository.NoteRepository
 	reactionRepo     repository.NoteReactionRepository
@@ -165,6 +183,15 @@ type Service struct {
 	countWriter      ReactionCountWriter
 	userRoles        UserRolesProvider
 	mediaSilence     MediaSilenceChecker
+	featuredRanking  FeaturedRanking
+	// randFn は featured ランキング更新の 30% sampling 用。テストで固定する。
+	randFn func() float64
+}
+
+// SetFeaturedRanking wires the engagement ranking store so reactions update the
+// featured ranking (#1687). nil 注入時 (= 未配線 / test) は ranking 更新を skip。
+func (s *Service) SetFeaturedRanking(r FeaturedRanking) {
+	s.featuredRanking = r
 }
 
 // SetUserRolesProvider wires role lookup for role-gated emoji reaction gating (#1538).
@@ -202,6 +229,7 @@ func NewService(
 		followingRepo: followingRepo,
 		idGen:         idGen,
 		countWriter:   NewDirectWriter(noteRepo),
+		randFn:        rand.Float64,
 	}
 }
 
@@ -344,8 +372,41 @@ func (s *Service) Create(user *model.User, noteID, rawReaction string) (string, 
 	if s.noteStreamHook != nil {
 		s.noteStreamHook.OnReacted(target.ID, user.ID, decodeReactionForStream(reaction), s.resolveStreamEmoji(reaction))
 	}
+	// featured engagement ランキング更新もベストエフォート (#1687)。
+	s.updateFeaturedOnReaction(target, user.ID)
 
 	return reaction, nil
+}
+
+// updateFeaturedOnReaction boosts the reacted note's featured engagement ranking
+// (#1687, upstream ReactionService)。30% sampling、self-reaction 除外、note が
+// 3日以内、の gate を通った場合のみ。channel note は in-channel ranking、それ以外は
+// public かつ local かつ非 reply のときに global + per-user ranking を更新する。
+func (s *Service) updateFeaturedOnReaction(target *model.Note, reactorID string) {
+	if s.featuredRanking == nil || s.randFn == nil {
+		return
+	}
+	if s.randFn() >= featuredSampleRate {
+		return
+	}
+	if target.UserID == reactorID {
+		return
+	}
+	created, err := s.idGen.ParseTime(target.ID)
+	if err != nil || time.Since(created) >= featuredMaxNoteAge {
+		return
+	}
+	ctx := context.Background()
+	if target.ChannelID != nil && *target.ChannelID != "" {
+		if target.ReplyID == nil {
+			_ = s.featuredRanking.UpdateInChannelNotesRanking(ctx, *target.ChannelID, target.ID, 1)
+		}
+		return
+	}
+	if target.Visibility == model.NoteVisibilityPublic && target.UserHost == nil && target.ReplyID == nil {
+		_ = s.featuredRanking.UpdateGlobalNotesRanking(ctx, target.ID, 1)
+		_ = s.featuredRanking.UpdatePerUserNotesRanking(ctx, target.UserID, target.ID, 1)
+	}
 }
 
 // Delete removes the user's reaction from the note.

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -74,6 +74,7 @@ import (
 	coredrive "github.com/shiroha-a/mk/internal/core/drive"
 	coreemojiimport "github.com/shiroha-a/mk/internal/core/emojiimport"
 	"github.com/shiroha-a/mk/internal/core/event"
+	corefeatured "github.com/shiroha-a/mk/internal/core/featured"
 	corefederation "github.com/shiroha-a/mk/internal/core/federation"
 	coreflash "github.com/shiroha-a/mk/internal/core/flash"
 	corefollowing "github.com/shiroha-a/mk/internal/core/following"
@@ -289,8 +290,15 @@ func (s *Server) setupRoutes() {
 	pageService := corepage.NewService(pageRepo, pageLikeRepo, idGen)
 	flashService := coreflash.NewService(flashRepo, flashLikeRepo, idGen)
 
+	// featured engagement ランキング (#1687)。reaction / renote の hook が
+	// global / in-channel / per-user の Redis windowed ZSET を更新し、
+	// notes/featured・users/featured-notes が読む。upstream と同じ default Redis。
+	featuredService := corefeatured.NewService(s.redis.Default)
+	noteCreateService.SetFeaturedRanking(featuredService)
+
 	// Reactions
 	reactionService := corereaction.NewService(noteRepo, reactionRepo, emojiRepo, followingRepo, idGen)
+	reactionService.SetFeaturedRanking(featuredService)
 
 	// Reactions buffering (issue #57): meta.enableReactionsBuffering が true なら
 	// Redis にバッファし、30秒ごとに DB へ flush する。


### PR DESCRIPTION
## Summary

#1687 PR2。reaction 付与・renote 作成時に `featured.Service` の windowed ZSET を更新する hook を配線する (upstream `ReactionService` / `NoteCreateService.incRenoteCount` の `featuredService` 更新分岐)。本 hook が ranking を populate し、後続 PR で notes/featured・users/featured-notes endpoint が読む。

## 主な変更点

- **reaction** (score 1、`reaction_service.go`): `Create` 末尾で対象 note を boost。`30% sampling` → `self-reaction 除外` → `note が 3日以内` を gate。channel note は in-channel ranking (非 reply 時)、それ以外は `public && local && 非reply` のとき global + per-user ranking。
- **renote** (score 5、`note_create_service.go`): renote count 増加箇所で、`renoteTarget.UserID != renoter.ID && !renoter.IsBot` の renote について renote **対象** note を boost (quote renote も含む = upstream `incRenoteCount` 呼び出し条件)。内部 gate は reaction と同じ。
- note 年齢は `idGen.ParseTime(noteID)` で判定し error 時は安全側 skip。Redis 更新は best-effort (error 無視) で reaction/note 作成自体を止めない。`randFn` を注入可能にして 30% sampling をテストで固定。
- `router.go` で `featuredService` を default Redis で構築し両 service に `SetFeaturedRanking`。

## テスト

- reaction (internal test): global+per-user / channel / self skip / 古い note skip / 未sample skip / reply skip / 未配線 no-op
- renote (internal test): global+per-user / channel / self skip / bot skip / 古い note skip / 未sample skip
- `internal/core/reaction` (94.2%) / `internal/core/note` (94.5%) / `go vet ./...` pass

## 関連

#1687。基盤 service は #1692 でマージ済。後続 PR で notes/featured・users/featured-notes endpoint をこの ranking に接続する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)