### PR TITLE
featured ランキング: notes/featured・users/featured-notes を engagement ランキングに接続 (#1687)

### DIFF
--- a/internal/api/notes/featured_ranking_test.go
+++ b/internal/api/notes/featured_ranking_test.go
@@ -1,0 +1,116 @@
+package notes
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeFeaturedReader implements FeaturedRankingReader for notes/featured tests.
+type fakeFeaturedReader struct {
+	global      []string
+	inCh        map[string][]string
+	globalErr   error
+	globalCalls int
+}
+
+func (f *fakeFeaturedReader) GetGlobalNotesRanking(_ context.Context, _ int) ([]string, error) {
+	f.globalCalls++
+	return f.global, f.globalErr
+}
+
+func (f *fakeFeaturedReader) GetInChannelNotesRanking(_ context.Context, channelID string, _ int) ([]string, error) {
+	return f.inCh[channelID], nil
+}
+
+func featuredTestIDs(notes []*model.Note) []string {
+	ids := make([]string, len(notes))
+	for i, n := range notes {
+		ids[i] = n.ID
+	}
+	return ids
+}
+
+func TestFeaturedNotes_GlobalRankingPath(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	for _, fid := range []string{"a", "b", "c"} {
+		noteRepo.Notes[fid] = &model.Note{ID: fid, UserID: "u", Visibility: "public", User: &model.User{ID: "u"}}
+	}
+	h.SetFeaturedRanking(&fakeFeaturedReader{global: []string{"b", "a", "c"}})
+	notes, err := h.featuredNotes(context.Background(), "", "", 10, 0)
+	require.NoError(t, err)
+	// ranking 集合を id DESC で返す (upstream featured.ts)。
+	assert.Equal(t, []string{"c", "b", "a"}, featuredTestIDs(notes))
+}
+
+func TestFeaturedNotes_ChannelRankingPath(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	ch := "ch1"
+	noteRepo.Notes["x"] = &model.Note{ID: "x", UserID: "u", Visibility: "public", ChannelID: &ch, User: &model.User{ID: "u"}}
+	h.SetFeaturedRanking(&fakeFeaturedReader{inCh: map[string][]string{"ch1": {"x"}}})
+	notes, err := h.featuredNotes(context.Background(), "ch1", "", 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"x"}, featuredTestIDs(notes))
+}
+
+func TestFeaturedNotes_UntilIDFilter(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	for _, fid := range []string{"a", "b", "c"} {
+		noteRepo.Notes[fid] = &model.Note{ID: fid, UserID: "u", Visibility: "public", User: &model.User{ID: "u"}}
+	}
+	h.SetFeaturedRanking(&fakeFeaturedReader{global: []string{"a", "b", "c"}})
+	notes, err := h.featuredNotes(context.Background(), "", "c", 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"b", "a"}, featuredTestIDs(notes))
+}
+
+func TestFeaturedNotes_EmptyRankingFallsBackToSQL(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	noteRepo.Notes["sql"] = &model.Note{ID: "sql", UserID: "u", Visibility: "public", User: &model.User{ID: "u"}}
+	h.SetFeaturedRanking(&fakeFeaturedReader{global: nil})
+	notes, err := h.featuredNotes(context.Background(), "", "", 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sql"}, featuredTestIDs(notes))
+}
+
+func TestFeaturedNotes_RankingErrorFallsBackToSQL(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	noteRepo.Notes["sql"] = &model.Note{ID: "sql", UserID: "u", Visibility: "public", User: &model.User{ID: "u"}}
+	h.SetFeaturedRanking(&fakeFeaturedReader{globalErr: errors.New("redis down")})
+	notes, err := h.featuredNotes(context.Background(), "", "", 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sql"}, featuredTestIDs(notes))
+}
+
+func TestFeaturedNotes_UnwiredUsesSQL(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	noteRepo.Notes["sql"] = &model.Note{ID: "sql", UserID: "u", Visibility: "public", User: &model.User{ID: "u"}}
+	notes, err := h.featuredNotes(context.Background(), "", "", 10, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sql"}, featuredTestIDs(notes))
+}
+
+func TestCachedGlobalRanking_CachesWithinTTL(t *testing.T) {
+	h, _, _ := newExtraHandler(t)
+	fake := &fakeFeaturedReader{global: []string{"a"}}
+	h.SetFeaturedRanking(fake)
+	_, err := h.cachedGlobalRanking(context.Background())
+	require.NoError(t, err)
+	_, err = h.cachedGlobalRanking(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, fake.globalCalls, "30分以内は cache され Redis を再呼び出ししない")
+}
+
+func TestSortAndPageFeaturedIDs(t *testing.T) {
+	in := []string{"a", "c", "b"}
+	out := sortAndPageFeaturedIDs(in, "", 10)
+	assert.Equal(t, []string{"c", "b", "a"}, out)
+	// 入力 slice を破壊しない (global cache 共有のため)。
+	assert.Equal(t, []string{"a", "c", "b"}, in)
+	assert.Equal(t, []string{"b", "a"}, sortAndPageFeaturedIDs([]string{"a", "b", "c"}, "c", 10))
+	assert.Equal(t, []string{"c", "b"}, sortAndPageFeaturedIDs([]string{"a", "b", "c"}, "", 2))
+}

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -85,6 +86,33 @@ type Handler struct {
 	// timelineCache は config flag enableTimelineCache (MK_ENABLETIMELINECACHE)
 	// 有効時のみ non-nil。first-page timeline 応答を per-viewer で短期キャッシュする。
 	timelineCache *timelineJSONCache
+	// featuredRanking は notes/featured の engagement ランキング (#1687)。nil 時
+	// (= 未配線 / test) は SQL count-DESC fallback を使う。
+	featuredRanking FeaturedRankingReader
+	// featuredGlobalCache は global ranking の 30分 in-memory cache
+	// (upstream featured.ts の globalNotesRankingCache)。channel ranking は cache
+	// しない (channel ごとなので)。
+	featuredGlobalCache featuredGlobalRankingCache
+}
+
+// FeaturedRankingReader reads the engagement ranking for notes/featured (#1687).
+// 循環依存回避のため narrow interface (実装は core/featured.Service)。
+type FeaturedRankingReader interface {
+	GetGlobalNotesRanking(ctx context.Context, threshold int) ([]string, error)
+	GetInChannelNotesRanking(ctx context.Context, channelID string, threshold int) ([]string, error)
+}
+
+// featuredGlobalRankingCache holds the 30-min global ranking cache.
+type featuredGlobalRankingCache struct {
+	mu        sync.Mutex
+	ids       []string
+	fetchedAt time.Time
+}
+
+// SetFeaturedRanking wires the engagement ranking reader so notes/featured uses
+// it (#1687). nil 注入時は SQL count-DESC fallback。
+func (h *Handler) SetFeaturedRanking(r FeaturedRankingReader) {
+	h.featuredRanking = r
 }
 
 // EnableTimelineJSONCache turns on the first-page timeline response cache with

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -1,8 +1,10 @@
 package notes
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -112,7 +114,7 @@ func (h *Handler) Featured(c echo.Context) error {
 	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	// untilDate を aidx prefix に正規化 (#1166)。
 	_, untilID := id.NormalizeCursor("", req.UntilID, nil, req.UntilDate)
-	notes, err := h.noteRepo.ListFeatured(req.ChannelID, untilID, req.Limit, req.Offset)
+	notes, err := h.featuredNotes(c.Request().Context(), req.ChannelID, untilID, req.Limit, req.Offset)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
@@ -125,6 +127,78 @@ func (h *Handler) Featured(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))
+}
+
+// featured ランキング取得の threshold / cache TTL (upstream featured.ts)。
+const (
+	featuredGlobalThreshold    = 100
+	featuredInChannelThreshold = 50
+	featuredGlobalCacheTTL     = 30 * time.Minute
+)
+
+// featuredNotes returns featured notes from the engagement ranking (#1687) when
+// the ranking reader is wired, falling back to the SQL count-DESC ranking when
+// it is unavailable or empty (fresh instance / Redis flush)。ranking 経路は
+// upstream featured.ts と同じく id DESC sort → untilId filter → limit。
+func (h *Handler) featuredNotes(ctx context.Context, channelID, untilID string, limit, offset int) ([]*model.Note, error) {
+	if h.featuredRanking == nil {
+		return h.noteRepo.ListFeatured(channelID, untilID, limit, offset)
+	}
+	var ids []string
+	var err error
+	if channelID != "" {
+		ids, err = h.featuredRanking.GetInChannelNotesRanking(ctx, channelID, featuredInChannelThreshold)
+	} else {
+		ids, err = h.cachedGlobalRanking(ctx)
+	}
+	if err != nil || len(ids) == 0 {
+		// Redis ranking が空 / 取得失敗 (fresh instance 等) は SQL fallback。
+		return h.noteRepo.ListFeatured(channelID, untilID, limit, offset)
+	}
+	ids = sortAndPageFeaturedIDs(ids, untilID, limit)
+	if len(ids) == 0 {
+		return []*model.Note{}, nil
+	}
+	return h.noteRepo.FindManyByIDsWithUser(ids)
+}
+
+// cachedGlobalRanking returns the global ranking with a 30-min in-memory cache
+// (upstream featured.ts の globalNotesRankingCache)。
+func (h *Handler) cachedGlobalRanking(ctx context.Context) ([]string, error) {
+	h.featuredGlobalCache.mu.Lock()
+	defer h.featuredGlobalCache.mu.Unlock()
+	if !h.featuredGlobalCache.fetchedAt.IsZero() && time.Since(h.featuredGlobalCache.fetchedAt) < featuredGlobalCacheTTL {
+		return h.featuredGlobalCache.ids, nil
+	}
+	ids, err := h.featuredRanking.GetGlobalNotesRanking(ctx, featuredGlobalThreshold)
+	if err != nil {
+		return nil, err
+	}
+	h.featuredGlobalCache.ids = ids
+	h.featuredGlobalCache.fetchedAt = time.Now()
+	return ids, nil
+}
+
+// sortAndPageFeaturedIDs sorts note IDs DESC, drops IDs >= untilID, and caps the
+// result to limit (upstream featured.ts の noteIds.sort / filter / slice)。入力
+// slice を破壊しないようコピーしてから操作する (cache 共有のため)。
+func sortAndPageFeaturedIDs(ids []string, untilID string, limit int) []string {
+	out := make([]string, len(ids))
+	copy(out, ids)
+	sort.Slice(out, func(i, j int) bool { return out[i] > out[j] })
+	if untilID != "" {
+		filtered := out[:0]
+		for _, noteID := range out {
+			if noteID < untilID {
+				filtered = append(filtered, noteID)
+			}
+		}
+		out = filtered
+	}
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out
 }
 
 // Unrenote handles POST /api/notes/unrenote.

--- a/internal/api/users/featured_ranking_test.go
+++ b/internal/api/users/featured_ranking_test.go
@@ -1,0 +1,106 @@
+package users_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakePerUserReader implements users.FeaturedRankingReader for
+// users/featured-notes ranking-path tests.
+type fakePerUserReader struct {
+	perUser map[string][]string
+	err     error
+}
+
+func (f *fakePerUserReader) GetPerUserNotesRanking(_ context.Context, userID string, _ int) ([]string, error) {
+	return f.perUser[userID], f.err
+}
+
+func featRespIDs(t *testing.T, body []byte) []string {
+	t.Helper()
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(body, &out))
+	ids := make([]string, len(out))
+	for i, n := range out {
+		ids[i] = n["id"].(string)
+	}
+	return ids
+}
+
+// ranking が wired なら per-user ranking を id DESC で返す (#1687)。
+func TestFeaturedNotes_RankingPath(t *testing.T) {
+	h, _, noteRepo := newExtraHandler(t)
+	for _, fid := range []string{"a", "b", "c"} {
+		noteRepo.Notes[fid] = &model.Note{ID: fid, UserID: "u1", Visibility: "public", User: &model.User{ID: "u1"}}
+	}
+	h.SetFeaturedRanking(&fakePerUserReader{perUser: map[string][]string{"u1": {"b", "a", "c"}}})
+	rec := postExtra(h.FeaturedNotes, `{"userId":"u1"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, []string{"c", "b", "a"}, featRespIDs(t, rec.Body.Bytes()))
+}
+
+func TestFeaturedNotes_RankingUntilID(t *testing.T) {
+	h, _, noteRepo := newExtraHandler(t)
+	for _, fid := range []string{"a", "b", "c"} {
+		noteRepo.Notes[fid] = &model.Note{ID: fid, UserID: "u1", Visibility: "public", User: &model.User{ID: "u1"}}
+	}
+	h.SetFeaturedRanking(&fakePerUserReader{perUser: map[string][]string{"u1": {"a", "b", "c"}}})
+	rec := postExtra(h.FeaturedNotes, `{"userId":"u1","untilId":"c"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, []string{"b", "a"}, featRespIDs(t, rec.Body.Bytes()))
+}
+
+// ranking が空なら SQL count-DESC fallback (fresh instance / Redis flush)。
+func TestFeaturedNotes_RankingEmptyFallsBackToSQL(t *testing.T) {
+	h, _, noteRepo := newExtraHandler(t)
+	noteRepo.Notes["sql"] = &model.Note{ID: "sql", UserID: "u1", Visibility: "public", User: &model.User{ID: "u1"}}
+	h.SetFeaturedRanking(&fakePerUserReader{perUser: nil})
+	rec := postExtra(h.FeaturedNotes, `{"userId":"u1"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, []string{"sql"}, featRespIDs(t, rec.Body.Bytes()))
+}
+
+func TestFeaturedNotes_RankingErrorFallsBackToSQL(t *testing.T) {
+	h, _, noteRepo := newExtraHandler(t)
+	noteRepo.Notes["sql"] = &model.Note{ID: "sql", UserID: "u1", Visibility: "public", User: &model.User{ID: "u1"}}
+	h.SetFeaturedRanking(&fakePerUserReader{err: context.DeadlineExceeded})
+	rec := postExtra(h.FeaturedNotes, `{"userId":"u1"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, []string{"sql"}, featRespIDs(t, rec.Body.Bytes()))
+}
+
+// untilId が ranking の全 ID を弾くと空配列を返す (SQL fallback には落ちない:
+// ranking 自体は非空なため)。
+func TestFeaturedNotes_RankingUntilIDFiltersAll(t *testing.T) {
+	h, _, noteRepo := newExtraHandler(t)
+	noteRepo.Notes["a"] = &model.Note{ID: "a", UserID: "u1", Visibility: "public", User: &model.User{ID: "u1"}}
+	noteRepo.Notes["b"] = &model.Note{ID: "b", UserID: "u1", Visibility: "public", User: &model.User{ID: "u1"}}
+	h.SetFeaturedRanking(&fakePerUserReader{perUser: map[string][]string{"u1": {"a", "b"}}})
+	rec := postExtra(h.FeaturedNotes, `{"userId":"u1","untilId":"a"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, featRespIDs(t, rec.Body.Bytes()))
+}
+
+// ranking が limit より多くても limit 件に切り詰める。
+func TestFeaturedNotes_RankingLimitCap(t *testing.T) {
+	h, _, noteRepo := newExtraHandler(t)
+	ranking := make([]string, 0, 12)
+	for _, fid := range []string{"n01", "n02", "n03", "n04", "n05", "n06", "n07", "n08", "n09", "n10", "n11", "n12"} {
+		noteRepo.Notes[fid] = &model.Note{ID: fid, UserID: "u1", Visibility: "public", User: &model.User{ID: "u1"}}
+		ranking = append(ranking, fid)
+	}
+	h.SetFeaturedRanking(&fakePerUserReader{perUser: map[string][]string{"u1": ranking}})
+	rec := postExtra(h.FeaturedNotes, `{"userId":"u1","limit":10}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	ids := featRespIDs(t, rec.Body.Bytes())
+	assert.Len(t, ids, 10)
+	assert.Equal(t, "n12", ids[0]) // id DESC top
+	assert.NotContains(t, ids, "n01")
+	assert.NotContains(t, ids, "n02")
+}

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -74,6 +74,22 @@ type Handler struct {
 	// driveFileRepo は users/pages で page の attachedFiles / eyeCatchingImage を
 	// drive file から解決するのに使う (#1662)。未配線なら両 field は default。
 	driveFileRepo repository.DriveFileRepository
+	// featuredRanking は users/featured-notes の per-user engagement ランキング
+	// (#1687)。nil 時 (= 未配線 / test) は SQL count-DESC fallback を使う。
+	featuredRanking FeaturedRankingReader
+}
+
+// FeaturedRankingReader reads the per-user engagement ranking for
+// users/featured-notes (#1687). 循環依存回避のため narrow interface
+// (実装は core/featured.Service)。
+type FeaturedRankingReader interface {
+	GetPerUserNotesRanking(ctx context.Context, userID string, threshold int) ([]string, error)
+}
+
+// SetFeaturedRanking wires the per-user engagement ranking reader (#1687).
+// nil 注入時は SQL count-DESC fallback。
+func (h *Handler) SetFeaturedRanking(r FeaturedRankingReader) {
+	h.featuredRanking = r
 }
 
 // SetDriveFileRepo wires the drive file repo used by users/pages to resolve a

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -1,10 +1,12 @@
 package users
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
+	"sort"
 	"time"
 	"unicode/utf8"
 
@@ -400,7 +402,7 @@ func (h *Handler) FeaturedNotes(c echo.Context) error {
 	if h.isBlockedByTarget(viewer, req.UserID) {
 		return c.JSON(http.StatusOK, []entity.NoteEntity{})
 	}
-	notes, err := h.noteRepo.ListFeaturedByUser(req.UserID, viewerID, req.UntilID, req.Limit)
+	notes, err := h.featuredNotesByUser(c.Request().Context(), req.UserID, viewerID, req.UntilID, req.Limit)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
@@ -419,6 +421,50 @@ func (h *Handler) FeaturedNotes(c echo.Context) error {
 	h.fieldRes.Apply(result, viewer)
 	notehide.HideEmbeds(viewer, result)
 	return c.JSON(http.StatusOK, result)
+}
+
+// featuredPerUserThreshold は per-user ranking から取得する上位件数 (upstream
+// featured-notes.ts の getPerUserNotesRanking(50))。
+const featuredPerUserThreshold = 50
+
+// featuredNotesByUser returns userID's featured notes from the per-user
+// engagement ranking (#1687)。ranking 未配線 / 空 (fresh instance 等) のときは
+// 既存の SQL count-DESC ranking (ListFeaturedByUser) に fallback する。ranking
+// 経路は upstream featured-notes.ts と同じく id DESC sort → untilId filter → limit。
+func (h *Handler) featuredNotesByUser(ctx context.Context, userID, viewerID, untilID string, limit int) ([]*model.Note, error) {
+	if h.featuredRanking == nil {
+		return h.noteRepo.ListFeaturedByUser(userID, viewerID, untilID, limit)
+	}
+	ids, err := h.featuredRanking.GetPerUserNotesRanking(ctx, userID, featuredPerUserThreshold)
+	if err != nil || len(ids) == 0 {
+		return h.noteRepo.ListFeaturedByUser(userID, viewerID, untilID, limit)
+	}
+	ids = sortAndPageFeaturedIDs(ids, untilID, limit)
+	if len(ids) == 0 {
+		return []*model.Note{}, nil
+	}
+	return h.noteRepo.FindManyByIDsWithUser(ids)
+}
+
+// sortAndPageFeaturedIDs sorts note IDs DESC, drops IDs >= untilID, and caps to
+// limit (upstream featured-notes.ts の noteIds.sort / filter / slice)。
+func sortAndPageFeaturedIDs(ids []string, untilID string, limit int) []string {
+	out := make([]string, len(ids))
+	copy(out, ids)
+	sort.Slice(out, func(i, j int) bool { return out[i] > out[j] })
+	if untilID != "" {
+		filtered := out[:0]
+		for _, noteID := range out {
+			if noteID < untilID {
+				filtered = append(filtered, noteID)
+			}
+		}
+		out = filtered
+	}
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out
 }
 
 // SearchByUsernameAndHost handles POST /api/users/search-by-username-and-host.

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1193,6 +1193,8 @@ func (s *Server) setupRoutes() {
 	notesHandler.SetChannelMutingRepo(channelMutingRepo)
 	// home timeline で follow 中 channel の note を含める (#1686)。
 	notesHandler.SetChannelFollowingRepo(channelFollowingRepo)
+	// notes/featured の engagement ランキング読み取り (#1687)。
+	notesHandler.SetFeaturedRanking(featuredService)
 	// timeline endpoint で muted user の note を除外する filter (#874)。
 	// 未配線だと user mute は read 時に効かず、cache のみ DB 整合の状態
 	// になる security/UX regression が残る。production では必ず wire する。
@@ -1287,6 +1289,7 @@ func (s *Server) setupRoutes() {
 	// Users endpoints
 	usersHandler := users.NewHandler(userService, followingService, noteRepo, idGen)
 	usersHandler.SetChartHook(chartHooks)
+	usersHandler.SetFeaturedRanking(featuredService) // #1687: users/featured-notes ランキング
 	usersHandler.SetPiningRepo(piningRepo)
 	usersHandler.SetFollowingRepo(followingRepo)
 	usersHandler.SetBlockingRepo(blockingRepo)


### PR DESCRIPTION
## Summary

#1687 PR3 (最終)。PR1 (#1692 `featured.Service`) と PR2 (#1693 reaction/renote hook) で populate した Redis windowed ZSET を notes/featured・users/featured-notes が読む。Redis 不在/空 (fresh instance / flush) のときは既存の SQL count-DESC ranking に fallback する。

## 主な変更点

- **notes/featured**: `channelId` 指定時は `GetInChannelNotesRanking(50)`、無指定は `GetGlobalNotesRanking(100)` を 30分 in-memory cache (upstream `featured.ts` の `globalNotesRankingCache`)。id DESC sort → untilId filter → limit で切り、`FindManyByIDsWithUser` で hydrate。`applyMuteBlock` (#1682) は従来通り。
- **users/featured-notes**: `GetPerUserNotesRanking(50)` を同じ後処理。block-by-target / `ApplyHardMute` / `ApplyMuteBlockChannel` (#1547) は従来通り。
- ranking には public 非reply local note のみ入る (PR2 hook gate) ため visibility filter は省略 (upstream も ranking 経路に visibility WHERE を足さない)。`sortAndPageFeaturedIDs` は cache 共有 slice を破壊しないよう copy してから sort/filter する。削除済 note は hydrate で自然に欠落。
- `router.go` で両 handler に `SetFeaturedRanking`。未配線時は SQL path で後方互換。

## テスト

- notes (internal): global / channel ranking path、untilId filter、空/err/未配線 → SQL fallback、30分 cache、`sortAndPageFeaturedIDs` 単体 (DESC/untilId/limit/非破壊)
- users (HTTP): ranking path id DESC、untilId、空/err → SQL fallback、untilId 全 filter → 空、limit cap
- `internal/api/notes` (91.6%) / `internal/api/users` (90.9%) / `go vet ./...` / `-race` pass

## 関連

Closes #1687。PR1 (#1692 service) + PR2 (#1693 hooks) + 本 PR (endpoints) で engagement ランキング (reaction + renote、時間窓/decay、global/in-channel/per-user) を完結。

🤖 Generated with [Claude Code](https://claude.com/claude-code)