### PR TITLE
Fix: misc singletons parity の REAL 差分を解消 (#1551)

### DIFF
--- a/internal/api/i/email_update.go
+++ b/internal/api/i/email_update.go
@@ -146,5 +146,9 @@ func (h *Handler) VerifyEmail(c echo.Context) error {
 		return apierr.JSONInternalError(c)
 	}
 
+	// upstream verify-email.ts は update 後に meUpdated を main stream へ publish
+	// しクライアントへ即時反映する (#1551)。2FA handler と同じ publisher を使う。
+	h.publishMeUpdated(profile.UserID)
+
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/i/email_update_test.go
+++ b/internal/api/i/email_update_test.go
@@ -97,3 +97,19 @@ func TestVerifyEmail_Success(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 	assert.True(t, repo.Profiles["u1"].EmailVerified)
 }
+
+// #1551 verify-email 成功時に meUpdated を main stream へ publish する
+// (upstream verify-email.ts)。
+func TestVerifyEmail_PublishesMeUpdated(t *testing.T) {
+	h, repo := newExtraHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	code := "abc"
+	repo.Profiles["u1"].EmailVerifyCode = &code
+	pub := &stubIMainStreamPublisher{}
+	h.SetMainStreamPublisher(pub)
+
+	rec := postExtra(h.VerifyEmail, `{"code":"abc"}`, user)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.True(t, repo.Profiles["u1"].EmailVerified)
+	requireMeUpdated(t, pub, "u1")
+}

--- a/internal/core/signup/signup_service.go
+++ b/internal/core/signup/signup_service.go
@@ -43,6 +43,14 @@ func normalizeAndValidateUsername(username string) (string, error) {
 	return username, nil
 }
 
+// ValidUsernameFormat reports whether username matches the local username
+// schema (`^[a-zA-Z0-9_]{1,20}$`). Exposed so the username/available endpoint
+// shares the exact same format validation as signup (upstream localUsernameSchema、
+// #1551)。trim はしない (caller が必要なら行う)。
+func ValidUsernameFormat(username string) bool {
+	return localUsernamePattern.MatchString(username)
+}
+
 var (
 	// ErrUsernameAlreadyExists is returned when the username is taken.
 	ErrUsernameAlreadyExists = errors.New("username already exists")
@@ -627,4 +635,11 @@ func isReservedUsername(lower string, reserved []string) bool {
 		}
 	}
 	return false
+}
+
+// IsReservedUsername reports whether lower (already lowercased) matches any
+// entry in reserved case-insensitively. Exposed for the username/available
+// endpoint so it shares signup's preservedUsernames check (#1551)。
+func IsReservedUsername(lower string, reserved []string) bool {
+	return isReservedUsername(lower, reserved)
 }

--- a/internal/core/signup/username_helpers_test.go
+++ b/internal/core/signup/username_helpers_test.go
@@ -1,0 +1,31 @@
+package signup_test
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/core/signup"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidUsernameFormat(t *testing.T) {
+	assert.True(t, signup.ValidUsernameFormat("alice"))
+	assert.True(t, signup.ValidUsernameFormat("a_1"))
+	assert.True(t, signup.ValidUsernameFormat("ABCdef123_"))
+	assert.True(t, signup.ValidUsernameFormat("a")) // length 1 OK
+
+	assert.False(t, signup.ValidUsernameFormat(""))                      // 空
+	assert.False(t, signup.ValidUsernameFormat("has space"))             // 空白
+	assert.False(t, signup.ValidUsernameFormat("dash-not-allowed"))      // ハイフン不可
+	assert.False(t, signup.ValidUsernameFormat("dot.not.allowed"))       // ドット不可
+	assert.False(t, signup.ValidUsernameFormat("aaaaaaaaaaaaaaaaaaaaa")) // 21 文字 (>20)
+	assert.False(t, signup.ValidUsernameFormat("ünïcode"))               // 非 ASCII
+}
+
+func TestIsReservedUsername(t *testing.T) {
+	reserved := []string{"admin", "Root", " system "}
+	assert.True(t, signup.IsReservedUsername("admin", reserved))
+	assert.True(t, signup.IsReservedUsername("root", reserved))   // case-insensitive
+	assert.True(t, signup.IsReservedUsername("system", reserved)) // trim 済比較
+	assert.False(t, signup.IsReservedUsername("alice", reserved))
+	assert.False(t, signup.IsReservedUsername("admin", nil))
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -72,6 +72,7 @@ import (
 	corechat "github.com/shiroha-a/mk/internal/core/chat"
 	coreclip "github.com/shiroha-a/mk/internal/core/clip"
 	coredrive "github.com/shiroha-a/mk/internal/core/drive"
+	coreemail "github.com/shiroha-a/mk/internal/core/email"
 	coreemojiimport "github.com/shiroha-a/mk/internal/core/emojiimport"
 	"github.com/shiroha-a/mk/internal/core/event"
 	corefeatured "github.com/shiroha-a/mk/internal/core/featured"
@@ -1046,19 +1047,27 @@ func (s *Server) setupRoutes() {
 	})
 
 	// Pinned users (public)
+	//
+	// upstream pinned-users.ts は res が UserDetailed 配列で、各 pinnedUsers の
+	// acct を Acct.parse して host?? IsNull() で local/remote 両方を検索する
+	// (#1551)。mk-go も acct の host 部分を解決し UserDetailed で返す。
 	api.POST("/pinned-users", func(c echo.Context) error {
 		m, err := metaRepo.Fetch()
 		if err != nil || len(m.PinnedUsers) == 0 {
 			return c.JSON(http.StatusOK, []any{})
 		}
-		var result []entity.UserLite
-		for _, username := range m.PinnedUsers {
-			if u, err := userRepo.FindByUsernameLower(username, nil); err == nil {
-				result = append(result, entity.PackUserLite(u))
+		result := make([]entity.UserDetailed, 0, len(m.PinnedUsers))
+		for _, acct := range m.PinnedUsers {
+			username, host := parseAcct(acct, localHost)
+			if username == "" {
+				continue
 			}
-		}
-		if result == nil {
-			result = []entity.UserLite{}
+			u, err := userRepo.FindByUsernameLower(strings.ToLower(username), host)
+			if err != nil {
+				continue
+			}
+			profile, _ := userRepo.FindProfileByUserID(u.ID)
+			result = append(result, entity.PackUserDetailed(u, profile, idGen))
 		}
 		return c.JSON(http.StatusOK, result)
 	})
@@ -1099,15 +1108,35 @@ func (s *Server) setupRoutes() {
 	api.POST("/signup-pending", signupHandler.SignupPending)
 
 	// Username availability check (フロントエンドの signup フォームが呼ぶ)
+	//
+	// upstream username/available.ts は available = (既存 user 無し) && (used_usernames
+	// 無し) && (preservedUsernames 非該当) の3条件で判定し、paramDef の
+	// localUsernameSchema で format 検証する (#1551)。format 不正は paramDef レベルで
+	// 弾かれるため INVALID_PARAM を返す。
+	usedUsernameRepo := repository.NewUsedUsernameRepository(s.db)
 	api.POST("/username/available", func(c echo.Context) error {
 		var req struct {
 			Username string `json:"username"`
 		}
-		if err := c.Bind(&req); err != nil || req.Username == "" {
-			return c.JSON(http.StatusOK, map[string]any{"available": false})
+		if err := c.Bind(&req); err != nil {
+			return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
 		}
-		_, err := userRepo.FindByUsernameLower(strings.ToLower(req.Username), nil)
-		available := err != nil
+		// format 検証 (upstream localUsernameSchema、paramDef レベル拒否相当)。
+		if !coresignup.ValidUsernameFormat(req.Username) {
+			return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
+		}
+		lower := strings.ToLower(req.Username)
+		// (1) 既存 local user
+		_, userErr := userRepo.FindByUsernameLower(lower, nil)
+		existsUser := userErr == nil
+		// (2) used_usernames (過去に使われ解放された username)
+		usedExists, _ := usedUsernameRepo.Exists(lower)
+		// (3) preservedUsernames (予約 username)
+		preserved := false
+		if m, err := metaRepo.Fetch(); err == nil && m != nil {
+			preserved = coresignup.IsReservedUsername(lower, m.PreservedUsernames)
+		}
+		available := !existsUser && !usedExists && !preserved
 		return c.JSON(http.StatusOK, map[string]any{"available": available})
 	})
 
@@ -2528,27 +2557,56 @@ func (s *Server) setupRoutes() {
 		return c.JSON(http.StatusOK, out)
 	})
 
-	// email-address/available — メールアドレスの利用可否チェック (認証必須)
+	// email-address/available — メールアドレスの利用可否チェック (public)
+	//
+	// upstream email-address/available.ts は requireCredential:false の public
+	// endpoint で、EmailService.validateEmailForAccount が reason を
+	// null|'used'|'format'|'disposable'|'mx'|'smtp'|'banned'|'network'|'blacklist'
+	// で返す (#1551)。mk-go は外部依存の active validation (mx/smtp/disposable) は
+	// 行わず、format → used (emailVerified=true 一致) → banned の順で判定する
+	// (upstream の enableActiveEmailValidation=false 相当)。
 	api.POST("/email-address/available", func(c echo.Context) error {
 		var req struct {
 			EmailAddress string `json:"emailAddress"`
 		}
-		if err := c.Bind(&req); err != nil || req.EmailAddress == "" {
+		if err := c.Bind(&req); err != nil {
 			return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
 		}
-		var count int64
-		s.db.Model(&model.UserProfile{}).Where(`"email" = ?`, req.EmailAddress).Count(&count)
-		available := count == 0
+		// upstream paramDef は emailAddress に minLength を持たないため、空文字は
+		// 400 ではなく format 不正として available:false / reason:"format" を返す。
+		available := true
 		var reason *string
-		if !available {
-			r := "unavailable"
+		setReason := func(r string) {
+			available = false
 			reason = &r
+		}
+		switch {
+		case !coreemail.ValidateFormat(req.EmailAddress):
+			setReason("format")
+		default:
+			// emailVerified=true の profile とだけ照合する (upstream は
+			// countBy({emailVerified:true, email}))。未認証 email は重複扱いしない。
+			var count int64
+			s.db.Model(&model.UserProfile{}).
+				Where(`"email" = ? AND "emailVerified" = ?`, req.EmailAddress, true).
+				Count(&count)
+			if count > 0 {
+				setReason("used")
+			} else {
+				domain := ""
+				if at := strings.IndexByte(req.EmailAddress, '@'); at >= 0 {
+					domain = strings.ToLower(req.EmailAddress[at+1:])
+				}
+				if m, err := metaRepo.Fetch(); err == nil && m != nil && coreemail.IsBannedDomain(domain, m.BannedEmailDomains) {
+					setReason("banned")
+				}
+			}
 		}
 		return c.JSON(http.StatusOK, map[string]any{
 			"available": available,
 			"reason":    reason,
 		})
-	}, middleware.RequireAuth())
+	})
 
 	// promo/read — プロモノートの既読マーク (認証必須)
 	api.POST("/promo/read", func(c echo.Context) error {
@@ -2624,9 +2682,37 @@ func (s *Server) setupRoutes() {
 	api.POST("/v2/admin/emoji/list", adminHandler.EmojiListV2, middleware.RequireRolePolicy(roleService, corerole.PolicyCanManageCustomEmojis), middleware.RequireScope("read:admin:emoji"))
 
 	// --- その他の残りエンドポイント ---
-	// test — フロントエンドのテスト用
+	// test — フロントエンドのテスト用。upstream test.ts は validate 済の ps を
+	// そのまま echo し、required:['required'] が未指定なら 400 を返す (#1551)。
+	// default は 'hello'、nullableDefault も既定 'hello'。string / id は指定時のみ
+	// 含める。explicit null と absent の区別は test 用途なので簡略化している。
 	api.POST("/test", func(c echo.Context) error {
-		return c.JSON(http.StatusOK, map[string]any{})
+		var req struct {
+			Required        *bool   `json:"required"`
+			String          *string `json:"string"`
+			Default         *string `json:"default"`
+			NullableDefault *string `json:"nullableDefault"`
+			ID              *string `json:"id"`
+		}
+		if err := c.Bind(&req); err != nil || req.Required == nil {
+			return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
+		}
+		out := map[string]any{"required": *req.Required}
+		if req.String != nil {
+			out["string"] = *req.String
+		}
+		out["default"] = "hello"
+		if req.Default != nil {
+			out["default"] = *req.Default
+		}
+		out["nullableDefault"] = "hello"
+		if req.NullableDefault != nil {
+			out["nullableDefault"] = *req.NullableDefault
+		}
+		if req.ID != nil {
+			out["id"] = *req.ID
+		}
+		return c.JSON(http.StatusOK, out)
 	})
 
 	// API catchall — 意図的に 200 + 空オブジェクトを返す。未登録エンドポイントへの


### PR DESCRIPTION
## Summary

#1551 (misc singletons parity、当初 1H 6M 4L) の各項目を再検証 (敵対的) し、**未対応だった 6 件**を upstream Misskey に合わせた。再検証で **4 件は既に対応済 (STALE/FALSE)**、**1 件は registry 新設が必要なため #1695 に分離**。

### 再検証結果

| 項目 | 判定 | 対応 |
|---|---|---|
| pinned-users UserDetailed [HIGH] | REAL | 本PR |
| pinned-users host acct [MED] | REAL | 本PR |
| username/available [MED] | REAL | 本PR |
| email-address/available [MED] | REAL | 本PR |
| /api/test echo [LOW] | REAL | 本PR |
| verify-email meUpdated [LOW] | REAL | 本PR |
| emoji url fallback [MED] | STALE | 対応済 (handler + PackEmojiDetailed で publicUrl\|\|originalUrl) |
| my/apps kind + isAuthorized [MED] | STALE | 対応済 (RequireScope("read:account") + isAuthorizedFor) |
| emojis roleIds [LOW] | STALE | 対応済 (length>0 で条件付き emit) |
| promo/read scope [LOW] | FALSE | 対応済 (RequireScope("write:account") 配線済) |
| /api/endpoint params [MED] | REAL | **#1695 に分離** (endpoint registry が必要) |

## 主な変更点

- **pinned-users**: `UserLite` → `UserDetailed` (`PackUserDetailed`)。`pinnedUsers` の acct を `parseAcct` で username/host に分解し local/remote 両方を解決 (upstream `packMany(schema:UserDetailed)` + `Acct.parse` + `host??IsNull()`)。
- **username/available**: 既存 user 有無のみ → 既存 user / `used_usernames` / `preservedUsernames` の3条件 + `localUsernameSchema` format 検証 (format 不正は `INVALID_PARAM`)。signup の format/reserved 判定を `ValidUsernameFormat` / `IsReservedUsername` として export し共用。
- **email-address/available**: `RequireAuth` を外し public 化 (upstream `requireCredential:false`)。reason を `format`→`used`(emailVerified=true 照合)→`banned` で判定 (upstream 列挙のサブセット、mx/smtp/disposable の active validation は外部依存のため省略 = `enableActiveEmailValidation=false` 相当)。空 emailAddress は 400 でなく `available:false`/`reason:"format"`。
- **/api/test**: 空 `{}` → validate 済 param の echo + `required` 必須 (400) + `default`/`nullableDefault` 既定 `'hello'`。
- **verify-email**: `emailVerified` 更新後に `meUpdated` を main stream へ publish (upstream `publishMainStream`)。

## テスト

- `signup`: `ValidUsernameFormat` / `IsReservedUsername` の export helper を単体テスト
- `i`: `TestVerifyEmail_PublishesMeUpdated` で meUpdated publish を検証
- router.go の inline handler は server package (CIカバレッジ 0% 例外、drop-in/e2e で検証) のため、delegate 先の helper (signup/email) 側でロジックを担保
- `go build ./...` / `go vet ./...` / `gofmt -s` / 全テスト pass

## 関連

Closes #1551。`/api/endpoint` は #1695 に分離。

🤖 Generated with [Claude Code](https://claude.com/claude-code)