### PR TITLE
Fix /api/endpoint: 未知 endpoint で null + params を配列 shape に (#1695)

### DIFF
--- a/internal/server/endpoint_catalog.go
+++ b/internal/server/endpoint_catalog.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+)
+
+// apiEndpointNames returns the deduped names of every registered POST /api/*
+// route — the endpoint catalog. `/api/endpoints` lists them, and `/api/endpoint`
+// (#1695) uses it to distinguish known endpoints from unknown ones. Names are
+// the route path with the leading "/api/" stripped (e.g. "notes/create").
+// GET-only routes, the no-prefix routes, and the "*" catchall are excluded.
+func apiEndpointNames(e *echo.Echo) []string {
+	names := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, r := range e.Routes() {
+		if r.Method != http.MethodPost {
+			continue
+		}
+		name := strings.TrimPrefix(r.Path, "/api/")
+		if name == r.Path || name == "" || name == "*" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	return names
+}
+
+// isRegisteredAPIEndpoint reports whether name is a registered POST /api/* route.
+func isRegisteredAPIEndpoint(e *echo.Echo, name string) bool {
+	for _, n := range apiEndpointNames(e) {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/endpoint_catalog_test.go
+++ b/internal/server/endpoint_catalog_test.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func noopHandler(c echo.Context) error { return c.NoContent(http.StatusOK) }
+
+func TestAPIEndpointNames(t *testing.T) {
+	e := echo.New()
+	e.POST("/api/notes/create", noopHandler)
+	e.POST("/api/meta", noopHandler)
+	e.POST("/api/notes/create", noopHandler) // duplicate → dedup
+	e.GET("/api/users/show", noopHandler)    // GET → excluded
+	e.POST("/health", noopHandler)           // no /api/ prefix → excluded
+	e.POST("/api/*", noopHandler)            // catchall → excluded
+
+	names := apiEndpointNames(e)
+	assert.Contains(t, names, "notes/create")
+	assert.Contains(t, names, "meta")
+	assert.NotContains(t, names, "users/show", "GET routes are excluded")
+	assert.NotContains(t, names, "/health", "non-/api/ routes are excluded")
+	assert.NotContains(t, names, "*", "catchall is excluded")
+
+	// dedup: notes/create は 2 回登録しても 1 つだけ。
+	count := 0
+	for _, n := range names {
+		if n == "notes/create" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "duplicate routes are deduped")
+}
+
+func TestIsRegisteredAPIEndpoint(t *testing.T) {
+	e := echo.New()
+	e.POST("/api/notes/create", noopHandler)
+	e.GET("/api/users/show", noopHandler)
+
+	assert.True(t, isRegisteredAPIEndpoint(e, "notes/create"))
+	assert.False(t, isRegisteredAPIEndpoint(e, "users/show"), "GET-only route is not a POST endpoint")
+	assert.False(t, isRegisteredAPIEndpoint(e, "nonexistent"))
+	assert.False(t, isRegisteredAPIEndpoint(e, ""))
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2487,27 +2487,17 @@ func (s *Server) setupRoutes() {
 
 	// endpoints — 登録済みAPIエンドポイント一覧
 	api.POST("/endpoints", func(c echo.Context) error {
-		routes := s.echo.Routes()
-		names := make([]string, 0, len(routes))
-		seen := make(map[string]bool)
-		for _, r := range routes {
-			if r.Method != http.MethodPost {
-				continue
-			}
-			name := strings.TrimPrefix(r.Path, "/api/")
-			if name == r.Path || name == "" || name == "*" {
-				continue
-			}
-			if seen[name] {
-				continue
-			}
-			seen[name] = true
-			names = append(names, name)
-		}
-		return c.JSON(http.StatusOK, names)
+		return c.JSON(http.StatusOK, apiEndpointNames(s.echo))
 	})
 
-	// endpoint — エンドポイント情報 (簡易版: パラメータ情報なし)
+	// endpoint — 指定 endpoint の情報を返す (#1695)。upstream endpoint.ts は
+	// 未知 endpoint で null、既知なら { params: [{name,type}, ...] } を返す。
+	// mk-go は per-endpoint の paramDef メタデータを保持しない (handler は
+	// router.go の inline closure で param schema を構造化していない) ため、
+	// param 名/型までは導出できない。ここでは response の shape (params は配列)
+	// と未知 endpoint の null だけ upstream に揃える。params 内容の導出は
+	// endpoint registry の新設が必要で本 endpoint の用途 (API introspection) に
+	// 対して費用対効果が低いため非対応 (#1695 に明記)。
 	api.POST("/endpoint", func(c echo.Context) error {
 		var req struct {
 			Endpoint string `json:"endpoint"`
@@ -2515,7 +2505,11 @@ func (s *Server) setupRoutes() {
 		if err := c.Bind(&req); err != nil || req.Endpoint == "" {
 			return c.JSON(http.StatusBadRequest, apierr.InvalidParam())
 		}
-		return c.JSON(http.StatusOK, map[string]any{"params": map[string]any{}})
+		// 未知 endpoint は null (upstream: ep == null → return null)。
+		if !isRegisteredAPIEndpoint(s.echo, req.Endpoint) {
+			return c.JSON(http.StatusOK, nil)
+		}
+		return c.JSON(http.StatusOK, map[string]any{"params": []any{}})
 	})
 
 	// retention — リテンション統計


### PR DESCRIPTION
## Summary

#1695。`/api/endpoint` は endpoint 名に関わらず `{"params": {}}` (空 object) を返す stub だった。upstream `endpoint.ts` は未知 endpoint で `null`、既知 endpoint で `{ params: [{name,type}, ...] }` (配列) を返す。frontend は `params` を配列として扱うため object だと壊れ、未知 endpoint も判別できなかった。

## 主な変更点

- `internal/server/endpoint_catalog.go` (新規): `apiEndpointNames(echo)` を切り出し、登録済 POST `/api/*` route から endpoint 名を dedup 抽出 (GET / prefix無し / catchall は除外)。`/api/endpoints` をこの helper に refactor (挙動は同一)。
- `/api/endpoint`: 未知 endpoint は `null`、既知 endpoint は `{ params: [] }` を返すよう修正。
  - param を持たない endpoint は upstream も `[]` を返すため**完全一致**。
  - param を持つ endpoint は **shape のみ一致** (`params` 配列)。

## スコープ (param 内容の非対応について)

mk-go の API handler は `router.go` の inline closure で、param schema を構造化した per-endpoint paramDef メタデータを保持していない。upstream のように param 名/型まで導出するには全 endpoint の paramDef を宣言する endpoint registry の新設が必要で、`/api/endpoint` (API introspection 用の補助 endpoint) の用途に対して費用対効果が著しく低い。本 PR では actionable な構造バグ (誤った object shape / 未知 endpoint の null 欠落) を解消し、param 内容の導出は意図的に非対応とする。

## テスト

- `internal/server/endpoint_catalog_test.go`: `TestAPIEndpointNames` (POST限定 / prefix trim / prefix無し・catchall・GET除外 / dedup) と `TestIsRegisteredAPIEndpoint`
- `go build ./...` / `go vet ./...` / `gofmt -s` / 全テスト pass

## 関連

Closes #1695。

🤖 Generated with [Claude Code](https://claude.com/claude-code)