### PR TITLE
Fix users/lists/create-from-public・update: UserList packer shape で返す (#1550)

### DIFF
--- a/internal/api/users/handler_p189_test.go
+++ b/internal/api/users/handler_p189_test.go
@@ -263,16 +263,21 @@ func TestListsCreateFromPublic_CopiesMembers(t *testing.T) {
 	rec := postP189(k.h.ListsCreateFromPublic, `{"listId":"src","name":"mine"}`, &model.User{ID: "me"})
 	assert.Equal(t, http.StatusOK, rec.Code)
 
-	var resp model.UserList
+	// #1550: res は UserList packer shape ({id,createdAt,name,userIds,isPublic})。
+	// model.UserList 生 JSON の userId は露出しない。
+	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	assert.Equal(t, "me", resp.UserID)
-	assert.Equal(t, "mine", resp.Name)
-	assert.False(t, resp.IsPublic)
+	assert.Equal(t, "mine", resp["name"])
+	assert.Equal(t, false, resp["isPublic"])
+	assert.NotContains(t, resp, "userId", "userId は露出しない")
+	assert.NotEmpty(t, resp["createdAt"], "createdAt が含まれる")
+	assert.ElementsMatch(t, []any{"u1", "u2"}, resp["userIds"], "コピーされた member が userIds に反映される")
 
 	// 新 list に u1, u2 が追加されているはず。
+	newID := resp["id"].(string)
 	copied := 0
 	for _, m := range k.listRepo.Members {
-		if m.UserListID == resp.ID {
+		if m.UserListID == newID {
 			copied++
 		}
 	}

--- a/internal/api/users/lists.go
+++ b/internal/api/users/lists.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"net/http"
 	"time"
+	"unicode/utf8"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -65,17 +67,24 @@ func (h *Handler) ListsCreateFromPublic(c echo.Context) error {
 	members, err := h.userListRepo.ListMembers(req.ListID)
 	if err != nil {
 		// list 自体は既に作成済みなので、メンバーコピー失敗時も新 list を返す。
-		return c.JSON(http.StatusOK, newList)
+		return c.JSON(http.StatusOK, entity.PackUserList(newList, nil, h.idGen))
 	}
+	memberIDs := make([]string, 0, len(members))
 	for _, m := range members {
 		mb := &model.UserListMembership{
 			ID:         h.idGen.Generate(time.Now()),
 			UserListID: newList.ID,
 			UserID:     m.UserID,
 		}
-		_ = h.userListRepo.AddMember(mb)
+		// メンバー追加に成功したものだけ userIds に反映する (block/dup の
+		// 詳細エラーは #1550 follow-up、ここでは shape を upstream に揃える)。
+		if err := h.userListRepo.AddMember(mb); err == nil {
+			memberIDs = append(memberIDs, m.UserID)
+		}
 	}
-	return c.JSON(http.StatusOK, newList)
+	// upstream create-from-public.ts は res:ref'UserList' を userListEntityService.pack
+	// で返す。model.UserList 生 JSON だと createdAt/userIds 欠落 + userId 露出する (#1550)。
+	return c.JSON(http.StatusOK, entity.PackUserList(newList, memberIDs, h.idGen))
 }
 
 // ListsFavorite handles POST /api/users/lists/favorite.
@@ -161,12 +170,19 @@ func (h *Handler) ListsUnfavorite(c echo.Context) error {
 func (h *Handler) ListsUpdate(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req struct {
-		ListID   string `json:"listId"`
-		Name     string `json:"name"`
-		IsPublic *bool  `json:"isPublic"`
+		ListID   string  `json:"listId"`
+		Name     *string `json:"name"`
+		IsPublic *bool   `json:"isPublic"`
 	}
 	if err := c.Bind(&req); err != nil || req.ListID == "" {
 		return apierr.JSONInvalidParam(c)
+	}
+	// upstream update.ts は name を minLength:1/maxLength:100 で validate する。
+	// name は optional だが、渡されたら検証する (空文字や 100 超は INVALID_PARAM、#1550)。
+	if req.Name != nil {
+		if rc := utf8.RuneCountInString(*req.Name); rc < 1 || rc > 100 {
+			return apierr.JSONInvalidParam(c)
+		}
 	}
 	if h.userListRepo == nil {
 		return c.NoContent(http.StatusNoContent)
@@ -180,9 +196,9 @@ func (h *Handler) ListsUpdate(c echo.Context) error {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "796666fe-3dff-4d39-becb-8a5932c1d5b7"))
 	}
 	fields := map[string]any{}
-	if req.Name != "" {
-		fields["name"] = req.Name
-		list.Name = req.Name
+	if req.Name != nil {
+		fields["name"] = *req.Name
+		list.Name = *req.Name
 	}
 	if req.IsPublic != nil {
 		fields["isPublic"] = *req.IsPublic
@@ -193,7 +209,22 @@ func (h *Handler) ListsUpdate(c echo.Context) error {
 			return apierr.JSONInternalError(c)
 		}
 	}
-	return c.JSON(http.StatusOK, list)
+	// upstream update.ts は res:ref'UserList' を userListEntityService.pack で返す (#1550)。
+	return c.JSON(http.StatusOK, entity.PackUserList(list, h.listMemberIDs(req.ListID), h.idGen))
+}
+
+// listMemberIDs returns the member user IDs of a list for UserList packing.
+// 取得失敗時は nil (PackUserList が空配列に正規化する)。
+func (h *Handler) listMemberIDs(listID string) []string {
+	members, err := h.userListRepo.ListMembers(listID)
+	if err != nil {
+		return nil
+	}
+	ids := make([]string, 0, len(members))
+	for _, m := range members {
+		ids = append(ids, m.UserID)
+	}
+	return ids
 }
 
 // ListsUpdateMembership handles POST /api/users/lists/update-membership.

--- a/internal/api/users/lists_test.go
+++ b/internal/api/users/lists_test.go
@@ -3,6 +3,7 @@ package users
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/shiroha-a/mk/internal/model"
@@ -261,6 +262,42 @@ func TestListsUpdate_Success(t *testing.T) {
 	rec := postStub(h.ListsUpdate, `{"listId":"l1","name":"new"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "new", listRepo.Lists["l1"].Name)
+}
+
+// #1550: update は UserList packer shape ({id,createdAt,name,userIds,isPublic}) を
+// 返し userId を露出しない。
+func TestListsUpdate_ReturnsPackedShape(t *testing.T) {
+	h, _ := newTestHandler(t)
+	listRepo := testutil.NewMockUserListRepository()
+	listRepo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "u1", Name: "old"}
+	listRepo.Members = append(listRepo.Members, &model.UserListMembership{ID: "m1", UserListID: "l1", UserID: "member1"})
+	h.SetUserListRepo(listRepo)
+
+	rec := postStub(h.ListsUpdate, `{"listId":"l1","name":"new"}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "new", resp["name"])
+	assert.NotContains(t, resp, "userId", "userId は露出しない")
+	assert.Contains(t, resp, "createdAt", "createdAt field が shape に含まれる")
+	assert.ElementsMatch(t, []any{"member1"}, resp["userIds"])
+}
+
+// #1550: name は minLength:1/maxLength:100 で validate (渡された場合)。
+func TestListsUpdate_NameTooLong(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.SetUserListRepo(testutil.NewMockUserListRepository())
+	body := `{"listId":"l1","name":"` + strings.Repeat("a", 101) + `"}`
+	rec := postStub(h.ListsUpdate, body, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestListsUpdate_NameEmptyRejected(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.SetUserListRepo(testutil.NewMockUserListRepository())
+	// 空文字 name が渡されたら minLength 違反で 400 (絞り込み前に検証)。
+	rec := postStub(h.ListsUpdate, `{"listId":"l1","name":""}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestListsUpdate_NotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

#1550 の HIGH×2 + LOW name validation。`users/lists/create-from-public` と `users/lists/update` は `model.UserList` を生 serialize していたため、レスポンスが `{id,userId,name,isPublic}` となり **`createdAt`/`userIds` が欠落・`userId` が余分露出**していた。upstream は `res:ref'UserList'` を `userListEntityService.pack` で返す ({id,createdAt,name,userIds,isPublic})。

## 主な変更点

- **create-from-public / update**: `entity.PackUserList(list, memberIDs, idGen)` を返すよう修正。`memberIDs` は create-from-public ではコピー成功分、update では現 member 一覧 (`listMemberIDs` helper)。
- **update name validation** [LOW]: `name` を `*string` にし、渡された場合のみ `utf8.RuneCountInString` で `minLength:1`/`maxLength:100` を検証 (範囲外は `INVALID_PARAM`)。空文字 present は `minLength` 違反で 400、absent (nil) は skip — upstream `update.ts` 互換。

## テスト

- `TestListsCreateFromPublic_CopiesMembers` を packer shape 検証に更新 (userIds 反映 / userId 非露出 / createdAt 含む)
- `TestListsUpdate_ReturnsPackedShape` / `_NameTooLong` / `_NameEmptyRejected` を追加
- `internal/api/users` 全テスト + `go vet` / `gofmt` pass

## 関連

#1550 (users/lists/* parity)。get-memberships rewrite / list userId param / show forPublic / create-from-public の各種チェック / membership endpoint の error は後続 PR で対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)