### PR TITLE
Fix users/lists/get-memberships: listId の membership 配列を返す public endpoint に rewrite (#1550)

### DIFF
--- a/internal/api/users/lists.go
+++ b/internal/api/users/lists.go
@@ -9,6 +9,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -260,31 +261,71 @@ func (h *Handler) ListsUpdateMembership(c echo.Context) error {
 
 // ListsGetMemberships handles POST /api/users/lists/get-memberships.
 //
-// 認証ユーザが所有する UserList のうち、指定された userId を member として含む
-// ものの一覧を返す。Misskey 本家互換。認証は router の RequireAuth middleware
-// が 401 CREDENTIAL_REQUIRED で弾くため viewer は常に非 nil。
+// upstream get-memberships.ts: listId(required) の membership 配列
+// [{id, createdAt, userId, user(UserLite), withReplies}] を返す
+// (requireCredential:false の public endpoint)。可視性は forPublic=false かつ
+// 認証済なら own list のみ、それ以外は public list のみ (#1550)。
 func (h *Handler) ListsGetMemberships(c echo.Context) error {
 	viewer := middleware.GetUser(c)
 	var req struct {
-		UserID string `json:"userId"`
+		ListID    string `json:"listId"`
+		ForPublic bool   `json:"forPublic"`
+		Limit     int    `json:"limit"`
+		SinceID   string `json:"sinceId"`
+		UntilID   string `json:"untilId"`
+		SinceDate *int64 `json:"sinceDate"`
+		UntilDate *int64 `json:"untilDate"`
 	}
-	if err := c.Bind(&req); err != nil || req.UserID == "" {
+	if err := c.Bind(&req); err != nil || req.ListID == "" {
 		return apierr.JSONInvalidParam(c)
 	}
 	if h.userListRepo == nil {
-		return c.JSON(http.StatusOK, []any{})
+		return apierr.JSONInternalError(c)
 	}
-	lists, err := h.userListRepo.ListsContainingMember(viewer.ID, req.UserID)
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 30
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	const noSuchList = "7bc05c21-1d7a-41ae-88f1-66820f4dc686"
+	list, err := h.userListRepo.FindByID(req.ListID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", noSuchList))
+	}
+	// upstream: !forPublic && me!=null → own list (任意 visibility)、それ以外は public list。
+	if !req.ForPublic && viewer != nil {
+		if list.UserID != viewer.ID {
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", noSuchList))
+		}
+	} else if !list.IsPublic {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", noSuchList))
+	}
+
+	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	members, err := h.userListRepo.ListMembershipsPage(req.ListID, sinceID, untilID, limit)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	out := make([]map[string]any, 0, len(lists))
-	for _, l := range lists {
+	out := make([]map[string]any, 0, len(members))
+	for _, m := range members {
+		// User relation が取れない orphan membership は skip (UserLite を pack
+		// できないため。通常は FK で存在保証される)。
+		if m.User == nil {
+			continue
+		}
+		createdAt := ""
+		if t, perr := h.idGen.ParseTime(m.ID); perr == nil {
+			createdAt = t.UTC().Format("2006-01-02T15:04:05.000Z")
+		}
 		out = append(out, map[string]any{
-			"id":       l.ID,
-			"name":     l.Name,
-			"userId":   l.UserID,
-			"isPublic": l.IsPublic,
+			"id":          m.ID,
+			"createdAt":   createdAt,
+			"userId":      m.UserID,
+			"user":        entity.PackUserLite(m.User),
+			"withReplies": m.WithReplies,
 		})
 	}
 	return c.JSON(http.StatusOK, out)

--- a/internal/api/users/lists_test.go
+++ b/internal/api/users/lists_test.go
@@ -12,27 +12,88 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestListsGetMemberships(t *testing.T) {
+func TestListsGetMemberships_MissingListID(t *testing.T) {
 	h, _ := newTestHandler(t)
-	// 認証は router.RequireAuth が 401 を返す責務。ここでは userId 欠落のみ検証。
 	assert.Equal(t, http.StatusBadRequest, postStub(h.ListsGetMemberships, `{}`, &model.User{ID: "u1"}).Code)
 }
 
-func TestListsGetMemberships_ReturnsOwnedLists(t *testing.T) {
+// seedListWithMember seeds a list + a single member (with User preloaded) for
+// get-memberships tests.
+func seedListWithMember(repo *testutil.MockUserListRepository, listID, owner, memberID string, isPublic bool) {
+	repo.Lists[listID] = &model.UserList{ID: listID, UserID: owner, Name: "list", IsPublic: isPublic}
+	repo.Members = append(repo.Members, &model.UserListMembership{
+		ID: "mem_" + memberID, UserListID: listID, UserID: memberID, WithReplies: true,
+		User: &model.User{ID: memberID, Username: memberID, UsernameLower: memberID},
+	})
+}
+
+// #1550: get-memberships は listId の membership 配列 [{id,createdAt,userId,user,withReplies}]
+// を返す (own private list を owner が取得)。
+func TestListsGetMemberships_OwnPrivateList(t *testing.T) {
 	h, _ := newTestHandler(t)
 	repo := testutil.NewMockUserListRepository()
-	require.NoError(t, repo.Create(&model.UserList{ID: "l1", UserID: "owner", Name: "favs"}))
-	require.NoError(t, repo.Create(&model.UserList{ID: "l2", UserID: "other", Name: "other-favs"}))
-	require.NoError(t, repo.AddMember(&model.UserListMembership{UserListID: "l1", UserID: "u2"}))
-	require.NoError(t, repo.AddMember(&model.UserListMembership{UserListID: "l2", UserID: "u2"}))
+	seedListWithMember(repo, "l1", "owner", "u2", false)
 	h.SetUserListRepo(repo)
 
-	rec := postStub(h.ListsGetMemberships, `{"userId":"u2"}`, &model.User{ID: "owner"})
-	assert.Equal(t, http.StatusOK, rec.Code)
+	rec := postStub(h.ListsGetMemberships, `{"listId":"l1"}`, &model.User{ID: "owner"})
+	require.Equal(t, http.StatusOK, rec.Code)
 	var rows []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
-	require.Len(t, rows, 1, "only caller-owned lists should be returned")
-	assert.Equal(t, "l1", rows[0]["id"])
+	require.Len(t, rows, 1)
+	assert.Equal(t, "u2", rows[0]["userId"])
+	assert.Equal(t, true, rows[0]["withReplies"])
+	assert.Contains(t, rows[0], "createdAt")
+	user := rows[0]["user"].(map[string]any)
+	assert.Equal(t, "u2", user["id"], "user は UserLite で埋め込まれる")
+}
+
+// 非 owner は forPublic=false では他人の (private/public 問わず) list を取得できない
+// (upstream: !forPublic && me!=null → own list only)。
+func TestListsGetMemberships_NonOwnerDeniedWithoutForPublic(t *testing.T) {
+	h, _ := newTestHandler(t)
+	repo := testutil.NewMockUserListRepository()
+	seedListWithMember(repo, "l1", "owner", "u2", true) // public でも forPublic=false なら own-only
+	h.SetUserListRepo(repo)
+	rec := postStub(h.ListsGetMemberships, `{"listId":"l1"}`, &model.User{ID: "intruder"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// forPublic=true なら public list の membership を非 owner / 未認証でも取得できる。
+func TestListsGetMemberships_ForPublic(t *testing.T) {
+	h, _ := newTestHandler(t)
+	repo := testutil.NewMockUserListRepository()
+	seedListWithMember(repo, "l1", "owner", "u2", true)
+	h.SetUserListRepo(repo)
+	rec := postStub(h.ListsGetMemberships, `{"listId":"l1","forPublic":true}`, &model.User{ID: "viewer"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	assert.Len(t, rows, 1)
+}
+
+func TestListsGetMemberships_PublicUnauthenticatedAllowed(t *testing.T) {
+	h, _ := newTestHandler(t)
+	repo := testutil.NewMockUserListRepository()
+	seedListWithMember(repo, "l1", "owner", "u2", true)
+	h.SetUserListRepo(repo)
+	rec := postStub(h.ListsGetMemberships, `{"listId":"l1"}`, nil) // 未認証
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestListsGetMemberships_PrivateUnauthenticatedDenied(t *testing.T) {
+	h, _ := newTestHandler(t)
+	repo := testutil.NewMockUserListRepository()
+	seedListWithMember(repo, "l1", "owner", "u2", false)
+	h.SetUserListRepo(repo)
+	rec := postStub(h.ListsGetMemberships, `{"listId":"l1"}`, nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestListsGetMemberships_NoSuchList(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.SetUserListRepo(testutil.NewMockUserListRepository())
+	rec := postStub(h.ListsGetMemberships, `{"listId":"ghost"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
 // --- ListsCreateFromPublic ---

--- a/internal/core/antenna/antenna_service_test.go
+++ b/internal/core/antenna/antenna_service_test.go
@@ -955,6 +955,9 @@ func (r *failingUserListRepo) CountMembers(_ string) (int64, error)           { 
 func (r *failingUserListRepo) ListMembers(_ string) ([]*model.UserListMembership, error) {
 	return nil, errors.New("list members error")
 }
+func (r *failingUserListRepo) ListMembershipsPage(_, _, _ string, _ int) ([]*model.UserListMembership, error) {
+	return nil, errors.New("list memberships page error")
+}
 func (r *failingUserListRepo) ListMembersByListIDs(_ []string) (map[string][]string, error) {
 	return nil, errors.New("list members by ids error")
 }

--- a/internal/repository/user_list.go
+++ b/internal/repository/user_list.go
@@ -25,6 +25,10 @@ type UserListRepository interface {
 	AddMember(m *model.UserListMembership) error
 	RemoveMember(listID, userID string) error
 	ListMembers(listID string) ([]*model.UserListMembership, error)
+	// ListMembershipsPage returns a list's memberships (User preloaded) with
+	// cursor pagination by membership id. Used by users/lists/get-memberships
+	// (#1550)。
+	ListMembershipsPage(listID, sinceID, untilID string, limit int) ([]*model.UserListMembership, error)
 	// CountMembers returns the number of members in the given list. Used by
 	// userEachUserListsLimit policy gate (#1029 PR-1 follow-up).
 	CountMembers(listID string) (int64, error)
@@ -121,6 +125,24 @@ func (r *userListRepository) CountMembers(listID string) (int64, error) {
 func (r *userListRepository) ListMembers(listID string) ([]*model.UserListMembership, error) {
 	var members []*model.UserListMembership
 	if err := r.db.Preload("User").Where("\"userListId\" = ?", listID).Find(&members).Error; err != nil {
+		return nil, err
+	}
+	return members, nil
+}
+
+func (r *userListRepository) ListMembershipsPage(listID, sinceID, untilID string, limit int) ([]*model.UserListMembership, error) {
+	if limit <= 0 {
+		limit = 30
+	}
+	q := r.db.Preload("User").Where(`"userListId" = ?`, listID)
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	var members []*model.UserListMembership
+	if err := q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit).Find(&members).Error; err != nil {
 		return nil, err
 	}
 	return members, nil

--- a/internal/repository/user_list_test.go
+++ b/internal/repository/user_list_test.go
@@ -146,6 +146,52 @@ func TestUserListRepository_ListMembersByListIDs(t *testing.T) {
 	assert.False(t, ok)
 }
 
+// TestUserListRepository_ListMembershipsPage は #1550 の get-memberships 用
+// cursor pagination + User preload を検証する。
+func TestUserListRepository_ListMembershipsPage(t *testing.T) {
+	repo := NewUserListRepository(testDB)
+	createTestUser(t, "ulp_o")
+	createTestUser(t, "ulp_m1")
+	createTestUser(t, "ulp_m2")
+	createTestUser(t, "ulp_m3")
+	list := &model.UserList{ID: "ulp_list", UserID: "ulp_o", Name: "L"}
+	require.NoError(t, repo.Create(list))
+	defer cleanupUserList(t, list.ID)
+	require.NoError(t, repo.AddMember(&model.UserListMembership{ID: "ulm_p_1", UserListID: list.ID, UserID: "ulp_m1"}))
+	require.NoError(t, repo.AddMember(&model.UserListMembership{ID: "ulm_p_2", UserListID: list.ID, UserID: "ulp_m2"}))
+	require.NoError(t, repo.AddMember(&model.UserListMembership{ID: "ulm_p_3", UserListID: list.ID, UserID: "ulp_m3"}))
+
+	ids := func(rows []*model.UserListMembership) []string {
+		out := make([]string, 0, len(rows))
+		for _, r := range rows {
+			out = append(out, r.ID)
+		}
+		return out
+	}
+
+	// default: id DESC、User preload あり。
+	rows, err := repo.ListMembershipsPage(list.ID, "", "", 30)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ulm_p_3", "ulm_p_2", "ulm_p_1"}, ids(rows))
+	require.NotNil(t, rows[0].User, "User が preload される")
+	assert.Equal(t, "ulp_m3", rows[0].User.ID)
+
+	// limit cap。
+	rows, err = repo.ListMembershipsPage(list.ID, "", "", 2)
+	require.NoError(t, err)
+	assert.Len(t, rows, 2)
+
+	// untilID: cursor 未満 (DESC)。
+	rows, err = repo.ListMembershipsPage(list.ID, "", "ulm_p_3", 30)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ulm_p_2", "ulm_p_1"}, ids(rows))
+
+	// sinceID-only: cursor 超 + ASC。
+	rows, err = repo.ListMembershipsPage(list.ID, "ulm_p_1", "", 30)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ulm_p_2", "ulm_p_3"}, ids(rows))
+}
+
 // TestUserListRepository_AddMember_Duplicate verifies the (userListId, userId)
 // unique-constraint violation is mapped to ErrUserListDuplicateMember (#396),
 // so the API layer can return the TS-compat ALREADY_ADDED error.

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1372,7 +1372,9 @@ func (s *Server) setupRoutes() {
 	api.POST("/users/get-frequently-replied-users", usersHandler.GetFrequentlyRepliedUsers)
 	api.POST("/users/get-following-users-by-birthday", usersHandler.GetFollowingUsersByBirthday, middleware.RequireAuth(), middleware.RequireScope("read:account"))
 	api.POST("/users/recommendation", usersHandler.UserRecommendation, middleware.RequireAuth(), middleware.RequireScope("read:account"))
-	api.POST("/users/lists/get-memberships", usersHandler.ListsGetMemberships, middleware.RequireAuth(), middleware.RequireScope("read:account"))
+	// get-memberships は requireCredential:false の public endpoint (#1550)。
+	// RequireScope は app token のみ gate するため public でも残してよい。
+	api.POST("/users/lists/get-memberships", usersHandler.ListsGetMemberships, middleware.RequireScope("read:account"))
 	api.POST("/users/lists/create-from-public", usersHandler.ListsCreateFromPublic, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:account"))
 	api.POST("/users/lists/favorite", usersHandler.ListsFavorite, middleware.RequireAuth(), middleware.RequireScope("write:account"))
 	api.POST("/users/lists/unfavorite", usersHandler.ListsUnfavorite, middleware.RequireAuth(), middleware.RequireScope("write:account"))

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -5466,6 +5466,38 @@ func (m *MockUserListRepository) ListMembers(listID string) ([]*model.UserListMe
 	return result, nil
 }
 
+// ListMembershipsPage mirrors the production cursor pagination (id ASC when
+// sinceID-only, else DESC) over the in-memory Members slice.
+func (m *MockUserListRepository) ListMembershipsPage(listID, sinceID, untilID string, limit int) ([]*model.UserListMembership, error) {
+	if limit <= 0 {
+		limit = 30
+	}
+	var result []*model.UserListMembership
+	for _, mem := range m.Members {
+		if mem.UserListID != listID {
+			continue
+		}
+		if sinceID != "" && mem.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && mem.ID >= untilID {
+			continue
+		}
+		result = append(result, mem)
+	}
+	asc := sinceID != "" && untilID == ""
+	sort.Slice(result, func(i, j int) bool {
+		if asc {
+			return result[i].ID < result[j].ID
+		}
+		return result[i].ID > result[j].ID
+	})
+	if len(result) > limit {
+		result = result[:limit]
+	}
+	return result, nil
+}
+
 // ListMembersByListIDs returns userIDs grouped by listID. Mirrors the
 // production batch fetch (#876) but iterates the in-memory slice.
 func (m *MockUserListRepository) ListMembersByListIDs(listIDs []string) (map[string][]string, error) {


### PR DESCRIPTION
## Summary

#1550 の HIGH (get-memberships が別実装) + MED (requireCredential false)。旧実装は `userId` を受け「viewer 所有 list のうち userId を含むもの」を返す**全く別の API** だった (param/res/権限すべて upstream 非互換)。upstream `get-memberships.ts` は `listId` を受け、その list の **membership 配列**を返す `requireCredential:false` の public endpoint。

## 主な変更点

- **`ListsGetMemberships` rewrite**: `listId`(required) + `forPublic`/`limit`/`sinceId`/`untilId`/`sinceDate`/`untilDate` を受け、可視性を判定して membership 配列 `[{id, createdAt, userId, user(UserLite), withReplies}]` を返す。
  - 可視性: `!forPublic && 認証済` → own list (任意 visibility)、それ以外 (`forPublic` or 未認証) → public list のみ。不一致は `NO_SUCH_LIST` (`7bc05c21...`)。upstream `findOneBy` と同条件。
  - `createdAt` は membership ID (aidx) の `ParseTime`、`user` は `PackUserLite`。
- **repository `ListMembershipsPage`**: User preload + cursor pagination (`paginationOrder` で sinceID-only ASC / それ以外 DESC、limit)。
- **route 公開化**: `get-memberships` から `RequireAuth()` を削除 (`RequireScope("read:account")` は app token のみ gate するため維持)。

## テスト

- handler: 可視性マトリクス (own private / 非owner forPublic=false 拒否 / forPublic=true / 未認証 public 可 / 未認証 private 拒否 / NO_SUCH_LIST) + membership shape (userId/withReplies/user.id/createdAt)
- repository real-DB: `TestUserListRepository_ListMembershipsPage` (DESC / limit / untilID / sinceID-only ASC / User preload)
- interface 追加に伴う mock + 手動 fake 追従、`go vet ./...` 全体 pass、repository 90.4% / users 90.8%

## 関連

#1550。list userId param / show forPublic / create-from-public checks / membership endpoint の error は後続 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)