### PR TITLE
Fix users/lists/list: userId param で他ユーザーの public list を返す (#1550)

### DIFF
--- a/internal/api/userlists/handler.go
+++ b/internal/api/userlists/handler.go
@@ -59,15 +59,51 @@ func (h *Handler) SetBlockingRepo(r repository.BlockingRepository) {
 
 // List handles POST /api/users/lists/list.
 //
-// upstream Misskey TS と同じ packed shape ({id, createdAt, name, userIds,
-// isPublic}) で返す (#871)。userIds は ListMembersByListIDs で 1 query batch
-// fetch する (= per-list N+1 を回避、#876)。
+// upstream list.ts は requireCredential:false で、userId(optional) 指定時は対象
+// ユーザーの public list を返す (host!=null は REMOTE_USER_NOT_ALLOWED、不在は
+// NO_SUCH_USER)。userId 未指定 && 未認証は INVALID_PARAM (#1550)。packed shape
+// ({id, createdAt, name, userIds, isPublic})、userIds は ListMembersByListIDs で
+// batch fetch (#876)。
 func (h *Handler) List(c echo.Context) error {
-	user := middleware.GetUser(c)
-	lists, err := h.repo.ListByUser(user.ID)
-	if err != nil {
-		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	viewer := middleware.GetUser(c)
+	var req struct {
+		UserID string `json:"userId"`
 	}
+	_ = c.Bind(&req) // userId は optional (upstream paramDef required:[])
+
+	var lists []*model.UserList
+	if req.UserID != "" {
+		// 対象ユーザーの public list を返す (upstream: findBy {userId, isPublic:true})。
+		if h.userRepo != nil {
+			u, uerr := h.userRepo.FindByID(req.UserID)
+			if uerr != nil || u == nil {
+				return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "a8af4a82-0980-4cc4-a6af-8b0ffd54465e"))
+			}
+			if u.Host != nil && *u.Host != "" {
+				return c.JSON(http.StatusBadRequest, apierr.Error("REMOTE_USER_NOT_ALLOWED", "Not allowed to load the remote user's list", "53858f1b-3315-4a01-81b7-db9b48d4b79a"))
+			}
+		}
+		all, err := h.repo.ListByUser(req.UserID)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		}
+		for _, l := range all {
+			if l.IsPublic {
+				lists = append(lists, l)
+			}
+		}
+	} else {
+		// userId 未指定は認証必須 (upstream: me===null なら INVALID_PARAM)。
+		if viewer == nil {
+			return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid param.", "ab36de0e-29e9-48cb-9732-d82f1281620d"))
+		}
+		var err error
+		lists, err = h.repo.ListByUser(viewer.ID)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+		}
+	}
+
 	listIDs := make([]string, 0, len(lists))
 	for _, l := range lists {
 		listIDs = append(listIDs, l.ID)
@@ -77,7 +113,7 @@ func (h *Handler) List(c echo.Context) error {
 		// repo error は best-effort で空 map にフォールバックして shape を保つ
 		// (= memberIDs helper と同 pattern、entity.PackUserList が [] で
 		// serialize する)。観測のため slog.Warn は残す。
-		slog.Warn("users/lists/list: failed to batch fetch members", "userId", user.ID, "error", err)
+		slog.Warn("users/lists/list: failed to batch fetch members", "error", err)
 		membersByList = map[string][]string{}
 	}
 	out := make([]entity.UserList, 0, len(lists))

--- a/internal/api/userlists/handler_test.go
+++ b/internal/api/userlists/handler_test.go
@@ -46,6 +46,52 @@ func TestList_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// #1550: userId 指定で対象ユーザーの public list のみ返す (private は除外)。
+func TestList_ByUserIDReturnsPublicOnly(t *testing.T) {
+	h, repo := newTestHandler(t)
+	userRepo := testutil.NewMockUserRepository()
+	require.NoError(t, userRepo.Create(&model.User{ID: "u2"}))
+	h.SetUserRepo(userRepo)
+	repo.Lists["pub"] = &model.UserList{ID: "pub", UserID: "u2", Name: "public", IsPublic: true}
+	repo.Lists["priv"] = &model.UserList{ID: "priv", UserID: "u2", Name: "private", IsPublic: false}
+
+	rec := doPost(h.List, `{"userId":"u2"}`, &model.User{ID: "viewer"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1, "public list のみ返る")
+	assert.Equal(t, "pub", out[0]["id"])
+}
+
+// #1550: userId 指定で対象 user が不在なら NO_SUCH_USER。
+func TestList_ByUserIDNoSuchUser(t *testing.T) {
+	h, _ := newTestHandler(t)
+	h.SetUserRepo(testutil.NewMockUserRepository())
+	rec := doPost(h.List, `{"userId":"ghost"}`, &model.User{ID: "viewer"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "a8af4a82-0980-4cc4-a6af-8b0ffd54465e")
+}
+
+// #1550: userId 指定で対象が remote user なら REMOTE_USER_NOT_ALLOWED。
+func TestList_ByUserIDRemoteUser(t *testing.T) {
+	h, _ := newTestHandler(t)
+	userRepo := testutil.NewMockUserRepository()
+	host := "remote.example"
+	require.NoError(t, userRepo.Create(&model.User{ID: "r1", Host: &host}))
+	h.SetUserRepo(userRepo)
+	rec := doPost(h.List, `{"userId":"r1"}`, &model.User{ID: "viewer"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "53858f1b-3315-4a01-81b7-db9b48d4b79a")
+}
+
+// #1550: userId 未指定 && 未認証は INVALID_PARAM。
+func TestList_NoUserIDUnauthenticated(t *testing.T) {
+	h, _ := newTestHandler(t)
+	rec := doPost(h.List, `{}`, nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "ab36de0e-29e9-48cb-9732-d82f1281620d")
+}
+
 func TestCreate_Success(t *testing.T) {
 	h, repo := newTestHandler(t)
 	rec := doPost(h.Create, `{"name":"My List"}`, &model.User{ID: "u1"})

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2100,7 +2100,9 @@ func (s *Server) setupRoutes() {
 	userListHandler.SetRolePolicyProvider(roleService) // #1029: userListLimit / userEachUserListsLimit
 	userListHandler.SetUserRepo(userRepo)              // #1550: push NO_SUCH_USER check
 	userListHandler.SetBlockingRepo(blockingRepo)      // #1550: push YOU_HAVE_BEEN_BLOCKED check
-	api.POST("/users/lists/list", userListHandler.List, middleware.RequireAuth(), middleware.RequireScope("read:account"))
+	// list は requireCredential:false の public endpoint (userId 指定で他人の
+	// public list を閲覧可、#1550)。未認証 && userId 未指定は handler が INVALID_PARAM。
+	api.POST("/users/lists/list", userListHandler.List, middleware.RequireScope("read:account"))
 	api.POST("/users/lists/create", userListHandler.Create, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:account"))
 	api.POST("/users/lists/show", userListHandler.Show, middleware.RequireAuth(), middleware.RequireScope("read:account"))
 	api.POST("/users/lists/push", userListHandler.Push, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:account"))


### PR DESCRIPTION
## Summary

#1550 の MED (userId param 未対応) + LOW (NO_SUCH_USER/REMOTE_USER_NOT_ALLOWED/INVALID_PARAM 欠落)。旧 `List` は認証ユーザー自身の list のみ返し `userId` param 非対応 (`RequireAuth` 必須)。upstream `list.ts` は `requireCredential:false` で `userId`(optional) を受け、指定時は対象ユーザーの public list を返す。

## 主な変更点

- **`List`**: `userId`(optional) を bind。
  - userId 指定時: `userRepo.FindByID` で対象 user を検証 — 不在 → `NO_SUCH_USER` (`a8af4a82...`)、`host!=null` → `REMOTE_USER_NOT_ALLOWED` (`53858f1b...`)。その public list のみ返す。
  - userId 未指定: 認証必須 (未認証 → `INVALID_PARAM` `ab36de0e...`)、own list (全 visibility) を返す。
- **route 公開化**: `RequireAuth()` を削除 (`RequireScope("read:account")` は維持)。

## テスト

- `TestList_ByUserIDReturnsPublicOnly` / `_ByUserIDNoSuchUser` / `_ByUserIDRemoteUser` / `_NoUserIDUnauthenticated` を追加
- 既存 `TestList_Success` (own-list 分岐) 非回帰、`internal/api/userlists` 96.0%、`go vet`/`gofmt` pass

## 関連

#1550。show forPublic / create-from-public checks / membership endpoint の error は後続 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)