### PR TITLE
Fix users/lists/show: forPublic param + likedCount/isLiked を追加 (#1550)

### DIFF
--- a/internal/api/userlists/handler.go
+++ b/internal/api/userlists/handler.go
@@ -1,6 +1,7 @@
 package userlists
 
 import (
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -22,12 +23,21 @@ type Handler struct {
 	rolePolicyProvider RolePolicyProvider
 	userRepo           repository.UserRepository
 	blockingRepo       repository.BlockingRepository
+	favoriteRepo       UserListFavoriteReader
 }
 
 // RolePolicyProvider abstracts role-policy lookup for `userListLimit` /
 // `userEachUserListsLimit` enforcement (#1029)。実装は core/role.Service。
 type RolePolicyProvider interface {
 	GetUserPolicies(userID string) map[string]any
+}
+
+// UserListFavoriteReader abstracts the favorite count / exists lookup for
+// users/lists/show forPublic の likedCount/isLiked (#1550)。実装は
+// repository.UserListFavoriteRepository。
+type UserListFavoriteReader interface {
+	CountByList(listID string) (int64, error)
+	Exists(userID, listID string) (bool, error)
 }
 
 // NewHandler creates a new userlists Handler.
@@ -55,6 +65,12 @@ func (h *Handler) SetUserRepo(r repository.UserRepository) {
 // intent.
 func (h *Handler) SetBlockingRepo(r repository.BlockingRepository) {
 	h.blockingRepo = r
+}
+
+// SetFavoriteRepo wires a favorite reader so Show can return likedCount/isLiked
+// for forPublic public lists (#1550). nil 時は likedCount/isLiked を付与しない。
+func (h *Handler) SetFavoriteRepo(r UserListFavoriteReader) {
+	h.favoriteRepo = r
 }
 
 // List handles POST /api/users/lists/list.
@@ -163,7 +179,8 @@ func (h *Handler) Create(c echo.Context) error {
 // userIds を含む packed shape を返す (#871)。
 func (h *Handler) Show(c echo.Context) error {
 	var req struct {
-		ListID string `json:"listId"`
+		ListID    string `json:"listId"`
+		ForPublic bool   `json:"forPublic"`
 	}
 	if err := c.Bind(&req); err != nil || req.ListID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "listId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
@@ -179,7 +196,24 @@ func (h *Handler) Show(c echo.Context) error {
 	if !list.IsPublic && (viewer == nil || list.UserID != viewer.ID) {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7bc05c21-1d7a-41ae-88f1-66820f4dc686"))
 	}
-	return c.JSON(http.StatusOK, entity.PackUserList(list, h.memberIDs(list.ID), h.idGen))
+	packed := entity.PackUserList(list, h.memberIDs(list.ID), h.idGen)
+	// upstream show.ts: forPublic && public のとき likedCount/isLiked を付与する。
+	// それ以外は通常の UserList shape のまま返す。
+	if !(req.ForPublic && list.IsPublic && h.favoriteRepo != nil) {
+		return c.JSON(http.StatusOK, packed)
+	}
+	// 追加フィールドを足すため UserList struct を map に展開する。
+	b, _ := json.Marshal(packed)
+	resp := map[string]any{}
+	_ = json.Unmarshal(b, &resp)
+	likedCount, _ := h.favoriteRepo.CountByList(req.ListID)
+	resp["likedCount"] = likedCount
+	isLiked := false
+	if viewer != nil {
+		isLiked, _ = h.favoriteRepo.Exists(viewer.ID, req.ListID)
+	}
+	resp["isLiked"] = isLiked
+	return c.JSON(http.StatusOK, resp)
 }
 
 // memberIDs returns the userId list of members of the given list.

--- a/internal/api/userlists/handler_test.go
+++ b/internal/api/userlists/handler_test.go
@@ -506,6 +506,64 @@ func TestShow_PublicListNonOwnerVisible(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// #1550: forPublic && public のとき likedCount/isLiked を付与する。
+func TestShow_ForPublicLikedCountAndIsLiked(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "owner", Name: "pub", IsPublic: true}
+	favRepo := testutil.NewMockUserListFavoriteRepository()
+	require.NoError(t, favRepo.Create(&model.UserListFavorite{ID: "f1", UserID: "viewer", UserListID: "l1"}))
+	require.NoError(t, favRepo.Create(&model.UserListFavorite{ID: "f2", UserID: "other", UserListID: "l1"}))
+	h.SetFavoriteRepo(favRepo)
+
+	rec := doPost(h.Show, `{"listId":"l1","forPublic":true}`, &model.User{ID: "viewer"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, float64(2), resp["likedCount"])
+	assert.Equal(t, true, resp["isLiked"])
+}
+
+// 未認証 forPublic は likedCount を返すが isLiked は false。
+func TestShow_ForPublicUnauthenticatedIsLikedFalse(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "owner", Name: "pub", IsPublic: true}
+	favRepo := testutil.NewMockUserListFavoriteRepository()
+	require.NoError(t, favRepo.Create(&model.UserListFavorite{ID: "f1", UserID: "x", UserListID: "l1"}))
+	h.SetFavoriteRepo(favRepo)
+
+	rec := doPost(h.Show, `{"listId":"l1","forPublic":true}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, float64(1), resp["likedCount"])
+	assert.Equal(t, false, resp["isLiked"])
+}
+
+// forPublic 無しなら likedCount/isLiked は付かない (通常 UserList shape)。
+func TestShow_NoForPublicNoLikedFields(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "owner", Name: "pub", IsPublic: true}
+	h.SetFavoriteRepo(testutil.NewMockUserListFavoriteRepository())
+	rec := doPost(h.Show, `{"listId":"l1"}`, &model.User{ID: "owner"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotContains(t, resp, "likedCount")
+	assert.NotContains(t, resp, "isLiked")
+}
+
+// forPublic=true でも private list (owner 閲覧) には likedCount/isLiked を付けない。
+func TestShow_ForPublicPrivateNoLikedFields(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "owner", Name: "priv", IsPublic: false}
+	h.SetFavoriteRepo(testutil.NewMockUserListFavoriteRepository())
+	rec := doPost(h.Show, `{"listId":"l1","forPublic":true}`, &model.User{ID: "owner"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotContains(t, resp, "likedCount")
+}
+
 // 他人 list への push が「存在しない」扱いで弾かれること。viewer が list owner
 // 以外なら NO_SUCH_LIST を返し、AddMember が呼ばれてはならない (= owner gate
 // 抜けの IDOR 回帰防止)。

--- a/internal/repository/user_list_favorite.go
+++ b/internal/repository/user_list_favorite.go
@@ -11,6 +11,9 @@ type UserListFavoriteRepository interface {
 	Delete(userID, listID string) error
 	ListByUser(userID string) ([]*model.UserListFavorite, error)
 	Exists(userID, listID string) (bool, error)
+	// CountByList returns the number of favorites of a list. Used by
+	// users/lists/show forPublic の likedCount (#1550)。
+	CountByList(listID string) (int64, error)
 }
 
 type userListFavoriteRepository struct {
@@ -44,4 +47,11 @@ func (r *userListFavoriteRepository) Exists(userID, listID string) (bool, error)
 	err := r.db.Model(&model.UserListFavorite{}).
 		Where(`"userId" = ? AND "userListId" = ?`, userID, listID).Count(&count).Error
 	return count > 0, err
+}
+
+func (r *userListFavoriteRepository) CountByList(listID string) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.UserListFavorite{}).
+		Where(`"userListId" = ?`, listID).Count(&count).Error
+	return count, err
 }

--- a/internal/repository/user_list_favorite_test.go
+++ b/internal/repository/user_list_favorite_test.go
@@ -47,3 +47,22 @@ func TestUserListFavoriteRepository_ListEmpty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, list)
 }
+
+// #1550: CountByList は list の favorite 数を返す (show forPublic の likedCount)。
+func TestUserListFavoriteRepository_CountByList(t *testing.T) {
+	repo := NewUserListFavoriteRepository(testDB)
+	seedUser(t, "ulc_u1")
+	seedUser(t, "ulc_u2")
+	seedUserList(t, "ulc_l1", "ulc_u1")
+	t.Cleanup(func() { testDB.Exec(`DELETE FROM "user_list_favorite" WHERE "userListId" = ?`, "ulc_l1") })
+
+	n, err := repo.CountByList("ulc_l1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+
+	require.NoError(t, repo.Create(&model.UserListFavorite{ID: "ulc_f1", UserID: "ulc_u1", UserListID: "ulc_l1"}))
+	require.NoError(t, repo.Create(&model.UserListFavorite{ID: "ulc_f2", UserID: "ulc_u2", UserListID: "ulc_l1"}))
+	n, err = repo.CountByList("ulc_l1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), n)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2097,9 +2097,10 @@ func (s *Server) setupRoutes() {
 
 	// User lists (Phase 6)
 	userListHandler := apiuserlists.NewHandler(userListRepo, idGen)
-	userListHandler.SetRolePolicyProvider(roleService) // #1029: userListLimit / userEachUserListsLimit
-	userListHandler.SetUserRepo(userRepo)              // #1550: push NO_SUCH_USER check
-	userListHandler.SetBlockingRepo(blockingRepo)      // #1550: push YOU_HAVE_BEEN_BLOCKED check
+	userListHandler.SetRolePolicyProvider(roleService)    // #1029: userListLimit / userEachUserListsLimit
+	userListHandler.SetUserRepo(userRepo)                 // #1550: push NO_SUCH_USER check
+	userListHandler.SetBlockingRepo(blockingRepo)         // #1550: push YOU_HAVE_BEEN_BLOCKED check
+	userListHandler.SetFavoriteRepo(userListFavoriteRepo) // #1550: show forPublic likedCount/isLiked
 	// list は requireCredential:false の public endpoint (userId 指定で他人の
 	// public list を閲覧可、#1550)。未認証 && userId 未指定は handler が INVALID_PARAM。
 	api.POST("/users/lists/list", userListHandler.List, middleware.RequireScope("read:account"))

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -6862,6 +6862,16 @@ func (m *MockUserListFavoriteRepository) Exists(userID, listID string) (bool, er
 	return ok, nil
 }
 
+func (m *MockUserListFavoriteRepository) CountByList(listID string) (int64, error) {
+	var count int64
+	for k := range m.Favorites {
+		if strings.HasSuffix(k, ":"+listID) {
+			count++
+		}
+	}
+	return count, nil
+}
+
 // MockRetentionAggregationRepository is a test double for repository.RetentionAggregationRepository.
 type MockRetentionAggregationRepository struct {
 	Records []*model.RetentionAggregation


### PR DESCRIPTION
## Summary

#1550 の MED (show の forPublic param と likedCount/isLiked 欠落)。upstream `show.ts` は `forPublic`(default false) を受け、`forPublic && list.isPublic` のとき `likedCount`(number)/`isLiked`(boolean) を res に追加する。mk-go は `forPublic` を読まず両 field を返していなかった。

## 主な変更点

- **`Show`**: `forPublic` を bind。可視性チェックは従来どおり (非public は owner のみ、audit は visibility を flag していないため不変)。`forPublic && list.IsPublic` のとき `PackUserList` を map に展開して `likedCount` (`favoriteRepo.CountByList`) + `isLiked` (`viewer != nil ? Exists : false`) を付与。それ以外は通常の `UserList` shape を返す (shapetest 非回帰)。
- **repository `CountByList`**: list の favorite 数を返すメソッドを interface+impl+mock に追加。
- userlists handler に narrow favorite reader interface + `SetFavoriteRepo` を足し router で配線。

## テスト

- `TestShow_ForPublicLikedCountAndIsLiked` (likedCount=2 / isLiked=true) / `_ForPublicUnauthenticatedIsLikedFalse` / `_NoForPublicNoLikedFields` / `_ForPublicPrivateNoLikedFields`
- repository `TestUserListFavoriteRepository_CountByList` (real-DB)
- 既存 `TestShow_Success` (shapetest UserList) 非回帰、`internal/api/userlists` 96.4% / `internal/api/users` 90.8% / `go vet`/`gofmt` pass

## 関連

#1550。create-from-public checks / membership endpoint の error は後続 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)