### PR TITLE
Fix users/lists/create-from-public: upstream 準拠の各種チェックを追加 (#1550)

### DIFF
--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -42,6 +42,7 @@ type Handler struct {
 	followingRepo        repository.FollowingRepository
 	memoRepo             repository.UserMemoRepository
 	blockingRepo         repository.BlockingRepository
+	rolePolicyProvider   RolePolicyProvider
 	mutingRepo           repository.MutingRepository
 	renoteMutingRepo     repository.RenoteMutingRepository
 	followRequestRepo    repository.FollowRequestRepository
@@ -206,6 +207,20 @@ func (h *Handler) SetFollowingRepo(r repository.FollowingRepository) {
 // SetBlockingRepo attaches a BlockingRepository for block status queries.
 func (h *Handler) SetBlockingRepo(r repository.BlockingRepository) {
 	h.blockingRepo = r
+}
+
+// RolePolicyProvider abstracts role-policy lookup for `userListLimit` /
+// `userEachUserListsLimit` enforcement in create-from-public (#1550)。実装は
+// core/role.Service。
+type RolePolicyProvider interface {
+	GetUserPolicies(userID string) map[string]any
+}
+
+// SetRolePolicyProvider wires a RolePolicyProvider so create-from-public enforces
+// the userListLimit / userEachUserListsLimit role policies (#1550)。nil 時は
+// limit gate を skip する (= test / 旧挙動)。
+func (h *Handler) SetRolePolicyProvider(p RolePolicyProvider) {
+	h.rolePolicyProvider = p
 }
 
 // SetMutingRepo attaches a MutingRepository for mute status queries.

--- a/internal/api/users/lists.go
+++ b/internal/api/users/lists.go
@@ -36,9 +36,11 @@ func (h *Handler) SetUserListRepo(r repository.UserListRepository) {
 
 // ListsCreateFromPublic handles POST /api/users/lists/create-from-public.
 //
-// 公開済みの UserList (listId) から名前を引き継いだ新しい list (name) を作って、
-// 元 list のメンバーをそのままコピーする。メンバー追加で一部失敗しても残りは
-// 続行する (1 件のブロックや重複で全体を失敗させないほうが UX 上望ましい)。
+// 公開済みの UserList (listId) から名前を引き継いだ新しい list (name) を作り、
+// 元 list のメンバーをコピーする。upstream create-from-public.ts に合わせて
+// userListLimit gate (TOO_MANY_USERLISTS)、各メンバーで getUser (NO_SUCH_USER) /
+// blocking (YOU_HAVE_BEEN_BLOCKED) / 既存 (ALREADY_ADDED) / member 上限
+// (TOO_MANY_USERS) を検証し、最初の失敗で中断・エラーを返す (#1550)。
 func (h *Handler) ListsCreateFromPublic(c echo.Context) error {
 	viewer := middleware.GetUser(c)
 	var req struct {
@@ -48,12 +50,28 @@ func (h *Handler) ListsCreateFromPublic(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.Name == "" || req.ListID == "" {
 		return apierr.JSONInvalidParam(c)
 	}
+	// upstream paramDef: name minLength:1 (=空チェック) / maxLength:100。
+	if utf8.RuneCountInString(req.Name) > 100 {
+		return apierr.JSONInvalidParam(c)
+	}
 	if h.userListRepo == nil {
 		return apierr.JSONInternalError(c)
 	}
 	src, err := h.userListRepo.FindByID(req.ListID)
 	if err != nil || !src.IsPublic {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "9292f798-6175-4f7d-93f4-b6742279667d"))
+	}
+	// userListLimit gate (TOO_MANY_USERLISTS)。
+	if h.rolePolicyProvider != nil {
+		if limit, ok := h.rolePolicyProvider.GetUserPolicies(viewer.ID)["userListLimit"].(int); ok && limit >= 0 {
+			count, cerr := h.userListRepo.CountByUser(viewer.ID)
+			if cerr != nil {
+				return apierr.JSONInternalError(c)
+			}
+			if count >= int64(limit) {
+				return c.JSON(http.StatusBadRequest, apierr.Error("TOO_MANY_USERLISTS", "You cannot create user list any more.", "e9c105b2-c595-47de-97fb-7f7c2c33e92f"))
+			}
+		}
 	}
 	now := time.Now()
 	newList := &model.UserList{
@@ -70,21 +88,48 @@ func (h *Handler) ListsCreateFromPublic(c echo.Context) error {
 		// list 自体は既に作成済みなので、メンバーコピー失敗時も新 list を返す。
 		return c.JSON(http.StatusOK, entity.PackUserList(newList, nil, h.idGen))
 	}
+	// member 上限 (userEachUserListsLimit)。-1 は無制限扱い。
+	memberLimit := -1
+	if h.rolePolicyProvider != nil {
+		if l, ok := h.rolePolicyProvider.GetUserPolicies(viewer.ID)["userEachUserListsLimit"].(int); ok {
+			memberLimit = l
+		}
+	}
 	memberIDs := make([]string, 0, len(members))
 	for _, m := range members {
+		// NO_SUCH_USER: 対象 user が存在しなければ中断 (upstream getterService.getUser)。
+		if h.userRepo != nil {
+			if _, uerr := h.userRepo.FindByID(m.UserID); uerr != nil {
+				return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "13c457db-a8cb-4d88-b70a-211ceeeabb5f"))
+			}
+		}
+		// YOU_HAVE_BEEN_BLOCKED: 対象が viewer を block していれば中断 (自分自身は除外)。
+		if h.blockingRepo != nil && m.UserID != viewer.ID {
+			blocked, berr := h.blockingRepo.Exists(m.UserID, viewer.ID)
+			if berr != nil || blocked {
+				return c.JSON(http.StatusForbidden, apierr.Error("YOU_HAVE_BEEN_BLOCKED", "You cannot push this user because you have been blocked by this user.", "a2497f2a-2389-439c-8626-5298540530f4"))
+			}
+		}
+		// TOO_MANY_USERS: member 上限に達したら中断 (upstream addMember の TooManyUsersError)。
+		if memberLimit >= 0 && len(memberIDs) >= memberLimit {
+			return c.JSON(http.StatusBadRequest, apierr.Error("TOO_MANY_USERS", "You can not push users any more.", "1845ea77-38d1-426e-8e4e-8b83b24f5bd7"))
+		}
 		mb := &model.UserListMembership{
 			ID:         h.idGen.Generate(time.Now()),
 			UserListID: newList.ID,
 			UserID:     m.UserID,
 		}
-		// メンバー追加に成功したものだけ userIds に反映する (block/dup の
-		// 詳細エラーは #1550 follow-up、ここでは shape を upstream に揃える)。
-		if err := h.userListRepo.AddMember(mb); err == nil {
-			memberIDs = append(memberIDs, m.UserID)
+		if aerr := h.userListRepo.AddMember(mb); aerr != nil {
+			// 既 member は ALREADY_ADDED (copy 元が unique なら通常起きない、defensive)。
+			if errors.Is(aerr, repository.ErrUserListDuplicateMember) {
+				return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_ADDED", "That user has already been added to that list.", "c3ad6fdb-692b-47ee-a455-7bd12c7af615"))
+			}
+			return apierr.JSONInternalError(c)
 		}
+		memberIDs = append(memberIDs, m.UserID)
 	}
 	// upstream create-from-public.ts は res:ref'UserList' を userListEntityService.pack
-	// で返す。model.UserList 生 JSON だと createdAt/userIds 欠落 + userId 露出する (#1550)。
+	// で返す (#1550)。
 	return c.JSON(http.StatusOK, entity.PackUserList(newList, memberIDs, h.idGen))
 }
 

--- a/internal/api/users/lists_test.go
+++ b/internal/api/users/lists_test.go
@@ -308,6 +308,96 @@ func TestListsUnfavorite_NotFavorited(t *testing.T) {
 
 // --- ListsUpdate ---
 
+// stubListsPolicy is a RolePolicyProvider stub for create-from-public limit tests.
+type stubListsPolicy struct{ policies map[string]any }
+
+func (s *stubListsPolicy) GetUserPolicies(_ string) map[string]any { return s.policies }
+
+// newListsHandlerFull wires userListRepo / userRepo / blockingRepo /
+// rolePolicyProvider so create-from-public の各 gate を test できる。
+func newListsHandlerFull(t *testing.T) (*Handler, *testutil.MockUserListRepository, *testutil.MockUserRepository, *testutil.MockBlockingRepository, *stubListsPolicy) {
+	t.Helper()
+	h, userRepo := newTestHandler(t)
+	listRepo := testutil.NewMockUserListRepository()
+	blockRepo := testutil.NewMockBlockingRepository()
+	policy := &stubListsPolicy{policies: map[string]any{}}
+	h.SetUserListRepo(listRepo)
+	h.SetUserRepo(userRepo)
+	h.SetBlockingRepo(blockRepo)
+	h.SetRolePolicyProvider(policy)
+	return h, listRepo, userRepo, blockRepo, policy
+}
+
+// seedPublicSrc seeds a public source list with the given member user IDs (and
+// registers those users so NO_SUCH_USER passes).
+func seedPublicSrc(t *testing.T, listRepo *testutil.MockUserListRepository, userRepo *testutil.MockUserRepository, listID string, memberIDs ...string) {
+	t.Helper()
+	listRepo.Lists[listID] = &model.UserList{ID: listID, UserID: "srcowner", Name: "src", IsPublic: true}
+	for i, mid := range memberIDs {
+		require.NoError(t, listRepo.AddMember(&model.UserListMembership{ID: "srcm_" + string(rune('a'+i)), UserListID: listID, UserID: mid}))
+		require.NoError(t, userRepo.Create(&model.User{ID: mid}))
+	}
+}
+
+// #1550: create-from-public は member を copy して packer shape を返す (全 gate 通過)。
+func TestListsCreateFromPublic_FullCopiesMembers(t *testing.T) {
+	h, listRepo, userRepo, _, _ := newListsHandlerFull(t)
+	seedPublicSrc(t, listRepo, userRepo, "src", "m1", "m2")
+	rec := postStub(h.ListsCreateFromPublic, `{"listId":"src","name":"mine"}`, &model.User{ID: "me"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.ElementsMatch(t, []any{"m1", "m2"}, resp["userIds"])
+	assert.NotContains(t, resp, "userId")
+}
+
+func TestListsCreateFromPublic_TooManyUserLists(t *testing.T) {
+	h, listRepo, userRepo, _, policy := newListsHandlerFull(t)
+	seedPublicSrc(t, listRepo, userRepo, "src")
+	// viewer は既に 1 list 所有、userListLimit=1 → TOO_MANY_USERLISTS。
+	listRepo.Lists["own1"] = &model.UserList{ID: "own1", UserID: "me", Name: "owned"}
+	policy.policies["userListLimit"] = 1
+	rec := postStub(h.ListsCreateFromPublic, `{"listId":"src","name":"mine"}`, &model.User{ID: "me"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "e9c105b2-c595-47de-97fb-7f7c2c33e92f")
+}
+
+func TestListsCreateFromPublic_NoSuchUserMember(t *testing.T) {
+	h, listRepo, _, _, _ := newListsHandlerFull(t)
+	// member u_missing を memberships に入れるが userRepo には登録しない。
+	listRepo.Lists["src"] = &model.UserList{ID: "src", UserID: "srcowner", Name: "src", IsPublic: true}
+	require.NoError(t, listRepo.AddMember(&model.UserListMembership{ID: "sm1", UserListID: "src", UserID: "u_missing"}))
+	rec := postStub(h.ListsCreateFromPublic, `{"listId":"src","name":"mine"}`, &model.User{ID: "me"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "13c457db-a8cb-4d88-b70a-211ceeeabb5f")
+}
+
+func TestListsCreateFromPublic_BlockedMember(t *testing.T) {
+	h, listRepo, userRepo, blockRepo, _ := newListsHandlerFull(t)
+	seedPublicSrc(t, listRepo, userRepo, "src", "blocker")
+	require.NoError(t, blockRepo.Create(&model.Blocking{ID: "b1", BlockerID: "blocker", BlockeeID: "me"}))
+	rec := postStub(h.ListsCreateFromPublic, `{"listId":"src","name":"mine"}`, &model.User{ID: "me"})
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "a2497f2a-2389-439c-8626-5298540530f4")
+}
+
+func TestListsCreateFromPublic_TooManyUsers(t *testing.T) {
+	h, listRepo, userRepo, _, policy := newListsHandlerFull(t)
+	seedPublicSrc(t, listRepo, userRepo, "src", "m1", "m2")
+	policy.policies["userEachUserListsLimit"] = 1 // 1 件追加後に次で TOO_MANY_USERS
+	rec := postStub(h.ListsCreateFromPublic, `{"listId":"src","name":"mine"}`, &model.User{ID: "me"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "1845ea77-38d1-426e-8e4e-8b83b24f5bd7")
+}
+
+func TestListsCreateFromPublic_NameTooLong(t *testing.T) {
+	h, listRepo, userRepo, _, _ := newListsHandlerFull(t)
+	seedPublicSrc(t, listRepo, userRepo, "src")
+	body := `{"listId":"src","name":"` + strings.Repeat("a", 101) + `"}`
+	rec := postStub(h.ListsCreateFromPublic, body, &model.User{ID: "me"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
 func TestListsUpdate_MissingListID(t *testing.T) {
 	h, _ := newTestHandler(t)
 	rec := postStub(h.ListsUpdate, `{}`, &model.User{ID: "u1"})

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1323,6 +1323,7 @@ func (s *Server) setupRoutes() {
 	usersHandler.SetFollowingRepo(followingRepo)
 	usersHandler.SetBlockingRepo(blockingRepo)
 	usersHandler.SetMutingRepo(mutingRepo)
+	usersHandler.SetRolePolicyProvider(roleService) // #1550: create-from-public userListLimit/userEachUserListsLimit
 	usersHandler.SetRenoteMutingRepo(renoteMutingRepo)
 	usersHandler.SetFollowRequestRepo(followRequestRepo)
 	usersHandler.SetInstanceRepo(instanceRepo)


### PR DESCRIPTION
## Summary

#1550 の MED (create-from-public が block/alreadyAdded/tooManyUsers/tooManyUserLists/noSuchUser チェックを省略)。旧実装は member コピーで全エラーを無視する best-effort だった。**ユーザー判断により完全 upstream 準拠** (strict abort) を採用。

## 主な変更点

upstream `create-from-public.ts` の順序で検証し、最初の失敗で中断・エラーを返す:
- `name` maxLength:100 検証
- 元 list 存在 + isPublic → `NO_SUCH_LIST` (`9292f798`)
- `userListLimit` gate (`CountByUser >= limit`) → `TOO_MANY_USERLISTS` (`e9c105b2`)
- list 作成
- 各 member: `getUser` 不在 → `NO_SUCH_USER` (`13c457db`) / blocking (member≠me) → `YOU_HAVE_BEEN_BLOCKED` (`a2497f2a`) / `userEachUserListsLimit` 超過 → `TOO_MANY_USERS` (`1845ea77`) / AddMember dup → `ALREADY_ADDED` (`c3ad6fdb`)

`users.Handler` に `RolePolicyProvider` を追加し router で `roleService` 配線。全 error UUID は `golden_error_ids.json` と一致 (`TestErrorIDDrift` pass)。

## テスト

- `TestListsCreateFromPublic_FullCopiesMembers` (全 gate 通過 + packer shape) / `_TooManyUserLists` / `_NoSuchUserMember` / `_BlockedMember` / `_TooManyUsers` / `_NameTooLong`
- 既存 `TestListsCreateFromPublic_CopiesMembers` (deps 未配線で gate skip) 非回帰
- `internal/api/users` 90.7% / `TestErrorIDDrift`・`TestErrorHTTPStatusDrift` pass / `go vet`・`gofmt` pass

## 関連

#1550。残りは membership endpoint の LOW error (pull NO_SUCH_USER / push userListUserId / update-membership) + internal event/stream/proxy follow (systematic、別 issue 候補)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)