### PR TITLE
Fix users/lists/pull・push・create-from-public: NO_SUCH_USER + userListUserId (#1550)

### DIFF
--- a/internal/api/userlists/handler.go
+++ b/internal/api/userlists/handler.go
@@ -296,6 +296,8 @@ func (h *Handler) Push(c echo.Context) error {
 		ID:         h.idGen.Generate(time.Now()),
 		UserListID: req.ListID,
 		UserID:     req.UserID,
+		// upstream addMember は userListUserId に list owner を入れる (#1550)。
+		UserListUserID: &list.UserID,
 	}
 	if err := h.repo.AddMember(m); err != nil {
 		// 既 member への push は TS 互換の ALREADY_ADDED (HTTP 400) で
@@ -327,6 +329,14 @@ func (h *Handler) Pull(c echo.Context) error {
 	viewer := middleware.GetUser(c)
 	if viewer == nil || list.UserID != viewer.ID {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7f44670e-ab16-43b8-b4c1-ccd2ee89cc02"))
+	}
+	// upstream pull.ts は removeMember 前に対象 user の存在を getterService.getUser
+	// で検証し、不在なら NO_SUCH_USER を返す (#1550)。userRepo 未配線の test 経路
+	// では skip する。
+	if h.userRepo != nil {
+		if _, uerr := h.userRepo.FindByID(req.UserID); uerr != nil {
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "588e7f72-c744-4a61-b180-d354e912bda2"))
+		}
 	}
 	if err := h.repo.RemoveMember(req.ListID, req.UserID); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))

--- a/internal/api/userlists/handler_test.go
+++ b/internal/api/userlists/handler_test.go
@@ -165,6 +165,41 @@ func TestPull_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// #1550: pull は removeMember 前に対象 user 存在を検証し不在なら NO_SUCH_USER。
+func TestPull_NoSuchUser(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "u1"}
+	h.SetUserRepo(testutil.NewMockUserRepository()) // u2 未登録
+	rec := doPost(h.Pull, `{"listId":"l1","userId":"u2"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "588e7f72-c744-4a61-b180-d354e912bda2")
+}
+
+func TestPull_UserExistsSucceeds(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "u1"}
+	userRepo := testutil.NewMockUserRepository()
+	require.NoError(t, userRepo.Create(&model.User{ID: "u2"}))
+	h.SetUserRepo(userRepo)
+	rec := doPost(h.Pull, `{"listId":"l1","userId":"u2"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+// #1550: push は membership.userListUserId に list owner を設定する。
+func TestPush_SetsUserListUserID(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "owner"}
+	userRepo := testutil.NewMockUserRepository()
+	require.NoError(t, userRepo.Create(&model.User{ID: "u2"}))
+	h.SetUserRepo(userRepo)
+	h.SetBlockingRepo(testutil.NewMockBlockingRepository())
+	rec := doPost(h.Push, `{"listId":"l1","userId":"u2"}`, &model.User{ID: "owner"})
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Len(t, repo.Members, 1)
+	require.NotNil(t, repo.Members[0].UserListUserID)
+	assert.Equal(t, "owner", *repo.Members[0].UserListUserID)
+}
+
 func TestDelete_Success(t *testing.T) {
 	h, repo := newTestHandler(t)
 	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "u1"}

--- a/internal/api/users/lists.go
+++ b/internal/api/users/lists.go
@@ -118,6 +118,8 @@ func (h *Handler) ListsCreateFromPublic(c echo.Context) error {
 			ID:         h.idGen.Generate(time.Now()),
 			UserListID: newList.ID,
 			UserID:     m.UserID,
+			// upstream addMember は userListUserId に list owner を入れる (#1550)。
+			UserListUserID: &newList.UserID,
 		}
 		if aerr := h.userListRepo.AddMember(mb); aerr != nil {
 			// 既 member は ALREADY_ADDED (copy 元が unique なら通常起きない、defensive)。

--- a/internal/api/users/lists_test.go
+++ b/internal/api/users/lists_test.go
@@ -351,6 +351,25 @@ func TestListsCreateFromPublic_FullCopiesMembers(t *testing.T) {
 	assert.NotContains(t, resp, "userId")
 }
 
+// #1550: create-from-public は copy した membership の userListUserId に新 list の
+// owner を設定する。
+func TestListsCreateFromPublic_SetsUserListUserID(t *testing.T) {
+	h, listRepo, userRepo, _, _ := newListsHandlerFull(t)
+	seedPublicSrc(t, listRepo, userRepo, "src", "m1")
+	rec := postStub(h.ListsCreateFromPublic, `{"listId":"src","name":"mine"}`, &model.User{ID: "me"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	// copy された membership (UserID=m1) の userListUserId が owner "me"。
+	var found *model.UserListMembership
+	for _, m := range listRepo.Members {
+		if m.UserID == "m1" && m.UserListID != "src" {
+			found = m
+		}
+	}
+	require.NotNil(t, found, "copy された m1 membership が存在する")
+	require.NotNil(t, found.UserListUserID)
+	assert.Equal(t, "me", *found.UserListUserID)
+}
+
 func TestListsCreateFromPublic_TooManyUserLists(t *testing.T) {
 	h, listRepo, userRepo, _, policy := newListsHandlerFull(t)
 	seedPublicSrc(t, listRepo, userRepo, "src")


### PR DESCRIPTION
## Summary

#1550 の LOW 2件。

- **pull NO_SUCH_USER**: `pull` は対象 user の存在を検証せず、不在 user でも 204 を返していた。upstream `pull.ts` は `getterService.getUser` で検証し不在なら `NO_SUCH_USER` を throw。removeMember 前に `userRepo.FindByID` を入れ `NO_SUCH_USER` (`588e7f72`) を返す。
- **userListUserId**: `push` / `create-from-public` の membership が `userListUserId` (nullable 列) を nil 放置していた。upstream `addMember` は `userListUserId: list.userId` を insert する。両 endpoint で list owner を設定。

(update-membership の member-not-found は mk-go では `NO_SUCH_USER` を返しており golden と一致 + upstream の 500 より helpful なため不変。)

## テスト

- `TestPull_NoSuchUser` / `TestPull_UserExistsSucceeds` / `TestPush_SetsUserListUserID` / `TestListsCreateFromPublic_SetsUserListUserID`
- 既存 Pull tests (userRepo 未配線で skip) 非回帰、`internal/api/userlists` 96.5% / `internal/api/users` 90.7% / `TestErrorIDDrift` / `go vet`・`gofmt` pass

## 関連

#1550。残る MED「membership 変更時の internal event / userList stream / proxy follow 副作用」は stream/queue infra を要する systematic 項目のため別 issue に切り出す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)