### PR TITLE
Fix users/lists: remote member 追加時に proxy account follow を発火 (#1704)

### DIFF
--- a/internal/api/userlists/handler.go
+++ b/internal/api/userlists/handler.go
@@ -24,6 +24,7 @@ type Handler struct {
 	userRepo           repository.UserRepository
 	blockingRepo       repository.BlockingRepository
 	favoriteRepo       UserListFavoriteReader
+	proxyFollow        ProxyFollowEnqueuer
 }
 
 // RolePolicyProvider abstracts role-policy lookup for `userListLimit` /
@@ -71,6 +72,19 @@ func (h *Handler) SetBlockingRepo(r repository.BlockingRepository) {
 // for forPublic public lists (#1550). nil 時は likedCount/isLiked を付与しない。
 func (h *Handler) SetFavoriteRepo(r UserListFavoriteReader) {
 	h.favoriteRepo = r
+}
+
+// ProxyFollowEnqueuer makes the proxy account follow remote users added to a
+// list so their posts federate to this instance (#1704)。実装は
+// core/userlist.ProxyFollower。
+type ProxyFollowEnqueuer interface {
+	EnqueueProxyFollow(remoteUserIDs []string)
+}
+
+// SetProxyFollow wires the proxy-follow enqueuer used when a remote user is
+// pushed to a list (#1704). nil 時は proxy follow を skip する。
+func (h *Handler) SetProxyFollow(p ProxyFollowEnqueuer) {
+	h.proxyFollow = p
 }
 
 // List handles POST /api/users/lists/list.
@@ -263,8 +277,11 @@ func (h *Handler) Push(c echo.Context) error {
 	// upstream users/lists/push は AddMember 前に対象 user の存在を
 	// getterService.getUser で検証し、不在なら NO_SUCH_USER を返す (#1550)。
 	// userRepo 未配線の test 経路では skip する (production は router が必ず wire)。
+	var target *model.User
 	if h.userRepo != nil {
-		if _, err := h.userRepo.FindByID(req.UserID); err != nil {
+		var ferr error
+		target, ferr = h.userRepo.FindByID(req.UserID)
+		if ferr != nil {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "a89abd3d-f0bc-4cce-beb1-2f446f4f1e6a"))
 		}
 	}
@@ -306,6 +323,11 @@ func (h *Handler) Push(c echo.Context) error {
 			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_ADDED", "That user has already been added to that list.", "1de7c884-1595-49e9-857e-61f12f4d4fc5"))
 		}
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	// remote user を list に追加したら proxy account がフォローして連合投稿を
+	// 受信できるようにする (#1704、upstream addMember の isRemoteUser 分岐)。
+	if h.proxyFollow != nil && target != nil && !target.IsLocal() {
+		h.proxyFollow.EnqueueProxyFollow([]string{req.UserID})
 	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/userlists/handler_test.go
+++ b/internal/api/userlists/handler_test.go
@@ -185,6 +185,48 @@ func TestPull_UserExistsSucceeds(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
+// stubProxyFollow records EnqueueProxyFollow calls for #1704 tests.
+type stubProxyFollow struct {
+	got  []string
+	hits int
+}
+
+func (s *stubProxyFollow) EnqueueProxyFollow(ids []string) { s.hits++; s.got = ids }
+
+// #1704: remote user を push したら proxy follow を enqueue する。
+func TestPush_RemoteUserProxyFollow(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "owner"}
+	userRepo := testutil.NewMockUserRepository()
+	host := "remote.example"
+	require.NoError(t, userRepo.Create(&model.User{ID: "r1", Host: &host}))
+	h.SetUserRepo(userRepo)
+	h.SetBlockingRepo(testutil.NewMockBlockingRepository())
+	pf := &stubProxyFollow{}
+	h.SetProxyFollow(pf)
+
+	rec := doPost(h.Push, `{"listId":"l1","userId":"r1"}`, &model.User{ID: "owner"})
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, 1, pf.hits)
+	assert.Equal(t, []string{"r1"}, pf.got)
+}
+
+// #1704: local user の push では proxy follow を enqueue しない。
+func TestPush_LocalUserNoProxyFollow(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "owner"}
+	userRepo := testutil.NewMockUserRepository()
+	require.NoError(t, userRepo.Create(&model.User{ID: "u2"})) // local (Host nil)
+	h.SetUserRepo(userRepo)
+	h.SetBlockingRepo(testutil.NewMockBlockingRepository())
+	pf := &stubProxyFollow{}
+	h.SetProxyFollow(pf)
+
+	rec := doPost(h.Push, `{"listId":"l1","userId":"u2"}`, &model.User{ID: "owner"})
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, 0, pf.hits, "local user は proxy follow しない")
+}
+
 // #1550: push は membership.userListUserId に list owner を設定する。
 func TestPush_SetsUserListUserID(t *testing.T) {
 	h, repo := newTestHandler(t)

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -43,6 +43,7 @@ type Handler struct {
 	memoRepo             repository.UserMemoRepository
 	blockingRepo         repository.BlockingRepository
 	rolePolicyProvider   RolePolicyProvider
+	proxyFollow          ProxyFollowEnqueuer
 	mutingRepo           repository.MutingRepository
 	renoteMutingRepo     repository.RenoteMutingRepository
 	followRequestRepo    repository.FollowRequestRepository
@@ -221,6 +222,18 @@ type RolePolicyProvider interface {
 // limit gate を skip する (= test / 旧挙動)。
 func (h *Handler) SetRolePolicyProvider(p RolePolicyProvider) {
 	h.rolePolicyProvider = p
+}
+
+// ProxyFollowEnqueuer makes the proxy account follow remote users added to a
+// list (#1704)。実装は core/userlist.ProxyFollower。
+type ProxyFollowEnqueuer interface {
+	EnqueueProxyFollow(remoteUserIDs []string)
+}
+
+// SetProxyFollow wires the proxy-follow enqueuer used by create-from-public when
+// remote users are copied into the new list (#1704). nil 時は skip。
+func (h *Handler) SetProxyFollow(p ProxyFollowEnqueuer) {
+	h.proxyFollow = p
 }
 
 // SetMutingRepo attaches a MutingRepository for mute status queries.

--- a/internal/api/users/lists.go
+++ b/internal/api/users/lists.go
@@ -96,10 +96,14 @@ func (h *Handler) ListsCreateFromPublic(c echo.Context) error {
 		}
 	}
 	memberIDs := make([]string, 0, len(members))
+	var remoteMembers []string
 	for _, m := range members {
 		// NO_SUCH_USER: 対象 user が存在しなければ中断 (upstream getterService.getUser)。
+		var target *model.User
 		if h.userRepo != nil {
-			if _, uerr := h.userRepo.FindByID(m.UserID); uerr != nil {
+			var uerr error
+			target, uerr = h.userRepo.FindByID(m.UserID)
+			if uerr != nil {
 				return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "13c457db-a8cb-4d88-b70a-211ceeeabb5f"))
 			}
 		}
@@ -129,6 +133,14 @@ func (h *Handler) ListsCreateFromPublic(c echo.Context) error {
 			return apierr.JSONInternalError(c)
 		}
 		memberIDs = append(memberIDs, m.UserID)
+		if target != nil && !target.IsLocal() {
+			remoteMembers = append(remoteMembers, m.UserID)
+		}
+	}
+	// remote member は proxy account がフォローして連合投稿を受信できるように
+	// する (#1704、upstream addMember の isRemoteUser 分岐)。
+	if h.proxyFollow != nil {
+		h.proxyFollow.EnqueueProxyFollow(remoteMembers)
 	}
 	// upstream create-from-public.ts は res:ref'UserList' を userListEntityService.pack
 	// で返す (#1550)。

--- a/internal/api/users/lists_test.go
+++ b/internal/api/users/lists_test.go
@@ -370,6 +370,31 @@ func TestListsCreateFromPublic_SetsUserListUserID(t *testing.T) {
 	assert.Equal(t, "me", *found.UserListUserID)
 }
 
+// stubUsersProxyFollow records EnqueueProxyFollow calls for #1704.
+type stubUsersProxyFollow struct {
+	got  []string
+	hits int
+}
+
+func (s *stubUsersProxyFollow) EnqueueProxyFollow(ids []string) { s.hits++; s.got = ids }
+
+// #1704: create-from-public で copy した remote member だけ proxy follow を enqueue。
+func TestListsCreateFromPublic_RemoteMemberProxyFollow(t *testing.T) {
+	h, listRepo, userRepo, _, _ := newListsHandlerFull(t)
+	listRepo.Lists["src"] = &model.UserList{ID: "src", UserID: "srcowner", Name: "src", IsPublic: true}
+	require.NoError(t, listRepo.AddMember(&model.UserListMembership{ID: "s1", UserListID: "src", UserID: "m1"}))
+	require.NoError(t, listRepo.AddMember(&model.UserListMembership{ID: "s2", UserListID: "src", UserID: "r1"}))
+	require.NoError(t, userRepo.Create(&model.User{ID: "m1"})) // local
+	host := "remote.example"
+	require.NoError(t, userRepo.Create(&model.User{ID: "r1", Host: &host})) // remote
+	pf := &stubUsersProxyFollow{}
+	h.SetProxyFollow(pf)
+
+	rec := postStub(h.ListsCreateFromPublic, `{"listId":"src","name":"mine"}`, &model.User{ID: "me"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, []string{"r1"}, pf.got, "remote member のみ proxy follow")
+}
+
 func TestListsCreateFromPublic_TooManyUserLists(t *testing.T) {
 	h, listRepo, userRepo, _, policy := newListsHandlerFull(t)
 	seedPublicSrc(t, listRepo, userRepo, "src")

--- a/internal/core/userlist/proxy_follow.go
+++ b/internal/core/userlist/proxy_follow.go
@@ -1,0 +1,57 @@
+// Package userlist provides side-effect helpers for user list membership
+// changes (#1704).
+package userlist
+
+import (
+	"log/slog"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
+)
+
+// SystemAccountFetcher fetches a system account by kind (e.g. "proxy").
+// 実装は core/systemaccount.Service。
+type SystemAccountFetcher interface {
+	Fetch(kind string) (*model.User, error)
+}
+
+// FollowEnqueuer enqueues per-pair follow jobs. 実装は queue.Client。
+type FollowEnqueuer interface {
+	EnqueueFollowBulk(payloads []queue.FollowPayload) error
+}
+
+// ProxyFollower makes the instance's "proxy" system account follow remote users
+// added to a user list, so their federated posts reach this instance even when
+// no local user follows them (upstream UserListService.addMember の
+// isRemoteUser → createFollowJob、#1704)。
+type ProxyFollower struct {
+	systemAcct SystemAccountFetcher
+	enqueuer   FollowEnqueuer
+}
+
+// NewProxyFollower constructs a ProxyFollower.
+func NewProxyFollower(systemAcct SystemAccountFetcher, enqueuer FollowEnqueuer) *ProxyFollower {
+	return &ProxyFollower{systemAcct: systemAcct, enqueuer: enqueuer}
+}
+
+// EnqueueProxyFollow makes the proxy account follow each remote user id. Best-
+// effort: membership は既に永続化済みなので、失敗してもログのみで request は
+// 失敗させない (upstream も createFollowJob を await せず投げっぱなし)。空 slice
+// は no-op。
+func (p *ProxyFollower) EnqueueProxyFollow(remoteUserIDs []string) {
+	if len(remoteUserIDs) == 0 {
+		return
+	}
+	proxy, err := p.systemAcct.Fetch("proxy")
+	if err != nil {
+		slog.Warn("userlist: fetch proxy account for remote follow failed", "err", err)
+		return
+	}
+	payloads := make([]queue.FollowPayload, 0, len(remoteUserIDs))
+	for _, id := range remoteUserIDs {
+		payloads = append(payloads, queue.FollowPayload{FollowerID: proxy.ID, FolloweeID: id})
+	}
+	if err := p.enqueuer.EnqueueFollowBulk(payloads); err != nil {
+		slog.Warn("userlist: enqueue proxy follow failed", "err", err)
+	}
+}

--- a/internal/core/userlist/proxy_follow_test.go
+++ b/internal/core/userlist/proxy_follow_test.go
@@ -1,0 +1,64 @@
+package userlist
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubSysAcct struct {
+	user *model.User
+	err  error
+}
+
+func (s *stubSysAcct) Fetch(_ string) (*model.User, error) { return s.user, s.err }
+
+type stubEnqueuer struct {
+	got  []queue.FollowPayload
+	err  error
+	hits int
+}
+
+func (s *stubEnqueuer) EnqueueFollowBulk(p []queue.FollowPayload) error {
+	s.hits++
+	s.got = p
+	return s.err
+}
+
+func TestProxyFollower_EnqueuesForEachRemote(t *testing.T) {
+	sa := &stubSysAcct{user: &model.User{ID: "proxy1"}}
+	enq := &stubEnqueuer{}
+	pf := NewProxyFollower(sa, enq)
+	pf.EnqueueProxyFollow([]string{"r1", "r2"})
+	require.Equal(t, 1, enq.hits)
+	require.Len(t, enq.got, 2)
+	assert.Equal(t, queue.FollowPayload{FollowerID: "proxy1", FolloweeID: "r1"}, enq.got[0])
+	assert.Equal(t, queue.FollowPayload{FollowerID: "proxy1", FolloweeID: "r2"}, enq.got[1])
+}
+
+func TestProxyFollower_EmptyIsNoop(t *testing.T) {
+	sa := &stubSysAcct{user: &model.User{ID: "proxy1"}}
+	enq := &stubEnqueuer{}
+	NewProxyFollower(sa, enq).EnqueueProxyFollow(nil)
+	assert.Equal(t, 0, enq.hits, "空 slice では proxy fetch も enqueue もしない")
+}
+
+// proxy account 取得失敗は best-effort で skip (enqueue しない、panic しない)。
+func TestProxyFollower_FetchErrorSkips(t *testing.T) {
+	sa := &stubSysAcct{err: errors.New("no proxy")}
+	enq := &stubEnqueuer{}
+	NewProxyFollower(sa, enq).EnqueueProxyFollow([]string{"r1"})
+	assert.Equal(t, 0, enq.hits)
+}
+
+// enqueue 失敗も best-effort で握り潰す (panic しない)。
+func TestProxyFollower_EnqueueErrorSwallowed(t *testing.T) {
+	sa := &stubSysAcct{user: &model.User{ID: "proxy1"}}
+	enq := &stubEnqueuer{err: errors.New("queue down")}
+	NewProxyFollower(sa, enq).EnqueueProxyFollow([]string{"r1"})
+	assert.Equal(t, 1, enq.hits)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -105,6 +105,7 @@ import (
 	coretwofactor "github.com/shiroha-a/mk/internal/core/twofactor"
 	coreurlpreview "github.com/shiroha-a/mk/internal/core/urlpreview"
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
+	coreuserlist "github.com/shiroha-a/mk/internal/core/userlist"
 	corewebhook "github.com/shiroha-a/mk/internal/core/webhook"
 	corewebpush "github.com/shiroha-a/mk/internal/core/webpush"
 	"github.com/shiroha-a/mk/internal/entity"
@@ -609,6 +610,9 @@ func (s *Server) setupRoutes() {
 	sysAcctSvc := coresystemaccount.NewService(userRepo, keypairRepo, repository.NewSystemAccountRepository(s.db), idGen)
 	// FEP-521a Multikey 対応で system account も Ed25519 鍵対を併発行 (#1067 / #1068)。
 	sysAcctSvc.SetKeypairExtraRepo(keypairExtraRepo)
+	// #1704: list に remote user を追加したとき proxy account がフォローして連合
+	// 投稿を受信できるようにする enqueuer。push / create-from-public で使う。
+	listProxyFollow := coreuserlist.NewProxyFollower(sysAcctSvc, s.queueClient)
 	relaySvc := corerelay.NewService(repository.NewRelayRepository(s.db), sysAcctSvc, apRenderer, deliverService, idGen)
 
 	// AP fetch のデフォルト signer に instance.actor を配線する (#419)。
@@ -1324,6 +1328,7 @@ func (s *Server) setupRoutes() {
 	usersHandler.SetBlockingRepo(blockingRepo)
 	usersHandler.SetMutingRepo(mutingRepo)
 	usersHandler.SetRolePolicyProvider(roleService) // #1550: create-from-public userListLimit/userEachUserListsLimit
+	usersHandler.SetProxyFollow(listProxyFollow)    // #1704: create-from-public remote member proxy follow
 	usersHandler.SetRenoteMutingRepo(renoteMutingRepo)
 	usersHandler.SetFollowRequestRepo(followRequestRepo)
 	usersHandler.SetInstanceRepo(instanceRepo)
@@ -2102,6 +2107,7 @@ func (s *Server) setupRoutes() {
 	userListHandler.SetUserRepo(userRepo)                 // #1550: push NO_SUCH_USER check
 	userListHandler.SetBlockingRepo(blockingRepo)         // #1550: push YOU_HAVE_BEEN_BLOCKED check
 	userListHandler.SetFavoriteRepo(userListFavoriteRepo) // #1550: show forPublic likedCount/isLiked
+	userListHandler.SetProxyFollow(listProxyFollow)       // #1704: push remote member proxy follow
 	// list は requireCredential:false の public endpoint (userId 指定で他人の
 	// public list を閲覧可、#1550)。未認証 && userId 未指定は handler が INVALID_PARAM。
 	api.POST("/users/lists/list", userListHandler.List, middleware.RequireScope("read:account"))


### PR DESCRIPTION
## Summary

#1704。list に remote user を追加しても、その remote user を誰もフォローしていなければ連合投稿が instance に届かず list timeline に出ない**機能 gap**を解消する。upstream `UserListService.addMember` は remote target で `systemAccountService.fetch('proxy')` + `queueService.createFollowJob` を発火し、proxy account 経由で remote user の投稿を連合受信する。

## 主な変更点

- **`core/userlist.ProxyFollower`** (新規): proxy system account を `Fetch("proxy")` で取得し、各 remote user への follow job を `EnqueueFollowBulk` で enqueue (best-effort、空は no-op、fetch/enqueue 失敗は log のみで request を止めない)。
- **push / create-from-public**: `AddMember` 成功後、remote user (`!IsLocal()`) について `EnqueueProxyFollow` を発火。local user は対象外。
- `router.go` で `sysAcctSvc` + `queueClient` から `ProxyFollower` を構築し両 handler に配線。
- proxy が既に follow 済なら follow processor が `ErrAlreadyFollowing` を冪等吸収するため、重複 list 追加は無害。

## #1704 の他 2 項目について (本 PR 対象外)

- **internal event (`userListMemberAdded`/`Removed`)**: upstream は in-process `membersCache` 無効化に使うが、mk-go は対応する membership cache / consumer を持たない (handler が repo を直接引く設計)。publish しても dead path のため未実装。
- **userList stream (`userAdded`/`userRemoved`)**: upstream は per-user subscription + membership map で note を絞るため必要だが、mk-go の list 配信は fanout が post 時に `ListIDsByMember` で list topic へ push する **topic-based** 方式で membership event を必要としない。残るのは client-UI の live-update 用途のみで、channel を 2nd topic に subscribe させる追加が要る低価値項目のため見送り。

→ **C (proxy follow) のみが「remote member の連合投稿が届かない」実機能 gap を埋める**もので、A/B はその gap に寄与しない。

## テスト

- `core/userlist`: `ProxyFollower` 単体 (各 remote / 空 no-op / fetch error / enqueue error)、100%
- push: remote→follow / local→no follow、create-from-public: remote member のみ follow
- 既存 push/create-from-public test (proxyFollow 未配線) 非回帰、`internal/api/userlists` 96.6% / `internal/api/users` 90.7% / `go vet`・`gofmt` pass

## 関連

#1704。