### PR TITLE
Fix reversiGame putStone: client op id を log event に echo (#1549)

### DIFF
--- a/internal/core/federation/reversi_inbox.go
+++ b/internal/core/federation/reversi_inbox.go
@@ -258,7 +258,8 @@ func (p *Processor) handleReversiUpdate(act genericActivity) error {
 		if state.Pos == nil {
 			return errors.New("reversi update putstone: missing pos")
 		}
-		return p.reversiSvc.PutStone(ctx, game.ID, actor.ID, *state.Pos)
+		// 連合経由の手番には client op id が無いため空文字を渡す (#1549)。
+		return p.reversiSvc.PutStone(ctx, game.ID, actor.ID, *state.Pos, "")
 	}
 	return fmt.Errorf("reversi update: unknown game_state.type %q", state.Type)
 }

--- a/internal/core/federation/reversi_inbox_test.go
+++ b/internal/core/federation/reversi_inbox_test.go
@@ -772,7 +772,7 @@ func TestReversiInbox_Update_PutStone(t *testing.T) {
 	_ = b.gameRepo.Update(g)
 
 	// bob (local, black) moves first, then alice (remote, white) via Update
-	require.NoError(t, b.reversiSvc.PutStone(context.Background(), g.ID, "bob", 19))
+	require.NoError(t, b.reversiSvc.PutStone(context.Background(), g.ID, "bob", 19, ""))
 
 	body := []byte(`{
 		"type": "Update",

--- a/internal/core/reversi/coverage_boost_test.go
+++ b/internal/core/reversi/coverage_boost_test.go
@@ -149,7 +149,7 @@ func TestService_Surrender_UpdateError(t *testing.T) {
 func TestService_PutStone_UpdateError(t *testing.T) {
 	game, repo, _, svc := startedGame(t)
 	repo.updateErr = errors.New("update boom")
-	err := svc.PutStone(context.Background(), game.ID, "alice", 19)
+	err := svc.PutStone(context.Background(), game.ID, "alice", 19, "")
 	assert.Error(t, err)
 }
 
@@ -159,7 +159,7 @@ func TestService_PutStone_BadLogs(t *testing.T) {
 	// 壊れた logs を書き込む
 	game.Logs = datatypes.JSON("not-json")
 	_ = repo.Update(game)
-	err := svc.PutStone(context.Background(), game.ID, "alice", 19)
+	err := svc.PutStone(context.Background(), game.ID, "alice", 19, "")
 	assert.Error(t, err)
 }
 

--- a/internal/core/reversi/service.go
+++ b/internal/core/reversi/service.go
@@ -535,7 +535,11 @@ func (s *Service) StartGame(ctx context.Context, game *model.ReversiGame) error 
 
 // PutStone validates and applies a move, publishes the log, and ends the game
 // if the engine reports terminal state.
-func (s *Service) PutStone(ctx context.Context, gameID, userID string, pos int) error {
+// PutStone places a stone at pos for userID. opID is the client-supplied
+// operation id (stream putStone の body.id); echoed back in the "log" event so
+// the client can reconcile its optimistic move (upstream putStoneToGame の id、
+// #1549)。federation 経由など op id が無い経路は空文字を渡す。
+func (s *Service) PutStone(ctx context.Context, gameID, userID string, pos int, opID string) error {
 	game, err := s.Get(ctx, gameID)
 	if err != nil {
 		return err
@@ -621,12 +625,19 @@ func (s *Service) PutStone(ctx context.Context, gameID, userID string, pos int) 
 		s.setTurnTimer(ctx, game.ID, len(logs), game.TimeLimitForEachTurn)
 	}
 
+	// upstream putStoneToGame は log event に client op id を含める
+	// (`{...log, id: id ?? null}`、#1549)。空 opID は null で返す。
+	var logID any
+	if opID != "" {
+		logID = opID
+	}
 	s.publish(gameID, "log", map[string]any{
 		"pos":       pos,
 		"color":     colorInt,
 		"player":    myColor,
 		"time":      time.Now().UnixMilli(),
 		"operation": "put",
+		"id":        logID,
 	})
 	if engine.Turn == nil {
 		s.publish(gameID, "ended", map[string]any{

--- a/internal/core/reversi/service_federation_test.go
+++ b/internal/core/reversi/service_federation_test.go
@@ -123,7 +123,7 @@ func TestService_PutStone_DeliversPutstoneUpdateToRemote(t *testing.T) {
 	before := len(d.calls)
 
 	// alice が 1 手置く (初手は 19 などの有効な黒手)
-	require.NoError(t, svc.PutStone(ctx, game.ID, "alice", 19))
+	require.NoError(t, svc.PutStone(ctx, game.ID, "alice", 19, ""))
 
 	assert.Equal(t, before+1, len(d.calls))
 	last := d.calls[len(d.calls)-1]

--- a/internal/core/reversi/service_redis_test.go
+++ b/internal/core/reversi/service_redis_test.go
@@ -150,7 +150,7 @@ func TestService_PutStone_EndsGame_SmallBoard(t *testing.T) {
 		}
 		uid := playerIDForColor(g, *engine.Turn)
 		require.NotEmpty(t, uid)
-		require.NoError(t, svc.PutStone(context.Background(), game.ID, uid, places[0]))
+		require.NoError(t, svc.PutStone(context.Background(), game.ID, uid, places[0], ""))
 	}
 
 	final, _ := repo.FindByID(game.ID)

--- a/internal/core/reversi/service_wire_test.go
+++ b/internal/core/reversi/service_wire_test.go
@@ -395,7 +395,7 @@ func TestService_PutStone_Valid(t *testing.T) {
 
 	// alice is black (BW="1")
 	// 8x8 default board: valid black moves include pos 19 (3,2), 26 (2,3), 37 (5,4), 44 (4,5)
-	require.NoError(t, svc.PutStone(context.Background(), game.ID, "alice", 19))
+	require.NoError(t, svc.PutStone(context.Background(), game.ID, "alice", 19, ""))
 
 	got, _ := repo.FindByID(game.ID)
 	var logs [][]int
@@ -411,6 +411,32 @@ func TestService_PutStone_Valid(t *testing.T) {
 	assert.Contains(t, types, "log")
 }
 
+// #1549: putStone の log event は client op id を含める。
+func TestService_PutStone_LogIncludesOpID(t *testing.T) {
+	game, _, pub, svc := startedGame(t)
+	require.NoError(t, svc.PutStone(context.Background(), game.ID, "alice", 19, "op123"))
+	var logBody map[string]any
+	for _, e := range pub.events {
+		if e.kind == "log" {
+			logBody, _ = e.body.(map[string]any)
+		}
+	}
+	require.NotNil(t, logBody, "log event published")
+	assert.Equal(t, "op123", logBody["id"])
+}
+
+// op id が空のときは log.id を null (nil) で返す (upstream `id ?? null`)。
+func TestService_PutStone_LogOpIDNilWhenEmpty(t *testing.T) {
+	game, _, pub, svc := startedGame(t)
+	require.NoError(t, svc.PutStone(context.Background(), game.ID, "alice", 19, ""))
+	for _, e := range pub.events {
+		if e.kind == "log" {
+			body, _ := e.body.(map[string]any)
+			assert.Nil(t, body["id"], "空 opID は null")
+		}
+	}
+}
+
 // TestService_CRC32MaintainedAcrossMoves guards that StartGame stores the
 // initial board crc32 and PutStone refreshes it on every move (#1553).
 // /reversi/verify は保存済み crc32 と比較する (upstream checkCrc 互換) ため、
@@ -424,7 +450,7 @@ func TestService_CRC32MaintainedAcrossMoves(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, strconv.FormatUint(uint64(engine.CalcCRC32()), 10), *started.CRC32)
 
-	require.NoError(t, svc.PutStone(context.Background(), game.ID, "alice", 19))
+	require.NoError(t, svc.PutStone(context.Background(), game.ID, "alice", 19, ""))
 
 	moved, _ := repo.FindByID(game.ID)
 	require.NotNil(t, moved.CRC32)
@@ -437,19 +463,19 @@ func TestService_CRC32MaintainedAcrossMoves(t *testing.T) {
 func TestService_PutStone_NotYourTurn(t *testing.T) {
 	game, _, _, svc := startedGame(t)
 	// bob is white; black moves first
-	err := svc.PutStone(context.Background(), game.ID, "bob", 19)
+	err := svc.PutStone(context.Background(), game.ID, "bob", 19, "")
 	assert.ErrorIs(t, err, ErrNotYourTurn)
 }
 
 func TestService_PutStone_InvalidMove(t *testing.T) {
 	game, _, _, svc := startedGame(t)
-	err := svc.PutStone(context.Background(), game.ID, "alice", 0) // corner, not valid opening
+	err := svc.PutStone(context.Background(), game.ID, "alice", 0, "") // corner, not valid opening
 	assert.ErrorIs(t, err, ErrInvalidMove)
 }
 
 func TestService_PutStone_NotStarted(t *testing.T) {
 	game, _, _, svc := newPendingGame(t)
-	err := svc.PutStone(context.Background(), game.ID, "alice", 19)
+	err := svc.PutStone(context.Background(), game.ID, "alice", 19, "")
 	assert.ErrorIs(t, err, ErrNotStarted)
 }
 
@@ -457,13 +483,13 @@ func TestService_PutStone_AlreadyEnded(t *testing.T) {
 	game, repo, _, svc := startedGame(t)
 	game.IsEnded = true
 	_ = repo.Update(game)
-	err := svc.PutStone(context.Background(), game.ID, "alice", 19)
+	err := svc.PutStone(context.Background(), game.ID, "alice", 19, "")
 	assert.ErrorIs(t, err, ErrAlreadyEnded)
 }
 
 func TestService_PutStone_NotPlayer(t *testing.T) {
 	game, _, _, svc := startedGame(t)
-	err := svc.PutStone(context.Background(), game.ID, "carol", 19)
+	err := svc.PutStone(context.Background(), game.ID, "carol", 19, "")
 	assert.ErrorIs(t, err, ErrNotPlayer)
 }
 
@@ -732,10 +758,10 @@ func TestService_PutStone_RestoresFromLogs(t *testing.T) {
 	// Two moves: ensure the second move sees the board state from the first
 	game, _, _, svc := startedGame(t)
 	ctx := context.Background()
-	require.NoError(t, svc.PutStone(ctx, game.ID, "alice", 19)) // black
+	require.NoError(t, svc.PutStone(ctx, game.ID, "alice", 19, "")) // black
 	// after black at 19, white's valid moves include 18 (2,2) among others
 	// alice is black here so bob is white
-	require.NoError(t, svc.PutStone(ctx, game.ID, "bob", 18))
+	require.NoError(t, svc.PutStone(ctx, game.ID, "bob", 18, ""))
 }
 
 // capture UpdateError path
@@ -760,7 +786,7 @@ func TestService_Surrender_GameNotFound(t *testing.T) {
 
 func TestService_PutStone_GameNotFound(t *testing.T) {
 	_, _, _, svc := newPendingGame(t)
-	err := svc.PutStone(context.Background(), "ghost", "alice", 19)
+	err := svc.PutStone(context.Background(), "ghost", "alice", 19, "")
 	assert.ErrorIs(t, err, ErrGameNotFound)
 }
 

--- a/internal/stream/channels/reversi_game.go
+++ b/internal/stream/channels/reversi_game.go
@@ -108,7 +108,7 @@ func (c *ReversiGameChannel) OnClientMessage(msgType string, body json.RawMessag
 		if jerr := json.Unmarshal(body, &req); jerr != nil {
 			return
 		}
-		err = c.svc.PutStone(ctx, c.gameID, user.ID, req.Pos)
+		err = c.svc.PutStone(ctx, c.gameID, user.ID, req.Pos, req.ID)
 	case "surrender":
 		err = c.svc.Surrender(ctx, c.gameID, user.ID)
 	case "cancel":


### PR DESCRIPTION
## Summary

#1549 の LOW。stream `putStone` は `body.id` (client の手番操作 id) を渡すが、mk-go は受け取った `req.ID` を `PutStone` に渡さず破棄していた。upstream `putStoneToGame` は id を `"log"` event に `{...log, id: id ?? null}` で含め、client が optimistic に置いた自分の手を reconcile できるようにする。

## 主な変更点

- `Service.PutStone` に `opID` 引数を追加し、`"log"` event body に `"id": opID|null` を含める (空 opID は null)。
- stream channel は `req.ID` を、federation 経由 (op id 無し) は空文字を渡す。

## テスト

- `TestService_PutStone_LogIncludesOpID` (op id echo) / `_LogOpIDNilWhenEmpty` (空→null)
- signature 変更は build + go vet + `reversi`/`federation`/`stream` 全テストで検証。既存テスト非回帰。

## 再検証メモ (#1549 全体)

この issue の audit は **#1549 の publisher PR より前**のもので、HIGH 4件 (hashtag/channel/antenna/roleTimeline publisher + gate) と一部 MED/LOW (drive folder events, channel/hashtag anon gate) は既に実装済 (STALE)。本 PR は REAL と再確認した項目の1つ。残る REAL (main mute filter / admin abuse report / chat react-unreact / chat read / userList events) は後続 PR で対応。

## 関連

#1549。

🤖 Generated with [Claude Code](https://claude.com/claude-code)