### PR TITLE
Fix chat stream: react/unreact イベント発火 + read を会話全体既読に (#1549)

### DIFF
--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -943,8 +943,8 @@ func (h *Handler) ReactionsCreate(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.MessageID == "" || req.Reaction == "" {
 		return apierr.JSONInvalidParam(c)
 	}
-	reaction := user.ID + "/" + req.Reaction
-	if err := h.repo.AddReaction(req.MessageID, reaction); err != nil {
+	// service 経由で AddReaction + react stream event を発火する (#1549)。
+	if err := h.svc.React(c.Request().Context(), req.MessageID, user, req.Reaction); err != nil {
 		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)
@@ -961,8 +961,8 @@ func (h *Handler) ReactionsDelete(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.MessageID == "" || req.Reaction == "" {
 		return apierr.JSONInvalidParam(c)
 	}
-	reaction := user.ID + "/" + req.Reaction
-	if err := h.repo.RemoveReaction(req.MessageID, reaction); err != nil {
+	// service 経由で RemoveReaction + unreact stream event を発火する (#1549)。
+	if err := h.svc.Unreact(c.Request().Context(), req.MessageID, user, req.Reaction); err != nil {
 		return apierr.JSONInternalError(c)
 	}
 	return c.NoContent(http.StatusNoContent)

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -633,19 +633,20 @@ func TestMessagesSearch(t *testing.T) {
 }
 
 func TestReactionsCreate(t *testing.T) {
-	h, _ := newTestHandler()
+	h, repo := newHandlerWithService(t)
 	// missing params → 400
 	assert.Equal(t, http.StatusBadRequest, post(h.ReactionsCreate, `{}`, u1).Code)
-	// valid
+	// #1549: React は service 経由で message を引くので seed が要る。
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "sender", Reads: pq.StringArray{}, Reactions: pq.StringArray{}}
 	rec := post(h.ReactionsCreate, `{"messageId":"m1","reaction":"👍"}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
 func TestReactionsDelete(t *testing.T) {
-	h, _ := newTestHandler()
+	h, repo := newHandlerWithService(t)
 	// missing params → 400
 	assert.Equal(t, http.StatusBadRequest, post(h.ReactionsDelete, `{}`, u1).Code)
-	// valid
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "sender", Reads: pq.StringArray{}, Reactions: pq.StringArray{}}
 	rec := post(h.ReactionsDelete, `{"messageId":"m1","reaction":"👍"}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }

--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -78,6 +78,8 @@ const (
 	EventDeleted = "deleted"
 	EventEdited  = "edited"
 	EventRead    = "read"
+	EventReact   = "react"
+	EventUnreact = "unreact"
 )
 
 // ModeratorChecker reports whether a given user has moderator privileges.
@@ -1001,6 +1003,65 @@ func (s *Service) MarkReadByMessageID(ctx context.Context, userID, messageID str
 		}
 	}
 	return nil
+}
+
+// React adds a reaction to a chat message and publishes a `react` stream event
+// to the room (or both DM peers) so clients update reactions live (#1549,
+// upstream ChatService.react)。reaction は reactor.ID+"/"+emoji で永続化し、
+// stream event には raw emoji + reactor (UserLite) を載せる。
+func (s *Service) React(ctx context.Context, messageID string, reactor *model.User, emoji string) error {
+	msg, err := s.repo.FindMessageByID(messageID)
+	if err != nil {
+		return ErrNotFound
+	}
+	if err := s.repo.AddReaction(messageID, reactor.ID+"/"+emoji); err != nil {
+		return fmt.Errorf("add reaction: %w", err)
+	}
+	s.publishReaction(ctx, msg, EventReact, reactor, emoji)
+	return nil
+}
+
+// Unreact removes a reaction and publishes an `unreact` stream event (#1549)。
+func (s *Service) Unreact(ctx context.Context, messageID string, reactor *model.User, emoji string) error {
+	msg, err := s.repo.FindMessageByID(messageID)
+	if err != nil {
+		return ErrNotFound
+	}
+	if err := s.repo.RemoveReaction(messageID, reactor.ID+"/"+emoji); err != nil {
+		return fmt.Errorf("remove reaction: %w", err)
+	}
+	s.publishReaction(ctx, msg, EventUnreact, reactor, emoji)
+	return nil
+}
+
+func (s *Service) publishReaction(ctx context.Context, msg *model.ChatMessage, eventType string, reactor *model.User, emoji string) {
+	if s.publisher == nil {
+		return
+	}
+	body := map[string]any{
+		"messageId": msg.ID,
+		"reaction":  emoji,
+		"user":      entity.PackUserLite(reactor),
+	}
+	switch {
+	case msg.ToRoomID != nil && *msg.ToRoomID != "":
+		s.publisher.PublishRoomMessage(ctx, *msg.ToRoomID, eventType, body)
+	case msg.ToUserID != nil && *msg.ToUserID != "":
+		s.publisher.PublishUserMessage(ctx, msg.FromUserID, *msg.ToUserID, eventType, body)
+	}
+}
+
+// ReadUserChat marks the whole DM conversation with otherID as read for readerID
+// (#1549, upstream readUserChatMessage)。stream channel の `read` (id 無し) が
+// 会話全体既読にするために使う。
+func (s *Service) ReadUserChat(_ context.Context, readerID, otherID string) error {
+	return s.repo.MarkAllReadFromUser(readerID, otherID)
+}
+
+// ReadRoomChat marks the whole room conversation as read for readerID (#1549,
+// upstream readRoomChatMessage)。
+func (s *Service) ReadRoomChat(_ context.Context, readerID, roomID string) error {
+	return s.repo.MarkAllReadInRoom(readerID, roomID)
 }
 
 // --- Queries used by the WebSocket channel for membership / auth checks ---

--- a/internal/core/chat/service_test.go
+++ b/internal/core/chat/service_test.go
@@ -590,3 +590,62 @@ func TestHasPermissionToViewRoomInfo_ModeratorCheckerNotConsulted(t *testing.T) 
 	require.NoError(t, err)
 	assert.False(t, ok)
 }
+
+// --- #1549: chat react / unreact stream events ---
+
+func TestReact_DMPublishesReact(t *testing.T) {
+	svc, repo, pub := newSvc(t)
+	to := "bob"
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "carol", ToUserID: &to}
+	reactor := &model.User{ID: "alice", Username: "alice"}
+	require.NoError(t, svc.React(context.Background(), "m1", reactor, "👍"))
+	require.Len(t, pub.userCalls, 1)
+	assert.Equal(t, corechat.EventReact, pub.userCalls[0].eventType)
+	body, ok := pub.userCalls[0].body.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "m1", body["messageId"])
+	assert.Equal(t, "👍", body["reaction"])
+	assert.NotNil(t, body["user"], "reactor が UserLite で含まれる")
+}
+
+func TestReact_RoomPublishesReact(t *testing.T) {
+	svc, repo, pub := newSvc(t)
+	room := "r1"
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "carol", ToRoomID: &room}
+	require.NoError(t, svc.React(context.Background(), "m1", &model.User{ID: "alice"}, "👍"))
+	require.Len(t, pub.roomCalls, 1)
+	assert.Equal(t, corechat.EventReact, pub.roomCalls[0].eventType)
+	assert.Empty(t, pub.userCalls)
+}
+
+func TestUnreact_PublishesUnreact(t *testing.T) {
+	svc, repo, pub := newSvc(t)
+	to := "bob"
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "carol", ToUserID: &to}
+	require.NoError(t, svc.Unreact(context.Background(), "m1", &model.User{ID: "alice"}, "👍"))
+	require.Len(t, pub.userCalls, 1)
+	assert.Equal(t, corechat.EventUnreact, pub.userCalls[0].eventType)
+}
+
+func TestReact_MessageNotFound(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	err := svc.React(context.Background(), "ghost", &model.User{ID: "alice"}, "👍")
+	assert.ErrorIs(t, err, corechat.ErrNotFound)
+}
+
+func TestUnreact_MessageNotFound(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	err := svc.Unreact(context.Background(), "ghost", &model.User{ID: "alice"}, "👍")
+	assert.ErrorIs(t, err, corechat.ErrNotFound)
+}
+
+// ReadUserChat / ReadRoomChat は会話全体既読 (repo へ委譲、no-error)。
+func TestReadUserChat_NoError(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	assert.NoError(t, svc.ReadUserChat(context.Background(), "alice", "bob"))
+}
+
+func TestReadRoomChat_NoError(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	assert.NoError(t, svc.ReadRoomChat(context.Background(), "alice", "r1"))
+}

--- a/internal/stream/channels/chat_room.go
+++ b/internal/stream/channels/chat_room.go
@@ -89,13 +89,9 @@ func (c *ChatRoomChannel) OnClientMessage(msgType string, body json.RawMessage) 
 	}
 	switch msgType {
 	case "read":
-		var req struct {
-			ID string `json:"id"`
-		}
-		if err := json.Unmarshal(body, &req); err != nil || req.ID == "" {
-			return
-		}
-		if err := c.svc.MarkReadByMessageID(context.Background(), user.ID, req.ID); err != nil {
+		// upstream chat-room.ts onMessage('read') は body を見ず部屋全体を既読化
+		// する (#1549)。
+		if err := c.svc.ReadRoomChat(context.Background(), user.ID, c.roomID); err != nil {
 			slog.Info("chat room channel: read failed",
 				"user", user.ID, "room", c.roomID, "err", err)
 		}

--- a/internal/stream/channels/chat_user.go
+++ b/internal/stream/channels/chat_user.go
@@ -81,13 +81,10 @@ func (c *ChatUserChannel) OnClientMessage(msgType string, body json.RawMessage) 
 	}
 	switch msgType {
 	case "read":
-		var req struct {
-			ID string `json:"id"`
-		}
-		if err := json.Unmarshal(body, &req); err != nil || req.ID == "" {
-			return
-		}
-		if err := c.svc.MarkReadByMessageID(context.Background(), user.ID, req.ID); err != nil {
+		// upstream chat-user.ts onMessage('read') は body を見ず会話全体を既読化
+		// する (#1549)。message id 必須だった旧実装は id 無し read を no-op にして
+		// しまい unread が消えなかった。
+		if err := c.svc.ReadUserChat(context.Background(), user.ID, c.otherID); err != nil {
 			slog.Info("chat user channel: read failed",
 				"user", user.ID, "other", c.otherID, "err", err)
 		}


### PR DESCRIPTION
## Summary

#1549 の M4 (chat react/unreact stream events) + L1 (chat read 会話全体既読)。

- **react/unreact (M4)**: `ReactionsCreate`/`ReactionsDelete` を repo 直叩き → `service.React`/`Unreact` 経由に変更。`AddReaction`/`RemoveReaction` 後に chatRoom (room message) / chatUser (DM、両方向) stream へ `react`/`unreact` event (`{messageId, reaction(raw emoji), user(UserLite)}`) を publish する (upstream `ChatService.react`/`unreact`)。従来は stream event を一切流さず、リアクションが live 反映されなかった。
- **read 会話全体 (L1)**: `chat_user`/`chat_room` channel の `read` を、body の message id 必須 → **id 無視で会話/部屋全体既読** に変更 (`svc.ReadUserChat`/`ReadRoomChat` → 既存 repo の `MarkAllReadFromUser`/`MarkAllReadInRoom`)。upstream `chat-user.ts`/`chat-room.ts` の `onMessage('read')` は body を見ず会話全体を既読化する。従来は id 無し read が no-op で unread が消えなかった。REST `messages/read` (id 指定) は従来どおり。

## テスト

- service: `TestReact_DMPublishesReact` / `_RoomPublishesReact` / `TestUnreact_PublishesUnreact` / `_MessageNotFound` / `TestReadUserChat_NoError` / `_RoomChat`
- handler reaction test を svc-wired + message seed に更新、既存 channel read smoke test は body 無視後も pass
- `core/chat` 90.9% / `api/chat` 93.2% / `stream/channels` 91.5% / `go vet`・`gofmt` pass

## 補足 (本 PR 範囲外の pre-existing gap)

DM の react event に `user` を載せる点は upstream (room のみ) と差があるが misskey-js 型上 optional で無害。react の権限チェック / emoji 正規化欠落は変更前から同一の pre-existing gap。

## 再検証メモ (#1549)

この issue の audit は **#1549 publisher PR より前**で、HIGH 4件 (hashtag/channel/antenna/roleTimeline) と一部 MED/LOW は既に実装済 (STALE)。本 PR は REAL 項目の chat 分。残る REAL (main mute filter / admin abuse report / userList events) は後続 PR。

## 関連

#1549。

🤖 Generated with [Claude Code](https://claude.com/claude-code)