### PR TITLE
Fix admin stream: newAbuseUserReport 配信 + per-user topic 化 (#1549)

### DIFF
--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -44,6 +44,8 @@ type Handler struct {
 	blockingRepo         repository.BlockingRepository
 	rolePolicyProvider   RolePolicyProvider
 	proxyFollow          ProxyFollowEnqueuer
+	moderatorLister      ModeratorLister
+	abuseNotifier        AbuseReportNotifier
 	mutingRepo           repository.MutingRepository
 	renoteMutingRepo     repository.RenoteMutingRepository
 	followRequestRepo    repository.FollowRequestRepository
@@ -133,6 +135,26 @@ type ModeratorChecker interface {
 // nil keeps the gate strict (= test fixture / unwired)。
 func (h *Handler) SetModeratorChecker(m ModeratorChecker) {
 	h.moderatorChecker = m
+}
+
+// ModeratorLister lists moderator/administrator users for abuse-report fanout
+// (#1549)。実装は core/role.Service.GetModerators。
+type ModeratorLister interface {
+	GetModerators() ([]*model.User, error)
+}
+
+// AbuseReportNotifier publishes admin stream events (newAbuseUserReport) to a
+// moderator's per-user admin stream (#1549)。実装は stream.AdminStreamPublisher。
+type AbuseReportNotifier interface {
+	PublishAdminEvent(userID, eventType string, body any)
+}
+
+// SetAbuseReportFanout wires the moderator lister + admin event notifier so
+// report-abuse fans out newAbuseUserReport to every moderator/admin (#1549).
+// 片方でも nil なら fanout を skip する (= test / 旧挙動)。
+func (h *Handler) SetAbuseReportFanout(lister ModeratorLister, notifier AbuseReportNotifier) {
+	h.moderatorLister = lister
+	h.abuseNotifier = notifier
 }
 
 // SetUserRepo wires a UserRepository so users/notes filters out notes that

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -199,7 +199,36 @@ func (h *Handler) ReportAbuse(c echo.Context) error {
 	if err := h.abuseRepo.Create(report); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	// 各 moderator/admin の admin stream へ newAbuseUserReport を配信する
+	// (#1549, upstream AbuseReportNotificationService)。best-effort。
+	h.notifyModeratorsOfAbuseReport(report)
 	return c.NoContent(http.StatusNoContent)
+}
+
+// notifyModeratorsOfAbuseReport publishes a newAbuseUserReport admin stream
+// event to every moderator/administrator (#1549)。lister / notifier 未配線時は
+// no-op。失敗は best-effort で握り潰す (report 自体は永続化済)。
+func (h *Handler) notifyModeratorsOfAbuseReport(report *model.AbuseUserReport) {
+	if h.moderatorLister == nil || h.abuseNotifier == nil {
+		return
+	}
+	mods, err := h.moderatorLister.GetModerators()
+	if err != nil {
+		slog.Warn("report-abuse: list moderators failed", "err", err)
+		return
+	}
+	// upstream AbuseReportNotificationService.notifyAdminStream は
+	// {id, targetUserId, reporterId, comment} のみを送る (misskey-js
+	// newAbuseUserReport 型も同4 field)。shape を厳密に揃える。
+	body := map[string]any{
+		"id":           report.ID,
+		"targetUserId": report.TargetUserID,
+		"reporterId":   report.ReporterID,
+		"comment":      report.Comment,
+	}
+	for _, m := range mods {
+		h.abuseNotifier.PublishAdminEvent(m.ID, "newAbuseUserReport", body)
+	}
 }
 
 // Reactions handles POST /api/users/reactions.

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -202,6 +202,32 @@ func TestReportAbuse_NilRepo(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
+// #1549: report-abuse は各 moderator の adminStream へ newAbuseUserReport を配信。
+type stubModeratorLister struct{ mods []*model.User }
+
+func (s stubModeratorLister) GetModerators() ([]*model.User, error) { return s.mods, nil }
+
+type stubAbuseNotifier struct {
+	calls []struct{ userID, eventType string }
+}
+
+func (s *stubAbuseNotifier) PublishAdminEvent(userID, eventType string, _ any) {
+	s.calls = append(s.calls, struct{ userID, eventType string }{userID, eventType})
+}
+
+func TestReportAbuse_NotifiesModerators(t *testing.T) {
+	h, _, _ := newExtraHandler(t)
+	notifier := &stubAbuseNotifier{}
+	h.SetAbuseReportFanout(stubModeratorLister{mods: []*model.User{{ID: "mod1"}, {ID: "mod2"}}}, notifier)
+
+	rec := postExtra(h.ReportAbuse, `{"userId":"u2","comment":"spam"}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Len(t, notifier.calls, 2)
+	assert.Equal(t, "newAbuseUserReport", notifier.calls[0].eventType)
+	assert.ElementsMatch(t, []string{"mod1", "mod2"},
+		[]string{notifier.calls[0].userID, notifier.calls[1].userID})
+}
+
 // --- Reactions ---
 
 func TestReactions_Success(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1940,6 +1940,9 @@ func (s *Server) setupRoutes() {
 	drivePublisher := stream.NewDrivePublisher(streamPubSub)
 	reversiPublisher := stream.NewReversiGamePublisher(streamPubSub)
 	mainStreamPublisher := stream.NewMainStreamPublisher(streamPubSub)
+	// #1549: report-abuse が各 moderator の adminStream:<id> へ newAbuseUserReport
+	// を配信できるよう admin publisher + moderator lister を usersHandler に配線。
+	usersHandler.SetAbuseReportFanout(roleService, stream.NewAdminStreamPublisher(streamPubSub))
 
 	// server / queue stats publishers (#344)。起動時から tick を回して
 	// `serverStats` / `queueStats` トピックへ定期 publish する。

--- a/internal/stream/admin_publisher.go
+++ b/internal/stream/admin_publisher.go
@@ -1,0 +1,39 @@
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+)
+
+// AdminStreamPublisher serializes `{type, body}` envelopes to the Redis topic
+// `adminStream:{userID}` which the per-user `admin` WebSocket channel
+// subscribes to (#1549). Used to emit moderator events such as
+// `newAbuseUserReport` to a single moderator/administrator.
+type AdminStreamPublisher struct {
+	pub PubSubPublisher
+}
+
+// NewAdminStreamPublisher constructs an AdminStreamPublisher backed by the given
+// PubSubPublisher.
+func NewAdminStreamPublisher(pub PubSubPublisher) *AdminStreamPublisher {
+	return &AdminStreamPublisher{pub: pub}
+}
+
+// PublishAdminEvent emits an event to `adminStream:{userID}` with a
+// `{type, body}` envelope, matching TS `admin` stream event shape.
+func (p *AdminStreamPublisher) PublishAdminEvent(userID, eventType string, body any) {
+	if p.pub == nil || userID == "" || eventType == "" {
+		return
+	}
+	env := map[string]any{"type": eventType, "body": body}
+	raw, err := json.Marshal(env)
+	if err != nil {
+		slog.Warn("admin publisher: marshal failed", "event", eventType, "err", err)
+		return
+	}
+	topic := "adminStream:" + userID
+	if err := p.pub.Publish(context.Background(), topic, json.RawMessage(raw)); err != nil {
+		slog.Warn("admin publisher: publish failed", "topic", topic, "err", err)
+	}
+}

--- a/internal/stream/admin_publisher_test.go
+++ b/internal/stream/admin_publisher_test.go
@@ -1,0 +1,55 @@
+package stream
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdminStreamPublisher_PublishEnvelope(t *testing.T) {
+	bus := &capturingPubSub{}
+	p := NewAdminStreamPublisher(bus)
+	p.PublishAdminEvent("mod1", "newAbuseUserReport", map[string]any{"id": "r1", "comment": "spam"})
+
+	require.Len(t, bus.calls, 1)
+	assert.Equal(t, "adminStream:mod1", bus.calls[0].topic)
+
+	raw, ok := bus.calls[0].payload.(json.RawMessage)
+	require.True(t, ok)
+	var env struct {
+		Type string          `json:"type"`
+		Body json.RawMessage `json:"body"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &env))
+	assert.Equal(t, "newAbuseUserReport", env.Type)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(env.Body, &body))
+	assert.Equal(t, "r1", body["id"])
+	assert.Equal(t, "spam", body["comment"])
+}
+
+func TestAdminStreamPublisher_NilPub(t *testing.T) {
+	p := NewAdminStreamPublisher(nil)
+	p.PublishAdminEvent("mod1", "any", nil) // no panic
+}
+
+func TestAdminStreamPublisher_EmptyUserID(t *testing.T) {
+	bus := &capturingPubSub{}
+	NewAdminStreamPublisher(bus).PublishAdminEvent("", "newAbuseUserReport", nil)
+	assert.Empty(t, bus.calls)
+}
+
+func TestAdminStreamPublisher_EmptyEventType(t *testing.T) {
+	bus := &capturingPubSub{}
+	NewAdminStreamPublisher(bus).PublishAdminEvent("mod1", "", nil)
+	assert.Empty(t, bus.calls)
+}
+
+func TestAdminStreamPublisher_PublishError(t *testing.T) {
+	bus := &capturingPubSub{err: errors.New("pub boom")}
+	NewAdminStreamPublisher(bus).PublishAdminEvent("mod1", "newAbuseUserReport", nil) // logged, not panicked
+}

--- a/internal/stream/channels/admin.go
+++ b/internal/stream/channels/admin.go
@@ -16,6 +16,7 @@ type AdminRoleChecker interface {
 type AdminChannel struct {
 	ctx         stream.ChannelContext
 	roleChecker AdminRoleChecker
+	topic       string
 	connected   bool
 }
 
@@ -44,7 +45,10 @@ func (c *AdminChannel) Init(_ json.RawMessage) error {
 		return stream.ErrInvalidParams
 	}
 	c.connected = true
-	c.ctx.Subscribe("adminStream")
+	// upstream admin.ts は per-user topic `adminStream:${userId}` を購読する
+	// (#1549)。各 moderator/admin は自分宛の newAbuseUserReport 等のみ受信する。
+	c.topic = "adminStream:" + user.ID
+	c.ctx.Subscribe(c.topic)
 	return nil
 }
 
@@ -70,7 +74,7 @@ func (c *AdminChannel) ShouldShare() bool { return true }
 func (c *AdminChannel) RequiredPermission() string { return "read:admin:stream" }
 
 func (c *AdminChannel) Dispose() {
-	if c.connected {
-		c.ctx.Unsubscribe("adminStream")
+	if c.connected && c.topic != "" {
+		c.ctx.Unsubscribe(c.topic)
 	}
 }

--- a/internal/stream/channels/new_channels_test.go
+++ b/internal/stream/channels/new_channels_test.go
@@ -618,7 +618,8 @@ func TestAdmin_Lifecycle(t *testing.T) {
 	ctx := newCtx(&model.User{ID: "admin1"})
 	ch := newAdminCh(ctx, true)
 	ch.Init(nil)
-	assert.Equal(t, []string{"adminStream"}, ctx.subs)
+	// #1549: per-user topic adminStream:<userId> を購読する。
+	assert.Equal(t, []string{"adminStream:admin1"}, ctx.subs)
 
 	// エンベロープ展開
 	ch.OnRedisEvent([]byte(`{"type":"newReport","body":{"id":"r1"}}`))
@@ -626,7 +627,7 @@ func TestAdmin_Lifecycle(t *testing.T) {
 	assert.Equal(t, "newReport", ctx.sentType[0])
 
 	ch.Dispose()
-	assert.Equal(t, []string{"adminStream"}, ctx.unsubs)
+	assert.Equal(t, []string{"adminStream:admin1"}, ctx.unsubs)
 }
 
 func TestAdmin_NoAuth(t *testing.T) {


### PR DESCRIPTION
## Summary

#1549 の M2。admin channel は global `adminStream` を購読し、abuse report 作成時に何も publish していなかった。upstream は per-user `adminStream:${userId}` を購読し、`AbuseReportNotificationService` が各 moderator/admin へ `newAbuseUserReport` を配信する。

## 主な変更点

- **admin channel**: 購読 topic を global `adminStream` → per-user `adminStream:<userId>` に変更 (MainChannel と同じ per-connection dispatcher 前提で `ShouldShare` 維持、`topic` field 追加で Dispose も追従)。
- **`AdminStreamPublisher`** (新設): `PublishAdminEvent(userID, eventType, body)` → `{type,body}` を `adminStream:<userID>` へ publish (`MainStreamPublisher` と同 pattern)。
- **`ReportAbuse`**: `abuseRepo.Create` 後に全 moderator (`roleService.GetModerators`) の adminStream へ `newAbuseUserReport` (`{id, targetUserId, reporterId, comment}` = upstream と同 shape) を best-effort 配信。
- `users.Handler` に `ModeratorLister` / `AbuseReportNotifier` を `SetAbuseReportFanout` で配線。

## テスト

- `TestAdminStreamPublisher_*` (envelope / nil / empty / error)
- `TestReportAbuse_NotifiesModerators` (全 moderator へ newAbuseUserReport)
- admin channel per-user topic test 更新、既存 ReportAbuse test (未配線で no-op) 非回帰
- `stream` 90.5% / `stream/channels` 91.6% / `api/users` 90.7% / `go vet`・`gofmt` pass

## 関連

#1549。残る REAL は main mute filter (M5) / userList events (M1)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)