### PR TITLE
Fix userList stream: userAdded/userRemoved membership event を配信 (#1549)

### DIFF
--- a/internal/api/userlists/handler.go
+++ b/internal/api/userlists/handler.go
@@ -25,6 +25,7 @@ type Handler struct {
 	blockingRepo       repository.BlockingRepository
 	favoriteRepo       UserListFavoriteReader
 	proxyFollow        ProxyFollowEnqueuer
+	userListEventPub   UserListEventPublisher
 }
 
 // RolePolicyProvider abstracts role-policy lookup for `userListLimit` /
@@ -85,6 +86,19 @@ type ProxyFollowEnqueuer interface {
 // pushed to a list (#1704). nil 時は proxy follow を skip する。
 func (h *Handler) SetProxyFollow(p ProxyFollowEnqueuer) {
 	h.proxyFollow = p
+}
+
+// UserListEventPublisher publishes userAdded/userRemoved membership events to a
+// list's stream so the userList WS channel updates members live (#1549)。実装は
+// stream.UserListStreamPublisher。
+type UserListEventPublisher interface {
+	PublishUserListEvent(listID, eventType string, body any)
+}
+
+// SetUserListEventPublisher wires the membership event publisher used by
+// push/pull (#1549). nil 時は membership event を発火しない。
+func (h *Handler) SetUserListEventPublisher(p UserListEventPublisher) {
+	h.userListEventPub = p
 }
 
 // List handles POST /api/users/lists/list.
@@ -329,6 +343,12 @@ func (h *Handler) Push(c echo.Context) error {
 	if h.proxyFollow != nil && target != nil && !target.IsLocal() {
 		h.proxyFollow.EnqueueProxyFollow([]string{req.UserID})
 	}
+	// userList channel に userAdded を流して member list を live 更新する
+	// (#1549、upstream UserListService.addMember の publishUserListStream)。
+	// body は packed UserLite (= upstream userEntityService.pack(target))。
+	if h.userListEventPub != nil && target != nil {
+		h.userListEventPub.PublishUserListEvent(list.ID, "userAdded", entity.PackUserLite(target))
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -355,13 +375,21 @@ func (h *Handler) Pull(c echo.Context) error {
 	// upstream pull.ts は removeMember 前に対象 user の存在を getterService.getUser
 	// で検証し、不在なら NO_SUCH_USER を返す (#1550)。userRepo 未配線の test 経路
 	// では skip する。
+	var target *model.User
 	if h.userRepo != nil {
-		if _, uerr := h.userRepo.FindByID(req.UserID); uerr != nil {
+		var uerr error
+		target, uerr = h.userRepo.FindByID(req.UserID)
+		if uerr != nil {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "588e7f72-c744-4a61-b180-d354e912bda2"))
 		}
 	}
 	if err := h.repo.RemoveMember(req.ListID, req.UserID); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	// userList channel に userRemoved を流して member list を live 更新する
+	// (#1549、upstream UserListService.removeMember の publishUserListStream)。
+	if h.userListEventPub != nil && target != nil {
+		h.userListEventPub.PublishUserListEvent(list.ID, "userRemoved", entity.PackUserLite(target))
 	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/userlists/handler_test.go
+++ b/internal/api/userlists/handler_test.go
@@ -227,6 +227,73 @@ func TestPush_LocalUserNoProxyFollow(t *testing.T) {
 	assert.Equal(t, 0, pf.hits, "local user は proxy follow しない")
 }
 
+// stubUserListEventPublisher records PublishUserListEvent calls for #1549 tests.
+type stubUserListEventPublisher struct {
+	listIDs []string
+	types   []string
+	bodies  []any
+}
+
+func (s *stubUserListEventPublisher) PublishUserListEvent(listID, eventType string, body any) {
+	s.listIDs = append(s.listIDs, listID)
+	s.types = append(s.types, eventType)
+	s.bodies = append(s.bodies, body)
+}
+
+// #1549: push が成功したら userAdded membership event を publish する。
+func TestPush_PublishesUserAdded(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "owner"}
+	userRepo := testutil.NewMockUserRepository()
+	require.NoError(t, userRepo.Create(&model.User{ID: "u2", Username: "bob"}))
+	h.SetUserRepo(userRepo)
+	h.SetBlockingRepo(testutil.NewMockBlockingRepository())
+	pub := &stubUserListEventPublisher{}
+	h.SetUserListEventPublisher(pub)
+
+	rec := doPost(h.Push, `{"listId":"l1","userId":"u2"}`, &model.User{ID: "owner"})
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Len(t, pub.types, 1)
+	assert.Equal(t, "l1", pub.listIDs[0])
+	assert.Equal(t, "userAdded", pub.types[0])
+}
+
+// #1549: push が AddMember 失敗 (ALREADY_ADDED) で終わるときは userAdded を
+// publish しない。
+func TestPush_NoPublishOnAlreadyAdded(t *testing.T) {
+	repo := &duplicateAddMemberRepo{testutil.NewMockUserListRepository()}
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "owner"}
+	idGen, _ := id.NewGenerator("aidx")
+	h := userlists.NewHandler(repo, idGen)
+	userRepo := testutil.NewMockUserRepository()
+	require.NoError(t, userRepo.Create(&model.User{ID: "u2"}))
+	h.SetUserRepo(userRepo)
+	h.SetBlockingRepo(testutil.NewMockBlockingRepository())
+	pub := &stubUserListEventPublisher{}
+	h.SetUserListEventPublisher(pub)
+
+	rec := doPost(h.Push, `{"listId":"l1","userId":"u2"}`, &model.User{ID: "owner"})
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Empty(t, pub.types, "AddMember 失敗時は userAdded を publish しない")
+}
+
+// #1549: pull が成功したら userRemoved membership event を publish する。
+func TestPull_PublishesUserRemoved(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "owner"}
+	userRepo := testutil.NewMockUserRepository()
+	require.NoError(t, userRepo.Create(&model.User{ID: "u2", Username: "bob"}))
+	h.SetUserRepo(userRepo)
+	pub := &stubUserListEventPublisher{}
+	h.SetUserListEventPublisher(pub)
+
+	rec := doPost(h.Pull, `{"listId":"l1","userId":"u2"}`, &model.User{ID: "owner"})
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Len(t, pub.types, 1)
+	assert.Equal(t, "l1", pub.listIDs[0])
+	assert.Equal(t, "userRemoved", pub.types[0])
+}
+
 // #1550: push は membership.userListUserId に list owner を設定する。
 func TestPush_SetsUserListUserID(t *testing.T) {
 	h, repo := newTestHandler(t)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2106,11 +2106,12 @@ func (s *Server) setupRoutes() {
 
 	// User lists (Phase 6)
 	userListHandler := apiuserlists.NewHandler(userListRepo, idGen)
-	userListHandler.SetRolePolicyProvider(roleService)    // #1029: userListLimit / userEachUserListsLimit
-	userListHandler.SetUserRepo(userRepo)                 // #1550: push NO_SUCH_USER check
-	userListHandler.SetBlockingRepo(blockingRepo)         // #1550: push YOU_HAVE_BEEN_BLOCKED check
-	userListHandler.SetFavoriteRepo(userListFavoriteRepo) // #1550: show forPublic likedCount/isLiked
-	userListHandler.SetProxyFollow(listProxyFollow)       // #1704: push remote member proxy follow
+	userListHandler.SetRolePolicyProvider(roleService)                                         // #1029: userListLimit / userEachUserListsLimit
+	userListHandler.SetUserRepo(userRepo)                                                      // #1550: push NO_SUCH_USER check
+	userListHandler.SetBlockingRepo(blockingRepo)                                              // #1550: push YOU_HAVE_BEEN_BLOCKED check
+	userListHandler.SetFavoriteRepo(userListFavoriteRepo)                                      // #1550: show forPublic likedCount/isLiked
+	userListHandler.SetProxyFollow(listProxyFollow)                                            // #1704: push remote member proxy follow
+	userListHandler.SetUserListEventPublisher(stream.NewUserListStreamPublisher(streamPubSub)) // #1549: push/pull userAdded/userRemoved
 	// list は requireCredential:false の public endpoint (userId 指定で他人の
 	// public list を閲覧可、#1550)。未認証 && userId 未指定は handler が INVALID_PARAM。
 	api.POST("/users/lists/list", userListHandler.List, middleware.RequireScope("read:account"))

--- a/internal/stream/channels/new_channels_test.go
+++ b/internal/stream/channels/new_channels_test.go
@@ -391,13 +391,33 @@ func TestUserList_Lifecycle(t *testing.T) {
 	ctx := newCtx(&model.User{ID: "alice"})
 	ch := NewUserList(ctx)
 	ch.Init(json.RawMessage(`{"listId":"l1"}`))
-	assert.Equal(t, []string{"userListTimeline:l1"}, ctx.subs)
+	// note 配信 topic と membership event topic の両方を subscribe する (#1549)。
+	assert.Equal(t, []string{"userListTimeline:l1", "userListStream:l1"}, ctx.subs)
 
 	ch.OnRedisEvent([]byte(`{"id":"n1"}`))
 	require.Len(t, ctx.sentType, 1)
 
 	ch.Dispose()
-	assert.Equal(t, []string{"userListTimeline:l1"}, ctx.unsubs)
+	assert.Equal(t, []string{"userListTimeline:l1", "userListStream:l1"}, ctx.unsubs)
+}
+
+// #1549: userListStream: topic に流れる userAdded/userRemoved envelope は
+// note filter を経由せず、そのまま client に forward される。
+func TestUserList_MembershipEventForwarded(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewUserList(ctx)
+	ch.Init(json.RawMessage(`{"listId":"l1"}`))
+
+	ch.OnRedisEvent([]byte(`{"type":"userAdded","body":{"id":"u2","username":"bob"}}`))
+	require.Len(t, ctx.sentType, 1)
+	assert.Equal(t, "userAdded", ctx.sentType[0])
+	body, ok := ctx.sentBody[0].(json.RawMessage)
+	require.True(t, ok)
+	assert.Contains(t, string(body), "bob")
+
+	ch.OnRedisEvent([]byte(`{"type":"userRemoved","body":{"id":"u2","username":"bob"}}`))
+	require.Len(t, ctx.sentType, 2)
+	assert.Equal(t, "userRemoved", ctx.sentType[1])
 }
 
 func TestUserList_NoAuth(t *testing.T) {
@@ -420,7 +440,7 @@ func TestUserList_WithReplies(t *testing.T) {
 	ctx := newCtx(&model.User{ID: "alice"})
 	ch := NewUserList(ctx)
 	ch.Init(json.RawMessage(`{"listId":"l1","withReplies":true}`))
-	assert.Equal(t, []string{"userListTimeline:l1"}, ctx.subs)
+	assert.Equal(t, []string{"userListTimeline:l1", "userListStream:l1"}, ctx.subs)
 
 	// リプライが通過する
 	ch.OnRedisEvent([]byte(`{"text":"reply","replyId":"p1"}`))

--- a/internal/stream/channels/user_list.go
+++ b/internal/stream/channels/user_list.go
@@ -22,9 +22,10 @@ import (
 // `model.UserListMembership.WithReplies` 追加と Init での map snapshot
 // 取得を伴うので別 issue で扱う想定。
 type UserListChannel struct {
-	ctx    stream.ChannelContext
-	topic  string
-	filter noteFilter
+	ctx         stream.ChannelContext
+	topic       string
+	streamTopic string
+	filter      noteFilter
 }
 
 // NewUserList returns a channel factory for "userList".
@@ -55,10 +56,26 @@ func (c *UserListChannel) Init(params json.RawMessage) error {
 	}
 	c.topic = "userListTimeline:" + p.ListID
 	c.ctx.Subscribe(c.topic)
+	// membership event (userAdded/userRemoved) は別 topic で届く (#1549, upstream
+	// userListStream:${listId})。note 配信 (userListTimeline:) とは分離されている。
+	c.streamTopic = "userListStream:" + p.ListID
+	c.ctx.Subscribe(c.streamTopic)
 	return nil
 }
 
 func (c *UserListChannel) OnRedisEvent(payload []byte) {
+	// userListStream: topic からの membership event は {type, body} envelope で
+	// 届く (#1549)。note 配信 (userListTimeline:) は raw note payload なので
+	// top-level type を持たず、ここで分岐できる。
+	var env struct {
+		Type string          `json:"type"`
+		Body json.RawMessage `json:"body"`
+	}
+	if json.Unmarshal(payload, &env) == nil && (env.Type == "userAdded" || env.Type == "userRemoved") {
+		_ = c.ctx.Send(env.Type, env.Body)
+		return
+	}
+
 	viewerID := viewerIDFromCtx(c.ctx)
 	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerID) {
 		return
@@ -84,6 +101,9 @@ func (c *UserListChannel) OnClientMessage(string, json.RawMessage) {}
 func (c *UserListChannel) Dispose() {
 	if c.topic != "" {
 		c.ctx.Unsubscribe(c.topic)
+	}
+	if c.streamTopic != "" {
+		c.ctx.Unsubscribe(c.streamTopic)
 	}
 }
 

--- a/internal/stream/userlist_publisher.go
+++ b/internal/stream/userlist_publisher.go
@@ -1,0 +1,40 @@
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+)
+
+// UserListStreamPublisher serializes `{type, body}` envelopes to the Redis topic
+// `userListStream:{listID}` which the `userList` WebSocket channel subscribes to
+// for membership events (#1549). Used to emit `userAdded` / `userRemoved` so
+// clients update the member list live. Note delivery uses a separate
+// `userListTimeline:{listID}` topic.
+type UserListStreamPublisher struct {
+	pub PubSubPublisher
+}
+
+// NewUserListStreamPublisher constructs a UserListStreamPublisher backed by the
+// given PubSubPublisher.
+func NewUserListStreamPublisher(pub PubSubPublisher) *UserListStreamPublisher {
+	return &UserListStreamPublisher{pub: pub}
+}
+
+// PublishUserListEvent emits an event to `userListStream:{listID}` with a
+// `{type, body}` envelope, matching TS `userList` membership event shape.
+func (p *UserListStreamPublisher) PublishUserListEvent(listID, eventType string, body any) {
+	if p.pub == nil || listID == "" || eventType == "" {
+		return
+	}
+	env := map[string]any{"type": eventType, "body": body}
+	raw, err := json.Marshal(env)
+	if err != nil {
+		slog.Warn("userlist publisher: marshal failed", "event", eventType, "err", err)
+		return
+	}
+	topic := "userListStream:" + listID
+	if err := p.pub.Publish(context.Background(), topic, json.RawMessage(raw)); err != nil {
+		slog.Warn("userlist publisher: publish failed", "topic", topic, "err", err)
+	}
+}

--- a/internal/stream/userlist_publisher_test.go
+++ b/internal/stream/userlist_publisher_test.go
@@ -1,0 +1,62 @@
+package stream
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserListStreamPublisher_PublishEnvelope(t *testing.T) {
+	bus := &capturingPubSub{}
+	p := NewUserListStreamPublisher(bus)
+	p.PublishUserListEvent("list1", "userAdded", map[string]any{"id": "u1", "username": "alice"})
+
+	require.Len(t, bus.calls, 1)
+	assert.Equal(t, "userListStream:list1", bus.calls[0].topic)
+
+	raw, ok := bus.calls[0].payload.(json.RawMessage)
+	require.True(t, ok)
+	var env struct {
+		Type string          `json:"type"`
+		Body json.RawMessage `json:"body"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &env))
+	assert.Equal(t, "userAdded", env.Type)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(env.Body, &body))
+	assert.Equal(t, "u1", body["id"])
+	assert.Equal(t, "alice", body["username"])
+}
+
+func TestUserListStreamPublisher_NilPub(t *testing.T) {
+	p := NewUserListStreamPublisher(nil)
+	p.PublishUserListEvent("list1", "userAdded", nil) // no panic
+}
+
+func TestUserListStreamPublisher_EmptyListID(t *testing.T) {
+	bus := &capturingPubSub{}
+	NewUserListStreamPublisher(bus).PublishUserListEvent("", "userAdded", nil)
+	assert.Empty(t, bus.calls)
+}
+
+func TestUserListStreamPublisher_EmptyEventType(t *testing.T) {
+	bus := &capturingPubSub{}
+	NewUserListStreamPublisher(bus).PublishUserListEvent("list1", "", nil)
+	assert.Empty(t, bus.calls)
+}
+
+func TestUserListStreamPublisher_PublishError(t *testing.T) {
+	bus := &capturingPubSub{err: errors.New("pub boom")}
+	NewUserListStreamPublisher(bus).PublishUserListEvent("list1", "userRemoved", nil) // logged, not panicked
+}
+
+func TestUserListStreamPublisher_MarshalError(t *testing.T) {
+	bus := &capturingPubSub{}
+	// json.Marshal は chan を encode できず error を返す。publish には到達しない。
+	NewUserListStreamPublisher(bus).PublishUserListEvent("list1", "userAdded", make(chan int))
+	assert.Empty(t, bus.calls)
+}


### PR DESCRIPTION
## Summary

`#1549` (stream channels parity) の MEDIUM 項目「userList channel が userAdded / userRemoved イベントを配信しない」を解消する。

upstream `UserListService.addMember`/`removeMember` は member 増減時に `publishUserListStream(list.id, 'userAdded'|'userRemoved', pack(target))` を呼び、`userList` WS channel が `userListStream:${listId}` を購読して member list を live 更新する。mk-go では publisher も `userListStream:` topic 購読も無かったため、本 PR で両方を追加する。

## 主な変更点

- **`internal/stream/userlist_publisher.go` (新規)**: `UserListStreamPublisher` を追加。`{type, body}` envelope を `userListStream:<listId>` topic へ publish する (admin/main publisher と同じ best-effort + nil/empty guard パターン)。
- **`internal/stream/channels/user_list.go`**: note 配信用の `userListTimeline:<listId>` に加えて membership event 用の `userListStream:<listId>` も Subscribe。`OnRedisEvent` で `{type:userAdded|userRemoved}` envelope を検出したら note filter を経由せず `c.ctx.Send(type, body)` で client へ forward する。`Dispose` で両 topic を Unsubscribe。
  - note 配信 (`userListTimeline:`) は raw note payload で top-level `type` を持たないため、両 topic が同じ `OnRedisEvent` に届いても envelope の `type` で確実に分岐できる (upstream の `UserListEventTypes` は `userAdded`/`userRemoved` のみ)。
- **`internal/api/userlists/handler.go`**: `UserListEventPublisher` interface + field + setter を追加。`push` は `AddMember` 成功後に `userAdded` (`PackUserLite(target)`)、`pull` は `RemoveMember` 成功後に `userRemoved` を publish する。AddMember 失敗 (ALREADY_ADDED 等) の場合は publish しない。
- **`internal/server/router.go`**: `userListHandler.SetUserListEventPublisher(stream.NewUserListStreamPublisher(streamPubSub))` を配線。

## テスト

- `internal/stream/userlist_publisher_test.go` (新規): envelope shape / topic 名 / nil pub / empty listID / empty eventType / publish error / marshal error を網羅。
- `internal/stream/channels/new_channels_test.go`: `TestUserList_MembershipEventForwarded` を追加 (userAdded/userRemoved が note filter を経由せず forward されること)。既存の lifecycle / withReplies テストを 2nd topic (`userListStream:`) 購読込みに更新。
- `internal/api/userlists/handler_test.go`: `TestPush_PublishesUserAdded` / `TestPush_NoPublishOnAlreadyAdded` / `TestPull_PublishesUserRemoved` を追加。
- 実行:
  - `go test ./internal/stream/... ./internal/api/userlists/... -race -count=1` → pass
  - coverage: stream 90.7% / stream/channels 91.7% / userlists 96.8% (いずれも 90% gate 維持)
  - `go build ./... && go vet ./...` → pass

## Closes

`#1549` の userList 項目 (MEDIUM) を解消する。残項目の disposition は issue 本文に記載。

🤖 Generated with [Claude Code](https://claude.com/claude-code)