### PR TITLE
Fix channel/hashtag stream: 匿名 viewer に requireSignin note を drop (#1549)

### DIFF
--- a/internal/stream/channels/channel_timeline.go
+++ b/internal/stream/channels/channel_timeline.go
@@ -43,6 +43,12 @@ func (c *ChannelTimelineChannel) OnRedisEvent(payload []byte) {
 	if noteChannelID(payload) != c.channelID {
 		return
 	}
+	// anon viewer + 著者 requireSigninToViewContents は note を丸ごと drop する
+	// (#1549, upstream channel.ts の note/renote/reply 3 連 gate)。hideEmbeds の
+	// blank 化より前に弾いて「何も送らない」upstream 挙動に揃える。
+	if anonRequireSigninDrop(payload, viewerIDFromCtx(c.ctx)) {
+		return
+	}
 	// per-subscriber 可視性 gate (#1549, fail-closed)。channel note は通常
 	// public だが、共通ゲートを通して非可視/壊れた payload を drop する。
 	if !streamNoteVisibleForViewer(payload, viewerIDFromCtx(c.ctx), c.ctx.FollowingSnapshot()) {

--- a/internal/stream/channels/hashtag.go
+++ b/internal/stream/channels/hashtag.go
@@ -92,6 +92,12 @@ func (c *HashtagChannel) OnRedisEvent(payload []byte) {
 		c.seen[id] = struct{}{}
 		c.mu.Unlock()
 	}
+	// anon viewer + 著者 requireSigninToViewContents は note を丸ごと drop する
+	// (#1549, upstream hashtag.ts の note/renote/reply 3 連 gate)。hideEmbeds の
+	// blank 化より前に弾いて「何も送らない」upstream 挙動に揃える。
+	if anonRequireSigninDrop(payload, viewerIDFromCtx(c.ctx)) {
+		return
+	}
 	// per-subscriber 可視性 gate (#1549, fail-closed)。TS notesStream は全可視性を
 	// 流して consumer 側で isNoteVisibleForMe する設計に合わせる。
 	if !streamNoteVisibleForViewer(payload, viewerIDFromCtx(c.ctx), c.ctx.FollowingSnapshot()) {

--- a/internal/stream/channels/new_channels_test.go
+++ b/internal/stream/channels/new_channels_test.go
@@ -162,6 +162,39 @@ func TestHashtag_FollowersVisibilityGate(t *testing.T) {
 	assert.Empty(t, ctx.sentType, "followers note from non-followed author must be dropped")
 }
 
+// #1549: anon viewer + 著者 requireSigninToViewContents は note を丸ごと drop。
+// note/renote/reply のいずれかの author が requireSignin なら drop する。
+func TestHashtag_AnonRequireSigninDropped(t *testing.T) {
+	t.Run("top-level author", func(t *testing.T) {
+		ctx := newCtx(nil)
+		ch := NewHashtag(ctx)
+		ch.Init(json.RawMessage(`{"q":[["a"]]}`))
+		ch.OnRedisEvent([]byte(`{"id":"n1","tags":["a"],"visibility":"public","user":{"id":"author","requireSigninToViewContents":true}}`))
+		assert.Empty(t, ctx.sentType)
+	})
+	t.Run("renote author", func(t *testing.T) {
+		ctx := newCtx(nil)
+		ch := NewHashtag(ctx)
+		ch.Init(json.RawMessage(`{"q":[["a"]]}`))
+		ch.OnRedisEvent([]byte(`{"id":"n1","tags":["a"],"visibility":"public","user":{"id":"u"},"renote":{"id":"r1","user":{"id":"ra","requireSigninToViewContents":true}}}`))
+		assert.Empty(t, ctx.sentType)
+	})
+	t.Run("reply author", func(t *testing.T) {
+		ctx := newCtx(nil)
+		ch := NewHashtag(ctx)
+		ch.Init(json.RawMessage(`{"q":[["a"]]}`))
+		ch.OnRedisEvent([]byte(`{"id":"n1","tags":["a"],"visibility":"public","user":{"id":"u"},"reply":{"id":"p1","user":{"id":"pa","requireSigninToViewContents":true}}}`))
+		assert.Empty(t, ctx.sentType)
+	})
+	t.Run("authed viewer exempt", func(t *testing.T) {
+		ctx := newCtx(&model.User{ID: "viewer"})
+		ch := NewHashtag(ctx)
+		ch.Init(json.RawMessage(`{"q":[["a"]]}`))
+		ch.OnRedisEvent([]byte(`{"id":"n1","tags":["a"],"visibility":"public","user":{"id":"author","requireSigninToViewContents":true}}`))
+		require.Len(t, ctx.sentType, 1)
+	})
+}
+
 // --- Antenna ---
 
 func TestAntenna_Lifecycle(t *testing.T) {
@@ -383,6 +416,24 @@ func TestChannelTimeline_FollowersVisibilityGate(t *testing.T) {
 		ch.OnRedisEvent([]byte(`{"id":"n1","channelId":"ch1","userId":"alice","visibility":"followers"}`))
 		require.Len(t, ctx.sentType, 1)
 	})
+}
+
+// #1549: anon viewer + 著者 requireSigninToViewContents は note を丸ごと drop。
+func TestChannelTimeline_AnonRequireSigninDropped(t *testing.T) {
+	ctx := newCtx(nil) // anonymous connection
+	ch := NewChannelTimeline(ctx)
+	ch.Init(json.RawMessage(`{"channelId":"ch1"}`))
+	ch.OnRedisEvent([]byte(`{"id":"n1","channelId":"ch1","visibility":"public","user":{"id":"author","requireSigninToViewContents":true}}`))
+	assert.Empty(t, ctx.sentType, "anon viewer must not receive a requireSignin author's note")
+}
+
+// 認証済み viewer には requireSignin gate が適用されない。
+func TestChannelTimeline_AuthedRequireSigninPassed(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "viewer"})
+	ch := NewChannelTimeline(ctx)
+	ch.Init(json.RawMessage(`{"channelId":"ch1"}`))
+	ch.OnRedisEvent([]byte(`{"id":"n1","channelId":"ch1","visibility":"public","user":{"id":"author","requireSigninToViewContents":true}}`))
+	require.Len(t, ctx.sentType, 1, "authenticated viewer is exempt from the requireSignin gate")
 }
 
 // --- UserList ---

--- a/internal/stream/channels/note_filter.go
+++ b/internal/stream/channels/note_filter.go
@@ -117,6 +117,50 @@ func noteVisibility(payload []byte) string {
 	return p.Visibility
 }
 
+// anonRequireSigninDrop reports whether an anonymous viewer (viewerID == "")
+// must be denied this note ENTIRELY because the note — or its embedded renote /
+// reply — has an author who enabled requireSigninToViewContents.
+//
+// upstream channel.ts / hashtag.ts は anon viewer に対し
+// `note.user.requireSigninToViewContents` (+ renote.user / reply.user) を
+// 3 連で評価して `return` (= note を丸ごと drop) する (#1549)。mk-go の
+// hideEmbeds は HideNoteByPrefsDecision 経由で同条件を「blank 化」するが、
+// それだと anon client に空の note shell が送られてしまい upstream の
+// 「何も送らない」挙動と差が出る。本 gate で blank 前に drop して揃える。
+//
+// requireCredential=false で anon 接続を受け付ける channel / hashtag 専用。
+// 認証済み viewer には常に false (gate 対象外)。parse 失敗は他 gate に委ねる。
+func anonRequireSigninDrop(payload []byte, viewerID string) bool {
+	if viewerID != "" {
+		return false
+	}
+	type userProbe struct {
+		RequireSigninToViewContents *bool `json:"requireSigninToViewContents"`
+	}
+	type embedRef struct {
+		User userProbe `json:"user"`
+	}
+	var p struct {
+		User   userProbe `json:"user"`
+		Renote *embedRef `json:"renote"`
+		Reply  *embedRef `json:"reply"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return false
+	}
+	requiresSignin := func(b *bool) bool { return b != nil && *b }
+	if requiresSignin(p.User.RequireSigninToViewContents) {
+		return true
+	}
+	if p.Renote != nil && requiresSignin(p.Renote.User.RequireSigninToViewContents) {
+		return true
+	}
+	if p.Reply != nil && requiresSignin(p.Reply.User.RequireSigninToViewContents) {
+		return true
+	}
+	return false
+}
+
 // streamNoteID decodes the note id from a streamed note payload ("" when
 // absent / unparseable). Used by the hashtag channel to dedupe a note that
 // arrives via multiple subscribed tag topics (#1549).

--- a/internal/stream/channels/note_filter_test.go
+++ b/internal/stream/channels/note_filter_test.go
@@ -297,3 +297,33 @@ func TestShouldEmit_HardMute_NoRulesIsNoOp(t *testing.T) {
 	assert.True(t, f.shouldEmit(payload, nil, "viewer"))
 	assert.True(t, f.shouldEmit(payload, []byte("[]"), "viewer"))
 }
+
+func TestAnonRequireSigninDrop(t *testing.T) {
+	t.Run("authed viewer always false", func(t *testing.T) {
+		p := []byte(`{"user":{"requireSigninToViewContents":true}}`)
+		assert.False(t, anonRequireSigninDrop(p, "viewer"))
+	})
+	t.Run("anon + top-level requireSignin drops", func(t *testing.T) {
+		p := []byte(`{"user":{"requireSigninToViewContents":true}}`)
+		assert.True(t, anonRequireSigninDrop(p, ""))
+	})
+	t.Run("anon + renote requireSignin drops", func(t *testing.T) {
+		p := []byte(`{"user":{"id":"u"},"renote":{"user":{"requireSigninToViewContents":true}}}`)
+		assert.True(t, anonRequireSigninDrop(p, ""))
+	})
+	t.Run("anon + reply requireSignin drops", func(t *testing.T) {
+		p := []byte(`{"user":{"id":"u"},"reply":{"user":{"requireSigninToViewContents":true}}}`)
+		assert.True(t, anonRequireSigninDrop(p, ""))
+	})
+	t.Run("anon + flag false passes", func(t *testing.T) {
+		p := []byte(`{"user":{"requireSigninToViewContents":false}}`)
+		assert.False(t, anonRequireSigninDrop(p, ""))
+	})
+	t.Run("anon + flag absent passes", func(t *testing.T) {
+		p := []byte(`{"user":{"id":"author"}}`)
+		assert.False(t, anonRequireSigninDrop(p, ""))
+	})
+	t.Run("malformed payload passes (fail to other gates)", func(t *testing.T) {
+		assert.False(t, anonRequireSigninDrop([]byte(`{not json`), ""))
+	})
+}


### PR DESCRIPTION
## Summary

`#1549` (stream channels parity) の LOW 項目「channel / hashtag — 匿名 viewer に対する requireSigninToViewContents gate が無い」を解消する。

`channel` / `hashtag` は `requireCredential=false` で anon WS 接続を受け付ける (`/streaming` エンドポイントは `RequireAuth` 無し)。upstream `channel.ts` / `hashtag.ts` は anon viewer (`this.user == null`) に対し note・renote・reply の各 author の `requireSigninToViewContents` を評価し、いずれか該当すれば note を丸ごと `return` (drop) する。

mk-go では `hideEmbeds` (= `HideNoteByPrefsDecision`) が同条件を **blank 化** していたが、それだと anon client に空の note shell が送られ、upstream の「何も送らない」挙動と差が出ていた。本 PR で blank より前に **drop** する gate を追加して揃える。

## 主な変更点

- **`internal/stream/channels/note_filter.go`**: `anonRequireSigninDrop(payload, viewerID)` helper を追加。`viewerID == ""` (anon) のとき `note.user` / `renote.user` / `reply.user` の `requireSigninToViewContents` を評価し、いずれか true なら drop を返す。認証済み viewer には常に false (gate 対象外)。parse 失敗は fail-open で他 gate に委ねる。
- **`internal/stream/channels/channel_timeline.go` / `hashtag.go`**: `OnRedisEvent` の `hideEmbeds` (blank) より前に `anonRequireSigninDrop` gate を追加。

## 補足

- timeline 系 (LTL/GTL/HTL) は upstream `requireCredential=true` で anon 接続が無く viewer が nil にならないため対象外。anon を受け付けるのは `channel` / `hashtag` のみ。
- 認証済み viewer は従来どおり通過する (`HideNoteByPrefsDecision` の requireSignin branch も `viewer == nil` 条件なので blank もされない)。

## テスト

- `internal/stream/channels/note_filter_test.go`: `TestAnonRequireSigninDrop` を追加 (authed exempt / anon top-level・renote・reply drop / flag false・absent pass / malformed pass の 7 ケース)。
- `internal/stream/channels/new_channels_test.go`: `TestChannelTimeline_AnonRequireSigninDropped` / `TestChannelTimeline_AuthedRequireSigninPassed` / `TestHashtag_AnonRequireSigninDropped` (note/renote/reply/authed の 4 サブケース) を追加。
- 実行:
  - `go test ./internal/stream/channels/ -race -count=1` → pass
  - coverage 91.9% (90% gate 維持)
  - `go vet ./internal/stream/...` → pass

## Closes

`#1549` の channel/hashtag requireSignin 項目 (LOW) を解消する。残項目の disposition は issue 本文に記載。

🤖 Generated with [Claude Code](https://claude.com/claude-code)