### PR TITLE
Fix main/notifications stream: mention/notification に mute/block/instance-mute filter (#1711)

### DIFF
--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/pprof"
 	urlpkg "net/url"
@@ -1905,6 +1906,17 @@ func (s *Server) setupRoutes() {
 	// 失敗 / anonymous は nil 返却で degrade — channel は 3 escape hatch のみで
 	// 動く (= 旧来の "全 reply drop" よりは upstream 互換に近い)。
 	streamManager.SetFollowingSnapshotLookup(&followingSnapshotAdapter{repo: followingRepo})
+	// muteBlockSnapshot (#1711): main / notifications channel が notification /
+	// mention 配信時に instance-mute / block / mute を gate するための snapshot を
+	// 接続確立時に 1 回 fetch する。失敗 / anonymous は nil 返却で fail-open に
+	// degrade — filter 無しで動き続ける。
+	streamManager.SetMuteBlockSnapshotLookup(&muteBlockSnapshotAdapter{
+		muting:        mutingRepo,
+		blocking:      blockingRepo,
+		renoteMuting:  renoteMutingRepo,
+		channelMuting: channelMutingRepo,
+		userRepo:      userRepo,
+	})
 	// subNote visibility gate (#1460 IDOR fix): handleSubNote が任意の noteID
 	// で noteStream を subscribe させると、followers / specified note の
 	// reacted / unreacted / pollVoted / deleted event が非対象 viewer に
@@ -2895,6 +2907,81 @@ func (a *followingSnapshotAdapter) FollowingSnapshotForUser(userID string) map[s
 		}
 		offset += pageSize
 	}
+}
+
+// muteBlockSnapshotAdapter bridges the muting / blocking / renote-muting /
+// channel-muting repositories + user profile to stream.MuteBlockSnapshotLookup
+// so the streaming Manager can snapshot the viewer's mute/block relationships
+// at connection setup (#1711). The main / notifications channels consult it to
+// drop notifications / mentions involving muted instances, muted users, users
+// blocking the viewer, renote-muted authors, or muted channels.
+//
+// 各 set fetch は best-effort: 個別の repo error は空 set に degrade させ、
+// snapshot 全体は常に non-nil で返す (= 取得できた範囲だけ filter する)。
+// followingSnapshotAdapter と同じく接続ごとに 1 回読みだす connection-time
+// snapshot で、live refresh は未実装 (= 再接続まで stale)。
+type muteBlockSnapshotAdapter struct {
+	muting        repository.MutingRepository
+	blocking      repository.BlockingRepository
+	renoteMuting  repository.RenoteMutingRepository
+	channelMuting repository.ChannelMutingRepository
+	userRepo      repository.UserRepository
+}
+
+func (a *muteBlockSnapshotAdapter) MuteBlockSnapshotForUser(userID string) *stream.MuteBlockSnapshot {
+	if userID == "" {
+		return nil
+	}
+	snap := &stream.MuteBlockSnapshot{
+		Muting:         map[string]struct{}{},
+		BlockingMe:     map[string]struct{}{},
+		RenoteMuting:   map[string]struct{}{},
+		MutedInstances: map[string]struct{}{},
+		MutingChannels: map[string]struct{}{},
+	}
+	if a.muting != nil {
+		if ids, err := a.muting.ListMuteeIDs(userID); err == nil {
+			for _, id := range ids {
+				snap.Muting[id] = struct{}{}
+			}
+		}
+	}
+	if a.blocking != nil {
+		if ids, err := a.blocking.ListBlockerIDs(userID); err == nil {
+			for _, id := range ids {
+				snap.BlockingMe[id] = struct{}{}
+			}
+		}
+	}
+	if a.renoteMuting != nil {
+		if ids, err := a.renoteMuting.ListMuteeIDs(userID); err == nil {
+			for _, id := range ids {
+				snap.RenoteMuting[id] = struct{}{}
+			}
+		}
+	}
+	if a.channelMuting != nil {
+		if rows, err := a.channelMuting.ListByUser(userID); err == nil {
+			for _, r := range rows {
+				snap.MutingChannels[r.ChannelID] = struct{}{}
+			}
+		}
+	}
+	if a.userRepo != nil {
+		if profile, err := a.userRepo.FindProfileByUserID(userID); err == nil && profile != nil && len(profile.MutedInstances) > 0 {
+			var hosts []string
+			if json.Unmarshal(profile.MutedInstances, &hosts) == nil {
+				for _, h := range hosts {
+					if h != "" {
+						// host は AP canonical の lowercase で比較する
+						// (timeline filter / loadMutedInstances と統一)。
+						snap.MutedInstances[strings.ToLower(h)] = struct{}{}
+					}
+				}
+			}
+		}
+	}
+	return snap
 }
 
 // hardMutePublisherAdapter bridges PubSubService to i.HardMutePublisher so

--- a/internal/stream/channel.go
+++ b/internal/stream/channel.go
@@ -66,6 +66,13 @@ type ChannelContext interface {
 	// should fall back to the 3 escape hatches only (= drop reply unless
 	// reply-to-me / isMe / self-thread).
 	FollowingSnapshot() map[string]bool
+	// MuteBlockSnapshot returns the viewer's mute/block snapshot (muting /
+	// blocking-me / renote-muting / muted-instances / muting-channels). The
+	// main / notifications channels use it to drop notifications / mentions
+	// involving muted instances, muted users, or users blocking the viewer
+	// (#1711). Returns nil when the connection is anonymous or the lookup is
+	// unwired — callers must treat nil as "no filtering" (fail-open).
+	MuteBlockSnapshot() *MuteBlockSnapshot
 }
 
 // PermittedChannel is an optional interface a Channel can implement to

--- a/internal/stream/channels/main_mute_filter.go
+++ b/internal/stream/channels/main_mute_filter.go
@@ -1,0 +1,180 @@
+package channels
+
+import (
+	"encoding/json"
+
+	"github.com/shiroha-a/mk/internal/stream"
+)
+
+// muteBlockUserProbe carries just the author host needed for the instance-mute
+// check. A nil/absent host (= local user) maps to "" which a mutedInstances set
+// never contains, so local notes are never instance-muted (upstream
+// `note.user?.host ?? ”`).
+type muteBlockUserProbe struct {
+	ID   string  `json:"id"`
+	Host *string `json:"host"`
+}
+
+// muteBlockEmbed is the depth-1 renote/reply metadata needed for isUserRelated /
+// isChannelRelated / isInstanceMuted.
+type muteBlockEmbed struct {
+	UserID    string             `json:"userId"`
+	ChannelID *string            `json:"channelId"`
+	User      muteBlockUserProbe `json:"user"`
+}
+
+// muteBlockProbe decodes the minimal packed-note fields the main-channel
+// mute/block gate needs. pure-renote detection mirrors upstream isQuotePacked
+// (text/cw/replyId/poll/fileIds は quote の指標)。
+type muteBlockProbe struct {
+	UserID    string             `json:"userId"`
+	ChannelID *string            `json:"channelId"`
+	User      muteBlockUserProbe `json:"user"`
+	RenoteID  *string            `json:"renoteId"`
+	ReplyID   *string            `json:"replyId"`
+	Text      *string            `json:"text"`
+	CW        *string            `json:"cw"`
+	Poll      json.RawMessage    `json:"poll"`
+	FileIDs   []string           `json:"fileIds"`
+	Reply     *muteBlockEmbed    `json:"reply"`
+	Renote    *muteBlockEmbed    `json:"renote"`
+}
+
+// hostMuted reports whether host (nil → "") is in the muted-instance set.
+func hostMuted(host *string, muted map[string]struct{}) bool {
+	h := ""
+	if host != nil {
+		h = *host
+	}
+	_, ok := muted[h]
+	return ok
+}
+
+// noteMutedOrBlocked ports upstream `Connection#isNoteMutedOrBlocked` +
+// `isInstanceMuted` for a streamed packed-note payload (#1711). Returns true
+// when the note (or its renote/reply target) involves a muted instance, a muted
+// user, a user who blocks the viewer, a renote-muted author (pure renote only),
+// or a muted channel. nil snapshot (anonymous / unwired) は fail-open で false。
+func noteMutedOrBlocked(payload []byte, snap *stream.MuteBlockSnapshot) bool {
+	if snap == nil {
+		return false
+	}
+	var p muteBlockProbe
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return false
+	}
+	// instance-mute: note / reply / renote の author host のいずれか。
+	if len(snap.MutedInstances) > 0 {
+		if hostMuted(p.User.Host, snap.MutedInstances) {
+			return true
+		}
+		if p.Reply != nil && hostMuted(p.Reply.User.Host, snap.MutedInstances) {
+			return true
+		}
+		if p.Renote != nil && hostMuted(p.Renote.User.Host, snap.MutedInstances) {
+			return true
+		}
+	}
+	// user-mute (userIdsWhoMeMuting) + block (userIdsWhoBlockingMe): いずれも
+	// isUserRelated (author / reply author / renote author) で判定する。
+	if userRelated(p, snap.Muting) {
+		return true
+	}
+	if userRelated(p, snap.BlockingMe) {
+		return true
+	}
+	// renote-mute: pure renote (= renote かつ quote でない) を行った user の
+	// renote を mute している場合に drop。
+	if len(snap.RenoteMuting) > 0 && isPureRenotePayload(p) {
+		if _, ok := snap.RenoteMuting[p.UserID]; ok {
+			return true
+		}
+	}
+	// channel-mute: note の所属 channel か、renote 先の channel が muted。
+	if channelRelated(p, snap.MutingChannels) {
+		return true
+	}
+	return false
+}
+
+// userRelated ports upstream `isUserRelated`: the note's author, reply target
+// author, or renote target author is in the set. reply/renote の author は
+// note.userId と異なる場合のみ評価する (upstream と一致)。
+func userRelated(p muteBlockProbe, set map[string]struct{}) bool {
+	if len(set) == 0 {
+		return false
+	}
+	if _, ok := set[p.UserID]; ok {
+		return true
+	}
+	if p.Reply != nil && p.Reply.UserID != "" && p.Reply.UserID != p.UserID {
+		if _, ok := set[p.Reply.UserID]; ok {
+			return true
+		}
+	}
+	if p.Renote != nil && p.Renote.UserID != "" && p.Renote.UserID != p.UserID {
+		if _, ok := set[p.Renote.UserID]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// channelRelated ports upstream `isChannelRelated`: the note's own channel, or
+// the renote target's channel (when different), is in the set. reply の channel
+// は upstream 同様チェックしない。
+func channelRelated(p muteBlockProbe, set map[string]struct{}) bool {
+	if len(set) == 0 {
+		return false
+	}
+	if p.ChannelID != nil {
+		if _, ok := set[*p.ChannelID]; ok {
+			return true
+		}
+	}
+	if p.Renote != nil && p.Renote.ChannelID != nil {
+		if p.ChannelID == nil || *p.Renote.ChannelID != *p.ChannelID {
+			if _, ok := set[*p.Renote.ChannelID]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isPureRenotePayload ports upstream `isRenotePacked && !isQuotePacked`: a note
+// with renoteId set and none of the quote indicators (text/cw/replyId/poll/
+// fileIds).
+func isPureRenotePayload(p muteBlockProbe) bool {
+	if p.RenoteID == nil {
+		return false
+	}
+	if p.Text != nil || p.CW != nil || p.ReplyID != nil {
+		return false
+	}
+	if len(p.Poll) > 0 && string(p.Poll) != "null" {
+		return false
+	}
+	if len(p.FileIDs) > 0 {
+		return false
+	}
+	return true
+}
+
+// notificationFromMutedInstance ports upstream `isUserFromMutedInstance` for a
+// streamed bare-notification payload (notifications: topic): drop when the
+// notifier's host is in the viewer's muted-instance set (#1711). user-mute は
+// 通知作成時 (notifyLocalUser の IsMuted) で既に適用済みのため、ここでは
+// instance-mute のみを評価する (二重適用を避ける)。
+func notificationFromMutedInstance(payload []byte, snap *stream.MuteBlockSnapshot) bool {
+	if snap == nil || len(snap.MutedInstances) == 0 {
+		return false
+	}
+	var p struct {
+		User *muteBlockUserProbe `json:"user"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil || p.User == nil {
+		return false
+	}
+	return hostMuted(p.User.Host, snap.MutedInstances)
+}

--- a/internal/stream/channels/main_mute_filter_test.go
+++ b/internal/stream/channels/main_mute_filter_test.go
@@ -1,0 +1,126 @@
+package channels
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/stream"
+	"github.com/stretchr/testify/assert"
+)
+
+func set(ids ...string) map[string]struct{} {
+	m := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		m[id] = struct{}{}
+	}
+	return m
+}
+
+func TestNoteMutedOrBlocked(t *testing.T) {
+	t.Run("nil snapshot is fail-open", func(t *testing.T) {
+		assert.False(t, noteMutedOrBlocked([]byte(`{"userId":"author"}`), nil))
+	})
+	t.Run("parse error is fail-open", func(t *testing.T) {
+		snap := &stream.MuteBlockSnapshot{Muting: set("author")}
+		assert.False(t, noteMutedOrBlocked([]byte(`{not json`), snap))
+	})
+	t.Run("clean note passes", func(t *testing.T) {
+		snap := &stream.MuteBlockSnapshot{
+			Muting:         set("x"),
+			BlockingMe:     set("y"),
+			MutedInstances: set("evil.example"),
+		}
+		assert.False(t, noteMutedOrBlocked([]byte(`{"userId":"author","user":{"host":"good.example"}}`), snap))
+	})
+	t.Run("instance-mute on top-level author", func(t *testing.T) {
+		snap := &stream.MuteBlockSnapshot{MutedInstances: set("evil.example")}
+		assert.True(t, noteMutedOrBlocked([]byte(`{"userId":"a","user":{"host":"evil.example"}}`), snap))
+	})
+	t.Run("instance-mute on reply author", func(t *testing.T) {
+		snap := &stream.MuteBlockSnapshot{MutedInstances: set("evil.example")}
+		p := []byte(`{"userId":"a","user":{"host":"good.example"},"reply":{"userId":"b","user":{"host":"evil.example"}}}`)
+		assert.True(t, noteMutedOrBlocked(p, snap))
+	})
+	t.Run("instance-mute on renote author", func(t *testing.T) {
+		snap := &stream.MuteBlockSnapshot{MutedInstances: set("evil.example")}
+		p := []byte(`{"userId":"a","user":{"host":"good.example"},"renote":{"userId":"b","user":{"host":"evil.example"}}}`)
+		assert.True(t, noteMutedOrBlocked(p, snap))
+	})
+	t.Run("user-mute on author", func(t *testing.T) {
+		snap := &stream.MuteBlockSnapshot{Muting: set("author")}
+		assert.True(t, noteMutedOrBlocked([]byte(`{"userId":"author"}`), snap))
+	})
+	t.Run("block (blocking me) on renote author", func(t *testing.T) {
+		snap := &stream.MuteBlockSnapshot{BlockingMe: set("blocker")}
+		p := []byte(`{"userId":"a","renote":{"userId":"blocker"}}`)
+		assert.True(t, noteMutedOrBlocked(p, snap))
+	})
+	t.Run("renote-mute drops pure renote", func(t *testing.T) {
+		snap := &stream.MuteBlockSnapshot{RenoteMuting: set("renoter")}
+		p := []byte(`{"userId":"renoter","renoteId":"r1","renote":{"userId":"orig"}}`)
+		assert.True(t, noteMutedOrBlocked(p, snap))
+	})
+	t.Run("renote-mute does NOT drop quote (has text)", func(t *testing.T) {
+		snap := &stream.MuteBlockSnapshot{RenoteMuting: set("renoter")}
+		p := []byte(`{"userId":"renoter","renoteId":"r1","text":"quote!","renote":{"userId":"orig"}}`)
+		assert.False(t, noteMutedOrBlocked(p, snap))
+	})
+	t.Run("channel-mute on own channel", func(t *testing.T) {
+		snap := &stream.MuteBlockSnapshot{MutingChannels: set("ch1")}
+		assert.True(t, noteMutedOrBlocked([]byte(`{"userId":"a","channelId":"ch1"}`), snap))
+	})
+	t.Run("channel-mute on renote channel", func(t *testing.T) {
+		snap := &stream.MuteBlockSnapshot{MutingChannels: set("ch2")}
+		p := []byte(`{"userId":"a","channelId":"ch1","renote":{"userId":"b","channelId":"ch2"}}`)
+		assert.True(t, noteMutedOrBlocked(p, snap))
+	})
+}
+
+func TestUserRelated(t *testing.T) {
+	t.Run("empty set false", func(t *testing.T) {
+		assert.False(t, userRelated(muteBlockProbe{UserID: "a"}, nil))
+	})
+	t.Run("reply author equal to top author is not double-checked", func(t *testing.T) {
+		// reply.userId == userId のとき、reply branch では評価しない (top で評価済)。
+		p := muteBlockProbe{UserID: "a", Reply: &muteBlockEmbed{UserID: "a"}}
+		assert.False(t, userRelated(p, set("b")))
+	})
+}
+
+func TestIsPureRenotePayload(t *testing.T) {
+	assert.False(t, isPureRenotePayload(muteBlockProbe{}), "no renoteId")
+	assert.True(t, isPureRenotePayload(muteBlockProbe{RenoteID: ptr("r1")}), "bare renote")
+	assert.False(t, isPureRenotePayload(muteBlockProbe{RenoteID: ptr("r1"), Text: ptr("hi")}), "text => quote")
+	assert.False(t, isPureRenotePayload(muteBlockProbe{RenoteID: ptr("r1"), CW: ptr("cw")}), "cw => quote")
+	assert.False(t, isPureRenotePayload(muteBlockProbe{RenoteID: ptr("r1"), ReplyID: ptr("p1")}), "replyId => quote")
+	assert.False(t, isPureRenotePayload(muteBlockProbe{RenoteID: ptr("r1"), Poll: []byte(`{}`)}), "poll => quote")
+	assert.False(t, isPureRenotePayload(muteBlockProbe{RenoteID: ptr("r1"), FileIDs: []string{"f1"}}), "files => quote")
+	assert.True(t, isPureRenotePayload(muteBlockProbe{RenoteID: ptr("r1"), Poll: []byte(`null`)}), "poll=null still pure")
+}
+
+func TestNotificationFromMutedInstance(t *testing.T) {
+	t.Run("nil snapshot false", func(t *testing.T) {
+		assert.False(t, notificationFromMutedInstance([]byte(`{"user":{"host":"evil.example"}}`), nil))
+	})
+	t.Run("empty muted set false", func(t *testing.T) {
+		snap := &stream.MuteBlockSnapshot{}
+		assert.False(t, notificationFromMutedInstance([]byte(`{"user":{"host":"evil.example"}}`), snap))
+	})
+	t.Run("muted instance drops", func(t *testing.T) {
+		snap := &stream.MuteBlockSnapshot{MutedInstances: set("evil.example")}
+		assert.True(t, notificationFromMutedInstance([]byte(`{"user":{"host":"evil.example"}}`), snap))
+	})
+	t.Run("local notifier (no host) passes", func(t *testing.T) {
+		snap := &stream.MuteBlockSnapshot{MutedInstances: set("evil.example")}
+		assert.False(t, notificationFromMutedInstance([]byte(`{"user":{"id":"local"}}`), snap))
+	})
+	t.Run("no user field passes", func(t *testing.T) {
+		snap := &stream.MuteBlockSnapshot{MutedInstances: set("evil.example")}
+		assert.False(t, notificationFromMutedInstance([]byte(`{"id":"n1"}`), snap))
+	})
+	t.Run("parse error passes", func(t *testing.T) {
+		snap := &stream.MuteBlockSnapshot{MutedInstances: set("evil.example")}
+		assert.False(t, notificationFromMutedInstance([]byte(`{not json`), snap))
+	})
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/internal/stream/channels/notifications.go
+++ b/internal/stream/channels/notifications.go
@@ -32,6 +32,12 @@ func (c *NotificationsChannel) Init(_ json.RawMessage) error {
 }
 
 func (c *NotificationsChannel) OnRedisEvent(payload []byte) {
+	// muted instance 由来の通知は drop する (#1711, upstream main.ts の
+	// isUserFromMutedInstance)。user-mute は通知作成時に適用済みなのでここでは
+	// instance-mute のみ評価する。
+	if notificationFromMutedInstance(payload, c.ctx.MuteBlockSnapshot()) {
+		return
+	}
 	payload = hideNotificationNote(c.ctx, payload)
 	_ = c.ctx.Send("notification", json.RawMessage(payload))
 }
@@ -107,12 +113,32 @@ func (c *MainChannel) OnRedisEvent(payload []byte) {
 		// note-hide ゲートより前に元の body で実行する。
 		c.maybeRefreshFollowing(env.Type, env.Body)
 		body := env.Body
+		// mention envelope は upstream main.ts と同じく isNoteVisibleForMe +
+		// isNoteMutedOrBlocked (instance-mute / user-mute / block / renote-mute /
+		// channel-mute) を適用してから送る (#1711)。reply / renote は upstream
+		// main.ts の switch でも gate されない (notification / mention のみ) ので
+		// そのまま転送する。可視性は publish 段の CanSeeNote でも gate 済だが、
+		// mention recipient は mentions/visibleUserIds に含まれるため再評価しても
+		// 誤 drop しない (defense-in-depth)。
+		if env.Type == "mention" {
+			if !streamNoteVisibleForViewer(env.Body, viewerIDFromCtx(c.ctx), c.ctx.FollowingSnapshot()) {
+				return
+			}
+			if noteMutedOrBlocked(env.Body, c.ctx.MuteBlockSnapshot()) {
+				return
+			}
+		}
 		// reply/renote/mention envelope の body は packed note。viewer 可視性で
 		// top-level 著者設定 + depth-2 embed を hide する (#1568)。
 		if isNoteEnvelope(env.Type) {
 			body = json.RawMessage(hideEmbedsForViewer(env.Body, viewerUserFromCtx(c.ctx), c.ctx.FollowingSnapshot(), time.Now().UnixMilli()))
 		}
 		_ = c.ctx.Send(env.Type, body)
+		return
+	}
+	// bare notification (notifications: topic) も muted instance 由来なら drop
+	// する (#1711)。NotificationsChannel と同 doctrine。
+	if notificationFromMutedInstance(payload, c.ctx.MuteBlockSnapshot()) {
 		return
 	}
 	payload = hideNotificationNote(c.ctx, payload)

--- a/internal/stream/channels/notifications_test.go
+++ b/internal/stream/channels/notifications_test.go
@@ -233,6 +233,111 @@ func TestMain_EnvelopeReplyNoteEmbedHidden(t *testing.T) {
 	assert.True(t, got.Renote.IsHidden, "reply-envelope note's depth-2 embed must be blanked")
 }
 
+// --- #1711: main channel mention / notification mute-block gate ---
+
+// mentionEnvelope builds a {type:mention, body:<public note>} payload addressed
+// to "alice" (so the visibility gate passes via the mentions branch).
+func mentionEnvelope(authorID, authorHost string) []byte {
+	host := any(nil)
+	if authorHost != "" {
+		host = authorHost
+	}
+	return []byte(`{"type":"mention","body":{"id":"n1","userId":"` + authorID +
+		`","visibility":"public","mentions":["alice"],"user":{"id":"` + authorID +
+		`","host":` + jsonStr(host) + `}}}`)
+}
+
+func jsonStr(v any) string {
+	if v == nil {
+		return "null"
+	}
+	return `"` + v.(string) + `"`
+}
+
+func TestMain_MentionDroppedByInstanceMute(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ctx.muteBlockSnap = &stream.MuteBlockSnapshot{MutedInstances: set("evil.example")}
+	ch := NewMain(ctx)
+	ch.Init(nil)
+	ch.OnRedisEvent(mentionEnvelope("bob", "evil.example"))
+	assert.Empty(t, ctx.sentType, "mention from muted instance must be dropped")
+}
+
+func TestMain_MentionDroppedByUserMute(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ctx.muteBlockSnap = &stream.MuteBlockSnapshot{Muting: set("bob")}
+	ch := NewMain(ctx)
+	ch.Init(nil)
+	ch.OnRedisEvent(mentionEnvelope("bob", ""))
+	assert.Empty(t, ctx.sentType, "mention from muted user must be dropped")
+}
+
+func TestMain_MentionDroppedByBlock(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ctx.muteBlockSnap = &stream.MuteBlockSnapshot{BlockingMe: set("bob")}
+	ch := NewMain(ctx)
+	ch.Init(nil)
+	ch.OnRedisEvent(mentionEnvelope("bob", ""))
+	assert.Empty(t, ctx.sentType, "mention from a user who blocks me must be dropped")
+}
+
+func TestMain_MentionPassesClean(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ctx.muteBlockSnap = &stream.MuteBlockSnapshot{Muting: set("someoneelse"), MutedInstances: set("other.example")}
+	ch := NewMain(ctx)
+	ch.Init(nil)
+	ch.OnRedisEvent(mentionEnvelope("bob", "good.example"))
+	require.Len(t, ctx.sentType, 1)
+	assert.Equal(t, "mention", ctx.sentType[0])
+}
+
+func TestMain_MentionNilSnapshotPasses(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"}) // muteBlockSnap nil → fail-open
+	ch := NewMain(ctx)
+	ch.Init(nil)
+	ch.OnRedisEvent(mentionEnvelope("bob", "evil.example"))
+	require.Len(t, ctx.sentType, 1, "nil snapshot must not drop anything")
+	assert.Equal(t, "mention", ctx.sentType[0])
+}
+
+func TestMain_MentionDroppedByVisibility(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewMain(ctx)
+	ch.Init(nil)
+	// specified note where alice is not in visibleUserIds → isNoteVisibleForMe false。
+	ch.OnRedisEvent([]byte(`{"type":"mention","body":{"id":"n1","userId":"bob","visibility":"specified","visibleUserIds":["carol"]}}`))
+	assert.Empty(t, ctx.sentType, "mention of a specified note not visible to me must be dropped")
+}
+
+func TestMain_ReplyNotGatedByMute(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ctx.muteBlockSnap = &stream.MuteBlockSnapshot{Muting: set("bob")}
+	ch := NewMain(ctx)
+	ch.Init(nil)
+	// upstream main.ts は reply を mute/block で gate しない (notification/mention のみ)。
+	ch.OnRedisEvent([]byte(`{"type":"reply","body":{"id":"n1","userId":"bob","visibility":"public"}}`))
+	require.Len(t, ctx.sentType, 1)
+	assert.Equal(t, "reply", ctx.sentType[0])
+}
+
+func TestNotifications_DroppedByInstanceMute(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ctx.muteBlockSnap = &stream.MuteBlockSnapshot{MutedInstances: set("evil.example")}
+	ch := NewNotifications(ctx)
+	ch.Init(nil)
+	ch.OnRedisEvent([]byte(`{"id":"x1","type":"mention","user":{"id":"bob","host":"evil.example"}}`))
+	assert.Empty(t, ctx.sentType, "notification from a muted instance must be dropped")
+}
+
+func TestMain_BareNotificationDroppedByInstanceMute(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ctx.muteBlockSnap = &stream.MuteBlockSnapshot{MutedInstances: set("evil.example")}
+	ch := NewMain(ctx)
+	ch.Init(nil)
+	ch.OnRedisEvent([]byte(`{"id":"x1","type":"reaction","user":{"id":"bob","host":"evil.example"}}`))
+	assert.Empty(t, ctx.sentType, "bare notification from a muted instance must be dropped")
+}
+
 func TestMain_NonNoteEnvelopeVerbatim(t *testing.T) {
 	ctx := newCtx(&model.User{ID: "viewer"})
 	ch := NewMain(ctx)

--- a/internal/stream/channels/timeline_test.go
+++ b/internal/stream/channels/timeline_test.go
@@ -24,6 +24,7 @@ type stubContext struct {
 	hardMuteRules []byte
 	followingSnap map[string]bool
 	followingUpd  []followingUpdate
+	muteBlockSnap *stream.MuteBlockSnapshot
 }
 
 // followingUpdate records a call to UpdateFollowingSnapshot for assertions.
@@ -53,6 +54,9 @@ func (s *stubContext) Unsubscribe(topic string) {
 }
 func (s *stubContext) HardMuteRules() []byte              { return s.hardMuteRules }
 func (s *stubContext) FollowingSnapshot() map[string]bool { return s.followingSnap }
+func (s *stubContext) MuteBlockSnapshot() *stream.MuteBlockSnapshot {
+	return s.muteBlockSnap
+}
 func (s *stubContext) UpdateFollowingSnapshot(followeeID string, following bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/stream/connection.go
+++ b/internal/stream/connection.go
@@ -85,6 +85,13 @@ type Connection struct {
 	// 完了する。read (per-publish) と write (refresh) は followingMu で protect。
 	followingMu       sync.RWMutex
 	followingSnapshot map[string]bool
+
+	// muteBlock は viewer の mute/block snapshot (#1711)。main / notifications
+	// channel が notification / mention 配信時に instance-mute / block / mute を
+	// gate するのに使う。接続確立時に 1 回 fetch する。followingSnapshot と同じく
+	// read (per-publish) と write (set) が並行するので muteBlockMu で protect。
+	muteBlockMu sync.RWMutex
+	muteBlock   *MuteBlockSnapshot
 }
 
 // NewConnection wraps an upgraded WebSocket. id は呼び出し側 (Manager) が一意
@@ -201,6 +208,31 @@ func (c *Connection) UpdateFollowingSnapshot(followeeID string, following bool) 
 		delete(next, followeeID)
 	}
 	c.followingSnapshot = next
+}
+
+// SetMuteBlockSnapshot attaches the viewer's mute/block snapshot so the main /
+// notifications channels can drop notifications / mentions involving muted
+// instances, muted users, or users blocking the viewer (#1711). Called once at
+// connection setup. nil leaves the gate disabled (fail-open: nothing dropped),
+// matching upstream の「Set が空 = 全通過」default。並行安全: 内部 pointer を
+// 全置換するだけで snapshot 内 map は mutate しない (reader は古い snapshot を
+// そのまま読み続けて GC される)。
+func (c *Connection) SetMuteBlockSnapshot(snap *MuteBlockSnapshot) {
+	c.muteBlockMu.Lock()
+	c.muteBlock = snap
+	c.muteBlockMu.Unlock()
+}
+
+// MuteBlockSnapshot returns the viewer's mute/block snapshot. Safe for
+// concurrent read while SetMuteBlockSnapshot updates the value. Returns nil for
+// anonymous connections / when the lookup is unwired or failed — callers must
+// treat nil as "no filtering" (fail-open).
+//
+// 戻り値は internal pointer / map の参照。caller は **mutate しないこと**。
+func (c *Connection) MuteBlockSnapshot() *MuteBlockSnapshot {
+	c.muteBlockMu.RLock()
+	defer c.muteBlockMu.RUnlock()
+	return c.muteBlock
 }
 
 // SetPermissions attaches OAuth2 permission scopes for this connection.

--- a/internal/stream/connection_test.go
+++ b/internal/stream/connection_test.go
@@ -304,6 +304,23 @@ func TestConnection_HardMuteRules(t *testing.T) {
 	}
 }
 
+// #1711: SetMuteBlockSnapshot / MuteBlockSnapshot round-trip。
+func TestConnection_MuteBlockSnapshot(t *testing.T) {
+	c := NewConnection("c1", nil, nil)
+	if got := c.MuteBlockSnapshot(); got != nil {
+		t.Fatalf("default MuteBlockSnapshot = %v, want nil", got)
+	}
+	snap := &MuteBlockSnapshot{Muting: map[string]struct{}{"u1": {}}}
+	c.SetMuteBlockSnapshot(snap)
+	got := c.MuteBlockSnapshot()
+	if got == nil || len(got.Muting) != 1 {
+		t.Fatalf("MuteBlockSnapshot = %v, want %v", got, snap)
+	}
+	if _, ok := got.Muting["u1"]; !ok {
+		t.Fatalf("MuteBlockSnapshot.Muting missing u1")
+	}
+}
+
 // #1063: SetFollowingSnapshot / FollowingSnapshot round-trip。
 func TestConnection_FollowingSnapshot(t *testing.T) {
 	c := NewConnection("c1", nil, nil)

--- a/internal/stream/dispatcher.go
+++ b/internal/stream/dispatcher.go
@@ -448,6 +448,16 @@ func (c *channelContext) UpdateFollowingSnapshot(followeeID string, following bo
 	c.dispatcher.conn.UpdateFollowingSnapshot(followeeID, following)
 }
 
+// MuteBlockSnapshot forwards the connection-level mute/block snapshot so the
+// main / notifications channels can gate notification / mention delivery
+// (#1711).
+func (c *channelContext) MuteBlockSnapshot() *MuteBlockSnapshot {
+	if c.dispatcher.conn == nil {
+		return nil
+	}
+	return c.dispatcher.conn.MuteBlockSnapshot()
+}
+
 // --- readNotification / subNote / unsubNote ---
 
 // handleReadNotification marks all notifications as read for the connected user.

--- a/internal/stream/dispatcher_test.go
+++ b/internal/stream/dispatcher_test.go
@@ -1080,3 +1080,24 @@ func TestChannelContext_HardMuteRules_NilConn(t *testing.T) {
 		t.Fatalf("expected nil, got %q", got)
 	}
 }
+
+// #1711: channelContext.MuteBlockSnapshot forwards from Connection.
+func TestChannelContext_MuteBlockSnapshot(t *testing.T) {
+	conn := NewConnection("c1", nil, newFakeConn())
+	conn.SetMuteBlockSnapshot(&MuteBlockSnapshot{Muting: map[string]struct{}{"u1": {}}})
+	d := NewDispatcher(conn, nil, newStubBus())
+	ctx := &channelContext{dispatcher: d, id: "ch1"}
+	got := ctx.MuteBlockSnapshot()
+	if got == nil || len(got.Muting) != 1 {
+		t.Fatalf("MuteBlockSnapshot = %v", got)
+	}
+}
+
+// nil connection (= disconnected) でも panic せず nil を返す。
+func TestChannelContext_MuteBlockSnapshot_NilConn(t *testing.T) {
+	d := &Dispatcher{}
+	ctx := &channelContext{dispatcher: d, id: "ch1"}
+	if got := ctx.MuteBlockSnapshot(); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}

--- a/internal/stream/manager.go
+++ b/internal/stream/manager.go
@@ -40,6 +40,7 @@ type Manager struct {
 	notifReader     NotificationReader
 	hardMute        HardMuteRulesLookup
 	followingLookup FollowingSnapshotLookup
+	muteBlockLookup MuteBlockSnapshotLookup
 	noteVisibility  NoteVisibilityChecker
 }
 
@@ -75,6 +76,15 @@ func (m *Manager) SetFollowingSnapshotLookup(l FollowingSnapshotLookup) {
 	m.followingLookup = l
 }
 
+// SetMuteBlockSnapshotLookup wires a lookup that returns the viewer's
+// mute/block snapshot (muting / blocking-me / renote-muting / muted-instances /
+// muting-channels). Called at connection setup so the main / notifications
+// channels can gate notification / mention delivery (#1711). nil disables the
+// per-publish mute/block filter (fail-open).
+func (m *Manager) SetMuteBlockSnapshotLookup(l MuteBlockSnapshotLookup) {
+	m.muteBlockLookup = l
+}
+
 // SetNoteVisibilityChecker wires a NoteVisibilityChecker so per-connection
 // Dispatcher can refuse subNote subscriptions to non-visible notes
 // (#1460 IDOR fix)。未配線時は fail-closed で全 subNote が subscribe しない
@@ -98,6 +108,12 @@ func (m *Manager) Accept(ws *websocket.Conn, user *model.User) {
 		// fetch 失敗 (= lookup nil 返却) は anonymous 同等に degrade し、reply
 		// gate は escape hatch のみで動く (#1063)。
 		c.SetFollowingSnapshot(m.followingLookup.FollowingSnapshotForUser(user.ID))
+	}
+	if m.muteBlockLookup != nil && user != nil {
+		// 接続後、最初の publish より前に mute/block snapshot を attach。fetch
+		// 失敗 (= nil 返却) は fail-open に degrade し、main / notifications は
+		// filter 無しで動き続ける (#1711)。
+		c.SetMuteBlockSnapshot(m.muteBlockLookup.MuteBlockSnapshotForUser(user.ID))
 	}
 	dispatcher := NewDispatcher(c, m.registry, m.bus)
 	if m.notifReader != nil {

--- a/internal/stream/manager_test.go
+++ b/internal/stream/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -87,6 +88,53 @@ func TestManager_AcceptViaHTTPTestServer(t *testing.T) {
 	require.Eventually(t, func() bool { return m.Count() == 1 }, time.Second, 10*time.Millisecond)
 	_ = conn.Close()
 	require.Eventually(t, func() bool { return m.Count() == 0 }, time.Second, 10*time.Millisecond)
+}
+
+// stubMuteBlockLookup records the userID Accept passes so the wiring can be
+// asserted without inspecting the (otherwise un-addressable) Connection.
+type stubMuteBlockLookup struct {
+	mu         sync.Mutex
+	calledWith string
+	snap       *MuteBlockSnapshot
+}
+
+func (s *stubMuteBlockLookup) MuteBlockSnapshotForUser(userID string) *MuteBlockSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calledWith = userID
+	return s.snap
+}
+
+func (s *stubMuteBlockLookup) called() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calledWith
+}
+
+// TestManager_AcceptInvokesMuteBlockLookup verifies Accept fetches and attaches
+// the viewer's mute/block snapshot at connection setup (#1711).
+func TestManager_AcceptInvokesMuteBlockLookup(t *testing.T) {
+	m := NewManager(nil, nil)
+	lookup := &stubMuteBlockLookup{snap: &MuteBlockSnapshot{Muting: map[string]struct{}{"x": {}}}}
+	m.SetMuteBlockSnapshotLookup(lookup)
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		go m.Accept(conn, &model.User{ID: "alice"})
+	}))
+	defer srv.Close()
+
+	url := "ws" + strings.TrimPrefix(srv.URL, "http")
+	dialer := websocket.Dialer{HandshakeTimeout: time.Second}
+	conn, _, err := dialer.Dial(url, nil)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	require.Eventually(t, func() bool { return lookup.called() == "alice" }, time.Second, 10*time.Millisecond)
 }
 
 // TestManager_AcceptDispatchesConnectMessages verifies that Accept wires the

--- a/internal/stream/mute_block_snapshot.go
+++ b/internal/stream/mute_block_snapshot.go
@@ -1,0 +1,39 @@
+package stream
+
+// MuteBlockSnapshot captures the viewer's mute / block relationships at
+// connection setup so the main / notifications channels can apply upstream
+// `main.ts` の instance-mute / block / mute gate per-publish without a DB round
+// trip (#1711). It mirrors the Connection-level Sets that upstream Misskey
+// fetches in `Connection#fetch` (userIdsWhoMeMuting / userIdsWhoBlockingMe /
+// userIdsWhoMeMutingRenotes / userMutedInstances / mutingChannels).
+//
+// 全 set は接続確立時に 1 回 fetch する snapshot で、followingSnapshot と同じく
+// mute/block 変更時の live refresh は現状未実装 (= 接続を張り直すまで stale)。
+// upstream は 10 秒間隔で再 fetch するが、mk-go では接続単位の精度で parity を
+// 回復する。nil snapshot (anonymous / lookup 未配線 / fetch 失敗) は fail-open
+// 扱い — gate は何も drop せず upstream の「空 Set = 全通過」default に degrade
+// する。
+type MuteBlockSnapshot struct {
+	// Muting は viewer が mute している user id の集合 (= userIdsWhoMeMuting)。
+	Muting map[string]struct{}
+	// BlockingMe は viewer を block している user id の集合
+	// (= userIdsWhoBlockingMe)。これらの user が関わる note は drop する。
+	BlockingMe map[string]struct{}
+	// RenoteMuting は viewer が renote-mute している user id の集合
+	// (= userIdsWhoMeMutingRenotes)。pure renote のみ gate する。
+	RenoteMuting map[string]struct{}
+	// MutedInstances は viewer が mute している instance host の集合
+	// (= userMutedInstances)。host は lowercase 前提 (AP canonical)。
+	MutedInstances map[string]struct{}
+	// MutingChannels は viewer が mute している channel id の集合
+	// (= mutingChannels)。
+	MutingChannels map[string]struct{}
+}
+
+// MuteBlockSnapshotLookup returns the viewer's mute/block snapshot for the
+// given user, used by the streaming Manager to attach it at connection setup
+// (#1711). Returns nil for anonymous connections or when the lookup fails — in
+// that case the main / notifications channels fall back to no filtering.
+type MuteBlockSnapshotLookup interface {
+	MuteBlockSnapshotForUser(userID string) *MuteBlockSnapshot
+}


### PR DESCRIPTION
## Summary

`#1711` (`#1549` 派生) の「main channel の mention / notification 送出時に mute / instance-mute / block フィルタが効かない」を解消する。

upstream `main.ts` は配信前に以下を適用する:
- **notification**: `isUserFromMutedInstance` (+ user-mute / isHidden 再 pack)
- **mention**: `isInstanceMuted` + `isNoteVisibleForMe` + `isNoteMutedOrBlocked` (+ isHidden 再 pack)

mk-go は user-mute のみ通知作成時 (`notifyLocalUser` の `IsMuted`) に適用しており、instance-mute / block / note-level mute が main / notifications channel で一切 gate されていなかった。viewer の mute/block snapshot を接続確立時に 1 回 fetch し、配信時に payload-based で gate する仕組みを追加する (`followingSnapshot` / `hardMuteRules` と同じ connection-time snapshot パターン)。

## 主な変更点

- **`internal/stream/mute_block_snapshot.go` (新規)**: `MuteBlockSnapshot` (muting / blocking-me / renote-muting / muted-instances / muting-channels の 5 set) + `MuteBlockSnapshotLookup` interface。
- **`internal/stream/connection.go`**: `SetMuteBlockSnapshot` / `MuteBlockSnapshot` を追加 (RWMutex 保護、全置換でスレッドセーフ)。
- **`internal/stream/manager.go`**: `SetMuteBlockSnapshotLookup` + `Accept` で snapshot を attach。
- **`internal/stream/channel.go` / `dispatcher.go`**: `ChannelContext` に `MuteBlockSnapshot()` を追加し `channelContext` から forward。
- **`internal/stream/channels/main_mute_filter.go` (新規)**: `noteMutedOrBlocked` / `notificationFromMutedInstance` helper。upstream の `isNoteMutedOrBlocked` / `isInstanceMuted` / `isUserRelated` / `isChannelRelated` / `isRenotePacked && !isQuotePacked` を payload-based に port。
- **`internal/stream/channels/notifications.go`**: `NotificationsChannel` + `MainChannel` の notification 配信に instance-mute gate、`MainChannel` の **mention** envelope に `isNoteVisibleForMe` + `isNoteMutedOrBlocked` gate を追加。`reply` / `renote` は upstream `main.ts` の switch でも gate されないためそのまま転送。
- **`internal/server/router.go`**: `muteBlockSnapshotAdapter` を muting / blocking / renote-muting / channel-muting repo + user profile (`mutedInstances`) から組んで配線。

## 設計上の判断

- **user-mute の二重適用回避**: notification path は user-mute を通知作成時に適用済みのため、ここでは instance-mute のみ評価する。mention path は通知とは別経路 (作成時 filter なし) なので `isNoteMutedOrBlocked` 内で user-mute も評価する (二重適用ではない)。
- **fail-open**: nil snapshot (anonymous / lookup 失敗) は何も drop しない (upstream の「空 Set = 全通過」default と一致)。
- **可視性の二重 gate**: mention の可視性は publish 段の `CanSeeNote` で per-recipient gate 済だが、mention recipient は `mentions` / `visibleUserIds` に必ず含まれるため channel 側で再評価しても誤 drop しない (defense-in-depth)。
- **既知の制限**: snapshot は接続確立時の 1 回 fetch で、mute/block 変更時の live refresh は未実装 (= 再接続まで stale)。upstream は 10 秒間隔で再 fetch するが、mk-go では `followingSnapshot` と同じ connection-time snapshot 方針に揃える。live refresh は follow-up 候補。

## テスト

- `internal/stream/channels/main_mute_filter_test.go` (新規): `noteMutedOrBlocked` (instance/user-mute/block/renote-mute/channel-mute + nil + parse-fail)、`notificationFromMutedInstance`、`userRelated`、`channelRelated`、`isPureRenotePayload` を網羅。
- `internal/stream/channels/notifications_test.go`: MainChannel mention の instance-mute / user-mute / block / visibility drop + clean/nil-snapshot pass、reply は非 gate、NotificationsChannel + MainChannel bare-notification の instance-mute drop を追加。
- `internal/stream/connection_test.go` / `manager_test.go` / `dispatcher_test.go`: snapshot round-trip + Accept での lookup 呼び出し + channelContext forward。
- 実行:
  - `go test ./internal/stream/... -race -count=1` → pass
  - coverage: stream 90.8% / stream/channels 92.7% (90% gate 維持)
  - `go build ./... && go vet ./...` → pass

## Closes

`#1711` を解消する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)