### PR TITLE
Fix gallery: like/unlike 存在チェック + delete モデレータ削除 + featured ランキング (#1548)

### DIFF
--- a/internal/api/gallery/handler.go
+++ b/internal/api/gallery/handler.go
@@ -1,13 +1,16 @@
 package gallery
 
 import (
+	"context"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
+	"github.com/shiroha-a/mk/internal/core/moderationlog"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -15,10 +18,38 @@ import (
 	"gorm.io/gorm"
 )
 
+// galleryPostsRankingWindow mirrors upstream GALLERY_POSTS_RANKING_WINDOW
+// (= 3日)。post 作成からこの期間内の like/unlike だけが featured ランキングへ
+// 反映される (#1548)。
+const galleryPostsRankingWindow = 3 * 24 * time.Hour
+
+// GalleryRanking is the subset of core/featured.Service used by gallery like /
+// unlike / featured (#1548). nil 配線時は ranking 更新を skip し、featured は
+// 空配列に degrade する。
+type GalleryRanking interface {
+	UpdateGalleryPostsRanking(ctx context.Context, postID string, score float64) error
+	GetGalleryPostsRanking(ctx context.Context, threshold int) ([]string, error)
+}
+
+// RoleChecker reports whether a user is a moderator. Satisfied by
+// *core/role.Service. nil 配線時は全員 non-moderator 扱い。
+type RoleChecker interface {
+	IsModerator(userID string) bool
+}
+
+// ModLogger records a moderation action. Satisfied by *core/moderationlog.Service.
+// nil 配線時は記録を skip する。
+type ModLogger interface {
+	Log(ctx context.Context, moderatorID string, t moderationlog.LogType, info map[string]any)
+}
+
 // Handler handles gallery-related API endpoints.
 type Handler struct {
-	db    *gorm.DB
-	idGen id.Generator
+	db      *gorm.DB
+	idGen   id.Generator
+	ranking GalleryRanking
+	roles   RoleChecker
+	modLog  ModLogger
 }
 
 // NewHandler creates a new gallery Handler.
@@ -26,18 +57,74 @@ func NewHandler(db *gorm.DB, idGen id.Generator) *Handler {
 	return &Handler{db: db, idGen: idGen}
 }
 
+// SetRanking wires the featured gallery-posts ranking used by like / unlike /
+// featured (#1548). nil disables ranking updates and degrades featured to [].
+func (h *Handler) SetRanking(r GalleryRanking) { h.ranking = r }
+
+// SetRoleChecker wires the moderator check used by posts/delete (#1548).
+func (h *Handler) SetRoleChecker(r RoleChecker) { h.roles = r }
+
+// SetModLog wires the moderation log writer used when a moderator deletes
+// another user's gallery post (#1548).
+func (h *Handler) SetModLog(m ModLogger) { h.modLog = m }
+
 // Featured handles POST /api/gallery/featured.
+//
+// upstream featured.ts は featuredService.getGalleryPostsRanking(100) (Redis
+// 時間窓ランキング) を読み、id DESC sort → untilId filter → limit slice →
+// id IN で取得して packMany する (#1548)。mk-go は upstream の 30 分メモリ
+// キャッシュは持たず毎回 Redis を読む (= 常に最新、API shape は同一)。ranking
+// 未配線時は空配列に degrade する。
 func (h *Handler) Featured(c echo.Context) error {
+	var req struct {
+		Limit   int    `json:"limit"`
+		UntilID string `json:"untilId"`
+	}
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	}
+	limit := pagination.ClampLimit(req.Limit, 10, 100)
+	if h.ranking == nil {
+		return c.JSON(http.StatusOK, []map[string]any{})
+	}
+	ids, err := h.ranking.GetGalleryPostsRanking(c.Request().Context(), 100)
+	if err != nil || len(ids) == 0 {
+		return c.JSON(http.StatusOK, []map[string]any{})
+	}
+	// upstream は postIds を id DESC に sort してから untilId/limit を適用する。
+	sort.Sort(sort.Reverse(sort.StringSlice(ids)))
+	if req.UntilID != "" {
+		filtered := ids[:0:0]
+		for _, pid := range ids {
+			if pid < req.UntilID {
+				filtered = append(filtered, pid)
+			}
+		}
+		ids = filtered
+	}
+	if len(ids) > limit {
+		ids = ids[:limit]
+	}
+	if len(ids) == 0 {
+		return c.JSON(http.StatusOK, []map[string]any{})
+	}
 	var posts []*model.GalleryPost
-	if err := h.db.Preload("User").Order("\"likedCount\" DESC").Limit(10).Find(&posts).Error; err != nil {
+	if err := h.db.Preload("User").Where("id IN ?", ids).Find(&posts).Error; err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.JSON(http.StatusOK, h.packMany(posts, middleware.GetUser(c)))
 }
 
 // Popular handles POST /api/gallery/popular.
+//
+// upstream popular.ts は likedCount>0 の post を likedCount DESC で 10 件返す
+// (#1548)。featured (Redis ランキング) とは別ロジック。
 func (h *Handler) Popular(c echo.Context) error {
-	return h.Featured(c) // 同じロジック
+	var posts []*model.GalleryPost
+	if err := h.db.Preload("User").Where("\"likedCount\" > 0").Order("\"likedCount\" DESC").Limit(10).Find(&posts).Error; err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	return c.JSON(http.StatusOK, h.packMany(posts, middleware.GetUser(c)))
 }
 
 // Posts handles POST /api/gallery/posts.
@@ -178,11 +265,40 @@ func (h *Handler) PostsDelete(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.PostID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "postId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	result := h.db.Where("id = ? AND \"userId\" = ?", req.PostID, user.ID).Delete(&model.GalleryPost{})
-	if result.RowsAffected == 0 {
+	var post model.GalleryPost
+	if err := h.db.Where("id = ?", req.PostID).First(&post).Error; err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_POST", "No such post.", "ae52f367-4bd7-4ecd-afc6-5672fff427f5"))
 	}
+	// upstream delete.ts: 所有者でもモデレータでもなければ ACCESS_DENIED。
+	// モデレータは他人の post も削除でき、その場合 moderationLog を残す (#1548)。
+	isOwner := post.UserID == user.ID
+	isModerator := h.roles != nil && h.roles.IsModerator(user.ID)
+	if !isOwner && !isModerator {
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "c86e09de-1c48-43ac-a435-1c7e42ed4496"))
+	}
+	if err := h.db.Where("id = ?", post.ID).Delete(&model.GalleryPost{}).Error; err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	// 他人の post をモデレータ権限で削除した場合のみ監査ログを残す。
+	if !isOwner && h.modLog != nil {
+		h.modLog.Log(c.Request().Context(), user.ID, moderationlog.LogDeleteGalleryPost, map[string]any{
+			"postId":           post.ID,
+			"postUserId":       post.UserID,
+			"postUserUsername": h.usernameOf(post.UserID),
+			"post":             h.buildPostMap(&post, h.resolveFiles(post.FileIDs), nil),
+		})
+	}
 	return c.NoContent(http.StatusNoContent)
+}
+
+// usernameOf returns the username for userID, or "" when the lookup fails.
+// Used to populate the moderation log info (#1548).
+func (h *Handler) usernameOf(userID string) string {
+	var u model.User
+	if err := h.db.Select("username").Where("id = ?", userID).First(&u).Error; err != nil {
+		return ""
+	}
+	return u.Username
 }
 
 // PostsUpdate handles POST /api/gallery/posts/update.
@@ -248,13 +364,37 @@ func (h *Handler) PostsLike(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.PostID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "postId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
+	// upstream like.ts: post 不在 → NO_SUCH_POST、自分の post → YOUR_POST、
+	// 既 like → ALREADY_LIKED の順で判定する (#1548)。
+	var post model.GalleryPost
+	if err := h.db.Where("id = ?", req.PostID).First(&post).Error; err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_POST", "No such post.", "56c06af3-1287-442f-9701-c93f7c4a62ff"))
+	}
+	if post.UserID == user.ID {
+		return c.JSON(http.StatusBadRequest, apierr.Error("YOUR_POST", "You cannot like your post.", "f78f1511-5ebc-4478-a888-1198d752da68"))
+	}
+	// 既 like は ALREADY_LIKED。upstream は insert 前に exists チェックするので、
+	// insert 自体の失敗 (= 想定外の DB error) は ALREADY_LIKED でなく 500 に倒す。
+	var existing int64
+	h.db.Model(&model.GalleryLike{}).Where("\"userId\" = ? AND \"postId\" = ?", user.ID, req.PostID).Count(&existing)
+	if existing > 0 {
+		return c.JSON(http.StatusConflict, apierr.Error("ALREADY_LIKED", "Already liked.", "40e9ed56-a59c-473a-bf3f-f289c54fb5a7"))
+	}
 	like := &model.GalleryLike{
 		ID:     h.idGen.Generate(time.Now()),
 		UserID: user.ID,
 		PostID: req.PostID,
 	}
 	if err := h.db.Create(like).Error; err != nil {
-		return c.JSON(http.StatusConflict, apierr.Error("ALREADY_LIKED", "Already liked.", "40e9ed56-a59c-473a-bf3f-f289c54fb5a7"))
+		// exists チェックを通った後の insert 失敗は競合 like の unique 違反含め
+		// 想定外。ALREADY_LIKED に丸めず INTERNAL_ERROR を返す。
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	// ランキング更新は post 作成から RANKING_WINDOW 内のみ (#1548)。
+	if h.ranking != nil {
+		if t, err := h.idGen.ParseTime(post.ID); err == nil && time.Since(t) < galleryPostsRankingWindow {
+			_ = h.ranking.UpdateGalleryPostsRanking(c.Request().Context(), post.ID, 1)
+		}
 	}
 	h.db.Model(&model.GalleryPost{}).Where("id = ?", req.PostID).UpdateColumn("\"likedCount\"", gorm.Expr("\"likedCount\" + 1"))
 	return c.NoContent(http.StatusNoContent)
@@ -269,7 +409,21 @@ func (h *Handler) PostsUnlike(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.PostID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "postId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	h.db.Where("\"userId\" = ? AND \"postId\" = ?", user.ID, req.PostID).Delete(&model.GalleryLike{})
+	// upstream unlike.ts: post 不在 → NO_SUCH_POST、未 like → NOT_LIKED (#1548)。
+	var post model.GalleryPost
+	if err := h.db.Where("id = ?", req.PostID).First(&post).Error; err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_POST", "No such post.", "c32e6dd0-b555-4413-925e-b3757d19ed84"))
+	}
+	result := h.db.Where("\"userId\" = ? AND \"postId\" = ?", user.ID, req.PostID).Delete(&model.GalleryLike{})
+	if result.RowsAffected == 0 {
+		return c.JSON(http.StatusBadRequest, apierr.Error("NOT_LIKED", "You have not liked that post.", "e3e8e06e-be37-41f7-a5b4-87a8250288f0"))
+	}
+	// ランキング更新は post 作成から RANKING_WINDOW 内のみ (#1548)。
+	if h.ranking != nil {
+		if t, err := h.idGen.ParseTime(post.ID); err == nil && time.Since(t) < galleryPostsRankingWindow {
+			_ = h.ranking.UpdateGalleryPostsRanking(c.Request().Context(), post.ID, -1)
+		}
+	}
 	h.db.Model(&model.GalleryPost{}).Where("id = ?", req.PostID).UpdateColumn("\"likedCount\"", gorm.Expr("GREATEST(\"likedCount\" - 1, 0)"))
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/gallery/handler_test.go
+++ b/internal/api/gallery/handler_test.go
@@ -1,6 +1,7 @@
 package gallery_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/gallery"
+	"github.com/shiroha-a/mk/internal/core/moderationlog"
 	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -28,6 +30,7 @@ func init() {
 	testIDGen, _ = id.NewGenerator("aidx")
 	testutil.ApplyMigrations(testDB)
 	testDB.Exec(`INSERT INTO "user" (id, username, "usernameLower", "avatarDecorations") VALUES ('gal_u1', 'galuser', 'galuser', '[]') ON CONFLICT DO NOTHING`)
+	testDB.Exec(`INSERT INTO "user" (id, username, "usernameLower", "avatarDecorations") VALUES ('gal_u2', 'galuser2', 'galuser2', '[]') ON CONFLICT DO NOTHING`)
 }
 
 func newHandler() *gallery.Handler {
@@ -39,6 +42,61 @@ func brokenHandler() *gallery.Handler {
 	sqlDB, _ := db.DB()
 	_ = sqlDB.Close()
 	return gallery.NewHandler(db, testIDGen)
+}
+
+// stubRanking is an in-memory GalleryRanking for #1548 tests. It records
+// UpdateGalleryPostsRanking calls and returns a fixed ID list from Get.
+type stubRanking struct {
+	ids     []string
+	getErr  error
+	updates []ratingUpdate
+}
+
+type ratingUpdate struct {
+	postID string
+	score  float64
+}
+
+func (s *stubRanking) UpdateGalleryPostsRanking(_ context.Context, postID string, score float64) error {
+	s.updates = append(s.updates, ratingUpdate{postID, score})
+	return nil
+}
+
+func (s *stubRanking) GetGalleryPostsRanking(_ context.Context, _ int) ([]string, error) {
+	return s.ids, s.getErr
+}
+
+// stubRoles implements gallery.RoleChecker.
+type stubRoles struct{ moderators map[string]bool }
+
+func (s *stubRoles) IsModerator(userID string) bool { return s.moderators[userID] }
+
+// stubModLog records moderation log calls for #1548 tests.
+type stubModLog struct{ calls []modLogCall }
+
+type modLogCall struct {
+	moderatorID string
+	logType     moderationlog.LogType
+	info        map[string]any
+}
+
+func (s *stubModLog) Log(_ context.Context, moderatorID string, t moderationlog.LogType, info map[string]any) {
+	s.calls = append(s.calls, modLogCall{moderatorID, t, info})
+}
+
+func newHandlerWithRanking(r gallery.GalleryRanking) *gallery.Handler {
+	h := gallery.NewHandler(testDB, testIDGen)
+	h.SetRanking(r)
+	return h
+}
+
+func brokenHandlerWithRanking(r gallery.GalleryRanking) *gallery.Handler {
+	db := testutil.MustOpenTestDB()
+	sqlDB, _ := db.DB()
+	_ = sqlDB.Close()
+	h := gallery.NewHandler(db, testIDGen)
+	h.SetRanking(r)
+	return h
 }
 
 func cleanup() {
@@ -71,23 +129,54 @@ func doPost(h func(echo.Context) error, body string, user *model.User) *httptest
 
 // --- Featured / Popular / Posts ---
 
-func TestFeatured_Empty(t *testing.T) {
+// nil ranking (= 未配線) は空配列に degrade する (#1548)。
+func TestFeatured_NilRankingEmpty(t *testing.T) {
 	cleanup()
-	assert.Equal(t, http.StatusOK, doPost(newHandler().Featured, `{}`, nil).Code)
+	rec := doPost(newHandler().Featured, `{}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "[]\n", rec.Body.String())
 }
 
-func TestFeatured_WithData(t *testing.T) {
+// ranking が空 ID なら空配列 (#1548)。
+func TestFeatured_EmptyRanking(t *testing.T) {
+	cleanup()
+	rec := doPost(newHandlerWithRanking(&stubRanking{ids: nil}).Featured, `{}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "[]\n", rec.Body.String())
+}
+
+// ranking の ID で post を引いて返す (#1548)。
+func TestFeatured_WithRanking(t *testing.T) {
 	cleanup()
 	testDB.Create(&model.GalleryPost{ID: "gp_f1", UpdatedAt: time.Now(), Title: "Art", UserID: "gal_u1", FileIDs: []string{}, Tags: []string{}})
 	defer cleanup()
-	rec := doPost(newHandler().Featured, `{}`, nil)
+	rec := doPost(newHandlerWithRanking(&stubRanking{ids: []string{"gp_f1"}}).Featured, `{}`, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "Art")
 }
 
-func TestPopular(t *testing.T) {
+// untilId フィルタで ID 範囲を絞る (#1548)。
+func TestFeatured_UntilIDFilter(t *testing.T) {
 	cleanup()
-	assert.Equal(t, http.StatusOK, doPost(newHandler().Popular, `{}`, nil).Code)
+	testDB.Create(&model.GalleryPost{ID: "gp_aaa", UpdatedAt: time.Now(), Title: "Low", UserID: "gal_u1", FileIDs: []string{}, Tags: []string{}})
+	testDB.Create(&model.GalleryPost{ID: "gp_zzz", UpdatedAt: time.Now(), Title: "High", UserID: "gal_u1", FileIDs: []string{}, Tags: []string{}})
+	defer cleanup()
+	rec := doPost(newHandlerWithRanking(&stubRanking{ids: []string{"gp_aaa", "gp_zzz"}}).Featured, `{"untilId":"gp_bbb"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "Low")
+	assert.NotContains(t, rec.Body.String(), "High")
+}
+
+// popular は likedCount>0 の post のみを likedCount DESC で返す (#1548)。
+func TestPopular_FiltersZeroLikes(t *testing.T) {
+	cleanup()
+	testDB.Create(&model.GalleryPost{ID: "gp_p0", UpdatedAt: time.Now(), Title: "Zero", UserID: "gal_u1", FileIDs: []string{}, Tags: []string{}, LikedCount: 0})
+	testDB.Create(&model.GalleryPost{ID: "gp_p1", UpdatedAt: time.Now(), Title: "Liked", UserID: "gal_u1", FileIDs: []string{}, Tags: []string{}, LikedCount: 3})
+	defer cleanup()
+	rec := doPost(newHandler().Popular, `{}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "Liked")
+	assert.NotContains(t, rec.Body.String(), "Zero")
 }
 
 func TestPosts_Success(t *testing.T) {
@@ -193,7 +282,9 @@ func TestPosts_InvalidJSON(t *testing.T) {
 }
 
 func TestFeatured_DBError(t *testing.T) {
-	assert.Equal(t, http.StatusInternalServerError, doPost(brokenHandler().Featured, `{}`, nil).Code)
+	// ranking が ID を返した後の id IN 取得で DB error → 500。
+	h := brokenHandlerWithRanking(&stubRanking{ids: []string{"gp_x"}})
+	assert.Equal(t, http.StatusInternalServerError, doPost(h.Featured, `{}`, nil).Code)
 }
 
 func TestPosts_DBError(t *testing.T) {
@@ -308,6 +399,58 @@ func TestPostsDelete_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, doPost(newHandler().PostsDelete, `{}`, &model.User{ID: "u1"}).Code)
 }
 
+// 非所有者かつ非モデレータの削除は ACCESS_DENIED (#1548)。
+func TestPostsDelete_AccessDenied(t *testing.T) {
+	cleanup()
+	testDB.Create(&model.GalleryPost{ID: "gp_ad", UpdatedAt: time.Now(), Title: "Del", UserID: "gal_u1", FileIDs: []string{}, Tags: []string{}})
+	defer cleanup()
+	h := newHandler()
+	h.SetRoleChecker(&stubRoles{moderators: map[string]bool{}})
+	rec := doPost(h.PostsDelete, `{"postId":"gp_ad"}`, &model.User{ID: "gal_u2"})
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "c86e09de-1c48-43ac-a435-1c7e42ed4496")
+	// post は削除されていない。
+	var cnt int64
+	testDB.Model(&model.GalleryPost{}).Where("id = ?", "gp_ad").Count(&cnt)
+	assert.Equal(t, int64(1), cnt)
+}
+
+// モデレータは他人の post を削除でき、moderationLog を残す (#1548)。
+func TestPostsDelete_ModeratorWithModLog(t *testing.T) {
+	cleanup()
+	testDB.Create(&model.GalleryPost{ID: "gp_mod", UpdatedAt: time.Now(), Title: "Del", UserID: "gal_u1", FileIDs: []string{}, Tags: []string{}})
+	defer cleanup()
+	h := newHandler()
+	h.SetRoleChecker(&stubRoles{moderators: map[string]bool{"gal_u2": true}})
+	ml := &stubModLog{}
+	h.SetModLog(ml)
+	rec := doPost(h.PostsDelete, `{"postId":"gp_mod"}`, &model.User{ID: "gal_u2"})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	var cnt int64
+	testDB.Model(&model.GalleryPost{}).Where("id = ?", "gp_mod").Count(&cnt)
+	assert.Equal(t, int64(0), cnt)
+	require.Len(t, ml.calls, 1)
+	assert.Equal(t, moderationlog.LogDeleteGalleryPost, ml.calls[0].logType)
+	assert.Equal(t, "gal_u2", ml.calls[0].moderatorID)
+	assert.Equal(t, "gp_mod", ml.calls[0].info["postId"])
+	assert.Equal(t, "gal_u1", ml.calls[0].info["postUserId"])
+	assert.Equal(t, "galuser", ml.calls[0].info["postUserUsername"])
+}
+
+// 所有者自身の削除では moderationLog を残さない (#1548)。
+func TestPostsDelete_OwnerNoModLog(t *testing.T) {
+	cleanup()
+	testDB.Create(&model.GalleryPost{ID: "gp_own", UpdatedAt: time.Now(), Title: "Del", UserID: "gal_u1", FileIDs: []string{}, Tags: []string{}})
+	defer cleanup()
+	h := newHandler()
+	h.SetRoleChecker(&stubRoles{moderators: map[string]bool{"gal_u1": true}})
+	ml := &stubModLog{}
+	h.SetModLog(ml)
+	rec := doPost(h.PostsDelete, `{"postId":"gp_own"}`, &model.User{ID: "gal_u1"})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Empty(t, ml.calls, "owner 自身の削除では監査ログを残さない")
+}
+
 // --- Update ---
 
 func TestPostsUpdate_Success(t *testing.T) {
@@ -370,7 +513,31 @@ func TestPostsLike_Success(t *testing.T) {
 	pid := testIDGen.Generate(time.Now())
 	testDB.Create(&model.GalleryPost{ID: pid, UpdatedAt: time.Now(), Title: "Likeable", UserID: "gal_u1", FileIDs: []string{}, Tags: []string{}})
 	defer cleanup()
-	assert.Equal(t, http.StatusNoContent, doPost(newHandler().PostsLike, `{"postId":"`+pid+`"}`, &model.User{ID: "gal_u1"}).Code)
+	rank := &stubRanking{}
+	// gal_u2 が gal_u1 の post を like する (他人の post)。
+	assert.Equal(t, http.StatusNoContent, doPost(newHandlerWithRanking(rank).PostsLike, `{"postId":"`+pid+`"}`, &model.User{ID: "gal_u2"}).Code)
+	// 作成直後の post なので ranking 更新が +1 で走る。
+	require.Len(t, rank.updates, 1)
+	assert.Equal(t, ratingUpdate{pid, 1}, rank.updates[0])
+}
+
+// 自分の post を like すると YOUR_POST (#1548)。
+func TestPostsLike_YourPost(t *testing.T) {
+	cleanup()
+	pid := testIDGen.Generate(time.Now())
+	testDB.Create(&model.GalleryPost{ID: pid, UpdatedAt: time.Now(), Title: "Mine", UserID: "gal_u1", FileIDs: []string{}, Tags: []string{}})
+	defer cleanup()
+	rec := doPost(newHandler().PostsLike, `{"postId":"`+pid+`"}`, &model.User{ID: "gal_u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "f78f1511-5ebc-4478-a888-1198d752da68")
+}
+
+// 不在 post の like は NO_SUCH_POST (#1548)。
+func TestPostsLike_NoSuchPost(t *testing.T) {
+	cleanup()
+	rec := doPost(newHandler().PostsLike, `{"postId":"ghost"}`, &model.User{ID: "gal_u2"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "56c06af3-1287-442f-9701-c93f7c4a62ff")
 }
 
 func TestPostsLike_AlreadyLiked(t *testing.T) {
@@ -379,8 +546,8 @@ func TestPostsLike_AlreadyLiked(t *testing.T) {
 	testDB.Create(&model.GalleryPost{ID: pid, UpdatedAt: time.Now(), Title: "Liked", UserID: "gal_u1", FileIDs: []string{}, Tags: []string{}})
 	defer cleanup()
 	h := newHandler()
-	doPost(h.PostsLike, `{"postId":"`+pid+`"}`, &model.User{ID: "gal_u1"})
-	assert.Equal(t, http.StatusConflict, doPost(h.PostsLike, `{"postId":"`+pid+`"}`, &model.User{ID: "gal_u1"}).Code)
+	doPost(h.PostsLike, `{"postId":"`+pid+`"}`, &model.User{ID: "gal_u2"})
+	assert.Equal(t, http.StatusConflict, doPost(h.PostsLike, `{"postId":"`+pid+`"}`, &model.User{ID: "gal_u2"}).Code)
 }
 
 func TestPostsLike_InvalidParam(t *testing.T) {
@@ -388,7 +555,35 @@ func TestPostsLike_InvalidParam(t *testing.T) {
 }
 
 func TestPostsUnlike_Success(t *testing.T) {
-	assert.Equal(t, http.StatusNoContent, doPost(newHandler().PostsUnlike, `{"postId":"p1"}`, &model.User{ID: "u1"}).Code)
+	cleanup()
+	pid := testIDGen.Generate(time.Now())
+	testDB.Create(&model.GalleryPost{ID: pid, UpdatedAt: time.Now(), Title: "Unlikeable", UserID: "gal_u1", FileIDs: []string{}, Tags: []string{}, LikedCount: 1})
+	testDB.Create(&model.GalleryLike{ID: testIDGen.Generate(time.Now()), UserID: "gal_u2", PostID: pid})
+	defer cleanup()
+	rank := &stubRanking{}
+	rec := doPost(newHandlerWithRanking(rank).PostsUnlike, `{"postId":"`+pid+`"}`, &model.User{ID: "gal_u2"})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	require.Len(t, rank.updates, 1)
+	assert.Equal(t, ratingUpdate{pid, -1}, rank.updates[0])
+}
+
+// 不在 post の unlike は NO_SUCH_POST (#1548)。
+func TestPostsUnlike_NoSuchPost(t *testing.T) {
+	cleanup()
+	rec := doPost(newHandler().PostsUnlike, `{"postId":"ghost"}`, &model.User{ID: "gal_u2"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "c32e6dd0-b555-4413-925e-b3757d19ed84")
+}
+
+// 未 like の post を unlike すると NOT_LIKED (#1548)。
+func TestPostsUnlike_NotLiked(t *testing.T) {
+	cleanup()
+	pid := testIDGen.Generate(time.Now())
+	testDB.Create(&model.GalleryPost{ID: pid, UpdatedAt: time.Now(), Title: "Unliked", UserID: "gal_u1", FileIDs: []string{}, Tags: []string{}})
+	defer cleanup()
+	rec := doPost(newHandler().PostsUnlike, `{"postId":"`+pid+`"}`, &model.User{ID: "gal_u2"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "e3e8e06e-be37-41f7-a5b4-87a8250288f0")
 }
 
 func TestPostsUnlike_InvalidParam(t *testing.T) {

--- a/internal/core/featured/featured_service.go
+++ b/internal/core/featured/featured_service.go
@@ -18,6 +18,7 @@ const (
 	globalNotesRankingName    = "featuredGlobalNotesRanking"
 	inChannelNotesRankingName = "featuredInChannelNotesRanking" // ":<channelId>" を付ける
 	perUserNotesRankingName   = "featuredPerUserNotesRanking"   // ":<userId>" を付ける
+	galleryPostsRankingName   = "featuredGalleryPostsRanking"   // gallery/featured ランキング (#1548)
 )
 
 // Ranking time windows (upstream の *_RANKING_WINDOW 定数に対応)。各 window ごと
@@ -25,6 +26,9 @@ const (
 const (
 	globalNotesRankingWindow  = 3 * 24 * time.Hour // 3日ごと
 	perUserNotesRankingWindow = 7 * 24 * time.Hour // 1週間ごと
+	// galleryPostsRankingWindow は upstream GALLERY_POSTS_RANKING_WINDOW
+	// (= 3日) に対応する (#1548)。
+	galleryPostsRankingWindow = 3 * 24 * time.Hour
 )
 
 // featuredEpoch は window 番号計算の基準時刻 (upstream featuredEpoc =
@@ -163,4 +167,17 @@ func (s *Service) RemoveInChannelNotesRanking(ctx context.Context, channelID, no
 // RemovePerUserNotesRanking removes noteID from userID's per-user ranking windows.
 func (s *Service) RemovePerUserNotesRanking(ctx context.Context, userID, noteID string) error {
 	return s.removeFromRanking(ctx, perUserNotesRankingName+":"+userID, perUserNotesRankingWindow, noteID)
+}
+
+// UpdateGalleryPostsRanking adds score to postID in the gallery posts ranking
+// (upstream FeaturedService.updateGalleryPostsRanking, #1548). gallery/posts/like
+// で +1、unlike で -1 を加算する。
+func (s *Service) UpdateGalleryPostsRanking(ctx context.Context, postID string, score float64) error {
+	return s.updateRankingOf(ctx, galleryPostsRankingName, galleryPostsRankingWindow, postID, score)
+}
+
+// GetGalleryPostsRanking returns the top-threshold ranked gallery post IDs
+// (upstream FeaturedService.getGalleryPostsRanking, #1548). gallery/featured で使う。
+func (s *Service) GetGalleryPostsRanking(ctx context.Context, threshold int) ([]string, error) {
+	return s.getRankingOf(ctx, galleryPostsRankingName, galleryPostsRankingWindow, threshold)
 }

--- a/internal/core/featured/featured_service_test.go
+++ b/internal/core/featured/featured_service_test.go
@@ -176,3 +176,25 @@ func TestNewService_DefaultClock(t *testing.T) {
 	require.NotNil(t, s.now)
 	assert.Positive(t, s.currentWindow(globalNotesRankingWindow))
 }
+
+// TestService_GalleryPostsRanking covers the gallery posts ranking used by
+// gallery/featured (#1548): +1 on like, -1 on unlike, score-DESC retrieval.
+func TestService_GalleryPostsRanking(t *testing.T) {
+	ctx := context.Background()
+	now := featuredEpoch.Add(80 * galleryPostsRankingWindow)
+	s := newSvc(t, now)
+
+	require.NoError(t, s.UpdateGalleryPostsRanking(ctx, "p_low", 1))
+	require.NoError(t, s.UpdateGalleryPostsRanking(ctx, "p_high", 1))
+	require.NoError(t, s.UpdateGalleryPostsRanking(ctx, "p_high", 2)) // p_high 累計 3
+
+	ids, err := s.GetGalleryPostsRanking(ctx, 100)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"p_high", "p_low"}, ids)
+
+	// unlike (-1) を 2 回入れて p_high を p_low 以下に落とす。
+	require.NoError(t, s.UpdateGalleryPostsRanking(ctx, "p_high", -3))
+	ids, err = s.GetGalleryPostsRanking(ctx, 100)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"p_low", "p_high"}, ids)
+}

--- a/internal/core/moderationlog/types.go
+++ b/internal/core/moderationlog/types.go
@@ -87,6 +87,9 @@ const (
 	LogUpdateAbuseReportNotificationRecipient LogType = "updateAbuseReportNotificationRecipient"
 	LogDeleteAbuseReportNotificationRecipient LogType = "deleteAbuseReportNotificationRecipient"
 
+	// Content deletion by moderators
+	LogDeleteGalleryPost LogType = "deleteGalleryPost"
+
 	// Misc
 	LogUpdateProxyAccountDescription LogType = "updateProxyAccountDescription"
 )

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1610,6 +1610,8 @@ func (s *Server) setupRoutes() {
 
 	// Gallery endpoints (Phase 6)
 	galleryHandler := apigallery.NewHandler(s.db, idGen)
+	galleryHandler.SetRanking(featuredService) // #1548: like/unlike/featured ランキング
+	galleryHandler.SetRoleChecker(roleService) // #1548: posts/delete モデレータ削除
 	api.POST("/gallery/featured", galleryHandler.Featured)
 	api.POST("/gallery/popular", galleryHandler.Popular)
 	api.POST("/gallery/posts", galleryHandler.Posts)
@@ -2198,6 +2200,7 @@ func (s *Server) setupRoutes() {
 	// modlog を書くため同じ service instance を共有する。
 	announcementHandler.SetModLogService(modLogService)
 	announcementHandler.SetUserRepo(userRepo)
+	galleryHandler.SetModLog(modLogService) // #1548: moderator による gallery post 削除の監査ログ
 	adminHandler.SetEmojiRepo(emojiRepo)
 	adminHandler.SetDriveFileRepo(driveFileRepo)
 	// bulk drive cleanup (clean-remote-files / delete-all-files-of-a-user) で


### PR DESCRIPTION
## Summary

`#1548` (flash/gallery/pages parity) の **gallery/*** 5 項目 (MEDIUM 3 + LOW 2) を解消する。

## 主な変更点

### gallery/posts/like (MEDIUM)
- post 不在 → `NO_SUCH_POST` (56c06af3)、自分の post → `YOUR_POST` (f78f1511)、既 like → `ALREADY_LIKED` (40e9ed56) を upstream の順で判定。
- 旧実装は存在チェック無しで insert し全 error を `ALREADY_LIKED` に丸めていた。exists チェックを明示し、insert 自体の失敗は `INTERNAL_ERROR` に倒す。
- like 後、post 作成から `GALLERY_POSTS_RANKING_WINDOW` (3日) 内なら featured ランキングへ +1。

### gallery/posts/unlike (MEDIUM)
- post 不在 → `NO_SUCH_POST` (c32e6dd0)、未 like → `NOT_LIKED` (e3e8e06e)。RANKING_WINDOW 内なら featured ランキングへ -1。

### gallery/posts/delete (MEDIUM)
- 所有者でもモデレータでもなければ `ACCESS_DENIED` (c86e09de)。モデレータが他人の post を削除した場合のみ `moderationLog(deleteGalleryPost)` を残す。

### gallery/featured (LOW)
- `likedCount DESC` ではなく `featuredService.getGalleryPostsRanking` (Redis 時間窓ランキング) を読み、id DESC sort → untilId filter → limit slice → id IN 取得で返す (upstream featured.ts と一致)。upstream の 30 分メモリキャッシュは持たず毎回 Redis を読む (= 常に最新、API shape は同一)。ranking 未配線時は `[]` に degrade。

### gallery/popular (LOW)
- featured への委譲をやめ、`likedCount>0` を `likedCount DESC` で 10 件返す。

### 基盤
- `core/featured`: `UpdateGalleryPostsRanking` / `GetGalleryPostsRanking` + `featuredGalleryPostsRanking` (window=3日) を追加。
- `core/moderationlog`: `LogDeleteGalleryPost` を追加。
- `gallery.Handler` に `GalleryRanking` / `RoleChecker` / `ModLogger` を setter 配線 (router で featuredService / roleService / modLogService を注入)。

## テスト

- gallery handler: like (success/YOUR_POST/NO_SUCH_POST/ALREADY_LIKED)、unlike (success/NO_SUCH_POST/NOT_LIKED)、delete (ACCESS_DENIED/moderator+modlog/owner-no-modlog)、featured (nil ranking/empty/with-ranking/untilId)、popular (likedCount>0 filter) を追加・更新。
- core/featured: `TestService_GalleryPostsRanking` を追加。
- 実行: `go test ./internal/api/gallery/ ./internal/core/featured/ ./internal/core/moderationlog/ -count=1` → pass。coverage gallery 92.3% / featured 94.1% / moderationlog 100%。`go build ./... && go vet ./...` → pass。

## Closes

`#1548` の gallery 項目を解消する (flash/pages は別 PR)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)