### PR TITLE
Fix flash: isLiked + YOUR_FLASH + delete モデレータ削除 + my-likes search + create 必須項目 (#1548)

### DIFF
--- a/internal/api/flash/handler.go
+++ b/internal/api/flash/handler.go
@@ -2,6 +2,7 @@
 package flash
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
 	coreflash "github.com/shiroha-a/mk/internal/core/flash"
+	"github.com/shiroha-a/mk/internal/core/moderationlog"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -16,11 +18,25 @@ import (
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
+// RoleChecker reports whether a user is a moderator. Satisfied by
+// *core/role.Service. nil 配線時は全員 non-moderator 扱い (#1548)。
+type RoleChecker interface {
+	IsModerator(userID string) bool
+}
+
+// ModLogger records a moderation action. Satisfied by *core/moderationlog.Service.
+// nil 配線時は記録を skip する (#1548)。
+type ModLogger interface {
+	Log(ctx context.Context, moderatorID string, t moderationlog.LogType, info map[string]any)
+}
+
 // Handler handles flash-related API endpoints.
 type Handler struct {
 	svc      *coreflash.Service
 	userRepo repository.UserRepository
 	idGen    id.Generator
+	roles    RoleChecker
+	modLog   ModLogger
 }
 
 // NewHandler creates a new flash Handler.
@@ -31,28 +47,39 @@ func NewHandler(svc *coreflash.Service, userRepo repository.UserRepository, idGe
 	return &Handler{svc: svc, userRepo: userRepo, idGen: idGen}
 }
 
-// CreateRequest is the request body for flash/create.
+// SetRoleChecker wires the moderator check used by flash/delete (#1548).
+func (h *Handler) SetRoleChecker(r RoleChecker) { h.roles = r }
+
+// SetModLog wires the moderation log writer used when a moderator deletes
+// another user's flash (#1548).
+func (h *Handler) SetModLog(m ModLogger) { h.modLog = m }
+
+// CreateRequest is the request body for flash/create. summary / permissions は
+// upstream paramDef で required なので pointer で受けて「キー欠如」を検出する
+// (#1548)。空文字 / 空配列は present 扱い (= upstream の required は presence 検査)。
 type CreateRequest struct {
-	Title       string   `json:"title"`
-	Summary     string   `json:"summary"`
-	Script      string   `json:"script"`
-	Permissions []string `json:"permissions"`
-	Visibility  string   `json:"visibility"`
+	Title       string    `json:"title"`
+	Summary     *string   `json:"summary"`
+	Script      string    `json:"script"`
+	Permissions *[]string `json:"permissions"`
+	Visibility  string    `json:"visibility"`
 }
 
 // Create handles POST /api/flash/create.
 func (h *Handler) Create(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req CreateRequest
-	if err := c.Bind(&req); err != nil || req.Title == "" || req.Script == "" {
+	// upstream paramDef required: ['title','summary','script','permissions']。
+	// summary/permissions の欠如は 400 にする (title/script は従来どおり空も弾く)。
+	if err := c.Bind(&req); err != nil || req.Title == "" || req.Script == "" || req.Summary == nil || req.Permissions == nil {
 		return apierr.JSONInvalidParam(c)
 	}
 	f, err := h.svc.Create(coreflash.CreateInput{
 		OwnerID:     user.ID,
 		Title:       req.Title,
-		Summary:     req.Summary,
+		Summary:     *req.Summary,
 		Script:      req.Script,
-		Permissions: req.Permissions,
+		Permissions: *req.Permissions,
 		Visibility:  req.Visibility,
 	})
 	if err != nil {
@@ -144,16 +171,45 @@ func (h *Handler) Delete(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.FlashID == "" {
 		return apierr.JSONInvalidParam(c)
 	}
-	if err := h.svc.Delete(user.ID, req.FlashID); err != nil {
-		switch {
-		case errors.Is(err, coreflash.ErrFlashNotFound):
+	// upstream delete.ts: 所有者でもモデレータでもなければ ACCESS_DENIED。
+	// モデレータは他人の flash も削除でき、その場合 moderationLog を残す (#1548)。
+	f, err := h.svc.Show("", req.FlashID)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FLASH", "No such flash.", "de1623ef-bbb3-4289-a71e-14cfa83d9740"))
+	}
+	isOwner := f.UserID == user.ID
+	isModerator := h.roles != nil && h.roles.IsModerator(user.ID)
+	if !isOwner && !isModerator {
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "1036ad7b-9f92-4fff-89c3-0e50dc941704"))
+	}
+	if err := h.svc.DeleteByID(req.FlashID); err != nil {
+		if errors.Is(err, coreflash.ErrFlashNotFound) {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FLASH", "No such flash.", "de1623ef-bbb3-4289-a71e-14cfa83d9740"))
-		case errors.Is(err, coreflash.ErrAccessDenied):
-			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "1036ad7b-9f92-4fff-89c3-0e50dc941704"))
 		}
 		return apierr.JSONInternalError(c)
 	}
+	if !isOwner && h.modLog != nil {
+		h.modLog.Log(c.Request().Context(), user.ID, moderationlog.LogDeleteFlash, map[string]any{
+			"flashId":           f.ID,
+			"flashUserId":       f.UserID,
+			"flashUserUsername": h.usernameOf(f.UserID),
+			"flash":             flashToMap(f),
+		})
+	}
 	return c.NoContent(http.StatusNoContent)
+}
+
+// usernameOf returns the username for userID, or "" when the lookup fails.
+// Used to populate the moderation log info (#1548).
+func (h *Handler) usernameOf(userID string) string {
+	if h.userRepo == nil {
+		return ""
+	}
+	u, err := h.userRepo.FindByID(userID)
+	if err != nil || u == nil {
+		return ""
+	}
+	return u.Username
 }
 
 // PaginationRequest is the shared body for list-style endpoints.
@@ -193,7 +249,7 @@ func (h *Handler) My(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, h.flashesToListWithUser(rows))
+	return c.JSON(http.StatusOK, h.flashesToListForViewer(rows, user))
 }
 
 // Featured handles POST /api/flash/featured.
@@ -209,7 +265,7 @@ func (h *Handler) Featured(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, h.flashesToListWithUser(rows))
+	return c.JSON(http.StatusOK, h.flashesToListForViewer(rows, middleware.GetUser(c)))
 }
 
 // Search handles POST /api/flash/search.
@@ -225,7 +281,7 @@ func (h *Handler) Search(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, h.flashesToListWithUser(rows))
+	return c.JSON(http.StatusOK, h.flashesToListForViewer(rows, middleware.GetUser(c)))
 }
 
 // LikeRequest is the request body for flash/like and flash/unlike.
@@ -244,6 +300,8 @@ func (h *Handler) Like(c echo.Context) error {
 		switch {
 		case errors.Is(err, coreflash.ErrFlashNotFound):
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FLASH", "No such flash.", "c07c1491-9161-4c5c-9d75-01906f911f73"))
+		case errors.Is(err, coreflash.ErrYourFlash):
+			return c.JSON(http.StatusBadRequest, apierr.Error("YOUR_FLASH", "You cannot like your flash.", "3fd8a0e7-5955-4ba9-85bb-bf3e0c30e13b"))
 		case errors.Is(err, coreflash.ErrAlreadyLiked):
 			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_LIKED", "You already liked that flash.", "010065cf-ad43-40df-8067-abff9f4686e3"))
 		}
@@ -278,14 +336,18 @@ func (h *Handler) Unlike(c echo.Context) error {
 // flatten された Flash 配列を返しており frontend が空表示になっていた。
 func (h *Handler) MyLikes(c echo.Context) error {
 	user := middleware.GetUser(c)
-	var req PaginationRequest
+	var req struct {
+		PaginationRequest
+		// upstream my-likes paramDef: search (string, 1-100, nullable)。
+		Search string `json:"search"`
+	}
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
 	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
-	pairs, err := h.svc.MyLikes(user.ID, sinceID, untilID, req.Limit, req.Offset)
+	pairs, err := h.svc.MyLikes(user.ID, req.Search, sinceID, untilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
@@ -293,7 +355,7 @@ func (h *Handler) MyLikes(c echo.Context) error {
 	for _, p := range pairs {
 		flashes = append(flashes, p.Flash)
 	}
-	packed := h.flashesToListWithUser(flashes)
+	packed := h.flashesToListForViewer(flashes, user)
 	out := make([]map[string]any, 0, len(pairs))
 	for i, p := range pairs {
 		out = append(out, map[string]any{
@@ -340,18 +402,26 @@ func (h *Handler) flashWithKnownUser(f *model.Flash, owner *model.User) map[stri
 	return entry
 }
 
-// flashesToListWithUser packs flashes including the embedded `user`
-// (UserLite) and ISO-formatted `createdAt`, matching upstream Misskey TS
-// FlashEntityService output. The frontend Play page reads `flash.user`
-// for display so a missing user object causes empty card render.
+// flashesToListWithUser packs flashes for an anonymous viewer (no isLiked).
+func (h *Handler) flashesToListWithUser(rows []*model.Flash) []map[string]any {
+	return h.flashesToListForViewer(rows, nil)
+}
+
+// flashesToListForViewer packs flashes including the embedded `user`
+// (UserLite), ISO-formatted `createdAt`, and (when viewer != nil) the per-flash
+// `isLiked` flag, matching upstream Misskey TS FlashEntityService output. The
+// frontend Play page reads `flash.user` for display so a missing user object
+// causes empty card render; the like button reads `isLiked` (#1548).
 //
 // User lookups are deduped by author and fetched in a single FindManyByIDs
-// call to avoid the N+1 pattern.
-func (h *Handler) flashesToListWithUser(rows []*model.Flash) []map[string]any {
+// call; liked-flash ids are batch-loaded in one query, both avoiding N+1.
+func (h *Handler) flashesToListForViewer(rows []*model.Flash, viewer *model.User) []map[string]any {
 	const tsFormat = "2006-01-02T15:04:05.000Z"
 	userIDs := make([]string, 0, len(rows))
+	flashIDs := make([]string, 0, len(rows))
 	seen := make(map[string]struct{}, len(rows))
 	for _, f := range rows {
+		flashIDs = append(flashIDs, f.ID)
 		if _, ok := seen[f.UserID]; ok {
 			continue
 		}
@@ -366,6 +436,11 @@ func (h *Handler) flashesToListWithUser(rows []*model.Flash) []map[string]any {
 			}
 		}
 	}
+	// 認証 viewer のときだけ isLiked を埋める (upstream optional field)。
+	var likedSet map[string]bool
+	if viewer != nil {
+		likedSet, _ = h.svc.LikedFlashIDs(viewer.ID, flashIDs)
+	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, f := range rows {
 		entry := flashToMap(f)
@@ -378,6 +453,9 @@ func (h *Handler) flashesToListWithUser(rows []*model.Flash) []map[string]any {
 		entry["createdAt"] = createdAt
 		if u, ok := userByID[f.UserID]; ok {
 			entry["user"] = entity.PackUserLite(u)
+		}
+		if viewer != nil {
+			entry["isLiked"] = likedSet[f.ID]
 		}
 		out = append(out, entry)
 	}

--- a/internal/api/flash/handler_test.go
+++ b/internal/api/flash/handler_test.go
@@ -1,6 +1,7 @@
 package flash
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	coreflash "github.com/shiroha-a/mk/internal/core/flash"
+	"github.com/shiroha-a/mk/internal/core/moderationlog"
 	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -41,11 +43,29 @@ func setUser(c echo.Context, userID string) {
 	c.Set(string(middleware.UserContextKey), &model.User{ID: userID})
 }
 
+// stubRoles implements flash.RoleChecker for #1548 tests.
+type stubRoles struct{ moderators map[string]bool }
+
+func (s *stubRoles) IsModerator(userID string) bool { return s.moderators[userID] }
+
+// stubModLog records moderation log calls for #1548 tests.
+type stubModLog struct{ calls []stubModLogCall }
+
+type stubModLogCall struct {
+	moderatorID string
+	logType     moderationlog.LogType
+	info        map[string]any
+}
+
+func (s *stubModLog) Log(_ context.Context, moderatorID string, t moderationlog.LogType, info map[string]any) {
+	s.calls = append(s.calls, stubModLogCall{moderatorID, t, info})
+}
+
 // --- Create ----------------------------------------------------------------
 
 func TestCreate_Success(t *testing.T) {
 	h, _, _ := newHandler(t)
-	c, rec := newReq(t, `{"title":"t","script":"x"}`)
+	c, rec := newReq(t, `{"title":"t","summary":"s","script":"x","permissions":[]}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Create(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -53,6 +73,33 @@ func TestCreate_Success(t *testing.T) {
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	shapetest.Assert(t, "Flash", resp) // L3 (#1270)
+}
+
+// #1548: summary が欠けると 400 (upstream paramDef required)。
+func TestCreate_SummaryRequired(t *testing.T) {
+	h, _, _ := newHandler(t)
+	c, rec := newReq(t, `{"title":"t","script":"x","permissions":[]}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// #1548: permissions が欠けると 400 (upstream paramDef required)。
+func TestCreate_PermissionsRequired(t *testing.T) {
+	h, _, _ := newHandler(t)
+	c, rec := newReq(t, `{"title":"t","summary":"s","script":"x"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// #1548: summary="" / permissions=[] は present 扱いで作成される。
+func TestCreate_EmptySummaryAndPermissionsAccepted(t *testing.T) {
+	h, _, _ := newHandler(t)
+	c, rec := newReq(t, `{"title":"t","summary":"","script":"x","permissions":[]}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
 func TestCreate_BadJSON(t *testing.T) {
@@ -92,7 +139,7 @@ func TestCreate_RepoError(t *testing.T) {
 	idGen, _ := id.NewGenerator("aidx")
 	svc := coreflash.NewService(repo, testutil.NewMockFlashLikeRepository(), idGen)
 	h := NewHandler(svc, nil, nil)
-	c, rec := newReq(t, `{"title":"t","script":"x"}`)
+	c, rec := newReq(t, `{"title":"t","summary":"s","script":"x","permissions":[]}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Create(c))
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
@@ -252,6 +299,47 @@ func TestDelete_RepoError(t *testing.T) {
 	setUser(c, "alice")
 	require.NoError(t, h.Delete(c))
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// #1548: モデレータは他人の flash を削除でき moderationLog を残す。
+func TestDelete_ModeratorWithModLog(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	repo := testutil.NewMockFlashRepository()
+	repo.Flashes["f1"] = &model.Flash{ID: "f1", UserID: "owner", Title: "T"}
+	userRepo := testutil.NewMockUserRepository()
+	require.NoError(t, userRepo.Create(&model.User{ID: "owner", Username: "ownername"}))
+	svc := coreflash.NewService(repo, testutil.NewMockFlashLikeRepository(), idGen)
+	h := NewHandler(svc, userRepo, idGen)
+	h.SetRoleChecker(&stubRoles{moderators: map[string]bool{"mod": true}})
+	ml := &stubModLog{}
+	h.SetModLog(ml)
+
+	c, rec := newReq(t, `{"flashId":"f1"}`)
+	setUser(c, "mod")
+	require.NoError(t, h.Delete(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	_, err := repo.FindByID("f1")
+	assert.Error(t, err, "flash must be deleted")
+	require.Len(t, ml.calls, 1)
+	assert.Equal(t, moderationlog.LogDeleteFlash, ml.calls[0].logType)
+	assert.Equal(t, "mod", ml.calls[0].moderatorID)
+	assert.Equal(t, "f1", ml.calls[0].info["flashId"])
+	assert.Equal(t, "owner", ml.calls[0].info["flashUserId"])
+	assert.Equal(t, "ownername", ml.calls[0].info["flashUserUsername"])
+}
+
+// #1548: 所有者自身の削除では moderationLog を残さない。
+func TestDelete_OwnerNoModLog(t *testing.T) {
+	h, repo, _ := newHandler(t)
+	repo.Flashes["f1"] = &model.Flash{ID: "f1", UserID: "alice"}
+	h.SetRoleChecker(&stubRoles{moderators: map[string]bool{"alice": true}})
+	ml := &stubModLog{}
+	h.SetModLog(ml)
+	c, rec := newReq(t, `{"flashId":"f1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Delete(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Empty(t, ml.calls)
 }
 
 // --- My ---------------------------------------------------------------------
@@ -414,6 +502,54 @@ func TestLike_AlreadyLiked(t *testing.T) {
 	_ = rec
 }
 
+// #1548: 自分の flash を like すると YOUR_FLASH。
+func TestLike_YourFlash(t *testing.T) {
+	h, repo, _ := newHandler(t)
+	repo.Flashes["f1"] = &model.Flash{ID: "f1", UserID: "alice"}
+	c, rec := newReq(t, `{"flashId":"f1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Like(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "3fd8a0e7-5955-4ba9-85bb-bf3e0c30e13b")
+}
+
+// #1548: list endpoint (featured/my/search/my-likes) は viewer の isLiked を返す。
+func TestList_IsLikedPopulated(t *testing.T) {
+	h, repo, likeRepo := newHandler(t)
+	repo.Flashes["f1"] = &model.Flash{ID: "f1", UserID: "owner", Title: "liked"}
+	repo.Flashes["f2"] = &model.Flash{ID: "f2", UserID: "owner", Title: "notliked"}
+	likeRepo.Likes["l1"] = &model.FlashLike{ID: "l1", UserID: "bob", FlashID: "f1"}
+
+	c, rec := newReq(t, `{}`)
+	setUser(c, "bob")
+	require.NoError(t, h.Featured(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	byID := map[string]map[string]any{}
+	for _, f := range resp {
+		byID[f["id"].(string)] = f
+	}
+	require.NotNil(t, byID["f1"])
+	require.NotNil(t, byID["f2"])
+	assert.Equal(t, true, byID["f1"]["isLiked"])
+	assert.Equal(t, false, byID["f2"]["isLiked"])
+}
+
+// 未認証 viewer では isLiked は省略される (upstream optional)。
+func TestList_IsLikedOmittedForAnon(t *testing.T) {
+	h, repo, _ := newHandler(t)
+	repo.Flashes["f1"] = &model.Flash{ID: "f1", UserID: "owner", Title: "x"}
+	c, rec := newReq(t, `{}`)
+	require.NoError(t, h.Featured(c)) // no user
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	_, has := resp[0]["isLiked"]
+	assert.False(t, has, "anonymous viewer must not get isLiked")
+}
+
 // failingCreateLikeRepo causes Create to fail.
 type failingCreateLikeRepo struct {
 	*testutil.MockFlashLikeRepository
@@ -521,12 +657,12 @@ func TestMyLikes_BadJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
-// myLikesFailRepo causes ListByUser on the like repo to fail.
+// myLikesFailRepo causes ListByUserSearch (used by MyLikes) on the like repo to fail.
 type myLikesFailRepo struct {
 	*testutil.MockFlashLikeRepository
 }
 
-func (r *myLikesFailRepo) ListByUser(_, _, _ string, _, _ int) ([]*model.FlashLike, error) {
+func (r *myLikesFailRepo) ListByUserSearch(_, _, _, _ string, _, _ int) ([]*model.FlashLike, error) {
 	return nil, errors.New("boom")
 }
 

--- a/internal/core/flash/flash_service.go
+++ b/internal/core/flash/flash_service.go
@@ -24,6 +24,9 @@ var (
 	// ErrAccessDenied is returned when a user attempts to mutate a Flash they
 	// do not own.
 	ErrAccessDenied = errors.New("not the owner of this flash")
+	// ErrYourFlash is returned when a user attempts to Like their own Flash
+	// (upstream flash/like の yourFlash, #1548)。
+	ErrYourFlash = errors.New("cannot like your own flash")
 	// ErrAlreadyLiked is returned when a user attempts to Like a Flash they
 	// have already liked.
 	ErrAlreadyLiked = errors.New("flash is already liked")
@@ -173,6 +176,18 @@ func (s *Service) Delete(ownerID, flashID string) error {
 	return s.repo.Delete(f)
 }
 
+// DeleteByID removes a Flash without an owner check. The caller is responsible
+// for authorization — used by the moderator-delete path in the handler where
+// the owner-or-moderator decision is made before calling (#1548). Returns
+// ErrFlashNotFound when the flash does not exist.
+func (s *Service) DeleteByID(flashID string) error {
+	f, err := s.repo.FindByID(flashID)
+	if err != nil {
+		return ErrFlashNotFound
+	}
+	return s.repo.Delete(f)
+}
+
 // My returns the flashes owned by userID with cursor (sinceID/untilID) or
 // offset pagination. Cursor 指定時は offset 無視。
 func (s *Service) My(userID, sinceID, untilID string, limit, offset int) ([]*model.Flash, error) {
@@ -195,8 +210,15 @@ func (s *Service) Like(userID, flashID string) error {
 	if userID == "" {
 		return errors.New("userId is required")
 	}
-	if _, err := s.repo.FindByID(flashID); err != nil {
+	f, err := s.repo.FindByID(flashID)
+	if err != nil {
 		return ErrFlashNotFound
+	}
+	// 自分の flash は like できない (upstream flash/like の yourFlash, #1548)。
+	// TS の順序 (noSuchFlash -> yourFlash -> alreadyLiked) に合わせ NotFound の
+	// 直後・already-liked チェックの前に置く。
+	if f.UserID == userID {
+		return ErrYourFlash
 	}
 	if exists, err := s.likeRepo.Exists(userID, flashID); err != nil {
 		return err
@@ -242,6 +264,24 @@ func (s *Service) IsLikedBy(userID, flashID string) (bool, error) {
 	return s.likeRepo.Exists(userID, flashID)
 }
 
+// LikedFlashIDs returns the set of flashIDs that userID has liked, in one
+// query. Used by list endpoints to batch-populate `isLiked` (#1548). Empty
+// userID / flashIDs returns an empty set without querying.
+func (s *Service) LikedFlashIDs(userID string, flashIDs []string) (map[string]bool, error) {
+	set := map[string]bool{}
+	if userID == "" || len(flashIDs) == 0 {
+		return set, nil
+	}
+	ids, err := s.likeRepo.ListLikedFlashIDs(userID, flashIDs)
+	if err != nil {
+		return set, err
+	}
+	for _, id := range ids {
+		set[id] = true
+	}
+	return set, nil
+}
+
 // LikedFlash pairs a flash_like row id with the flash it points to. Used by
 // flash/my-likes to match upstream's `{id, flash: Flash}` response shape
 // (id = flash_like row id, NOT flash id).
@@ -251,9 +291,10 @@ type LikedFlash struct {
 }
 
 // MyLikes returns the flashes that userID has liked, newest first, paired
-// with the flash_like row id used for cursor pagination.
-func (s *Service) MyLikes(userID, sinceID, untilID string, limit, offset int) ([]LikedFlash, error) {
-	likes, err := s.likeRepo.ListByUser(userID, sinceID, untilID, limit, offset)
+// with the flash_like row id used for cursor pagination. search が空でなければ
+// flash の title/summary を ILIKE 絞り込みする (#1548, upstream myLikes search)。
+func (s *Service) MyLikes(userID, search, sinceID, untilID string, limit, offset int) ([]LikedFlash, error) {
+	likes, err := s.likeRepo.ListByUserSearch(userID, search, sinceID, untilID, limit, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/flash/flash_service_test.go
+++ b/internal/core/flash/flash_service_test.go
@@ -337,7 +337,7 @@ func TestMyLikes_HappyPath(t *testing.T) {
 	repo.Flashes["f2"] = &model.Flash{ID: "f2", UserID: "u1"}
 	require.NoError(t, svc.Like("u2", "f1"))
 	require.NoError(t, svc.Like("u2", "f2"))
-	rows, err := svc.MyLikes("u2", "", "", 10, 0)
+	rows, err := svc.MyLikes("u2", "", "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 2)
 }
@@ -348,17 +348,17 @@ func TestMyLikes_SkipsMissingFlashes(t *testing.T) {
 	require.NoError(t, svc.Like("u2", "f1"))
 	// Insert a stale like pointing to a non-existent flash.
 	likeRepo.Likes["stale"] = &model.FlashLike{ID: "stale", UserID: "u2", FlashID: "missing"}
-	rows, err := svc.MyLikes("u2", "", "", 10, 0)
+	rows, err := svc.MyLikes("u2", "", "", "", 10, 0)
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 }
 
-// failingListLikeRepo causes ListByUser to fail.
+// failingListLikeRepo causes ListByUserSearch (used by MyLikes) to fail.
 type failingListLikeRepo struct {
 	*testutil.MockFlashLikeRepository
 }
 
-func (r *failingListLikeRepo) ListByUser(_, _, _ string, _, _ int) ([]*model.FlashLike, error) {
+func (r *failingListLikeRepo) ListByUserSearch(_, _, _, _ string, _, _ int) ([]*model.FlashLike, error) {
 	return nil, errors.New("boom")
 }
 
@@ -367,7 +367,7 @@ func TestMyLikes_RepoError(t *testing.T) {
 	likeRepo := &failingListLikeRepo{MockFlashLikeRepository: testutil.NewMockFlashLikeRepository()}
 	idGen, _ := id.NewGenerator("aidx")
 	svc := flash.NewService(repo, likeRepo, idGen)
-	_, err := svc.MyLikes("u2", "", "", 10, 0)
+	_, err := svc.MyLikes("u2", "", "", "", 10, 0)
 	assert.Error(t, err)
 }
 
@@ -381,4 +381,57 @@ func TestSetClock(t *testing.T) {
 	f, err := svc.Create(flash.CreateInput{OwnerID: "u1", Title: "t", Script: "x"})
 	require.NoError(t, err)
 	assert.NotEmpty(t, f.ID)
+}
+
+// #1548: 自分の flash を like すると ErrYourFlash。
+func TestLike_YourFlash(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	repo.Flashes["f1"] = &model.Flash{ID: "f1", UserID: "u1"}
+	err := svc.Like("u1", "f1")
+	assert.ErrorIs(t, err, flash.ErrYourFlash)
+}
+
+// #1548: DeleteByID は owner チェックなしで削除する (moderator 経路)。
+func TestDeleteByID(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	repo.Flashes["f1"] = &model.Flash{ID: "f1", UserID: "owner"}
+	require.NoError(t, svc.DeleteByID("f1"))
+	_, err := repo.FindByID("f1")
+	assert.Error(t, err)
+}
+
+func TestDeleteByID_NotFound(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	assert.ErrorIs(t, svc.DeleteByID("ghost"), flash.ErrFlashNotFound)
+}
+
+// #1548: LikedFlashIDs は viewer が like した flashId の集合を返す。
+func TestLikedFlashIDs(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	repo.Flashes["f1"] = &model.Flash{ID: "f1", UserID: "owner"}
+	repo.Flashes["f2"] = &model.Flash{ID: "f2", UserID: "owner"}
+	require.NoError(t, svc.Like("u2", "f1"))
+
+	set, err := svc.LikedFlashIDs("u2", []string{"f1", "f2"})
+	require.NoError(t, err)
+	assert.True(t, set["f1"])
+	assert.False(t, set["f2"])
+
+	// 空 userID / flashIDs は空集合。
+	empty, err := svc.LikedFlashIDs("", []string{"f1"})
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+}
+
+// IsLikedBy reports the viewer's like state for a single flash.
+func TestIsLikedBy(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	repo.Flashes["f1"] = &model.Flash{ID: "f1", UserID: "owner"}
+	require.NoError(t, svc.Like("u2", "f1"))
+	liked, err := svc.IsLikedBy("u2", "f1")
+	require.NoError(t, err)
+	assert.True(t, liked)
+	notLiked, err := svc.IsLikedBy("u3", "f1")
+	require.NoError(t, err)
+	assert.False(t, notLiked)
 }

--- a/internal/core/moderationlog/types.go
+++ b/internal/core/moderationlog/types.go
@@ -89,6 +89,7 @@ const (
 
 	// Content deletion by moderators
 	LogDeleteGalleryPost LogType = "deleteGalleryPost"
+	LogDeleteFlash       LogType = "deleteFlash"
 
 	// Misc
 	LogUpdateProxyAccountDescription LogType = "updateProxyAccountDescription"

--- a/internal/repository/flash_like.go
+++ b/internal/repository/flash_like.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"strings"
+
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/gorm"
 )
@@ -14,6 +16,15 @@ type FlashLikeRepository interface {
 	// ListByUser supports cursor (sinceID/untilID) and offset pagination on
 	// flash_like.id (newest first). Cursor 指定時は offset 無視。
 	ListByUser(userID, sinceID, untilID string, limit, offset int) ([]*model.FlashLike, error)
+	// ListByUserSearch is ListByUser plus a title/summary ILIKE filter on the
+	// joined flash. search is whitespace-split; a row must match every word
+	// (each word matches title OR summary). Empty search behaves like ListByUser
+	// (#1548, upstream FlashService.myLikes search).
+	ListByUserSearch(userID, search, sinceID, untilID string, limit, offset int) ([]*model.FlashLike, error)
+	// ListLikedFlashIDs returns the subset of flashIDs that userID has liked, in
+	// one query. Used to batch-populate `isLiked` on flash list endpoints
+	// (#1548, upstream FlashEntityService.packMany likedFlashIds).
+	ListLikedFlashIDs(userID string, flashIDs []string) ([]string, error)
 }
 
 type flashLikeRepository struct {
@@ -76,4 +87,61 @@ func (r *flashLikeRepository) ListByUser(userID, sinceID, untilID string, limit,
 		return nil, err
 	}
 	return rows, nil
+}
+
+// ListByUserSearch returns the flash_like rows owned by userID whose joined
+// flash matches every search word (title OR summary ILIKE), newest first.
+// Empty search delegates to ListByUser. Cursor / offset semantics match
+// ListByUser but are anchored on flash_like.id (#1548).
+func (r *flashLikeRepository) ListByUserSearch(userID, search, sinceID, untilID string, limit, offset int) ([]*model.FlashLike, error) {
+	words := strings.Fields(search)
+	if len(words) == 0 {
+		return r.ListByUser(userID, sinceID, untilID, limit, offset)
+	}
+	if limit <= 0 {
+		limit = 30
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	// flash_like と flash を join し、各語を title/summary への ILIKE (語内 OR、
+	// 語間 AND) で絞る。両表に id/userId 列があるため Select で flash_like 側を
+	// 明示する (scan ambiguity 回避)。
+	q := r.db.Model(&model.FlashLike{}).
+		Select(`flash_like.*`).
+		Joins(`JOIN flash ON flash.id = flash_like."flashId"`).
+		Where(`flash_like."userId" = ?`, userID)
+	for _, word := range words {
+		like := "%" + escapeLike(word) + "%"
+		q = q.Where(`flash.title ILIKE ? OR flash.summary ILIKE ?`, like, like)
+	}
+	if sinceID != "" {
+		q = q.Where(`flash_like.id > ?`, sinceID)
+	}
+	if untilID != "" {
+		q = q.Where(`flash_like.id < ?`, untilID)
+	}
+	q = q.Order(paginationOrder(sinceID, untilID, "flash_like.id")).Limit(limit)
+	if sinceID == "" && untilID == "" && offset > 0 {
+		q = q.Offset(offset)
+	}
+	var rows []*model.FlashLike
+	if err := q.Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// ListLikedFlashIDs returns the subset of flashIDs that userID has liked.
+func (r *flashLikeRepository) ListLikedFlashIDs(userID string, flashIDs []string) ([]string, error) {
+	if len(flashIDs) == 0 {
+		return nil, nil
+	}
+	var ids []string
+	if err := r.db.Model(&model.FlashLike{}).
+		Where(`"userId" = ? AND "flashId" IN ?`, userID, flashIDs).
+		Pluck(`"flashId"`, &ids).Error; err != nil {
+		return nil, err
+	}
+	return ids, nil
 }

--- a/internal/repository/flash_like_test.go
+++ b/internal/repository/flash_like_test.go
@@ -40,6 +40,73 @@ func TestFlashLikeRepository_LifeCycle(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// #1548: ListByUserSearch joins flash and filters by title/summary ILIKE.
+func TestFlashLikeRepository_ListByUserSearch(t *testing.T) {
+	flashRepo := NewFlashRepository(testDB)
+	repo := NewFlashLikeRepository(testDB)
+	user := insertTestUser(t, "u_fls_1", "flsuser1")
+	defer cleanupUser(t, user.ID)
+
+	fa := newTestFlash("fl_s_a", user.ID, "golang tips")
+	fb := newTestFlash("fl_s_b", user.ID, "ruby notes")
+	require.NoError(t, flashRepo.Create(fa))
+	require.NoError(t, flashRepo.Create(fb))
+	defer cleanupFlash(t, fa.ID)
+	defer cleanupFlash(t, fb.ID)
+
+	la := &model.FlashLike{ID: "fll_s_a", UserID: user.ID, FlashID: fa.ID}
+	lb := &model.FlashLike{ID: "fll_s_b", UserID: user.ID, FlashID: fb.ID}
+	require.NoError(t, repo.Create(la))
+	require.NoError(t, repo.Create(lb))
+	defer testDB.Exec(`DELETE FROM "flash_like" WHERE id IN (?, ?)`, la.ID, lb.ID)
+
+	// "golang" は title が golang の fa のみにマッチ。
+	rows, err := repo.ListByUserSearch(user.ID, "golang", "", "", 10, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, fa.ID, rows[0].FlashID)
+
+	// summary 由来のマッチ (summary-ruby notes は "ruby" を含む)。
+	rows, err = repo.ListByUserSearch(user.ID, "ruby", "", "", 10, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, lb.ID, rows[0].ID)
+
+	// 空 search は ListByUser 同等 (全件)。
+	rows, err = repo.ListByUserSearch(user.ID, "", "", "", 10, 0)
+	require.NoError(t, err)
+	assert.Len(t, rows, 2)
+
+	// 複数語は語間 AND (両方の語にマッチするものだけ)。
+	rows, err = repo.ListByUserSearch(user.ID, "golang ruby", "", "", 10, 0)
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+// #1548: ListLikedFlashIDs returns the subset of flashIDs liked by the user.
+func TestFlashLikeRepository_ListLikedFlashIDs(t *testing.T) {
+	flashRepo := NewFlashRepository(testDB)
+	repo := NewFlashLikeRepository(testDB)
+	user := insertTestUser(t, "u_fll_2", "flluser2")
+	defer cleanupUser(t, user.ID)
+
+	f := newTestFlash("fl_l_a", user.ID, "x")
+	require.NoError(t, flashRepo.Create(f))
+	defer cleanupFlash(t, f.ID)
+	fl := &model.FlashLike{ID: "fll_l_a", UserID: user.ID, FlashID: f.ID}
+	require.NoError(t, repo.Create(fl))
+	defer testDB.Exec(`DELETE FROM "flash_like" WHERE id = ?`, fl.ID)
+
+	ids, err := repo.ListLikedFlashIDs(user.ID, []string{f.ID, "other"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{f.ID}, ids)
+
+	// 空入力は空。
+	ids, err = repo.ListLikedFlashIDs(user.ID, nil)
+	require.NoError(t, err)
+	assert.Empty(t, ids)
+}
+
 func TestFlashLikeRepository_FindByPair_NotFound(t *testing.T) {
 	repo := NewFlashLikeRepository(testDB)
 	_, err := repo.FindByPair("nope", "nope")

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1849,6 +1849,7 @@ func (s *Server) setupRoutes() {
 
 	// Flash endpoints (Phase 4.5)
 	flashHandler := apiflash.NewHandler(flashService, userRepo, idGen)
+	flashHandler.SetRoleChecker(roleService) // #1548: flash/delete モデレータ削除
 	api.POST("/flash/create", flashHandler.Create, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:flash"))
 	api.POST("/flash/show", flashHandler.Show)
 	api.POST("/flash/update", flashHandler.Update, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:flash"))
@@ -2201,6 +2202,7 @@ func (s *Server) setupRoutes() {
 	announcementHandler.SetModLogService(modLogService)
 	announcementHandler.SetUserRepo(userRepo)
 	galleryHandler.SetModLog(modLogService) // #1548: moderator による gallery post 削除の監査ログ
+	flashHandler.SetModLog(modLogService)   // #1548: moderator による flash 削除の監査ログ
 	adminHandler.SetEmojiRepo(emojiRepo)
 	adminHandler.SetDriveFileRepo(driveFileRepo)
 	// bulk drive cleanup (clean-remote-files / delete-all-files-of-a-user) で

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -4174,6 +4174,31 @@ func (m *MockFlashLikeRepository) ListByUser(userID, sinceID, untilID string, li
 	return rows[offset:end], nil
 }
 
+// ListByUserSearch ignores the search filter (the mock holds no flash title /
+// summary to match against) and delegates to ListByUser. The SQL search path is
+// covered by the repository-level DB test.
+func (m *MockFlashLikeRepository) ListByUserSearch(userID, _, sinceID, untilID string, limit, offset int) ([]*model.FlashLike, error) {
+	return m.ListByUser(userID, sinceID, untilID, limit, offset)
+}
+
+// ListLikedFlashIDs returns the subset of flashIDs liked by userID.
+func (m *MockFlashLikeRepository) ListLikedFlashIDs(userID string, flashIDs []string) ([]string, error) {
+	want := make(map[string]struct{}, len(flashIDs))
+	for _, id := range flashIDs {
+		want[id] = struct{}{}
+	}
+	var out []string
+	for _, l := range m.Likes {
+		if l.UserID != userID {
+			continue
+		}
+		if _, ok := want[l.FlashID]; ok {
+			out = append(out, l.FlashID)
+		}
+	}
+	return out, nil
+}
+
 // MockPageLikeRepository is a test double for repository.PageLikeRepository.
 type MockPageLikeRepository struct {
 	Likes map[string]*model.PageLike


### PR DESCRIPTION
## Summary

`#1548` (flash/gallery/pages parity) の **flash/*** 5 項目 (MEDIUM 3 + LOW 2) を解消する。

## 主な変更点

### flash/{featured,my,search,my-likes} — isLiked (MEDIUM)
- 認証 viewer の liked flash id を 1 query で一括取得し各 flash に `isLiked` をセットする (upstream `FlashEntityService.packMany`)。未認証 viewer では省略 (optional field)。

### flash/like — YOUR_FLASH (MEDIUM)
- 自分の flash を like すると `YOUR_FLASH` (3fd8a0e7) を返す。判定順は noSuchFlash → yourFlash → alreadyLiked (upstream 準拠)。

### flash/delete — モデレータ削除 + moderationLog (MEDIUM)
- 所有者でもモデレータでもなければ `ACCESS_DENIED` (1036ad7b)。モデレータが他人の flash を削除した場合のみ `moderationLog(deleteFlash)` を残す。

### flash/my-likes — search (LOW)
- `search` パラメータを受け付け、joined flash の title/summary を ILIKE 絞り込み (語間 AND / 語内 OR、upstream `FlashService.myLikes`)。

### flash/create — summary/permissions 必須 (LOW)
- upstream paramDef `required: ['title','summary','script','permissions']` に合わせ、summary / permissions の欠如を 400 にする。空文字 / 空配列は present 扱い。title/script は従来どおり非空チェックを維持。

## 基盤
- `core/flash`: `ErrYourFlash` + Like の owner チェック、`DeleteByID` (owner チェック無しの moderator 経路)、`MyLikes` に search 引数、`LikedFlashIDs` (batch) を追加。
- `repository/flash_like`: `ListByUserSearch` (flash join + ILIKE) と `ListLikedFlashIDs` (batch isLiked) を追加 + mock 実装。
- `core/moderationlog`: `LogDeleteFlash` を追加。
- `flash.Handler` に `RoleChecker` / `ModLogger` を setter 配線 (router で roleService / modLogService を注入)。

## テスト

- flash handler: Create (summary/permissions required + empty accepted)、Like YOUR_FLASH、Delete (moderator+modlog / owner-no-modlog)、list isLiked (populated / anon omitted) を追加・更新。
- core/flash: YOUR_FLASH / DeleteByID / LikedFlashIDs / IsLikedBy を追加。
- repository/flash_like: `ListByUserSearch` (title/summary ILIKE, AND/OR) + `ListLikedFlashIDs` を DB-backed で追加。
- 実行: `go test ./internal/api/flash/ ./internal/core/flash/ ./internal/repository/ -race -count=1` → pass。coverage api/flash 93.7% / core/flash 99.0% / repository 90.3%。`go build ./... && go vet ./...` → pass。

## Closes

`#1548` の flash 項目を解消する (pages は別 PR)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)