### PR TITLE
Fix pages: eyeCatchingImageId 所有検証 + name パターン検証 + featured likedCount>0 (#1548)

### DIFF
--- a/internal/api/pages/handler.go
+++ b/internal/api/pages/handler.go
@@ -99,6 +99,11 @@ func (h *Handler) Create(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.Title == "" || req.Name == "" {
 		return apierr.JSONInvalidParam(c)
 	}
+	// upstream create.ts: eyeCatchingImageId 指定時は自分の drive file か検証し、
+	// 不在なら NO_SUCH_FILE (#1548)。
+	if !h.eyeCatchingImageOK(req.EyeCatchingImageID, user.ID) {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", "b7b97489-0f66-4b12-a5ff-b21bd63f6e1c"))
+	}
 	p, err := h.svc.Create(corepage.CreateInput{
 		OwnerID:             user.ID,
 		Title:               req.Title,
@@ -117,9 +122,29 @@ func (h *Handler) Create(c echo.Context) error {
 		if errors.Is(err, corepage.ErrPageNameConflict) {
 			return c.JSON(http.StatusBadRequest, apierr.Error("NAME_ALREADY_EXISTS", "The page name is already in use.", "4650348e-301c-499a-83c9-6aa988c66bc1"))
 		}
+		if errors.Is(err, corepage.ErrPageNameInvalid) {
+			return apierr.JSONInvalidParam(c)
+		}
 		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, h.pageToMap(p))
+}
+
+// eyeCatchingImageOK reports whether imageID (when non-nil / non-empty) refers
+// to a drive file owned by userID. Returns true when no image is set or when
+// the drive repo is unwired (test path). false means NO_SUCH_FILE (#1548).
+func (h *Handler) eyeCatchingImageOK(imageID *string, userID string) bool {
+	if imageID == nil || *imageID == "" {
+		return true
+	}
+	if h.driveFileRepo == nil {
+		return true
+	}
+	f, err := h.driveFileRepo.FindByID(*imageID)
+	if err != nil || f == nil || f.UserID == nil || *f.UserID != userID {
+		return false
+	}
+	return true
 }
 
 // ShowRequest is the request body for pages/show. upstream Misskey TS の
@@ -216,6 +241,11 @@ func (h *Handler) Update(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.PageID == "" {
 		return apierr.JSONInvalidParam(c)
 	}
+	// upstream update.ts: eyeCatchingImageId 指定時は自分の drive file か検証し、
+	// 不在なら NO_SUCH_FILE (#1548)。
+	if !h.eyeCatchingImageOK(req.EyeCatchingImageID, user.ID) {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_FILE", "No such file.", "cfc23c7c-3887-490e-af30-0ed576703c82"))
+	}
 	in := corepage.UpdateInput{
 		Title:               req.Title,
 		Name:                req.Name,
@@ -249,7 +279,8 @@ func (h *Handler) Update(c echo.Context) error {
 		case errors.Is(err, corepage.ErrAccessDenied):
 			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "3c15cd52-3b4b-4274-967d-6456fc4f792b"))
 		case errors.Is(err, corepage.ErrPageNameRequired),
-			errors.Is(err, corepage.ErrPageTitleRequired):
+			errors.Is(err, corepage.ErrPageTitleRequired),
+			errors.Is(err, corepage.ErrPageNameInvalid):
 			return apierr.JSONInvalidParam(c)
 		case errors.Is(err, corepage.ErrPageNameConflict):
 			return c.JSON(http.StatusBadRequest, apierr.Error("NAME_ALREADY_EXISTS", "The page name is already in use.", "2298a392-d4a1-44c5-9ebb-ac1aeaa5a9ab"))

--- a/internal/api/pages/handler_test.go
+++ b/internal/api/pages/handler_test.go
@@ -61,6 +61,64 @@ func TestCreate_BadJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// #1548: name が禁止文字を含むと INVALID_PARAM (pageNameSchema)。
+func TestCreate_NameInvalidPattern(t *testing.T) {
+	h, _, _ := newHandler(t)
+	c, rec := newReq(t, `{"title":"t","name":"has space"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// #1548: eyeCatchingImageId が自分の drive file でなければ NO_SUCH_FILE。
+func TestCreate_EyeCatchingImageNoSuchFile(t *testing.T) {
+	h, _, _ := newHandler(t)
+	h.SetDriveFileRepo(testutil.NewMockDriveFileRepository()) // 空 = 不在
+	c, rec := newReq(t, `{"title":"t","name":"alpha","eyeCatchingImageId":"f_ghost"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "b7b97489-0f66-4b12-a5ff-b21bd63f6e1c")
+}
+
+// 他人の drive file を eyeCatchingImageId に指定しても NO_SUCH_FILE。
+func TestCreate_EyeCatchingImageForeignFile(t *testing.T) {
+	h, _, _ := newHandler(t)
+	dr := testutil.NewMockDriveFileRepository()
+	other := "bob"
+	dr.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &other}
+	h.SetDriveFileRepo(dr)
+	c, rec := newReq(t, `{"title":"t","name":"alpha","eyeCatchingImageId":"f1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// 自分の drive file なら作成成功。
+func TestCreate_EyeCatchingImageOwned(t *testing.T) {
+	h, _, _ := newHandler(t)
+	dr := testutil.NewMockDriveFileRepository()
+	owner := "alice"
+	dr.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &owner}
+	h.SetDriveFileRepo(dr)
+	c, rec := newReq(t, `{"title":"t","name":"alpha","eyeCatchingImageId":"f1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// #1548: update でも eyeCatchingImageId の所有検証が効く。
+func TestUpdate_EyeCatchingImageNoSuchFile(t *testing.T) {
+	h, repo, _ := newHandler(t)
+	repo.Pages["p1"] = &model.Page{ID: "p1", UserID: "alice", Name: "alpha"}
+	h.SetDriveFileRepo(testutil.NewMockDriveFileRepository())
+	c, rec := newReq(t, `{"pageId":"p1","eyeCatchingImageId":"f_ghost"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Update(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "cfc23c7c-3887-490e-af30-0ed576703c82")
+}
+
 func TestCreate_TitleRequired(t *testing.T) {
 	h, _, _ := newHandler(t)
 	c, rec := newReq(t, `{"name":"alpha"}`)

--- a/internal/core/page/page_service.go
+++ b/internal/core/page/page_service.go
@@ -5,6 +5,7 @@ package page
 
 import (
 	"errors"
+	"regexp"
 	"time"
 
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -12,12 +13,19 @@ import (
 	"github.com/shiroha-a/mk/internal/repository"
 )
 
+// pageNameRe mirrors upstream pageNameSchema (Page.ts): 1-256 文字で、空白 /
+// 制御文字 / 予約記号 (:/?#[]@!$&'()*+,;=\%) を含まない (#1548)。
+var pageNameRe = regexp.MustCompile(`^[^\s:/?#\[\]@!$&'()*+,;=\\%\x00-\x20]{1,256}$`)
+
 // Errors returned by Service.
 var (
 	// ErrPageNotFound is returned when the requested page does not exist.
 	ErrPageNotFound = errors.New("page not found")
 	// ErrPageNameRequired is returned when name is empty on Create / Update.
 	ErrPageNameRequired = errors.New("page name is required")
+	// ErrPageNameInvalid is returned when name violates pageNameSchema
+	// (禁止文字 / 長さ超過、#1548)。
+	ErrPageNameInvalid = errors.New("page name has invalid characters")
 	// ErrPageTitleRequired is returned when title is empty on Create / Update.
 	ErrPageTitleRequired = errors.New("page title is required")
 	// ErrAccessDenied is returned when the requester cannot view or mutate
@@ -95,6 +103,9 @@ func (s *Service) Create(in CreateInput) (*model.Page, error) {
 	}
 	if in.Name == "" {
 		return nil, ErrPageNameRequired
+	}
+	if !pageNameRe.MatchString(in.Name) {
+		return nil, ErrPageNameInvalid
 	}
 	if _, err := s.repo.FindByUserAndName(in.OwnerID, in.Name); err == nil {
 		return nil, ErrPageNameConflict
@@ -207,6 +218,9 @@ func (s *Service) Update(ownerID, pageID string, in UpdateInput) (*model.Page, e
 	if in.Name != nil {
 		if *in.Name == "" {
 			return nil, ErrPageNameRequired
+		}
+		if !pageNameRe.MatchString(*in.Name) {
+			return nil, ErrPageNameInvalid
 		}
 		// 名前変更時は (userId, name) 一意制約と衝突しないことを確認する。
 		if *in.Name != p.Name {

--- a/internal/core/page/page_service_test.go
+++ b/internal/core/page/page_service_test.go
@@ -83,6 +83,31 @@ func TestCreate_NameRequired(t *testing.T) {
 	assert.ErrorIs(t, err, page.ErrPageNameRequired)
 }
 
+// #1548: name が pageNameSchema の禁止文字を含むと ErrPageNameInvalid。
+func TestCreate_NameInvalidPattern(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	for _, bad := range []string{"has space", "slash/x", "colon:x", "hash#x", "at@x", "q?x"} {
+		_, err := svc.Create(page.CreateInput{OwnerID: "u1", Title: "t", Name: bad})
+		assert.ErrorIs(t, err, page.ErrPageNameInvalid, "name %q must be rejected", bad)
+	}
+}
+
+// 正常な name (英数 / ハイフン / アンダースコア等) は通る。
+func TestCreate_NameValidPattern(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	_, err := svc.Create(page.CreateInput{OwnerID: "u1", Title: "t", Name: "my-page_01.draft"})
+	require.NoError(t, err)
+}
+
+// #1548: update でも禁止文字 name は ErrPageNameInvalid。
+func TestUpdate_NameInvalidPattern(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	repo.Pages["p1"] = &model.Page{ID: "p1", UserID: "u1", Name: "ok"}
+	bad := "bad name"
+	_, err := svc.Update("u1", "p1", page.UpdateInput{Name: &bad})
+	assert.ErrorIs(t, err, page.ErrPageNameInvalid)
+}
+
 func TestCreate_NameConflict(t *testing.T) {
 	svc, repo, _ := newSvc(t)
 	repo.Pages["existing"] = &model.Page{ID: "existing", UserID: "u1", Name: "alpha"}

--- a/internal/repository/page.go
+++ b/internal/repository/page.go
@@ -144,7 +144,10 @@ func (r *pageRepository) ListFeatured(sinceID, untilID string, limit, offset int
 	if limit > 100 {
 		limit = 100
 	}
-	q := r.db.Where("visibility = ?", string(model.PageVisibilityPublic))
+	// upstream pages/featured は public かつ likedCount>0 の page のみを返す
+	// (#1548)。0 like の public page は featured に出さない。
+	q := r.db.Where("visibility = ?", string(model.PageVisibilityPublic)).
+		Where(`"likedCount" > 0`)
 	if sinceID != "" {
 		q = q.Where("id > ?", sinceID)
 	}

--- a/internal/repository/page_test.go
+++ b/internal/repository/page_test.go
@@ -238,6 +238,30 @@ func TestPageRepository_ListFeatured(t *testing.T) {
 	assert.Equal(t, "pg_ft_2", found[2].ID)
 }
 
+// #1548: likedCount==0 の public page は featured から除外される。
+func TestPageRepository_ListFeatured_ExcludesZeroLikes(t *testing.T) {
+	repo := NewPageRepository(testDB)
+	user := insertTestUser(t, "u_pr_ftz", "pageuserftz")
+	defer cleanupUser(t, user.ID)
+
+	zero := newTestPage("pg_ftz_0", user.ID, "ftz0") // LikedCount 0
+	liked := newTestPage("pg_ftz_1", user.ID, "ftz1")
+	liked.LikedCount = 3
+	require.NoError(t, repo.Create(zero))
+	require.NoError(t, repo.Create(liked))
+	defer cleanupPage(t, zero.ID)
+	defer cleanupPage(t, liked.ID)
+
+	rows, err := repo.ListFeatured("", "", 100, 0)
+	require.NoError(t, err)
+	ids := map[string]bool{}
+	for _, p := range rows {
+		ids[p.ID] = true
+	}
+	assert.True(t, ids["pg_ftz_1"], "liked page must appear")
+	assert.False(t, ids["pg_ftz_0"], "0-like page must be excluded")
+}
+
 func TestPageRepository_ListFeatured_LimitClamp(t *testing.T) {
 	repo := NewPageRepository(testDB)
 	rows, err := repo.ListFeatured("", "", 9999, 0)


### PR DESCRIPTION
## Summary

`#1548` (flash/gallery/pages parity) の **pages/*** 3 項目 (MEDIUM 1 + LOW 2) を解消する。

## 主な変更点

### pages/{create,update} — eyeCatchingImageId 所有検証 (MEDIUM)
- `eyeCatchingImageId` 指定時に、それが自分の drive file か検証する。不在 / 他人所有なら `NO_SUCH_FILE` (create `b7b97489` / update `cfc23c7c`)。upstream の `driveFilesRepository.findOneBy({id, userId:me})` 相当。画像未指定 (null) / driveFileRepo 未配線 (test) は skip。

### pages/{create,update} — name パターン検証 (LOW)
- `name` を upstream `pageNameSchema` (`^[^\s:/?#\[\]@!$&'()*+,;=\\%\x00-\x20]{1,256}$`、空白 / 制御文字 / 予約記号を禁止、1-256 文字) で検証し、違反は `INVALID_PARAM`。

### pages/featured — likedCount>0 (LOW)
- `repo.ListFeatured` に `likedCount > 0` フィルタを追加。0 like の public page を featured から除外する (upstream pages/featured.ts)。

## 基盤
- `core/page`: `ErrPageNameInvalid` + `pageNameRe` を追加し Create/Update で検証。
- `api/pages`: handler の Create/Update で `eyeCatchingImageOK` (driveFileRepo 経由の所有検証) を実行。

## テスト

- core/page: name invalid pattern (create/update) + valid pattern を追加。
- api/pages: eyeCatchingImageId の NO_SUCH_FILE (不在 / 他人所有) + 自分所有での成功、update での検証、name invalid pattern を追加。
- repository/page: `ListFeatured` の 0-like 除外を追加。
- 実行: `go test ./internal/api/pages/ ./internal/core/page/ ./internal/repository/ -count=1` → pass。coverage api/pages 97.8% / core/page 99.2% / repository 90.4%。`go build ./... && go vet ./...` → pass。

## Closes

`#1548` の pages 項目を解消する。これで gallery (#1713) / flash (#1714) / pages を合わせ `#1548` の全 13 項目が完了する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)