### PR TITLE
Fix i/update: 残り profile params 受付 + 禁止ワード名エラーを TS 準拠に (#1546)

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -960,6 +960,26 @@ type UpdateRequest struct {
 	// クリア。i/move の前提となる alsoKnownAs を設定する経路 (これが無いと
 	// 移行 flow が成立しない)。
 	AlsoKnownAs *[]string `json:"alsoKnownAs"`
+	// 以下は #1546 で追加した i/update 残りの paramDef field。いずれも model 列 /
+	// entity packer (read 側) は既にあり write 経路だけ抜けていた asymmetric drift。
+	//
+	// NotificationRecieveConfig は通知種別ごとの受信設定 object (jsonb)。
+	// MutedInstances / EmailNotificationTypes は string 配列 (jsonb)。
+	// いずれも json.RawMessage で受けて jsonb 列へそのまま書く (len 0 = 省略=不変)。
+	NotificationRecieveConfig json.RawMessage `json:"notificationRecieveConfig"`
+	MutedInstances            json.RawMessage `json:"mutedInstances"`
+	EmailNotificationTypes    json.RawMessage `json:"emailNotificationTypes"`
+	// PinnedPageID はプロフィールにピン留めする page id (nullable)。upstream は
+	// truthy-string で所有権検証後に SET、null で CLEAR、undefined で不変。
+	// json.RawMessage で 3 状態 (省略 / null / 値) を区別する。
+	PinnedPageID json.RawMessage `json:"pinnedPageId"`
+	// RequireSigninToViewContents は未ログインへのコンテンツ非表示設定 (bool)。
+	RequireSigninToViewContents *bool `json:"requireSigninToViewContents"`
+	// MakeNotesFollowersOnlyBefore / MakeNotesHiddenBefore は過去ノートの自動
+	// followers-only 化 / 非表示化の基準時刻 (integer nullable)。null で解除、
+	// 値で設定、省略で不変。json.RawMessage で 3 状態を区別する。
+	MakeNotesFollowersOnlyBefore json.RawMessage `json:"makeNotesFollowersOnlyBefore"`
+	MakeNotesHiddenBefore        json.RawMessage `json:"makeNotesHiddenBefore"`
 }
 
 // FieldInput is the {name, value} shape accepted by i/update for profile
@@ -1100,6 +1120,27 @@ func containsProhibitedWord(name string, words []string) bool {
 // followingVisibility / followersVisibility enum values accepted by upstream
 // Misskey i/update (public / followers / private). Used to fail-close on any
 // other value instead of silently persisting a bogus privacy setting.
+// parseNullableInt decodes a request json.RawMessage for an integer-nullable
+// i/update field into the **int 3-state convention used by user.UpdateInput
+// (#1546): absent (len 0) → (nil,false) no change; explicit null →
+// (&(*int)(nil),true) clear; integer value → (&&v,true) set. A non-integer,
+// non-null body is a bind error.
+func parseNullableInt(raw json.RawMessage) (**int, bool, error) {
+	if len(raw) == 0 {
+		return nil, false, nil
+	}
+	if string(bytes.TrimSpace(raw)) == "null" {
+		var clear *int
+		return &clear, true, nil
+	}
+	var n int
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return nil, false, err
+	}
+	p := &n
+	return &p, true, nil
+}
+
 func isValidFollowVisibility(v string) bool {
 	switch model.FollowingVisibility(v) {
 	case model.FollowingVisibilityPublic,
@@ -1160,7 +1201,9 @@ func (h *Handler) Update(c echo.Context) error {
 		// クリアリクエストは検査対象外 (ユーザー体験上必要)。
 		if h.metaRepo != nil && *req.Name != "" {
 			if m, err := h.metaRepo.Fetch(); err == nil && containsProhibitedWord(*req.Name, m.ProhibitedWordsForNameOfUser) {
-				return c.JSON(http.StatusBadRequest, apierr.Error("NAME_CONTAINS_PROHIBITED_WORDS", "Your new name contains prohibited words.", "0b3f9f6a-2e7d-4c2c-9d7a-8c6f9b2e1a44"))
+				// upstream update.ts: code=YOUR_NAME_CONTAINS_PROHIBITED_WORDS /
+				// id=0b3f9f6a-2f4d-4b1f-9fb4-49d3a2fd7191 / httpStatusCode=422 (#1546)。
+				return c.JSON(http.StatusUnprocessableEntity, apierr.Error("YOUR_NAME_CONTAINS_PROHIBITED_WORDS", "Your new name contains prohibited words.", "0b3f9f6a-2f4d-4b1f-9fb4-49d3a2fd7191"))
 			}
 		}
 		in.Name = &req.Name
@@ -1324,6 +1367,58 @@ func (h *Handler) Update(c echo.Context) error {
 			return c.JSON(apiErr.status, apiErr.body)
 		}
 		in.AlsoKnownAs = &resolved
+	}
+	// #1546 残り field の request → input 変換。
+	// jsonb passthrough (notificationRecieveConfig / mutedInstances /
+	// emailNotificationTypes)。len 0 = 省略=不変。親 Unmarshal 済バイト列を
+	// コピーして所有権を切り離す。
+	if len(req.NotificationRecieveConfig) > 0 {
+		v := append(json.RawMessage(nil), req.NotificationRecieveConfig...)
+		in.NotificationRecieveConfig = &v
+	}
+	if len(req.MutedInstances) > 0 {
+		v := append(json.RawMessage(nil), req.MutedInstances...)
+		in.MutedInstances = &v
+	}
+	if len(req.EmailNotificationTypes) > 0 {
+		v := append(json.RawMessage(nil), req.EmailNotificationTypes...)
+		in.EmailNotificationTypes = &v
+	}
+	in.RequireSigninToViewContents = req.RequireSigninToViewContents
+	if v, ok, err := parseNullableInt(req.MakeNotesFollowersOnlyBefore); err != nil {
+		return apierr.JSONInvalidParam(c)
+	} else if ok {
+		in.MakeNotesFollowersOnlyBefore = v
+	}
+	if v, ok, err := parseNullableInt(req.MakeNotesHiddenBefore); err != nil {
+		return apierr.JSONInvalidParam(c)
+	} else if ok {
+		in.MakeNotesHiddenBefore = v
+	}
+	// pinnedPageId は upstream と同じ 3 分岐: null → CLEAR、truthy id →
+	// 所有権検証して SET、それ以外 (省略 / "") → 不変 (upstream の
+	// `if (ps.pinnedPageId)` は "" が falsy で no-op)。
+	if len(req.PinnedPageID) > 0 {
+		if string(bytes.TrimSpace(req.PinnedPageID)) == "null" {
+			var clear *string
+			in.PinnedPageID = &clear
+		} else {
+			var pid string
+			if err := json.Unmarshal(req.PinnedPageID, &pid); err != nil {
+				return apierr.JSONInvalidParam(c)
+			}
+			if pid != "" {
+				// 所有権検証: 自分の page でなければ NO_SUCH_PAGE。
+				if h.pageRepo != nil {
+					p, perr := h.pageRepo.FindByID(pid)
+					if perr != nil || p == nil || p.UserID != me.ID {
+						return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_PAGE", "No such page.", "8e01b590-7eb9-431b-a239-860e086c408e"))
+					}
+				}
+				ptr := &pid
+				in.PinnedPageID = &ptr
+			}
+		}
 	}
 
 	bundle, err := h.userService.UpdateProfile(me.ID, in)

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -1155,6 +1155,98 @@ func TestUpdate_FieldsPersisted(t *testing.T) {
 	)
 }
 
+// --- #1546 i/update 残り params ---
+
+func newProfileUser(repo *testutil.MockUserRepository) *model.User {
+	user := &model.User{ID: "user1", Username: "user1", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["user1"] = user
+	repo.Profiles["user1"] = &model.UserProfile{UserID: "user1"}
+	return user
+}
+
+func TestUpdate_MutedInstancesPersisted(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := newProfileUser(repo)
+	rec := post(h.Update, `{"mutedInstances":["evil.example","bad.example"]}`, user)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.JSONEq(t, `["evil.example","bad.example"]`, string(repo.Profiles["user1"].MutedInstances))
+}
+
+func TestUpdate_EmailNotificationTypesPersisted(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := newProfileUser(repo)
+	rec := post(h.Update, `{"emailNotificationTypes":["mention","reply"]}`, user)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.JSONEq(t, `["mention","reply"]`, string(repo.Profiles["user1"].EmailNotificationTypes))
+}
+
+func TestUpdate_NotificationRecieveConfigPersisted(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := newProfileUser(repo)
+	rec := post(h.Update, `{"notificationRecieveConfig":{"mention":{"type":"following"}}}`, user)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.JSONEq(t, `{"mention":{"type":"following"}}`, string(repo.Profiles["user1"].NotificationRecieveConfig))
+}
+
+func TestUpdate_RequireSigninToViewContentsPersisted(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := newProfileUser(repo)
+	rec := post(h.Update, `{"requireSigninToViewContents":true}`, user)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, repo.Users["user1"].RequireSigninToViewContents)
+}
+
+func TestUpdate_MakeNotesBeforeSetAndClear(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := newProfileUser(repo)
+	// set
+	rec := post(h.Update, `{"makeNotesFollowersOnlyBefore":1700000000,"makeNotesHiddenBefore":1700000001}`, user)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, repo.Users["user1"].MakeNotesFollowersOnlyBefore)
+	assert.Equal(t, 1700000000, *repo.Users["user1"].MakeNotesFollowersOnlyBefore)
+	require.NotNil(t, repo.Users["user1"].MakeNotesHiddenBefore)
+	assert.Equal(t, 1700000001, *repo.Users["user1"].MakeNotesHiddenBefore)
+	// clear via null
+	rec = post(h.Update, `{"makeNotesFollowersOnlyBefore":null}`, user)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Nil(t, repo.Users["user1"].MakeNotesFollowersOnlyBefore)
+	// hidden unchanged (omitted)
+	require.NotNil(t, repo.Users["user1"].MakeNotesHiddenBefore)
+}
+
+func TestUpdate_PinnedPageOwned(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := newProfileUser(repo)
+	pageRepo := testutil.NewMockPageRepository()
+	pageRepo.Pages["pg1"] = &model.Page{ID: "pg1", UserID: "user1"}
+	h.SetPageRepo(pageRepo)
+	rec := post(h.Update, `{"pinnedPageId":"pg1"}`, user)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, repo.Profiles["user1"].PinnedPageID)
+	assert.Equal(t, "pg1", *repo.Profiles["user1"].PinnedPageID)
+}
+
+func TestUpdate_PinnedPageNotOwned(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := newProfileUser(repo)
+	pageRepo := testutil.NewMockPageRepository()
+	pageRepo.Pages["pg1"] = &model.Page{ID: "pg1", UserID: "someoneelse"}
+	h.SetPageRepo(pageRepo)
+	rec := post(h.Update, `{"pinnedPageId":"pg1"}`, user)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "8e01b590-7eb9-431b-a239-860e086c408e")
+}
+
+func TestUpdate_PinnedPageNullClears(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := newProfileUser(repo)
+	pinned := "pgOld"
+	repo.Profiles["user1"].PinnedPageID = &pinned
+	rec := post(h.Update, `{"pinnedPageId":null}`, user)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Nil(t, repo.Profiles["user1"].PinnedPageID)
+}
+
 // 空配列 fields=[] を投げると現状を `[]` で上書き (= clear)。nil との挙動
 // 差別化を handler 経路で確認する。
 func TestUpdate_FieldsEmptyClears(t *testing.T) {
@@ -1307,8 +1399,11 @@ func TestUpdate_ProhibitedWordRejected(t *testing.T) {
 	h.SetMetaRepo(metaRepo)
 
 	// "ContainsSpamString" は "Spam" を含むのでブロック (case-insensitive)。
+	// upstream は YOUR_NAME_CONTAINS_PROHIBITED_WORDS / 422 (#1546)。
 	rec := post(h.Update, `{"name":"ContainsSPAMString"}`, user)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	assert.Contains(t, rec.Body.String(), "YOUR_NAME_CONTAINS_PROHIBITED_WORDS")
+	assert.Contains(t, rec.Body.String(), "0b3f9f6a-2f4d-4b1f-9fb4-49d3a2fd7191")
 }
 
 func TestUpdate_ProhibitedWordAllowsClear(t *testing.T) {

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -443,6 +443,24 @@ type UpdateInput struct {
 	// 本家 update.ts は配列で保存するが mk-go は text csv で持つ (move_service
 	// 側の alsoKnownAsIncludes / appendIfMissing と同じ表現)。
 	AlsoKnownAs *[]string
+	// 以下は #1546 で追加した i/update 残り field。
+	//
+	// NotificationRecieveConfig / MutedInstances / EmailNotificationTypes は
+	// user_profile の jsonb 列にそのまま書く生バイト列。nil なら不変。
+	NotificationRecieveConfig *json.RawMessage
+	MutedInstances            *json.RawMessage
+	EmailNotificationTypes    *json.RawMessage
+	// PinnedPageID は user_profile.pinnedPageId。3 状態を **string で表す:
+	//   nil          → 不変 (no change)
+	//   &(*string)nil → CLEAR (NULL)
+	//   &&"<id>"     → SET (所有権検証はハンドラ側で済んでいる前提)
+	PinnedPageID **string
+	// RequireSigninToViewContents は user.requireSigninToViewContents。
+	RequireSigninToViewContents *bool
+	// MakeNotesFollowersOnlyBefore / MakeNotesHiddenBefore は user 列 (*int)。
+	// PinnedPageID と同じ 3 状態を **int で表す (nil=不変 / *nil=NULL / **v=値)。
+	MakeNotesFollowersOnlyBefore **int
+	MakeNotesHiddenBefore        **int
 }
 
 // FieldItem represents one row of user_profile.fields. upstream Misskey の
@@ -602,6 +620,41 @@ func (s *Service) UpdateProfile(userID string, in UpdateInput) (*UserWithProfile
 			userFields["alsoKnownAs"] = nil
 		} else {
 			userFields["alsoKnownAs"] = strings.Join(*in.AlsoKnownAs, ",")
+		}
+	}
+	// #1546 i/update 残り field。jsonb 列は Room と同じく string キャストで
+	// bytea 化を防ぐ。
+	if in.NotificationRecieveConfig != nil {
+		profileFields["notificationRecieveConfig"] = string(*in.NotificationRecieveConfig)
+	}
+	if in.MutedInstances != nil {
+		profileFields["mutedInstances"] = string(*in.MutedInstances)
+	}
+	if in.EmailNotificationTypes != nil {
+		profileFields["emailNotificationTypes"] = string(*in.EmailNotificationTypes)
+	}
+	if in.PinnedPageID != nil {
+		if *in.PinnedPageID == nil {
+			profileFields["pinnedPageId"] = nil
+		} else {
+			profileFields["pinnedPageId"] = **in.PinnedPageID
+		}
+	}
+	if in.RequireSigninToViewContents != nil {
+		userFields["requireSigninToViewContents"] = *in.RequireSigninToViewContents
+	}
+	if in.MakeNotesFollowersOnlyBefore != nil {
+		if *in.MakeNotesFollowersOnlyBefore == nil {
+			userFields["makeNotesFollowersOnlyBefore"] = nil
+		} else {
+			userFields["makeNotesFollowersOnlyBefore"] = **in.MakeNotesFollowersOnlyBefore
+		}
+	}
+	if in.MakeNotesHiddenBefore != nil {
+		if *in.MakeNotesHiddenBefore == nil {
+			userFields["makeNotesHiddenBefore"] = nil
+		} else {
+			userFields["makeNotesHiddenBefore"] = **in.MakeNotesHiddenBefore
 		}
 	}
 

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -436,6 +436,53 @@ func TestService_UpdateProfile_FollowVisibility(t *testing.T) {
 	assert.Equal(t, model.FollowingVisibilityPrivate, got.FollowersVisibility, "followersVisibility は omit で不変")
 }
 
+// #1546: jsonb passthrough (notificationRecieveConfig / mutedInstances /
+// emailNotificationTypes) と pinnedPageId / requireSigninToViewContents /
+// makeNotes*Before の set / clear を core 層で固定する。
+func TestService_UpdateProfile_ExtraParams(t *testing.T) {
+	svc, repo, _, _ := newFullSvc(t)
+	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	repo.Profiles["u1"] = &model.UserProfile{UserID: "u1"}
+
+	nrc := json.RawMessage(`{"mention":{"type":"following"}}`)
+	mi := json.RawMessage(`["evil.example"]`)
+	ent := json.RawMessage(`["mention"]`)
+	pid := "pg1"
+	pidPtr := &pid
+	sig := true
+	fob := 1700000000
+	fobPtr := &fob
+	_, err := svc.UpdateProfile("u1", user.UpdateInput{
+		NotificationRecieveConfig:    &nrc,
+		MutedInstances:               &mi,
+		EmailNotificationTypes:       &ent,
+		PinnedPageID:                 &pidPtr,
+		RequireSigninToViewContents:  &sig,
+		MakeNotesFollowersOnlyBefore: &fobPtr,
+	})
+	require.NoError(t, err)
+	p := repo.Profiles["u1"]
+	assert.JSONEq(t, `{"mention":{"type":"following"}}`, string(p.NotificationRecieveConfig))
+	assert.JSONEq(t, `["evil.example"]`, string(p.MutedInstances))
+	assert.JSONEq(t, `["mention"]`, string(p.EmailNotificationTypes))
+	require.NotNil(t, p.PinnedPageID)
+	assert.Equal(t, "pg1", *p.PinnedPageID)
+	assert.True(t, repo.Users["u1"].RequireSigninToViewContents)
+	require.NotNil(t, repo.Users["u1"].MakeNotesFollowersOnlyBefore)
+	assert.Equal(t, 1700000000, *repo.Users["u1"].MakeNotesFollowersOnlyBefore)
+
+	// clear: pinnedPageId / makeNotesFollowersOnlyBefore を null クリア。
+	var clearPage *string
+	var clearInt *int
+	_, err = svc.UpdateProfile("u1", user.UpdateInput{
+		PinnedPageID:                 &clearPage,
+		MakeNotesFollowersOnlyBefore: &clearInt,
+	})
+	require.NoError(t, err)
+	assert.Nil(t, repo.Profiles["u1"].PinnedPageID)
+	assert.Nil(t, repo.Users["u1"].MakeNotesFollowersOnlyBefore)
+}
+
 // #956: profile fields (name/value 配列) の persist + 正規化。
 // upstream Misskey TS は trim + 空 entry 排除を行うので、mk-go も同挙動に
 // 揃える (= name または value どちらかが trim 後に空なら drop)。

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -465,6 +465,20 @@ func ptrOrNilString(v any) *string {
 	return nil
 }
 
+// ptrOrNilInt normalises a fields-map value (int / *int / untyped nil) into the
+// *int form used by model.User for the i/update nullable-int fields (#1546).
+func ptrOrNilInt(v any) *int {
+	switch n := v.(type) {
+	case nil:
+		return nil
+	case int:
+		return &n
+	case *int:
+		return n
+	}
+	return nil
+}
+
 func applyUserFields(u *model.User, fields map[string]any) {
 	for k, v := range fields {
 		switch k {
@@ -548,6 +562,15 @@ func applyUserFields(u *model.User, fields map[string]any) {
 				// 経路を mock でも反映する。
 				u.AlsoKnownAs = nil
 			}
+		// #1546 i/update 残り user 列 field。
+		case "requireSigninToViewContents":
+			if b, ok := v.(bool); ok {
+				u.RequireSigninToViewContents = b
+			}
+		case "makeNotesFollowersOnlyBefore":
+			u.MakeNotesFollowersOnlyBefore = ptrOrNilInt(v)
+		case "makeNotesHiddenBefore":
+			u.MakeNotesHiddenBefore = ptrOrNilInt(v)
 		case "avatarUrl":
 			u.AvatarURL = ptrOrNilString(v)
 		case "bannerUrl":
@@ -699,6 +722,30 @@ func applyProfileFields(p *model.UserProfile, fields map[string]any) {
 			case []byte:
 				p.Room = val
 			}
+		// #1546 i/update 残り field の jsonb / pinnedPageId 反映。
+		case "notificationRecieveConfig":
+			switch val := v.(type) {
+			case string:
+				p.NotificationRecieveConfig = []byte(val)
+			case []byte:
+				p.NotificationRecieveConfig = val
+			}
+		case "mutedInstances":
+			switch val := v.(type) {
+			case string:
+				p.MutedInstances = []byte(val)
+			case []byte:
+				p.MutedInstances = val
+			}
+		case "emailNotificationTypes":
+			switch val := v.(type) {
+			case string:
+				p.EmailNotificationTypes = []byte(val)
+			case []byte:
+				p.EmailNotificationTypes = val
+			}
+		case "pinnedPageId":
+			p.PinnedPageID = ptrOrNilString(v)
 		case "mutedWords":
 			switch val := v.(type) {
 			case string:


### PR DESCRIPTION
## Summary

`#1546` (i/* part2 parity) の **i/update** 残り 7 項目を解消する。いずれも model 列 / entity packer (read 側) は既にあり、write 経路だけ抜けていて silent drop していた asymmetric drift。

## 主な変更点

| param | 種別 | 内容 |
|-------|------|------|
| `notificationRecieveConfig` | MEDIUM | 通知種別ごとの受信設定 object を jsonb 列へ書き込み |
| `mutedInstances` | MEDIUM | インスタンスミュート配列を jsonb 列へ書き込み |
| `emailNotificationTypes` | MEDIUM | メール通知種別配列を jsonb 列へ書き込み |
| `pinnedPageId` | MEDIUM | upstream と同じ 3 分岐 (null→CLEAR / truthy id→所有権検証して SET / 省略・""→不変)。他人の page は `NO_SUCH_PAGE` (8e01b590) |
| `requireSigninToViewContents` | MEDIUM | `user.requireSigninToViewContents` へ書き込み |
| `makeNotesFollowersOnlyBefore` / `makeNotesHiddenBefore` | MEDIUM | integer nullable を **int の 3 状態 (省略=不変 / null=NULL / 値=set) で受付 |
| 禁止ワード名エラー | MEDIUM | code `NAME_CONTAINS_PROHIBITED_WORDS` → `YOUR_NAME_CONTAINS_PROHIBITED_WORDS`、UUID `0b3f9f6a-2f4d-4b1f-9fb4-49d3a2fd7191`、HTTP 400 → 422 (upstream 一致) |

## 実装

- `internal/core/user`: `UpdateInput` に 7 field を追加し `UpdateProfile` で書き込み。jsonb は string キャスト (bytea 化回避)、pinnedPageId / makeNotes*Before は `**T` の 3 状態。
- `internal/api/i/handler.go`: `UpdateRequest` に field 追加 + request→input 変換。pinnedPageId 所有権検証 (pageRepo)、makeNotes*Before は `parseNullableInt` で 3 状態 decode。
- `internal/testutil`: mock の `applyProfileFields` / `applyUserFields` に新 field を反映 (+ `ptrOrNilInt`)。

## テスト

- api/i: mutedInstances / emailNotificationTypes / notificationRecieveConfig / requireSigninToViewContents の persist、makeNotes*Before の set+null clear、pinnedPage の owned / not-owned (NO_SUCH_PAGE) / null clear、禁止ワード名エラー (422 + code/UUID) を追加。
- core/user: `TestService_UpdateProfile_ExtraParams` で全 field の set / clear を固定。
- 実行: `go test ./internal/api/i/ ./internal/core/user/ -count=1` → pass。coverage api/i 90.7% / core/user 91.6%。`go build ./... && go vet ./...` → pass。

## Closes

`#1546` の i/update 関連 7 項目を解消する (registry / move / webhooks / notifications / 他は別 PR)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)