### PR TITLE
Fix i/registry: scopes-with-domain の domain 集約 shape + scope パターン検証 (#1546)

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -634,6 +634,9 @@ func (h *Handler) RegistryGet(c echo.Context) error {
 	if req.Scope == nil {
 		req.Scope = []string{}
 	}
+	if !validRegistryScope(req.Scope) {
+		return apierr.JSONInvalidParam(c)
+	}
 	item, err := h.registryRepo.Get(u.ID, req.Key, req.Scope, req.Domain)
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_KEY", "No such key.", "ac3ed68a-62f0-422b-a7bc-d5e09e8f6a6a"))
@@ -656,6 +659,9 @@ func (h *Handler) RegistrySet(c echo.Context) error {
 	}
 	if req.Scope == nil {
 		req.Scope = []string{}
+	}
+	if !validRegistryScope(req.Scope) {
+		return apierr.JSONInvalidParam(c)
 	}
 	item := &model.RegistryItem{
 		ID:        h.idGen.Generate(time.Now()),
@@ -695,6 +701,9 @@ func (h *Handler) RegistryGetAll(c echo.Context) error {
 	if req.Scope == nil {
 		req.Scope = []string{}
 	}
+	if !validRegistryScope(req.Scope) {
+		return apierr.JSONInvalidParam(c)
+	}
 	items, err := h.registryRepo.GetAll(u.ID, req.Scope, req.Domain)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
@@ -719,6 +728,9 @@ func (h *Handler) RegistryKeysWithType(c echo.Context) error {
 	if req.Scope == nil {
 		req.Scope = []string{}
 	}
+	if !validRegistryScope(req.Scope) {
+		return apierr.JSONInvalidParam(c)
+	}
 	keys, err := h.registryRepo.KeysWithType(u.ID, req.Scope, req.Domain)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
@@ -739,6 +751,9 @@ func (h *Handler) RegistryRemove(c echo.Context) error {
 	}
 	if req.Scope == nil {
 		req.Scope = []string{}
+	}
+	if !validRegistryScope(req.Scope) {
+		return apierr.JSONInvalidParam(c)
 	}
 	if err := h.registryRepo.Remove(u.ID, req.Key, req.Scope, req.Domain); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))

--- a/internal/api/i/registry.go
+++ b/internal/api/i/registry.go
@@ -2,11 +2,27 @@ package i
 
 import (
 	"net/http"
+	"regexp"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
+
+// registryScopeElemRe mirrors upstream registry paramDef scope items pattern
+// ^[a-zA-Z0-9_]+$ (#1546)。各 registry endpoint で scope 要素を検証する。
+var registryScopeElemRe = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
+
+// validRegistryScope reports whether every scope element matches the upstream
+// pattern. Empty scope ([]) is valid.
+func validRegistryScope(scope []string) bool {
+	for _, s := range scope {
+		if !registryScopeElemRe.MatchString(s) {
+			return false
+		}
+	}
+	return true
+}
 
 // registryScopeDomainRequest is the canonical input shape for registry
 // read endpoints. scope は []string、domain は *string (省略可)。
@@ -43,6 +59,9 @@ func (h *Handler) RegistryGetDetail(c echo.Context) error {
 		return apierr.JSONInvalidParam(c)
 	}
 	req.Scope = normalizeRegistryScope(req.Scope)
+	if !validRegistryScope(req.Scope) {
+		return apierr.JSONInvalidParam(c)
+	}
 	item, err := h.registryRepo.Get(u.ID, req.Key, req.Scope, req.Domain)
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_KEY", "No such key.", "97a1e8e7-c0f7-47d2-957a-92e61256e01a"))
@@ -65,6 +84,9 @@ func (h *Handler) RegistryKeys(c echo.Context) error {
 	var req registryScopeDomainRequest
 	_ = c.Bind(&req)
 	req.Scope = normalizeRegistryScope(req.Scope)
+	if !validRegistryScope(req.Scope) {
+		return apierr.JSONInvalidParam(c)
+	}
 	keysMap, err := h.registryRepo.KeysWithType(u.ID, req.Scope, req.Domain)
 	if err != nil {
 		return apierr.JSONInternalError(c)
@@ -87,12 +109,32 @@ func (h *Handler) RegistryScopesWithDomain(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	out := make([]map[string]any, 0, len(pairs))
+	// upstream getAllScopeAndDomains: domain ごとに集約し scopes は string[][]
+	// (1 domain につき複数 scope を束ねる、#1546)。repo は DISTINCT (scope,domain)
+	// を返すので domain 内の scope は既に一意。domain は null (main 空間) を保つ。
+	type scopeEntry struct {
+		Domain *string    `json:"domain"`
+		Scopes [][]string `json:"scopes"`
+	}
+	out := make([]*scopeEntry, 0, len(pairs))
+	byDomain := make(map[string]*scopeEntry, len(pairs))
 	for _, p := range pairs {
-		out = append(out, map[string]any{
-			"scope":  p.Scope,
-			"domain": p.Domain,
-		})
+		// nil domain と空文字 domain を区別するため sentinel を付与する。
+		key := "\x00nil"
+		if p.Domain != nil {
+			key = "d:" + *p.Domain
+		}
+		sc := p.Scope
+		if sc == nil {
+			sc = []string{}
+		}
+		if e, ok := byDomain[key]; ok {
+			e.Scopes = append(e.Scopes, sc)
+		} else {
+			e := &scopeEntry{Domain: p.Domain, Scopes: [][]string{sc}}
+			byDomain[key] = e
+			out = append(out, e)
+		}
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/i/registry_test.go
+++ b/internal/api/i/registry_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -25,6 +26,49 @@ func TestRegistryKeys(t *testing.T) {
 func TestRegistryScopesWithDomain(t *testing.T) {
 	h, _ := newExtraHandler(t)
 	assert.Equal(t, http.StatusOK, postExtra(h.RegistryScopesWithDomain, `{}`, stubUser).Code)
+}
+
+// #1546: scopes-with-domain は domain ごとに集約し scopes を string[][] で返す。
+func TestRegistryScopesWithDomain_GroupedByDomain(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	reg := testutil.NewMockRegistryRepository()
+	dom := "client.example"
+	require.NoError(t, reg.Set(&model.RegistryItem{ID: "r1", UserID: stubUser.ID, Key: "a", Scope: pq.StringArray{"client", "base"}, Domain: &dom}))
+	require.NoError(t, reg.Set(&model.RegistryItem{ID: "r2", UserID: stubUser.ID, Key: "b", Scope: pq.StringArray{"client", "theme"}, Domain: &dom}))
+	require.NoError(t, reg.Set(&model.RegistryItem{ID: "r3", UserID: stubUser.ID, Key: "c", Scope: pq.StringArray{"main"}}))
+	h.SetRegistryRepo(reg)
+
+	rec := postExtra(h.RegistryScopesWithDomain, `{}`, stubUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []struct {
+		Domain *string    `json:"domain"`
+		Scopes [][]string `json:"scopes"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	byDomain := map[string][][]string{}
+	for _, e := range out {
+		k := "nil"
+		if e.Domain != nil {
+			k = *e.Domain
+		}
+		byDomain[k] = e.Scopes
+	}
+	require.Contains(t, byDomain, "client.example")
+	assert.Len(t, byDomain["client.example"], 2, "同一 domain の scope を scopes 配列に束ねる")
+	require.Contains(t, byDomain, "nil")
+	assert.Len(t, byDomain["nil"], 1)
+}
+
+// #1546: scope 要素が ^[a-zA-Z0-9_]+$ に反すると INVALID_PARAM。
+func TestRegistryScopePatternRejected(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	h.SetRegistryRepo(testutil.NewMockRegistryRepository())
+	// RegistryGetDetail (registry.go) と RegistryGetAll (handler.go) の両系統を確認。
+	assert.Equal(t, http.StatusBadRequest, postExtra(h.RegistryGetDetail, `{"key":"k","scope":["bad scope"]}`, stubUser).Code)
+	assert.Equal(t, http.StatusBadRequest, postExtra(h.RegistryGetAll, `{"scope":["has.dot"]}`, stubUser).Code)
+	assert.Equal(t, http.StatusBadRequest, postExtra(h.RegistryKeys, `{"scope":["nope!"]}`, stubUser).Code)
+	// 正常な scope は通る。
+	assert.Equal(t, http.StatusOK, postExtra(h.RegistryKeys, `{"scope":["client","base_1"]}`, stubUser).Code)
 }
 
 // --- P4-6 (#166): i/registry/* ---
@@ -102,8 +146,14 @@ func TestRegistryScopesWithDomain_ReturnsDistinctPairs(t *testing.T) {
 	h.SetRegistryRepo(reg)
 	rec := postExtra(h.RegistryScopesWithDomain, `{}`, stubUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	var got []map[string]any
+	var got []struct {
+		Domain *string    `json:"domain"`
+		Scopes [][]string `json:"scopes"`
+	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
-	// 2 distinct scopes, domain は nil のみ
-	assert.Len(t, got, 2)
+	// #1546: domain (ここでは nil のみ) ごとに集約され、2 distinct scope が
+	// scopes 配列に束ねられる。
+	require.Len(t, got, 1)
+	assert.Nil(t, got[0].Domain)
+	assert.Len(t, got[0].Scopes, 2)
 }


### PR DESCRIPTION
## Summary

`#1546` (i/* part2 parity) の **i/registry** から HIGH 1 + LOW 1 を解消する。

## 主な変更点

### i/registry/scopes-with-domain — 応答 shape (HIGH)
- upstream `RegistryApiService.getAllScopeAndDomains` と同じく domain ごとに集約し `[{domain: string|null, scopes: string[][]}]` を返す。従来は `[{scope: string[], domain}]` の flat 返却で、field 名 (`scope` 単数 vs `scopes` 複数) も構造 (flat vs grouped) も二重に不一致だった。repo は DISTINCT (scope,domain) を返すため domain 内の scope は既に一意。

### i/registry/* — scope パターン検証 (LOW)
- `get` / `get-all` / `get-detail` / `keys` / `keys-with-type` / `remove` / `set` の全 endpoint で scope 要素を upstream paramDef pattern `^[a-zA-Z0-9_]+$` で検証し、違反は `INVALID_PARAM`。

## 別 issue へ分離

- registry の **access token による domain 分離** (MEDIUM) は `AuthScope` / token cache / auth middleware への横断変更を要するため `#1717` に分離した。

## テスト

- `TestRegistryScopesWithDomain_GroupedByDomain`: 同一 domain の複数 scope が `scopes` 配列に束ねられ、nil domain も別 entry になることを固定。
- 既存 `TestRegistryScopesWithDomain_ReturnsDistinctPairs` を grouped shape に更新。
- `TestRegistryScopePatternRejected`: 空白 / ドット / 記号入り scope が各系統 (registry.go / handler.go) で INVALID_PARAM、正常 scope は通ることを確認。
- 実行: `go test ./internal/api/i/ -count=1` → pass。coverage 90.7%。`go build ./... && go vet ./...` → pass。

## Closes

`#1546` の registry scopes-with-domain (HIGH) + scope パターン (LOW) を解消する。domain 分離は `#1717` で継続。

🤖 Generated with [Claude Code](https://claude.com/claude-code)