### PR TITLE
Fix i/move: password 任意化 + acct 形式受付 + root 移行禁止 (#1546)

### DIFF
--- a/internal/api/i/move.go
+++ b/internal/api/i/move.go
@@ -3,6 +3,7 @@ package i
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
@@ -13,46 +14,63 @@ import (
 
 // Move handles POST /api/i/move.
 //
-// Mastodon / Misskey 互換のアカウント引越し。moveToAccount には移行先ユーザーの
-// canonical URI (例: https://other.example/users/abc) を渡す。処理内容:
+// Mastodon / Misskey 互換のアカウント引越し。moveToAccount には移行先の
+// canonical URI (例: https://other.example/users/abc) または acct 形式
+// (@user@host) を渡す。処理内容:
 //
-//  1. パスワード照合 (不正 token による乗っ取り防止)
-//  2. 既に movedToUri を持っていれば ALREADY_MOVED
-//  3. URI 解決して dst ユーザーを取得 (失敗時は NO_SUCH_USER)
-//  4. dst.alsoKnownAs に自分の URI が含まれているかを検証
-//     (相互指定されていなければ DESTINATION_ACCOUNT_FORBIDS)
-//  5. movedToUri / movedAt / alsoKnownAs を DB に書き込み
-//  6. Move activity を follower inbox 群に配送
+//  1. root ユーザーは移行不可 (NOT_ROOT_FORBIDDEN, #1546)
+//  2. password が指定されていれば照合 (任意、後述)
+//  3. moveToAccount が acct 形式なら canonical URI へ解決
+//  4. mover が ALREADY_MOVED / URI 解決 / dst.alsoKnownAs 検証 / DB 書き込み + 配送
 //
-// 本家では moveToAccount に "@user@host" 形式も受け付けるが、こちらは
-// outbound WebFinger を持たないため URI のみを受け付ける。フロント側も
-// リモート actor 解決後の URI を渡す運用で対応可能。
+// password param について (#1546): 本家 move.ts は secure:true による session
+// 再認証で代替し password param を持たない。公式 frontend (migration.vue) は
+// moveToAccount のみ送るため、password 必須化すると公式移行フローが必ず 400 で
+// 失敗する。drop-in / API 互換を最優先する方針 (CLAUDE.md) に従い password を
+// 任意化し、送られた場合のみ照合する (再認証の強制は session-secure framework
+// 実装まで保留)。
 //
-// 本家は secure: true フラグで session 検証を行うが、我々は secure flag の枠
-// 組みを持たないため delete-account / change-password と同じく password
-// パラメータで直接照合する。アカウント移行は不可逆なので password 必須を
-// 崩してはいけない。
+// acct 形式の解決は alsoKnownAs と同じ lookupAlsoKnownAsTarget (local DB の
+// FindByURI / FindByUsernameLower) を再利用する。移行先は事前に alsoKnownAs で
+// src を指している必要があり、その時点で local に解決済のため local lookup で足りる。
 func (h *Handler) Move(c echo.Context) error {
 	me := middleware.GetUser(c)
 	var req struct {
 		MoveToAccount string `json:"moveToAccount"`
 		Password      string `json:"password"`
 	}
-	if err := c.Bind(&req); err != nil || req.MoveToAccount == "" || req.Password == "" {
+	if err := c.Bind(&req); err != nil || req.MoveToAccount == "" {
 		return apierr.JSONInvalidParam(c)
 	}
-	profile := h.userService.GetProfile(me.ID)
-	if profile == nil || profile.Password == nil {
+	// root ユーザーは移行不可 (upstream move.ts: rootUserId === me.id)。
+	// meta.rootUserId と user.isRoot の両方を見る (role_service.isRootUser と同 doctrine)。
+	isRoot := me.IsRoot
+	if h.metaRepo != nil {
+		if m, err := h.metaRepo.Fetch(); err == nil && m.RootUserID != nil && *m.RootUserID == me.ID {
+			isRoot = true
+		}
+	}
+	if isRoot {
 		return c.JSON(http.StatusForbidden, apierr.Error(
-			"ACCESS_DENIED", "No password set.",
-			"1fb7cb09-d46a-4fff-b8df-057708cce513",
+			"NOT_ROOT_FORBIDDEN", "This feature is not available for the root account.",
+			"4362e8dc-731f-4ad8-a694-be2a88922a24",
 		))
 	}
-	if err := bcrypt.CompareHashAndPassword([]byte(*profile.Password), []byte(req.Password)); err != nil {
-		return c.JSON(http.StatusForbidden, apierr.Error(
-			"INCORRECT_PASSWORD", "Incorrect password.",
-			"932c904e-9460-45b7-9ce6-7ed33be7eb2c",
-		))
+	// password は任意。指定された場合のみ照合する (#1546)。
+	if req.Password != "" {
+		profile := h.userService.GetProfile(me.ID)
+		if profile == nil || profile.Password == nil {
+			return c.JSON(http.StatusForbidden, apierr.Error(
+				"ACCESS_DENIED", "No password set.",
+				"1fb7cb09-d46a-4fff-b8df-057708cce513",
+			))
+		}
+		if err := bcrypt.CompareHashAndPassword([]byte(*profile.Password), []byte(req.Password)); err != nil {
+			return c.JSON(http.StatusForbidden, apierr.Error(
+				"INCORRECT_PASSWORD", "Incorrect password.",
+				"932c904e-9460-45b7-9ce6-7ed33be7eb2c",
+			))
+		}
 	}
 	if h.mover == nil {
 		return c.JSON(http.StatusNotImplemented, apierr.Error(
@@ -61,7 +79,27 @@ func (h *Handler) Move(c echo.Context) error {
 			"5d37dbcb-891e-41ca-a3d6-e690c97775ac",
 		))
 	}
-	err := h.mover.Move(me, req.MoveToAccount)
+	// acct 形式 (@user@host) は canonical URI へ解決してから mover に渡す。
+	// URI 形式 (http/https) はそのまま渡す。
+	moveTo := req.MoveToAccount
+	if !strings.HasPrefix(moveTo, "http://") && !strings.HasPrefix(moveTo, "https://") {
+		u := h.lookupAlsoKnownAsTarget(moveTo)
+		if u == nil {
+			return c.JSON(http.StatusNotFound, apierr.Error(
+				"NO_SUCH_USER", "No such user.",
+				"fcd2eef9-a9b2-4c4f-8624-038099e90aa5",
+			))
+		}
+		uri := h.canonicalUserURI(u)
+		if uri == "" {
+			return c.JSON(http.StatusNotFound, apierr.Error(
+				"NO_SUCH_USER", "No such user.",
+				"fcd2eef9-a9b2-4c4f-8624-038099e90aa5",
+			))
+		}
+		moveTo = uri
+	}
+	err := h.mover.Move(me, moveTo)
 	switch {
 	case err == nil:
 		return h.Me(c)

--- a/internal/api/i/move_handler_test.go
+++ b/internal/api/i/move_handler_test.go
@@ -29,12 +29,65 @@ func (s *stubMover) Move(src *model.User, dstURI string) error {
 func TestMove_InvalidParam(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	h.SetAccountMover(&stubMover{})
-	// moveToAccount 欠落
+	// moveToAccount 欠落は 400 (#1546: password は任意なので password だけでも moveToAccount 無しは 400)。
 	assert.Equal(t, http.StatusBadRequest, post(h.Move, `{"password":"pw"}`, &model.User{ID: "me"}).Code)
-	// password 欠落
-	assert.Equal(t, http.StatusBadRequest, post(h.Move, `{"moveToAccount":"https://x"}`, &model.User{ID: "me"}).Code)
-	// 両方欠落
 	assert.Equal(t, http.StatusBadRequest, post(h.Move, `{}`, &model.User{ID: "me"}).Code)
+}
+
+// #1546: password は任意。未指定でも 400 にならず移行が進む (upstream は password
+// param を持たず secure:true session 検証で代替するため)。
+func TestMove_PasswordOptional(t *testing.T) {
+	h, user, setMover := moveHandlerWithPasswordUser(t)
+	sm := &stubMover{}
+	setMover(sm)
+	// password を送らない。
+	rec := post(h.Move, `{"moveToAccount":"https://other.example/users/x"}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, sm.called)
+	assert.Equal(t, "https://other.example/users/x", sm.gotURI)
+}
+
+// #1546: root ユーザーは移行不可 (NOT_ROOT_FORBIDDEN)。
+func TestMove_RootForbidden(t *testing.T) {
+	h, _, setMover := moveHandlerWithPasswordUser(t)
+	sm := &stubMover{}
+	setMover(sm)
+	root := &model.User{ID: "me", Username: "me", IsRoot: true}
+	rec := post(h.Move, `{"moveToAccount":"https://x","password":"pw"}`, root)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NOT_ROOT_FORBIDDEN")
+	assert.Contains(t, rec.Body.String(), "4362e8dc-731f-4ad8-a694-be2a88922a24")
+	assert.False(t, sm.called)
+}
+
+// #1546: acct 形式 (@user@host) は canonical URI へ解決してから mover に渡す。
+func TestMove_AcctFormatResolved(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	user := &model.User{ID: "me", Username: "me"}
+	userRepo.Users["me"] = user
+	// 移行先 remote user を local DB に用意し、acct → URI 解決させる。
+	host := "remote.example"
+	uri := "https://remote.example/users/bob"
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", UsernameLower: "bob", Host: &host, URI: &uri}
+	h.SetUserRepo(userRepo)
+	sm := &stubMover{}
+	h.SetAccountMover(sm)
+	rec := post(h.Move, `{"moveToAccount":"@bob@remote.example"}`, user)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, sm.called)
+	assert.Equal(t, "https://remote.example/users/bob", sm.gotURI)
+}
+
+// acct を解決できなければ NO_SUCH_USER。
+func TestMove_AcctFormatNotFound(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	user := &model.User{ID: "me", Username: "me"}
+	userRepo.Users["me"] = user
+	h.SetUserRepo(userRepo)
+	h.SetAccountMover(&stubMover{})
+	rec := post(h.Move, `{"moveToAccount":"@ghost@remote.example"}`, user)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_USER")
 }
 
 func TestMove_NoProfile(t *testing.T) {

--- a/internal/api/i/move_test.go
+++ b/internal/api/i/move_test.go
@@ -9,9 +9,8 @@ import (
 
 func TestMoveAccount(t *testing.T) {
 	h, _ := newExtraHandler(t)
-	// moveToAccount / password 未指定は 400
+	// moveToAccount 未指定は 400 (#1546: password は任意)。
 	assert.Equal(t, http.StatusBadRequest, postExtra(h.Move, `{}`, stubUser).Code)
-	assert.Equal(t, http.StatusBadRequest, postExtra(h.Move, `{"moveToAccount":"https://x"}`, stubUser).Code)
-	// profile 未登録 → ACCESS_DENIED
+	// password を指定したが profile 未登録 → ACCESS_DENIED。
 	assert.Equal(t, http.StatusForbidden, postExtra(h.Move, `{"moveToAccount":"https://x","password":"pw"}`, stubUser).Code)
 }


### PR DESCRIPTION
## Summary

`#1546` (i/* part2 parity) の **i/move** 3 項目 (MEDIUM 2 + LOW 1) を解消する。

## 主な変更点

### password を任意化 (MEDIUM)
- 本家 `move.ts` は `secure:true` による session 再認証で代替し `password` param を持たない。公式 frontend (`migration.vue`) は `moveToAccount` のみ送るため、現状の password 必須化だと**公式移行フローが必ず 400 で失敗**していた (drop-in 互換 break)。
- drop-in / API 互換を最優先する方針 (CLAUDE.md) に従い password を任意化し、**送られた場合のみ照合**する。
- 注: 任意化に伴い再認証の強制は失われる (upstream は session-secure で担保するが mk-go は未実装)。session-secure framework は将来課題。**ユーザー承認のうえ任意化を選択。**

### acct 形式 (@user@host) の受付 (MEDIUM)
- `moveToAccount` が acct 形式なら canonical URI へ解決してから mover に渡す。URI 形式はそのまま。解決は alsoKnownAs と同じ `lookupAlsoKnownAsTarget` (local DB の `FindByURI` / `FindByUsernameLower`) を再利用。移行先は事前に alsoKnownAs で src を指す必要があり、その時点で local 解決済のため local lookup で足りる。

### root 移行禁止 (LOW)
- root ユーザーの移行を `NOT_ROOT_FORBIDDEN` (4362e8dc-731f-4ad8-a694-be2a88922a24) で禁止 (upstream `move.ts: rootUserId === me.id`)。`meta.rootUserId` と `user.isRoot` の両方を確認 (role_service.isRootUser と同 doctrine)。

## テスト

- `TestMove_PasswordOptional` (password 未指定でも移行が進む)、`TestMove_RootForbidden`、`TestMove_AcctFormatResolved` (@user@host → URI)、`TestMove_AcctFormatNotFound` を追加。
- 既存 `TestMove_InvalidParam` / `TestMoveAccount` を password-任意化に合わせて更新。
- 実行: `go test ./internal/api/i/ -count=1` → pass。coverage 90.5%。`go build ./... && go vet ./...` → pass。

## Closes

`#1546` の i/move 3 項目を解消する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)