### PR TITLE
Fix i/* small parity: revoke-token no-op + update-email EMAIL_REQUIRED + notifications includeTypes:[] (#1546)

### DIFF
--- a/internal/api/i/apps.go
+++ b/internal/api/i/apps.go
@@ -193,7 +193,10 @@ func (h *Handler) RevokeToken(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)
 	}
 	if tok.UserID != u.ID {
-		return apierr.JSONAccessDenied(c)
+		// upstream revoke-token は delete を {id/token, userId: me.id} 条件で
+		// 実行するだけで、他人の token は単に no-op (成功 204) になる (#1546)。
+		// 403 を返すと token の存在 / 所有者が leak するため、no-op 204 に揃える。
+		return c.NoContent(http.StatusNoContent)
 	}
 	if err := h.accessTokenRepo.DeleteByID(tok.ID); err != nil {
 		return apierr.JSONInternalError(c)

--- a/internal/api/i/apps_test.go
+++ b/internal/api/i/apps_test.go
@@ -213,14 +213,19 @@ func TestRevokeToken_Owned(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestRevokeToken_ForeignToken_AccessDenied(t *testing.T) {
+// #1546: 他人所有の token 指定は upstream と同じく no-op (204)。403 を返すと
+// token の存在 / 所有者が leak するため、削除せず 204 を返す。
+func TestRevokeToken_ForeignTokenIsNoOp(t *testing.T) {
 	h, _ := newExtraHandler(t)
 	tokens := testutil.NewMockAccessTokenRepository()
 	tokens.Tokens["h2"] = &model.AccessToken{ID: "t2", Hash: "h2", UserID: "other"}
 	h.SetAccessTokenRepo(tokens)
 
 	rec := postExtra(h.RevokeToken, `{"tokenId":"t2"}`, stubUser)
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	// 他人の token は削除されない。
+	_, err := tokens.FindByID("t2")
+	assert.NoError(t, err)
 }
 
 func TestRevokeToken_UnknownTokenIsIdempotent(t *testing.T) {

--- a/internal/api/i/email_update.go
+++ b/internal/api/i/email_update.go
@@ -77,8 +77,10 @@ func (h *Handler) UpdateEmail(c echo.Context) error {
 	if req.Email == nil {
 		// email クリア。emailRequiredForSignup 時はクリア不可。
 		if h.metaRepo != nil {
+			// upstream update-email: email=null かつ emailRequiredForSignup なら
+			// EMAIL_REQUIRED (324c7a88) を返す (#1546)。
 			if m, err := h.metaRepo.Fetch(); err == nil && m.EmailRequiredForSignup {
-				return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Email is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+				return c.JSON(http.StatusBadRequest, apierr.Error("EMAIL_REQUIRED", "Email is required.", "324c7a88-59f2-492f-903f-89134f93e47e"))
 			}
 		}
 		fields["email"] = nil

--- a/internal/api/i/email_update_test.go
+++ b/internal/api/i/email_update_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,6 +28,22 @@ func TestUpdateEmail_ClearEmail(t *testing.T) {
 	// email を null にセットしてクリア
 	rec := postExtra(h.UpdateEmail, `{"password":"secret","email":null}`, stubUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// #1546: email=null かつ emailRequiredForSignup なら EMAIL_REQUIRED (324c7a88)。
+func TestUpdateEmail_ClearEmailRequired(t *testing.T) {
+	h, repo := newExtraHandler(t)
+	pwd := hashPassword("secret")
+	email := "old@example.com"
+	repo.Profiles["u1"] = &model.UserProfile{UserID: "u1", Password: &pwd, Email: &email}
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "x", EmailRequiredForSignup: true}
+	h.SetMetaRepo(metaRepo)
+
+	rec := postExtra(h.UpdateEmail, `{"password":"secret","email":null}`, stubUser)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "EMAIL_REQUIRED")
+	assert.Contains(t, rec.Body.String(), "324c7a88-59f2-492f-903f-89134f93e47e")
 }
 
 func TestUpdateEmail_SetNewEmail(t *testing.T) {

--- a/internal/api/notifications/handler.go
+++ b/internal/api/notifications/handler.go
@@ -212,6 +212,14 @@ func (h *Handler) bindListRequest(c echo.Context) (ListRequest, bool) {
 // followers / specified notes the viewer cannot see are dropped so noteId
 // stays but the embedded detail does not leak.
 func (h *Handler) collectNotifications(c echo.Context, user *model.User, req ListRequest) ([]*notification.Notification, map[string]*model.User, map[string]*model.Note, error) {
+	// upstream notifications.ts: 明示的な includeTypes:[] は空配列を返す
+	// (= 何も含めない)。omit (nil) は全 type を通す。Go の []string は
+	// absent→nil / []→non-nil(len 0) で区別できるので、ここで早期 return する
+	// (#1546)。excludeTypes 全指定の空返却は下の per-row exclude filter で既に
+	// 成立するため特別扱い不要。
+	if req.IncludeTypes != nil && len(req.IncludeTypes) == 0 {
+		return nil, map[string]*model.User{}, map[string]*model.Note{}, nil
+	}
 	rows, err := h.svc.List(c.Request().Context(), user.ID, req.Limit)
 	if err != nil {
 		return nil, nil, nil, err

--- a/internal/api/notifications/handler_test.go
+++ b/internal/api/notifications/handler_test.go
@@ -105,6 +105,34 @@ func TestShow_WithEntries(t *testing.T) {
 	assert.Equal(t, "bob", resp[0]["userId"])
 }
 
+// #1546: 明示的な includeTypes:[] は空配列を返す (= 何も含めない)。
+// includeTypes 省略時は全件返ることと対比して固定する。
+func TestShow_IncludeTypesEmptyReturnsEmpty(t *testing.T) {
+	h, svc := newTestHandler(t)
+	ctx := context.Background()
+	_, err := svc.Create(ctx, notification.CreateInput{
+		NotifieeID: "alice", NotifierID: "bob", Type: notification.TypeFollow,
+	})
+	require.NoError(t, err)
+
+	// includeTypes:[] → []
+	c, rec := newJSONRequest(t, "/api/i/notifications", `{"limit":50,"includeTypes":[]}`)
+	setAuth(c, &model.User{ID: "alice"})
+	require.NoError(t, h.Show(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Empty(t, resp, "explicit includeTypes:[] must return []")
+
+	// includeTypes 省略 → 全件 (対比)。
+	c2, rec2 := newJSONRequest(t, "/api/i/notifications", `{"limit":50}`)
+	setAuth(c2, &model.User{ID: "alice"})
+	require.NoError(t, h.Show(c2))
+	var resp2 []map[string]any
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp2))
+	assert.Len(t, resp2, 1, "omitted includeTypes returns all")
+}
+
 // sinceDate=0 (= 1970 epoch) を渡したら全 notification が post-fetch filter
 // を通過する。adapter pattern (= sinceDate → aidx prefix) が effectively に
 // 動くことの positive case (#1174)。


### PR DESCRIPTION
## Summary

`#1546` (i/* part2 parity) の LOW 3 項目を解消する。

## 主な変更点

### i/revoke-token (LOW)
- 他人所有の token 指定を `ACCESS_DENIED` (403) でなく **no-op (204)** にする。upstream は `delete({id/token, userId: me.id})` 条件で実行するだけなので他人の token は単に非マッチ (204)。403 を返すと token の存在 / 所有者が leak するため揃える。

### i/update-email (LOW)
- `email=null` かつ `emailRequiredForSignup` 時のエラーを `INVALID_PARAM` から `EMAIL_REQUIRED` (324c7a88-59f2-492f-903f-89134f93e47e) に修正 (upstream update-email)。

### i/notifications(-grouped) (LOW)
- 明示的な `includeTypes:[]` を空配列で返す (upstream notifications.ts: `includeTypes.length===0 → []`)。Go の `[]string` は absent(nil) / `[]`(non-nil len 0) を区別できるので早期 return。`excludeTypes` 全指定の空返却は既存の per-row exclude filter で既に成立済 (結果同一)。

## STALE 判定 (本 issue で対応不要)

- **import-user-lists の同期検証** (NO_SUCH_FILE / EMPTY_FILE / TOO_BIG_FILE): `validateImportRequest` で既に実装済 (#1555)。
- **i/pin の prohibitMoved**: `RequireNotMoved` middleware が i/pin route に適用済 (#1562)、`YOUR_ACCOUNT_MOVED` を返す。

## テスト

- `TestRevokeToken_ForeignTokenIsNoOp` (旧 `_AccessDenied` を 204 + 非削除に更新)、`TestUpdateEmail_ClearEmailRequired` (EMAIL_REQUIRED + UUID)、`TestShow_IncludeTypesEmptyReturnsEmpty` (includeTypes:[] → [] / 省略 → 全件) を追加。
- 実行: `go test ./internal/api/i/ ./internal/api/notifications/ -count=1` → pass。coverage i 90.7% / notifications 93.8%。`go build ./... && go vet ./...` → pass。

## Closes

`#1546` の revoke-token / update-email / notifications includeTypes 3 項目を解消する。残るは webhooks/test (override + dummy payload)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)