### PR TITLE
Fix i/webhooks/test: override(url/secret) 受付 + type 別 dummy payload (#1546)

### DIFF
--- a/internal/api/webhooks/handler.go
+++ b/internal/api/webhooks/handler.go
@@ -45,9 +45,10 @@ func validateOnArray(on []string) bool {
 
 // TestDispatcher is the minimal interface the Test endpoint uses to enqueue
 // a synthetic webhook payload. 循環依存を避けるため interface で受ける
-// (実装は core/webhook.Service 経由、dispatch through DispatchUser)。
+// (実装は core/webhook.Service 経由)。DispatchUserTest は指定 webhook 1 件だけに
+// 送り、overrideURL/Secret 非空時は保存済 webhook でなくそちらへ送る (#1546)。
 type TestDispatcher interface {
-	DispatchUser(userID, eventType string, body any)
+	DispatchUserTest(webhookID, userID, eventType string, body any, overrideURL, overrideSecret string)
 }
 
 // Handler handles i/webhooks/* endpoints.
@@ -255,6 +256,12 @@ func (h *Handler) Test(c echo.Context) error {
 	var req struct {
 		WebhookID string `json:"webhookId"`
 		Type      string `json:"type"`
+		// Override (#1546): 指定すると保存済 webhook でなく override.url/secret へ
+		// 送る (保存せずに別 URL/secret でテスト送信できる、upstream test.ts)。
+		Override *struct {
+			URL    string `json:"url"`
+			Secret string `json:"secret"`
+		} `json:"override"`
 	}
 	if err := c.Bind(&req); err != nil || req.WebhookID == "" || req.Type == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "webhookId and type are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
@@ -269,12 +276,51 @@ func (h *Handler) Test(c echo.Context) error {
 	}
 
 	if h.dispatcher != nil {
-		// ダミー body。クライアント側で判定するための最低限のフィールドを入れる。
-		h.dispatcher.DispatchUser(user.ID, req.Type, map[string]any{
-			"test":      true,
-			"webhookId": webhook.ID,
-		})
+		overrideURL, overrideSecret := "", ""
+		if req.Override != nil {
+			overrideURL = req.Override.URL
+			overrideSecret = req.Override.Secret
+		}
+		// upstream WebhookTestService は type ごとに dummy note/user payload を
+		// 生成して送る (#1546)。テスト対象 webhook 1 件だけに、override 指定時は
+		// その url/secret へ送る。
+		h.dispatcher.DispatchUserTest(webhook.ID, user.ID, req.Type, dummyWebhookBody(req.Type), overrideURL, overrideSecret)
 	}
 
 	return c.NoContent(http.StatusNoContent)
+}
+
+// dummyWebhookBody builds a representative test payload per event type, matching
+// the body shape the real hooks emit (note events → {note}, reaction →
+// {note, userId, reaction}, follow events → {user}), so the webhook receiver can
+// validate its integration against production-like data (#1546).
+func dummyWebhookBody(eventType string) map[string]any {
+	dummyUser := map[string]any{
+		"id":        "dummy-user-1",
+		"name":      "Dummy User",
+		"username":  "dummy",
+		"host":      nil,
+		"avatarUrl": nil,
+		"createdAt": "2020-01-01T00:00:00.000Z",
+	}
+	dummyNote := map[string]any{
+		"id":         "dummy-note-1",
+		"createdAt":  "2020-01-01T00:00:00.000Z",
+		"userId":     "dummy-user-1",
+		"user":       dummyUser,
+		"text":       "This is a dummy note for testing purposes.",
+		"cw":         nil,
+		"visibility": "public",
+		"fileIds":    []string{},
+		"replyId":    nil,
+		"renoteId":   nil,
+	}
+	switch eventType {
+	case "follow", "followed", "unfollow":
+		return map[string]any{"user": dummyUser}
+	case "reaction":
+		return map[string]any{"note": dummyNote, "userId": "dummy-user-1", "reaction": "👍"}
+	default: // note / reply / renote / mention
+		return map[string]any{"note": dummyNote}
+	}
 }

--- a/internal/api/webhooks/handler_test.go
+++ b/internal/api/webhooks/handler_test.go
@@ -366,19 +366,22 @@ func TestDelete_Error(t *testing.T) {
 
 // --- Test ---
 
-// stubDispatcher captures DispatchUser invocations for assertions.
+// stubDispatcher captures DispatchUserTest invocations for assertions.
 type stubDispatcher struct {
 	calls []stubDispatchCall
 }
 
 type stubDispatchCall struct {
-	userID    string
-	eventType string
-	body      any
+	webhookID      string
+	userID         string
+	eventType      string
+	body           any
+	overrideURL    string
+	overrideSecret string
 }
 
-func (s *stubDispatcher) DispatchUser(userID, eventType string, body any) {
-	s.calls = append(s.calls, stubDispatchCall{userID, eventType, body})
+func (s *stubDispatcher) DispatchUserTest(webhookID, userID, eventType string, body any, overrideURL, overrideSecret string) {
+	s.calls = append(s.calls, stubDispatchCall{webhookID, userID, eventType, body, overrideURL, overrideSecret})
 }
 
 func TestTest_Success(t *testing.T) {
@@ -390,8 +393,33 @@ func TestTest_Success(t *testing.T) {
 	rec := post(h.Test, `{"webhookId":"w1","type":"note"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 	require.Len(t, disp.calls, 1)
+	assert.Equal(t, "w1", disp.calls[0].webhookID)
 	assert.Equal(t, "u1", disp.calls[0].userID)
 	assert.Equal(t, "note", disp.calls[0].eventType)
+	// #1546: dummy body は type に応じた shape ({note: ...})。{test:true} ではない。
+	body, ok := disp.calls[0].body.(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, body, "note")
+	assert.NotContains(t, body, "test")
+	// override 未指定なら空。
+	assert.Empty(t, disp.calls[0].overrideURL)
+}
+
+// #1546: override 指定で別 url/secret へ送る。
+func TestTest_Override(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.webhooks["w1"] = &model.Webhook{ID: "w1", UserID: "u1"}
+	disp := &stubDispatcher{}
+	h.SetDispatcher(disp)
+
+	rec := post(h.Test, `{"webhookId":"w1","type":"follow","override":{"url":"https://test.example/hook","secret":"sek"}}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	require.Len(t, disp.calls, 1)
+	assert.Equal(t, "https://test.example/hook", disp.calls[0].overrideURL)
+	assert.Equal(t, "sek", disp.calls[0].overrideSecret)
+	// follow event の dummy body は {user: ...}。
+	body, _ := disp.calls[0].body.(map[string]any)
+	assert.Contains(t, body, "user")
 }
 
 func TestTest_TypeRequired(t *testing.T) {

--- a/internal/core/webhook/service.go
+++ b/internal/core/webhook/service.go
@@ -117,6 +117,36 @@ func (s *Service) DispatchUser(userID, eventType string, body any) {
 	}
 }
 
+// DispatchUserTest enqueues a single test delivery for i/webhooks/test (#1546).
+// 通常の DispatchUser と違い (1) 指定 webhookID 1 件だけに送り (= テスト対象を
+// 限定)、(2) overrideURL/Secret が非空なら保存済 webhook でなくそちらへ送る。
+// イベント購読 (h.On) は無視する (テストは任意の type を送れる)。
+func (s *Service) DispatchUserTest(webhookID, userID, eventType string, body any, overrideURL, overrideSecret string) {
+	if s == nil || s.enqueuer == nil {
+		return
+	}
+	raw, _ := json.Marshal(Envelope{
+		Server:    s.server,
+		HookID:    webhookID,
+		UserID:    userID,
+		EventID:   uuid.NewString(),
+		CreatedAt: time.Now().UnixMilli(),
+		Type:      eventType,
+		Body:      body,
+	})
+	if err := s.enqueuer.EnqueueUserWebhook(context.Background(), queue.WebhookPayload{
+		WebhookID:      webhookID,
+		UserID:         userID,
+		EventType:      eventType,
+		Body:           raw,
+		OverrideURL:    overrideURL,
+		OverrideSecret: overrideSecret,
+	}); err != nil {
+		slog.Warn("webhook: enqueue test webhook failed",
+			"hookId", webhookID, "event", eventType, "err", err)
+	}
+}
+
 // DispatchSystem mirrors DispatchUser for system webhooks (admin-level
 // events such as abuseReport / userCreated). 本家 SystemWebhookService.enqueueSystemWebhook 相当。
 func (s *Service) DispatchSystem(eventType string, body any) {

--- a/internal/queue/processors/webhook.go
+++ b/internal/queue/processors/webhook.go
@@ -85,9 +85,16 @@ func (p *WebhookProcessor) handle(ctx context.Context, t driver.Task, user bool)
 		return fmt.Errorf("webhook payload missing webhookId: %w", driver.SkipRetry)
 	}
 
-	url, secret, err := p.resolveTarget(payload.WebhookID, user)
-	if err != nil {
-		return fmt.Errorf("resolve webhook %s: %w: %w", payload.WebhookID, err, driver.SkipRetry)
+	// i/webhooks/test の override (#1546): 非空なら保存済 webhook を引かず指定の
+	// url/secret へ送る。test 送信なので saved webhook の status は汚さない (下記)。
+	isOverride := payload.OverrideURL != ""
+	url, secret := payload.OverrideURL, payload.OverrideSecret
+	if !isOverride {
+		var err error
+		url, secret, err = p.resolveTarget(payload.WebhookID, user)
+		if err != nil {
+			return fmt.Errorf("resolve webhook %s: %w: %w", payload.WebhookID, err, driver.SkipRetry)
+		}
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload.Body))
@@ -106,8 +113,10 @@ func (p *WebhookProcessor) handle(ctx context.Context, t driver.Task, user bool)
 	sentAt := time.Now()
 	if err != nil {
 		// ネットワーク障害はリトライ対象 (asynq が再試行する)。
-		// ステータスコード 0 を記録しておく。
-		p.recordStatus(payload.WebhookID, user, sentAt, 0)
+		// ステータスコード 0 を記録しておく (override test 送信時は記録しない)。
+		if !isOverride {
+			p.recordStatus(payload.WebhookID, user, sentAt, 0)
+		}
 		slog.Warn("webhook deliver: http error",
 			"hookId", payload.WebhookID, "url", url, "err", err)
 		return err
@@ -117,7 +126,9 @@ func (p *WebhookProcessor) handle(ctx context.Context, t driver.Task, user bool)
 		_ = resp.Body.Close()
 	}()
 
-	p.recordStatus(payload.WebhookID, user, sentAt, resp.StatusCode)
+	if !isOverride {
+		p.recordStatus(payload.WebhookID, user, sentAt, resp.StatusCode)
+	}
 
 	switch {
 	case resp.StatusCode >= 200 && resp.StatusCode < 300:

--- a/internal/queue/processors/webhook_test.go
+++ b/internal/queue/processors/webhook_test.go
@@ -158,6 +158,25 @@ func TestWebhookProcessor_User_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, repo.statusCalled["h1"])
 }
 
+// #1546: OverrideURL/Secret 指定時は保存済 webhook でなく override 先へ送り、
+// 保存済 webhook の latestStatus も記録しない (test 送信は別 URL のため)。
+func TestWebhookProcessor_User_Override(t *testing.T) {
+	client := &stubHTTPClient{status: http.StatusOK}
+	p, repo, _ := newTestWebhookProcessor(t, client, map[string]*model.Webhook{
+		"h1": {ID: "h1", URL: "https://saved.example/u1", Secret: "saved"},
+	}, nil)
+	task := queue.NewUserWebhookTask(queue.WebhookPayload{
+		WebhookID: "h1", UserID: "alice", EventType: "note", Body: []byte(`{}`),
+		OverrideURL: "https://override.example/hook", OverrideSecret: "ovr",
+	})
+	require.NoError(t, p.HandleUser(context.Background(), task))
+	require.Len(t, client.reqs, 1)
+	assert.Equal(t, "https://override.example/hook", client.reqs[0].URL.String())
+	assert.Equal(t, "ovr", client.reqs[0].Header.Get("X-Misskey-Hook-Secret"))
+	_, recorded := repo.statusCalled["h1"]
+	assert.False(t, recorded, "override test send must not record status on the saved webhook")
+}
+
 func TestWebhookProcessor_User_NoSecretOmitsHeader(t *testing.T) {
 	client := &stubHTTPClient{}
 	p, _, _ := newTestWebhookProcessor(t, client, map[string]*model.Webhook{

--- a/internal/queue/tasks.go
+++ b/internal/queue/tasks.go
@@ -281,6 +281,11 @@ type WebhookPayload struct {
 	UserID    string          `json:"userId,omitempty"` // user webhooks only
 	EventType string          `json:"eventType"`
 	Body      json.RawMessage `json:"body"`
+	// OverrideURL / OverrideSecret は i/webhooks/test の override 用 (#1546)。
+	// 非空のとき processor は保存済 webhook の url/secret でなくこちらへ送り、
+	// 保存済 webhook の latestStatus も汚さない (= テスト送信は別 URL なので)。
+	OverrideURL    string `json:"overrideUrl,omitempty"`
+	OverrideSecret string `json:"overrideSecret,omitempty"`
 }
 
 // NewUserWebhookTask serializes the payload into a driver.Task for


### PR DESCRIPTION
## Summary

`#1546` (i/* part2 parity) の **i/webhooks/test** 2 項目 (MEDIUM 1 + LOW 1) を解消する。これで `#1546` の全項目に決着がつく。

## 主な変更点

### override (url/secret) の受付 (MEDIUM)
- paramDef の `override: {url, secret}` を受け付け、保存せず別 URL/secret でテスト送信できるようにする (upstream `WebhookTestService.testUserWebhook`)。
- `queue.WebhookPayload` に `OverrideURL` / `OverrideSecret` を追加。processor は非空時に保存済 webhook を引かずそちらへ送り、**saved webhook の latestStatus も記録しない** (別 URL への test 送信のため status を汚さない)。
- `core/webhook.Service.DispatchUserTest` を追加し、テスト対象 webhook **1 件だけ**に (override 込みで) 送る (従来は全 webhook へ DispatchUser していた quirk も upstream の単一対象に是正)。

### type 別 dummy payload (LOW)
- `{test:true, webhookId}` の最小 body をやめ、type ごとに hooks.go が実際に emit する shape と同じ dummy payload を生成: note 系 → `{note}`、reaction → `{note, userId, reaction}`、follow 系 → `{user}`。webhook 受信側が本番同等の形状でテストできる。

## テスト

- `internal/api/webhooks`: `TestTest_Success` を dummy body shape ({note}, not {test:true}) + targeted webhookId に更新、`TestTest_Override` (override url/secret + follow 系の {user} body) を追加。
- `internal/queue/processors`: `TestWebhookProcessor_User_Override` (override URL/secret 使用 + saved webhook の status 非記録) を追加。
- 実行: `go test ./internal/api/webhooks/ ./internal/core/webhook/ ./internal/queue/processors/ -count=1` → pass。coverage webhooks 99% / core/webhook 93.6% / processors 92%。`go build ./... && go vet ./...` → pass。

## Closes

`#1546` の webhooks/test 2 項目を解消する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)