### PR TITLE
Fix i/registry: access token によるドメイン分離 (#1717)

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -637,7 +637,7 @@ func (h *Handler) RegistryGet(c echo.Context) error {
 	if !validRegistryScope(req.Scope) {
 		return apierr.JSONInvalidParam(c)
 	}
-	item, err := h.registryRepo.Get(u.ID, req.Key, req.Scope, req.Domain)
+	item, err := h.registryRepo.Get(u.ID, req.Key, req.Scope, registryEffectiveDomain(c, req.Domain))
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_KEY", "No such key.", "ac3ed68a-62f0-422b-a7bc-d5e09e8f6a6a"))
 	}
@@ -663,6 +663,8 @@ func (h *Handler) RegistrySet(c echo.Context) error {
 	if !validRegistryScope(req.Scope) {
 		return apierr.JSONInvalidParam(c)
 	}
+	// app token は自分の token id を domain に強制する (#1717)。
+	domain := registryEffectiveDomain(c, req.Domain)
 	item := &model.RegistryItem{
 		ID:        h.idGen.Generate(time.Now()),
 		UpdatedAt: time.Now(),
@@ -670,15 +672,16 @@ func (h *Handler) RegistrySet(c echo.Context) error {
 		Key:       req.Key,
 		Value:     []byte(req.Value),
 		Scope:     req.Scope,
-		Domain:    req.Domain,
+		Domain:    domain,
 	}
 	if err := h.registryRepo.Set(item); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	// TS本家 RegistryApiService.set (lines 59-66): domain == null のとき
 	// のみmainにpublishする。domain指定はサードパーティアプリ固有の領域
-	// なので他クライアントには broadcast しない仕様。
-	if h.mainStreamPublisher != nil && req.Domain == nil {
+	// なので他クライアントには broadcast しない仕様。app token は domain が
+	// token id に強制されるため publish されない (#1717)。
+	if h.mainStreamPublisher != nil && domain == nil {
 		h.mainStreamPublisher.PublishMainEvent(u.ID, "registryUpdated", map[string]any{
 			"scope": req.Scope,
 			"key":   req.Key,
@@ -704,7 +707,7 @@ func (h *Handler) RegistryGetAll(c echo.Context) error {
 	if !validRegistryScope(req.Scope) {
 		return apierr.JSONInvalidParam(c)
 	}
-	items, err := h.registryRepo.GetAll(u.ID, req.Scope, req.Domain)
+	items, err := h.registryRepo.GetAll(u.ID, req.Scope, registryEffectiveDomain(c, req.Domain))
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
@@ -731,7 +734,7 @@ func (h *Handler) RegistryKeysWithType(c echo.Context) error {
 	if !validRegistryScope(req.Scope) {
 		return apierr.JSONInvalidParam(c)
 	}
-	keys, err := h.registryRepo.KeysWithType(u.ID, req.Scope, req.Domain)
+	keys, err := h.registryRepo.KeysWithType(u.ID, req.Scope, registryEffectiveDomain(c, req.Domain))
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
@@ -755,7 +758,7 @@ func (h *Handler) RegistryRemove(c echo.Context) error {
 	if !validRegistryScope(req.Scope) {
 		return apierr.JSONInvalidParam(c)
 	}
-	if err := h.registryRepo.Remove(u.ID, req.Key, req.Scope, req.Domain); err != nil {
+	if err := h.registryRepo.Remove(u.ID, req.Key, req.Scope, registryEffectiveDomain(c, req.Domain)); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	return c.NoContent(http.StatusNoContent)

--- a/internal/api/i/registry.go
+++ b/internal/api/i/registry.go
@@ -24,6 +24,19 @@ func validRegistryScope(scope []string) bool {
 	return true
 }
 
+// registryEffectiveDomain returns the domain a registry request operates on.
+// An app access token forces its own id as the domain (= per-app isolated
+// registry space; it cannot read/write the main domain=null space). A native
+// login token / cookie session uses the request's domain unchanged (#1717,
+// upstream `accessToken != null ? accessToken.id : ps.domain ?? null`)。
+func registryEffectiveDomain(c echo.Context, reqDomain *string) *string {
+	if scope := middleware.GetAuthScope(c); scope != nil && scope.IsApp {
+		id := scope.TokenID
+		return &id
+	}
+	return reqDomain
+}
+
 // registryScopeDomainRequest is the canonical input shape for registry
 // read endpoints. scope は []string、domain は *string (省略可)。
 type registryScopeDomainRequest struct {
@@ -62,7 +75,7 @@ func (h *Handler) RegistryGetDetail(c echo.Context) error {
 	if !validRegistryScope(req.Scope) {
 		return apierr.JSONInvalidParam(c)
 	}
-	item, err := h.registryRepo.Get(u.ID, req.Key, req.Scope, req.Domain)
+	item, err := h.registryRepo.Get(u.ID, req.Key, req.Scope, registryEffectiveDomain(c, req.Domain))
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_KEY", "No such key.", "97a1e8e7-c0f7-47d2-957a-92e61256e01a"))
 	}
@@ -87,7 +100,7 @@ func (h *Handler) RegistryKeys(c echo.Context) error {
 	if !validRegistryScope(req.Scope) {
 		return apierr.JSONInvalidParam(c)
 	}
-	keysMap, err := h.registryRepo.KeysWithType(u.ID, req.Scope, req.Domain)
+	keysMap, err := h.registryRepo.KeysWithType(u.ID, req.Scope, registryEffectiveDomain(c, req.Domain))
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/i/registry_test.go
+++ b/internal/api/i/registry_test.go
@@ -3,15 +3,101 @@ package i
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/server/middleware"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/datatypes"
 )
+
+// postRegistryWithScope posts to a registry handler with both the authenticated
+// user and an AuthScope (app token / native) set in the context, so #1717
+// domain-isolation can be exercised.
+func postRegistryWithScope(h func(echo.Context) error, body string, user *model.User, scope *middleware.AuthScope) *httptest.ResponseRecorder {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), user)
+	if scope != nil {
+		c.Set(string(middleware.AuthScopeContextKey), scope)
+	}
+	_ = h(c)
+	return rec
+}
+
+// firstRegistryItem returns the single stored item (tests store exactly one).
+func firstRegistryItem(reg *testutil.MockRegistryRepository) *model.RegistryItem {
+	for _, it := range reg.Items {
+		return it
+	}
+	return nil
+}
+
+// #1717: app access token は registry domain を自分の token id に強制する。
+func TestRegistrySet_AppTokenForcesDomain(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	reg := testutil.NewMockRegistryRepository()
+	h.SetRegistryRepo(reg)
+	// client が domain を送っても app token は token id に上書きされる。
+	rec := postRegistryWithScope(h.RegistrySet, `{"key":"theme","value":"dark","scope":["client"],"domain":"ignored.example"}`,
+		stubUser, &middleware.AuthScope{IsApp: true, TokenID: "tok-1"})
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	it := firstRegistryItem(reg)
+	require.NotNil(t, it)
+	require.NotNil(t, it.Domain)
+	assert.Equal(t, "tok-1", *it.Domain, "app token は domain を token id に強制する")
+}
+
+// native token / cookie session は request の domain をそのまま使う。
+func TestRegistrySet_NativeUsesRequestDomain(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	reg := testutil.NewMockRegistryRepository()
+	h.SetRegistryRepo(reg)
+	// AuthScope 無し (native)。
+	rec := postRegistryWithScope(h.RegistrySet, `{"key":"theme","value":"dark","scope":["client"],"domain":"client.example"}`,
+		stubUser, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	it := firstRegistryItem(reg)
+	require.NotNil(t, it)
+	require.NotNil(t, it.Domain)
+	assert.Equal(t, "client.example", *it.Domain)
+}
+
+// app token の set は domain が token id (非 nil) に強制されるため main へ
+// publish されない。
+func TestRegistrySet_AppTokenNoMainPublish(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	reg := testutil.NewMockRegistryRepository()
+	h.SetRegistryRepo(reg)
+	pub := &stubIMainStreamPublisher{}
+	h.SetMainStreamPublisher(pub)
+	rec := postRegistryWithScope(h.RegistrySet, `{"key":"theme","value":"dark","scope":["client"]}`,
+		stubUser, &middleware.AuthScope{IsApp: true, TokenID: "tok-1"})
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Empty(t, pub.calls, "app token (domain=token id) の set は main へ broadcast しない")
+}
+
+// native token (domain なし) の set は main へ publish される (従来挙動)。
+func TestRegistrySet_NativeMainPublish(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	reg := testutil.NewMockRegistryRepository()
+	h.SetRegistryRepo(reg)
+	pub := &stubIMainStreamPublisher{}
+	h.SetMainStreamPublisher(pub)
+	rec := postRegistryWithScope(h.RegistrySet, `{"key":"theme","value":"dark","scope":["client"]}`, stubUser, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Len(t, pub.calls, 1)
+	assert.Equal(t, "registryUpdated", pub.calls[0].eventType)
+}
 
 func TestRegistryGetDetail(t *testing.T) {
 	h, _ := newExtraHandler(t)

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -49,6 +49,10 @@ const (
 type AuthScope struct {
 	IsApp  bool
 	Scopes []string
+	// TokenID は app access_token の id。i/registry/* が app ごとの registry
+	// 空間を分離するための domain として使う (#1717)。native token / cookie
+	// session では "" (= 分離しない、ps.domain をそのまま使う)。
+	TokenID string
 }
 
 // lastActiveUpdateInterval は同一ユーザーの lastActiveDate 書き込みを抑制
@@ -120,7 +124,7 @@ func (a *AuthMiddleware) Authenticate() echo.MiddlewareFunc {
 				return next(c)
 			}
 
-			user, scopes, isApp, err := a.resolveUser(token)
+			user, scopes, tokenID, isApp, err := a.resolveUser(token)
 			if err != nil {
 				// token はあるが解決できない。token 不在 (= 無効 token) は
 				// upstream ApiCallService が AuthenticationError として 401
@@ -163,7 +167,7 @@ func (a *AuthMiddleware) Authenticate() echo.MiddlewareFunc {
 			// OAuth scope view を積む。RequireScope が endpoint の meta.kind を
 			// app token の permission で強制する (#1552)。native token は
 			// IsApp=false で full access 扱い。
-			c.Set(string(AuthScopeContextKey), &AuthScope{IsApp: isApp, Scopes: scopes})
+			c.Set(string(AuthScopeContextKey), &AuthScope{IsApp: isApp, Scopes: scopes, TokenID: tokenID})
 			a.touchLastActive(user.ID)
 			return next(c)
 		}
@@ -446,17 +450,17 @@ func extractToken(c echo.Context) string {
 // isApp is true when the token is an app access_token (its permission array
 // is returned as scopes); false for a native login token (full access,
 // scopes nil). RequireScope (#1552) uses these to enforce endpoint meta.kind.
-func (a *AuthMiddleware) resolveUser(token string) (user *model.User, scopes []string, isApp bool, err error) {
+func (a *AuthMiddleware) resolveUser(token string) (user *model.User, scopes []string, tokenID string, isApp bool, err error) {
 	// hot path: TTL 内なら DB を引かずに cached user/scope を返す (#512)。
-	if u, sc, app, ok := a.tokenCache.get(token); ok {
-		return u, sc, app, nil
+	if u, sc, tid, app, ok := a.tokenCache.get(token); ok {
+		return u, sc, tid, app, nil
 	}
 
 	// まずnative tokenで検索 (= user 自身の login token, full access)。
 	user, err = a.userRepo.FindByToken(token)
 	if err == nil {
-		a.tokenCache.put(token, user, nil, false)
-		return user, nil, false, nil
+		a.tokenCache.put(token, user, nil, "", false)
+		return user, nil, "", false, nil
 	}
 
 	// hash 列 (miauth: sha256(token)) と token 列 (raw, app/auth) を 1 query
@@ -468,7 +472,7 @@ func (a *AuthMiddleware) resolveUser(token string) (user *model.User, scopes []s
 		// not-found 系は cache に積まない: 失効後 30 秒間 stale を返さない
 		// ようにするのと、未知 token 連打への DDoS を rate limiter 側に任せる
 		// 設計のため (#512 scope)。
-		return nil, nil, false, err
+		return nil, nil, "", false, err
 	}
 
 	// orphaned access_token (User 行が削除済み) のとき GORM の Preload は
@@ -476,13 +480,14 @@ func (a *AuthMiddleware) resolveUser(token string) (user *model.User, scopes []s
 	// user.ID dereference panic になるので、専用 error を返して anonymous
 	// request 扱いに落とす (Devin #514 FLAG-1)。cache にも積まない。
 	if accessToken.User == nil {
-		return nil, nil, false, errOrphanedAccessToken
+		return nil, nil, "", false, errOrphanedAccessToken
 	}
 	// app token は permission 配列を scope として持つ。空 ([]) でも isApp=true
-	// として扱い、RequireScope が kind 不足を弾けるようにする。
+	// として扱い、RequireScope が kind 不足を弾けるようにする。tokenID は
+	// registry domain 分離用 (#1717)。
 	scopes = []string(accessToken.Permission)
-	a.tokenCache.put(token, accessToken.User, scopes, true)
-	return accessToken.User, scopes, true, nil
+	a.tokenCache.put(token, accessToken.User, scopes, accessToken.ID, true)
+	return accessToken.User, scopes, accessToken.ID, true, nil
 }
 
 func sha256Hash(s string) string {

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -111,19 +111,19 @@ func TestAuthMiddleware_InvalidateTokensForUser(t *testing.T) {
 	auth := NewAuthMiddleware(userRepo, tokenRepo)
 
 	// 直接 cache に詰めて exported method の挙動だけを isolate に test する。
-	auth.tokenCache.put("a", &model.User{ID: "u1"}, nil, false)
-	auth.tokenCache.put("b", &model.User{ID: "u1"}, nil, false)
-	auth.tokenCache.put("c", &model.User{ID: "u2"}, nil, false)
+	auth.tokenCache.put("a", &model.User{ID: "u1"}, nil, "", false)
+	auth.tokenCache.put("b", &model.User{ID: "u1"}, nil, "", false)
+	auth.tokenCache.put("c", &model.User{ID: "u2"}, nil, "", false)
 
 	auth.InvalidateTokensForUser("u1")
 
-	if _, _, _, ok := auth.tokenCache.get("a"); ok {
+	if _, _, _, _, ok := auth.tokenCache.get("a"); ok {
 		t.Error("u1 token a が残っている")
 	}
-	if _, _, _, ok := auth.tokenCache.get("b"); ok {
+	if _, _, _, _, ok := auth.tokenCache.get("b"); ok {
 		t.Error("u1 token b が残っている")
 	}
-	if _, _, _, ok := auth.tokenCache.get("c"); !ok {
+	if _, _, _, _, ok := auth.tokenCache.get("c"); !ok {
 		t.Error("u2 token c が誤って削除された")
 	}
 }
@@ -132,9 +132,9 @@ func TestAuthMiddleware_InvalidateTokensForUser_EmptyUserIDIsNoop(t *testing.T) 
 	userRepo := testutil.NewMockUserRepository()
 	tokenRepo := testutil.NewMockAccessTokenRepository()
 	auth := NewAuthMiddleware(userRepo, tokenRepo)
-	auth.tokenCache.put("a", &model.User{ID: "u1"}, nil, false)
+	auth.tokenCache.put("a", &model.User{ID: "u1"}, nil, "", false)
 	auth.InvalidateTokensForUser("")
-	if _, _, _, ok := auth.tokenCache.get("a"); !ok {
+	if _, _, _, _, ok := auth.tokenCache.get("a"); !ok {
 		t.Error("userID 空で invalidate が走って巻き添えになった")
 	}
 }

--- a/internal/server/middleware/token_cache.go
+++ b/internal/server/middleware/token_cache.go
@@ -27,6 +27,7 @@ type cachedAuthEntry struct {
 	user      *model.User
 	scopes    []string
 	isApp     bool
+	tokenID   string // app access_token の id (registry domain 分離用、#1717)。native は ""。
 	expiresAt time.Time
 }
 
@@ -54,27 +55,28 @@ func newTokenCache() *tokenCache {
 
 // get returns the cached user and its scope view if present and not expired.
 // Expired entries are deleted lazily on read.
-func (c *tokenCache) get(token string) (user *model.User, scopes []string, isApp, ok bool) {
+func (c *tokenCache) get(token string) (user *model.User, scopes []string, tokenID string, isApp, ok bool) {
 	v, loaded := c.m.Load(token)
 	if !loaded {
-		return nil, nil, false, false
+		return nil, nil, "", false, false
 	}
 	entry, isEntry := v.(*cachedAuthEntry)
 	if !isEntry || c.now().After(entry.expiresAt) {
 		c.m.Delete(token)
-		return nil, nil, false, false
+		return nil, nil, "", false, false
 	}
-	return entry.user, entry.scopes, entry.isApp, true
+	return entry.user, entry.scopes, entry.tokenID, entry.isApp, true
 }
 
 // put stores token → (user, scope view) with TTL. Triggers a full sweep every
 // sweepEvery stores so the cache size stays bounded by "active tokens within
 // the TTL window" rather than "every token ever seen".
-func (c *tokenCache) put(token string, user *model.User, scopes []string, isApp bool) {
+func (c *tokenCache) put(token string, user *model.User, scopes []string, tokenID string, isApp bool) {
 	c.m.Store(token, &cachedAuthEntry{
 		user:      user,
 		scopes:    scopes,
 		isApp:     isApp,
+		tokenID:   tokenID,
 		expiresAt: c.now().Add(c.ttl),
 	})
 	if c.sweepEvery > 0 && c.storeCount.Add(1)%c.sweepEvery == 0 {

--- a/internal/server/middleware/token_cache_test.go
+++ b/internal/server/middleware/token_cache_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // fakeClock returns a stub `now` function whose value can be advanced from
@@ -28,27 +29,45 @@ func (c *fakeClock) Advance(d time.Duration) {
 
 func TestTokenCache_GetMiss(t *testing.T) {
 	c := newTokenCache()
-	_, _, _, ok := c.get("ghost")
+	_, _, _, _, ok := c.get("ghost")
 	assert.False(t, ok)
 }
 
 func TestTokenCache_PutGet(t *testing.T) {
 	c := newTokenCache()
 	u := &model.User{ID: "u1"}
-	c.put("tok", u, nil, false)
-	got, _, _, ok := c.get("tok")
+	c.put("tok", u, nil, "", false)
+	got, _, _, _, ok := c.get("tok")
 	assert.True(t, ok)
 	assert.Same(t, u, got)
+}
+
+// #1717: app access_token の tokenID が put/get で round-trip する。
+func TestTokenCache_TokenIDRoundTrip(t *testing.T) {
+	c := newTokenCache()
+	u := &model.User{ID: "u1"}
+	c.put("apptok", u, []string{"read:account"}, "at-1", true)
+	got, scopes, tokenID, isApp, ok := c.get("apptok")
+	require.True(t, ok)
+	assert.Same(t, u, got)
+	assert.Equal(t, []string{"read:account"}, scopes)
+	assert.Equal(t, "at-1", tokenID)
+	assert.True(t, isApp)
+	// native token は tokenID 空。
+	c.put("nativetok", u, nil, "", false)
+	_, _, ntid, napp, _ := c.get("nativetok")
+	assert.Empty(t, ntid)
+	assert.False(t, napp)
 }
 
 func TestTokenCache_TTLExpired(t *testing.T) {
 	clock := newFakeClock(time.Unix(1_700_000_000, 0))
 	c := newTokenCache()
 	c.now = clock.Now
-	c.put("tok", &model.User{ID: "u1"}, nil, false)
+	c.put("tok", &model.User{ID: "u1"}, nil, "", false)
 
 	clock.Advance(authCacheTTL + time.Second)
-	_, _, _, ok := c.get("tok")
+	_, _, _, _, ok := c.get("tok")
 	assert.False(t, ok, "expired entry must be evicted on get")
 	assert.Equal(t, 0, c.len(), "expired entry should be deleted from map")
 }
@@ -58,14 +77,14 @@ func TestTokenCache_Sweep(t *testing.T) {
 	c := newTokenCache()
 	c.now = clock.Now
 	c.sweepEvery = 0 // disable auto-sweep so we can call it explicitly
-	c.put("a", &model.User{ID: "ua"}, nil, false)
-	c.put("b", &model.User{ID: "ub"}, nil, false)
+	c.put("a", &model.User{ID: "ua"}, nil, "", false)
+	c.put("b", &model.User{ID: "ub"}, nil, "", false)
 	clock.Advance(authCacheTTL + time.Second)
-	c.put("c", &model.User{ID: "uc"}, nil, false) // c is fresh
+	c.put("c", &model.User{ID: "uc"}, nil, "", false) // c is fresh
 	c.sweep()
 
 	assert.Equal(t, 1, c.len(), "only c should survive sweep")
-	_, _, _, ok := c.get("c")
+	_, _, _, _, ok := c.get("c")
 	assert.True(t, ok)
 }
 
@@ -75,19 +94,19 @@ func TestTokenCache_AutoSweepOnPut(t *testing.T) {
 	c.now = clock.Now
 	c.sweepEvery = 4
 	for i := 0; i < 3; i++ {
-		c.put("stale-"+string(rune('a'+i)), &model.User{ID: "u"}, nil, false)
+		c.put("stale-"+string(rune('a'+i)), &model.User{ID: "u"}, nil, "", false)
 	}
 	clock.Advance(authCacheTTL + time.Second)
 	// 4th put should hit the sweep threshold and clean the 3 stale entries.
-	c.put("fresh", &model.User{ID: "fresh"}, nil, false)
+	c.put("fresh", &model.User{ID: "fresh"}, nil, "", false)
 	assert.Equal(t, 1, c.len(), "only the fresh entry should remain after auto-sweep")
 }
 
 func TestTokenCache_Invalidate(t *testing.T) {
 	c := newTokenCache()
-	c.put("tok", &model.User{ID: "u1"}, nil, false)
+	c.put("tok", &model.User{ID: "u1"}, nil, "", false)
 	c.invalidate("tok")
-	_, _, _, ok := c.get("tok")
+	_, _, _, _, ok := c.get("tok")
 	assert.False(t, ok)
 }
 
@@ -96,23 +115,23 @@ func TestTokenCache_Invalidate(t *testing.T) {
 // 削除できる必要がある。userID で linear scan + delete する。
 func TestTokenCache_InvalidateByUserID(t *testing.T) {
 	c := newTokenCache()
-	c.put("native-tok", &model.User{ID: "u1"}, nil, false)
-	c.put("access-tok-1", &model.User{ID: "u1"}, nil, false)
-	c.put("access-tok-2", &model.User{ID: "u1"}, nil, false)
-	c.put("other-user-tok", &model.User{ID: "u2"}, nil, false)
+	c.put("native-tok", &model.User{ID: "u1"}, nil, "", false)
+	c.put("access-tok-1", &model.User{ID: "u1"}, nil, "", false)
+	c.put("access-tok-2", &model.User{ID: "u1"}, nil, "", false)
+	c.put("other-user-tok", &model.User{ID: "u2"}, nil, "", false)
 
 	c.invalidateByUserID("u1")
 
-	if _, _, _, ok := c.get("native-tok"); ok {
+	if _, _, _, _, ok := c.get("native-tok"); ok {
 		t.Error("u1 native token entry が残っている")
 	}
-	if _, _, _, ok := c.get("access-tok-1"); ok {
+	if _, _, _, _, ok := c.get("access-tok-1"); ok {
 		t.Error("u1 access token 1 entry が残っている")
 	}
-	if _, _, _, ok := c.get("access-tok-2"); ok {
+	if _, _, _, _, ok := c.get("access-tok-2"); ok {
 		t.Error("u1 access token 2 entry が残っている")
 	}
-	if _, _, _, ok := c.get("other-user-tok"); !ok {
+	if _, _, _, _, ok := c.get("other-user-tok"); !ok {
 		t.Error("u2 の token entry が誤って削除された (= 巻き添え)")
 	}
 }
@@ -120,16 +139,16 @@ func TestTokenCache_InvalidateByUserID(t *testing.T) {
 func TestTokenCache_InvalidateByUserID_EmptyUserIDIsNoop(t *testing.T) {
 	// userID="" を渡されたとき全 entry が消える事故を防ぐ defensive。
 	c := newTokenCache()
-	c.put("tok", &model.User{ID: "u1"}, nil, false)
+	c.put("tok", &model.User{ID: "u1"}, nil, "", false)
 	c.invalidateByUserID("")
-	_, _, _, ok := c.get("tok")
+	_, _, _, _, ok := c.get("tok")
 	assert.True(t, ok, "userID 空のとき invalidate は noop であるべき")
 }
 
 func TestTokenCache_InvalidateByUserID_NoMatchIsNoop(t *testing.T) {
 	c := newTokenCache()
-	c.put("tok", &model.User{ID: "u1"}, nil, false)
+	c.put("tok", &model.User{ID: "u1"}, nil, "", false)
 	c.invalidateByUserID("nonexistent")
-	_, _, _, ok := c.get("tok")
+	_, _, _, _, ok := c.get("tok")
 	assert.True(t, ok, "match なしのとき他 entry は触らない")
 }


### PR DESCRIPTION
## Summary

`#1717` (`#1546` 派生) の「registry 系が access token によるドメイン分離を行わない」を解消する。

upstream の全 registry endpoint は `domain = (accessToken != null ? accessToken.id : ps.domain ?? null)` で、サードパーティアプリ経由のアクセスを `token.id` を domain にして各アプリのレジストリ空間に隔離する。mk-go は `req.Domain` をそのまま使い access token を参照しなかったため、アプリ経由のレジストリが main 空間 (domain=null) を上書き/読取できていた。

## 主な変更点

### auth middleware
- `AuthScope` に `TokenID` を追加し、app access_token 認証時に `accessToken.ID` をセット。
- token cache (`cachedAuthEntry` / `put` / `get`) と `resolveUser` も tokenID を round-trip させる。native login token / cookie session は `""` (= 分離しない)。

### i/registry/*
- `registryEffectiveDomain(c, req.Domain)` ヘルパーを追加: app token なら domain を `token.id` に強制、それ以外は `req.Domain`。`get` / `set` / `get-all` / `get-detail` / `keys` / `keys-with-type` / `remove` の全 endpoint に適用。
- `set` の main publish も effective domain が nil のときのみ (app token は domain が token id に強制されるため broadcast しない)。
- `scopes-with-domain` は全 domain を列挙する endpoint なので分離対象外 (変更なし)。

## テスト

- `internal/server/middleware`: `TestTokenCache_TokenIDRoundTrip` (app token の tokenID round-trip + native は空)。既存 put/get テストは 5-return signature に更新。
- `internal/api/i`: `TestRegistrySet_AppTokenForcesDomain` / `_NativeUsesRequestDomain` / `_AppTokenNoMainPublish` / `_NativeMainPublish` を追加 (AuthScope を注入する `postRegistryWithScope` ヘルパー経由)。
- 実行: `go test ./internal/server/middleware/ ./internal/api/i/ -count=1` → pass。coverage middleware 96.6% / api/i 90.7%。`go build ./... && go vet ./...` → pass。

## Closes

Closes #1717

🤖 Generated with [Claude Code](https://claude.com/claude-code)