### PR TITLE
Fix admin parity: ad/list publishing+cursor + drive origin default + invite sort + announcements createdAt (#1545)

### DIFF
--- a/internal/api/admin/ad.go
+++ b/internal/api/admin/ad.go
@@ -8,6 +8,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
 	"github.com/shiroha-a/mk/internal/core/moderationlog"
+	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 )
 
@@ -91,13 +92,32 @@ func (h *Handler) AdList(c echo.Context) error {
 	if h.adRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
+	// upstream admin/ad/list: {limit, sinceId, untilId, sinceDate, untilDate,
+	// publishing(boolean,nullable)} の cursor pagination + 配信中フィルタ (#1545)。
 	var req struct {
-		Limit  int `json:"limit"`
-		Offset int `json:"offset"`
+		Limit      int    `json:"limit"`
+		Offset     int    `json:"offset"` // 後方互換 (cursor / publishing 未指定時のみ)
+		SinceID    string `json:"sinceId"`
+		UntilID    string `json:"untilId"`
+		SinceDate  *int64 `json:"sinceDate"`
+		UntilDate  *int64 `json:"untilDate"`
+		Publishing *bool  `json:"publishing"`
 	}
 	_ = c.Bind(&req)
 	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
-	rows, err := h.adRepo.List(req.Limit, req.Offset)
+	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	// cursor も publishing も無く offset 指定がある旧クライアント向けに offset 経路を維持。
+	if sinceID == "" && untilID == "" && req.Publishing == nil && req.Offset > 0 {
+		rows, err := h.adRepo.List(req.Limit, req.Offset)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, apierr.InternalError())
+		}
+		if rows == nil {
+			return c.JSON(http.StatusOK, []any{})
+		}
+		return c.JSON(http.StatusOK, rows)
+	}
+	rows, err := h.adRepo.ListFiltered(req.Publishing, sinceID, untilID, req.Limit, time.Now())
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 	}

--- a/internal/api/admin/ad_invite_promo_test.go
+++ b/internal/api/admin/ad_invite_promo_test.go
@@ -120,6 +120,51 @@ func TestAdList_Paginated(t *testing.T) {
 	shapetest.Assert(t, "Ad", rawRows[0]) // L3 (#1292)
 }
 
+// #1545: publishing=true は配信中 (startsAt<=now<expiresAt) のみ返す。
+func TestAdList_PublishingFilter(t *testing.T) {
+	now := time.Now()
+	h, _ := setupAdHandler(t,
+		&model.Ad{ID: "a_live", URL: "u", ImageURL: "i", Place: "square", Priority: "middle", Ratio: 1,
+			StartsAt: now.Add(-time.Hour), ExpiresAt: now.Add(time.Hour)}, // 配信中
+		&model.Ad{ID: "a_expired", URL: "u", ImageURL: "i", Place: "square", Priority: "middle", Ratio: 1,
+			StartsAt: now.Add(-2 * time.Hour), ExpiresAt: now.Add(-time.Hour)}, // 終了
+		&model.Ad{ID: "a_future", URL: "u", ImageURL: "i", Place: "square", Priority: "middle", Ratio: 1,
+			StartsAt: now.Add(time.Hour), ExpiresAt: now.Add(2 * time.Hour)}, // 未開始
+	)
+
+	rec := doPost(h.AdList, `{"limit":10,"publishing":true}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "a_live", rows[0]["id"])
+
+	// publishing=false は非配信 (終了 + 未開始)。
+	rec = doPost(h.AdList, `{"limit":10,"publishing":false}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	rows = nil
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 2)
+}
+
+// #1545: untilId による cursor pagination。
+func TestAdList_CursorPagination(t *testing.T) {
+	ads := make([]*model.Ad, 5)
+	for i := 0; i < 5; i++ {
+		ads[i] = &model.Ad{ID: fmt.Sprintf("a%02d", i), URL: "u", ImageURL: "i", Place: "square", Priority: "middle", Ratio: 1,
+			StartsAt: time.Now().Add(-time.Hour), ExpiresAt: time.Now().Add(time.Hour)}
+	}
+	h, _ := setupAdHandler(t, ads...)
+
+	rec := doPost(h.AdList, `{"limit":10,"untilId":"a03"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	// a03 より小さい id (a02,a01,a00) を id DESC で返す。
+	require.Len(t, rows, 3)
+	assert.Equal(t, "a02", rows[0]["id"])
+}
+
 func TestAdUpdate_PartialFields(t *testing.T) {
 	h, repo := setupAdHandler(t,
 		&model.Ad{ID: "a1", URL: "old", Place: "square", Priority: "middle", Ratio: 1, ImageURL: "i"},
@@ -370,6 +415,30 @@ func TestInviteList_FilterUnused(t *testing.T) {
 	require.Len(t, rows, 1)
 	assert.Equal(t, "t1", rows[0]["id"])
 	assert.Equal(t, false, rows[0]["used"])
+}
+
+// #1545: sort=-createdAt は id ASC (古い順)、default は id DESC。
+func TestInviteList_Sort(t *testing.T) {
+	h, _ := setupInviteHandler(t,
+		&model.RegistrationTicket{ID: "t1", Code: "c1"},
+		&model.RegistrationTicket{ID: "t2", Code: "c2"},
+		&model.RegistrationTicket{ID: "t3", Code: "c3"},
+	)
+	// default (sort 省略) は id DESC。
+	rec := doPost(h.InviteList, `{}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 3)
+	assert.Equal(t, "t3", rows[0]["id"])
+
+	// -createdAt は id ASC。
+	rec = doPost(h.InviteList, `{"sort":"-createdAt"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	rows = nil
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 3)
+	assert.Equal(t, "t1", rows[0]["id"])
 }
 
 // #1048 / #1049: createdBy / usedBy が hardcoded nil で返って frontend で

--- a/internal/api/admin/drive.go
+++ b/internal/api/admin/drive.go
@@ -151,7 +151,11 @@ func (h *Handler) DriveFiles(c echo.Context) error {
 		return c.JSON(http.StatusOK, out)
 	}
 	switch req.Origin {
-	case "", "combined", "local", "remote":
+	case "combined", "local", "remote":
+	case "":
+		// upstream files.ts paramDef は origin default='local' (#1545)。
+		// userId 未指定時は userHost IS NULL のローカルのみ返す。
+		req.Origin = "local"
 	default:
 		req.Origin = "combined"
 	}

--- a/internal/api/admin/drive_emoji_test.go
+++ b/internal/api/admin/drive_emoji_test.go
@@ -81,6 +81,22 @@ func TestDriveFiles_FiltersByOrigin(t *testing.T) {
 	assert.Equal(t, "d2", rows[0]["id"])
 }
 
+// #1545: origin 省略時は upstream paramDef default の 'local' (userHost IS NULL) を返す。
+func TestDriveFiles_OriginDefaultsToLocal(t *testing.T) {
+	localUser := "u1"
+	remoteHost := "remote.example"
+	h, _ := setupDriveFileHandler(t,
+		&model.DriveFile{ID: "d1", UserID: &localUser, Type: "image/png"},
+		&model.DriveFile{ID: "d2", UserHost: &remoteHost, Type: "image/jpeg"},
+	)
+	rec := doPost(h.DriveFiles, `{"limit":10}`, adminUser)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "d1", rows[0]["id"])
+}
+
 func TestDriveFiles_FiltersByUserID(t *testing.T) {
 	// admin/user/<id> のドライブタブは userId だけを送ってくる (#471)。
 	// upstream は userId 指定時に origin / hostname を読まないので、それに

--- a/internal/api/admin/invite.go
+++ b/internal/api/admin/invite.go
@@ -166,6 +166,7 @@ func (h *Handler) InviteList(c echo.Context) error {
 		Limit  int    `json:"limit"`
 		Offset int    `json:"offset"`
 		Type   string `json:"type"`
+		Sort   string `json:"sort"`
 	}
 	_ = c.Bind(&req)
 	req.Limit = pagination.ClampLimit(req.Limit, 30, 100)
@@ -175,7 +176,14 @@ func (h *Handler) InviteList(c echo.Context) error {
 	default:
 		filter = "all"
 	}
-	rows, err := h.inviteRepo.List(filter, req.Limit, req.Offset, time.Now())
+	// upstream admin/invite/list sort enum (#1545)。未知値は repo 側で id DESC に倒れる。
+	sort := req.Sort
+	switch sort {
+	case "+createdAt", "-createdAt", "+usedAt", "-usedAt":
+	default:
+		sort = ""
+	}
+	rows, err := h.inviteRepo.ListSorted(filter, sort, req.Limit, req.Offset, time.Now())
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 	}

--- a/internal/api/announcements/handler.go
+++ b/internal/api/announcements/handler.go
@@ -254,7 +254,9 @@ func (h *Handler) AdminCreate(c echo.Context) error {
 		"announcementId": a.ID,
 		"announcement":   a,
 	})
-	return c.JSON(http.StatusOK, a)
+	// upstream create.ts は packed (createdAt 等を含む) を返す。raw model は
+	// createdAt 列を持たない (ID 由来) ため packer を通す (#1545)。
+	return c.JSON(http.StatusOK, entity.PackAnnouncement(a, h.idGen, false))
 }
 
 // isValidAnnouncementIcon reports whether v matches upstream's

--- a/internal/api/announcements/handler_test.go
+++ b/internal/api/announcements/handler_test.go
@@ -159,6 +159,12 @@ func TestAdminCreate_Success(t *testing.T) {
 	rec := doPost(h.AdminCreate, `{"title":"News","text":"Big news!"}`, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Len(t, repo.Items, 1)
+	// #1545: レスポンスは packed で createdAt (ID 由来) を含む。
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	createdAt, ok := resp["createdAt"].(string)
+	require.True(t, ok, "create response must include createdAt")
+	assert.NotEmpty(t, createdAt)
 }
 
 func TestAdminCreate_InvalidParam(t *testing.T) {

--- a/internal/api/meta/handler_test.go
+++ b/internal/api/meta/handler_test.go
@@ -334,9 +334,12 @@ type stubAdRepo struct {
 func (s *stubAdRepo) ListActive(_ time.Time) ([]*model.Ad, error) {
 	return s.ads, s.err
 }
-func (s *stubAdRepo) Create(_ *model.Ad) error                      { return nil }
-func (s *stubAdRepo) FindByID(_ string) (*model.Ad, error)          { return nil, nil }
-func (s *stubAdRepo) List(_, _ int) ([]*model.Ad, error)            { return nil, nil }
+func (s *stubAdRepo) Create(_ *model.Ad) error             { return nil }
+func (s *stubAdRepo) FindByID(_ string) (*model.Ad, error) { return nil, nil }
+func (s *stubAdRepo) List(_, _ int) ([]*model.Ad, error)   { return nil, nil }
+func (s *stubAdRepo) ListFiltered(_ *bool, _, _ string, _ int, _ time.Time) ([]*model.Ad, error) {
+	return nil, nil
+}
 func (s *stubAdRepo) UpdateFields(_ string, _ map[string]any) error { return nil }
 func (s *stubAdRepo) Delete(_ string) error                         { return nil }
 

--- a/internal/repository/ad.go
+++ b/internal/repository/ad.go
@@ -17,6 +17,10 @@ type AdRepository interface {
 	FindByID(id string) (*model.Ad, error)
 	// List returns ads ordered by id DESC with limit/offset pagination.
 	List(limit, offset int) ([]*model.Ad, error)
+	// ListFiltered returns ads with cursor pagination (sinceID/untilID) and an
+	// optional publishing filter (#1545, upstream admin/ad/list)。publishing が
+	// nil なら全件、true なら配信中 (startsAt<=now<expiresAt)、false なら非配信。
+	ListFiltered(publishing *bool, sinceID, untilID string, limit int, now time.Time) ([]*model.Ad, error)
 	// UpdateFields applies a partial update. Keys must be GORM column names.
 	UpdateFields(id string, fields map[string]any) error
 	Delete(id string) error
@@ -63,6 +67,36 @@ func (r *adRepository) List(limit, offset int) ([]*model.Ad, error) {
 	}
 	var ads []*model.Ad
 	if err := r.db.Order(`"id" DESC`).Limit(limit).Offset(offset).Find(&ads).Error; err != nil {
+		return nil, err
+	}
+	return ads, nil
+}
+
+func (r *adRepository) ListFiltered(publishing *bool, sinceID, untilID string, limit int, now time.Time) ([]*model.Ad, error) {
+	if limit <= 0 {
+		limit = 30
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	q := r.db.Model(&model.Ad{})
+	// upstream admin/ad/list: publishing=true は配信中 (startsAt<=now<expiresAt)、
+	// false は非配信 (expiresAt<=now OR startsAt>now)。
+	if publishing != nil {
+		if *publishing {
+			q = q.Where(`"startsAt" <= ? AND "expiresAt" > ?`, now, now)
+		} else {
+			q = q.Where(`"expiresAt" <= ? OR "startsAt" > ?`, now, now)
+		}
+	}
+	if sinceID != "" {
+		q = q.Where(`"id" > ?`, sinceID)
+	}
+	if untilID != "" {
+		q = q.Where(`"id" < ?`, untilID)
+	}
+	var ads []*model.Ad
+	if err := q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit).Find(&ads).Error; err != nil {
 		return nil, err
 	}
 	return ads, nil

--- a/internal/repository/ad_test.go
+++ b/internal/repository/ad_test.go
@@ -118,3 +118,49 @@ func TestAdRepository_ListDefaults(t *testing.T) {
 	_, err := repo.List(0, -1)
 	require.NoError(t, err)
 }
+
+// #1545: ListFiltered の publishing フィルタ + cursor pagination。
+func TestAdRepository_ListFiltered(t *testing.T) {
+	repo := NewAdRepository(testDB)
+	now := time.Now()
+	mk := func(id string, starts, expires time.Duration) *model.Ad {
+		return &model.Ad{ID: id, URL: "u", ImageURL: "i", Place: "square", Priority: "middle", Ratio: 1,
+			StartsAt: now.Add(starts), ExpiresAt: now.Add(expires)}
+	}
+	live := mk("adf_live", -time.Hour, time.Hour)
+	expired := mk("adf_expired", -2*time.Hour, -time.Hour)
+	future := mk("adf_future", time.Hour, 2*time.Hour)
+	for _, a := range []*model.Ad{live, expired, future} {
+		require.NoError(t, repo.Create(a))
+		defer cleanupAd(t, a.ID)
+	}
+
+	yes := true
+	pub, err := repo.ListFiltered(&yes, "", "", 100, now)
+	require.NoError(t, err)
+	ids := map[string]bool{}
+	for _, a := range pub {
+		ids[a.ID] = true
+	}
+	assert.True(t, ids["adf_live"])
+	assert.False(t, ids["adf_expired"])
+	assert.False(t, ids["adf_future"])
+
+	no := false
+	notPub, err := repo.ListFiltered(&no, "", "", 100, now)
+	require.NoError(t, err)
+	ids = map[string]bool{}
+	for _, a := range notPub {
+		ids[a.ID] = true
+	}
+	assert.False(t, ids["adf_live"])
+	assert.True(t, ids["adf_expired"])
+	assert.True(t, ids["adf_future"])
+
+	// publishing=nil は全件、untilId で cursor 絞り込み。
+	all, err := repo.ListFiltered(nil, "", "adf_future", 100, now)
+	require.NoError(t, err)
+	for _, a := range all {
+		assert.Less(t, a.ID, "adf_future")
+	}
+}

--- a/internal/repository/registration_ticket.go
+++ b/internal/repository/registration_ticket.go
@@ -48,6 +48,9 @@ type RegistrationTicketRepository interface {
 	// `now` is passed by callers so tests can supply a deterministic clock
 	// when evaluating the `expired` filter.
 	List(filter string, limit, offset int, now time.Time) ([]*model.RegistrationTicket, error)
+	// ListSorted is List plus the upstream admin/invite/list sort enum
+	// (+createdAt/-createdAt/+usedAt/-usedAt、#1545)。空 sort は id DESC。
+	ListSorted(filter, sort string, limit, offset int, now time.Time) ([]*model.RegistrationTicket, error)
 	// CountByCreatorSince returns the number of tickets created by creatorID
 	// whose ID compares strictly greater than sinceID. Used by
 	// invite/create + invite/limit endpoints to enforce the
@@ -113,6 +116,10 @@ func (r *registrationTicketRepository) markUsedOn(db *gorm.DB, ticketID, userID 
 }
 
 func (r *registrationTicketRepository) List(filter string, limit, offset int, now time.Time) ([]*model.RegistrationTicket, error) {
+	return r.ListSorted(filter, "", limit, offset, now)
+}
+
+func (r *registrationTicketRepository) ListSorted(filter, sort string, limit, offset int, now time.Time) ([]*model.RegistrationTicket, error) {
 	if limit <= 0 {
 		limit = 30
 	}
@@ -128,8 +135,21 @@ func (r *registrationTicketRepository) List(filter string, limit, offset int, no
 	case RegistrationTicketExpired:
 		q = q.Where(`"expiresAt" IS NOT NULL AND "expiresAt" < ?`, now)
 	}
+	// upstream admin/invite/list sort enum (#1545)。createdAt は aidx id に対応
+	// (+ が DESC、- が ASC という upstream の符号付け)。usedAt は NULLS 順も合わせる。
+	var order string
+	switch sort {
+	case "-createdAt":
+		order = `"id" ASC`
+	case "+usedAt":
+		order = `"usedAt" DESC NULLS LAST`
+	case "-usedAt":
+		order = `"usedAt" ASC NULLS FIRST`
+	default: // "+createdAt" / 空 / 不正値
+		order = `"id" DESC`
+	}
 	var rows []*model.RegistrationTicket
-	if err := q.Order(`"id" DESC`).Limit(limit).Offset(offset).Find(&rows).Error; err != nil {
+	if err := q.Order(order).Limit(limit).Offset(offset).Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil

--- a/internal/repository/registration_ticket_test.go
+++ b/internal/repository/registration_ticket_test.go
@@ -250,3 +250,55 @@ func TestRegistrationTicketRepository_ListByCreator_DBError(t *testing.T) {
 	_, err := repo.ListByCreator("any", "", "", 10)
 	assert.Error(t, err)
 }
+
+// #1545: ListSorted の sort enum (createdAt = id, usedAt 順 + NULLS 配置)。
+func TestRegistrationTicketRepository_ListSorted(t *testing.T) {
+	repo := NewRegistrationTicketRepository(testDB)
+	cleanupInvite(t, "rts_a", "rts_b", "rts_c")
+	u := insertTestUser(t, "rts_user", "rtsu")
+	defer cleanupUser(t, u.ID)
+
+	t1 := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
+	t2 := time.Now().Add(-time.Hour).UTC().Truncate(time.Second)
+	// a: usedAt=t1, b: usedAt=t2, c: 未使用 (usedAt nil)。id は a<b<c。
+	a := &model.RegistrationTicket{ID: "rts_a", Code: "rts-a", UsedByID: &u.ID, UsedAt: &t1}
+	b := &model.RegistrationTicket{ID: "rts_b", Code: "rts-b", UsedByID: &u.ID, UsedAt: &t2}
+	c := &model.RegistrationTicket{ID: "rts_c", Code: "rts-c"}
+	for _, tk := range []*model.RegistrationTicket{a, b, c} {
+		require.NoError(t, repo.Create(tk))
+	}
+	defer cleanupInvite(t, a.ID, b.ID, c.ID)
+
+	only := func(rows []*model.RegistrationTicket) []string {
+		var out []string
+		for _, r := range rows {
+			switch r.ID {
+			case "rts_a", "rts_b", "rts_c":
+				out = append(out, r.ID)
+			}
+		}
+		return out
+	}
+
+	// -createdAt = id ASC。
+	asc, err := repo.ListSorted(RegistrationTicketAll, "-createdAt", 100, 0, time.Now())
+	require.NoError(t, err)
+	got := only(asc)
+	require.Len(t, got, 3)
+	assert.Equal(t, []string{"rts_a", "rts_b", "rts_c"}, got)
+
+	// +createdAt = id DESC。
+	desc, err := repo.ListSorted(RegistrationTicketAll, "+createdAt", 100, 0, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"rts_c", "rts_b", "rts_a"}, only(desc))
+
+	// +usedAt = usedAt DESC NULLS LAST (b=t2 newest, a=t1, c=nil last)。
+	uDesc, err := repo.ListSorted(RegistrationTicketAll, "+usedAt", 100, 0, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"rts_b", "rts_a", "rts_c"}, only(uDesc))
+
+	// -usedAt = usedAt ASC NULLS FIRST (c=nil first, a=t1, b=t2)。
+	uAsc, err := repo.ListSorted(RegistrationTicketAll, "-usedAt", 100, 0, time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"rts_c", "rts_a", "rts_b"}, only(uAsc))
+}

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -7378,6 +7378,43 @@ func (m *MockAdRepository) List(limit, offset int) ([]*model.Ad, error) {
 	return rows[offset:end], nil
 }
 
+// ListFiltered applies the publishing filter + cursor pagination (#1545).
+func (m *MockAdRepository) ListFiltered(publishing *bool, sinceID, untilID string, limit int, now time.Time) ([]*model.Ad, error) {
+	if m.ListErr != nil {
+		return nil, m.ListErr
+	}
+	rows := make([]*model.Ad, 0, len(m.Ads))
+	for _, a := range m.Ads {
+		if publishing != nil {
+			isPublishing := !a.StartsAt.After(now) && a.ExpiresAt.After(now)
+			if *publishing != isPublishing {
+				continue
+			}
+		}
+		if sinceID != "" && a.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && a.ID >= untilID {
+			continue
+		}
+		rows = append(rows, a)
+	}
+	asc := sinceID != "" && untilID == ""
+	sortAdsByIDDesc(rows)
+	if asc {
+		for i, j := 0, len(rows)-1; i < j; i, j = i+1, j-1 {
+			rows[i], rows[j] = rows[j], rows[i]
+		}
+	}
+	if limit <= 0 || limit > 100 {
+		limit = 30
+	}
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	return rows, nil
+}
+
 func (m *MockAdRepository) UpdateFields(id string, fields map[string]any) error {
 	if len(fields) == 0 {
 		return nil
@@ -7622,6 +7659,80 @@ func (m *MockRegistrationTicketRepository) FindByID(id string) (*model.Registrat
 		return t, nil
 	}
 	return nil, ErrNotFound
+}
+
+// ListSorted filters like List and applies the upstream sort enum (#1545).
+func (m *MockRegistrationTicketRepository) ListSorted(filter, sort string, limit, offset int, now time.Time) ([]*model.RegistrationTicket, error) {
+	rows := make([]*model.RegistrationTicket, 0, len(m.Tickets))
+	for _, t := range m.Tickets {
+		switch filter {
+		case "unused":
+			if t.UsedByID != nil {
+				continue
+			}
+		case "used":
+			if t.UsedByID == nil {
+				continue
+			}
+		case "expired":
+			if t.ExpiresAt == nil || !t.ExpiresAt.Before(now) {
+				continue
+			}
+		}
+		rows = append(rows, t)
+	}
+	// sort: createdAt は id 順、usedAt は UsedAt 順 (NULLS 配置も合わせる)。
+	less := func(a, b *model.RegistrationTicket) bool {
+		switch sort {
+		case "-createdAt":
+			return a.ID < b.ID
+		case "+usedAt", "-usedAt":
+			ai, bi := a.UsedAt, b.UsedAt
+			if ai == nil && bi == nil {
+				return a.ID > b.ID
+			}
+			if sort == "+usedAt" { // DESC NULLS LAST
+				if ai == nil {
+					return false
+				}
+				if bi == nil {
+					return true
+				}
+				return ai.After(*bi)
+			}
+			// -usedAt: ASC NULLS FIRST
+			if ai == nil {
+				return true
+			}
+			if bi == nil {
+				return false
+			}
+			return ai.Before(*bi)
+		default: // +createdAt / 空: id DESC
+			return a.ID > b.ID
+		}
+	}
+	for i := 0; i < len(rows); i++ {
+		for j := i + 1; j < len(rows); j++ {
+			if less(rows[j], rows[i]) {
+				rows[i], rows[j] = rows[j], rows[i]
+			}
+		}
+	}
+	if limit <= 0 {
+		limit = 30
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(rows) {
+		return []*model.RegistrationTicket{}, nil
+	}
+	end := offset + limit
+	if end > len(rows) {
+		end = len(rows)
+	}
+	return rows[offset:end], nil
 }
 
 func (m *MockRegistrationTicketRepository) ListByCreator(creatorID, sinceID, untilID string, limit int) ([]*model.RegistrationTicket, error) {


### PR DESCRIPTION
## Summary

`#1545` (admin parity) の 4 項目 (MEDIUM 3 + LOW 1) を解消する。残る 2 項目は dispatch pipeline / storage 削除を要するため派生 issue に分離した。

## 主な変更点

### admin/ad/list — publishing + cursor (MEDIUM)
- `publishing(boolean,nullable)` フィルタ (true=配信中 startsAt<=now<expiresAt / false=非配信) と cursor pagination (`sinceId`/`untilId`/`sinceDate`/`untilDate`) を受け付ける (upstream ad/list)。`offset` 経路は後方互換で維持。`adRepo.ListFiltered` を追加。

### admin/drive/files — origin default (MEDIUM)
- `origin` 省略時の既定を `combined` から `local` に変更 (upstream `files.ts` paramDef `default='local'`)。userId 未指定時は `userHost IS NULL` のローカルのみ返す。

### admin/invite/list — sort (LOW)
- `sort` enum (`+createdAt`/`-createdAt`/`+usedAt`/`-usedAt`) を受け付ける (upstream invite/list)。`registrationTicketRepo.ListSorted` を追加 (usedAt は NULLS 配置も upstream に合わせる)。

### admin/announcements/create — createdAt (MEDIUM)
- レスポンスを raw `model.Announcement` でなく `entity.PackAnnouncement` で返し、`createdAt` (ID 由来) を含める (upstream create.ts)。

## 派生 issue へ分離

- **resolve-abuse の `abuseReportResolved` system webhook** (MEDIUM の webhook 部分) → `#1723`。assigneeId 設定は対応済。webhook は abuse-report-notification の recipient-driven dispatch pipeline を要する。
- **drive/cleanup の object storage 削除** (LOW) → `#1724`。DriveService 経由の storage 削除 + hazard。

## テスト

- repository: `TestAdRepository_ListFiltered` (publishing true/false + cursor)、`TestRegistrationTicketRepository_ListSorted` (4 sort enum + NULLS) を DB-backed で追加。
- api/admin: `TestAdList_PublishingFilter` / `TestAdList_CursorPagination` / `TestInviteList_Sort` / `TestDriveFiles_OriginDefaultsToLocal` を追加。
- api/announcements: `TestAdminCreate_Success` に createdAt assertion を追加。
- mock: `MockAdRepository.ListFiltered` / `MockRegistrationTicketRepository.ListSorted` を追加。
- 実行: `go test ./internal/api/admin/ ./internal/api/announcements/ ./internal/repository/ -count=1` → pass。coverage admin 89.3% (>80% gate) / announcements 96.1% / repository 90.2%。`go build ./... && go vet ./...` → pass。

## Closes

`#1545` の ad/drive/invite/announcements 4 項目を解消する (abuse webhook は #1723、drive cleanup は #1724 で継続)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)