### PR TITLE
Fix admin/resolve-abuse-user-report: abuseReportResolved system webhook を発火 (#1723)

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/shiroha-a/mk/internal/core/moderationlog"
 	"github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/core/signup"
+	corewebhook "github.com/shiroha-a/mk/internal/core/webhook"
 	"github.com/shiroha-a/mk/internal/core/webpush"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -83,25 +84,29 @@ type UnfollowEnqueuer interface {
 
 // Handler handles admin API endpoints.
 type Handler struct {
-	signupService           *signup.Service
-	roleService             *role.Service
-	metaRepo                repository.MetaRepository
-	userRepo                repository.UserRepository
-	abuseRepo               repository.AbuseReportRepository
-	modLogService           *moderationlog.Service
-	emojiRepo               repository.EmojiRepository
-	driveFileRepo           repository.DriveFileRepository
-	adminDB                 *gorm.DB
-	userIPRepo              repository.UserIPRepository
-	queueInspector          QueueInspector
-	queueRedis              QueueRedisInfoProvider
-	emojiEnqueuer           EmojiImportEnqueuer
-	emojiImageFetcher       EmojiImageFetcher
-	relayService            RelayService
-	abuseForwarder          AbuseForwarder
-	deleteAccountEnqueuer   DeleteAccountEnqueuer
-	systemWebhookRepo       repository.SystemWebhookRepository
-	recipientRepo           repository.AbuseReportNotificationRecipientRepository
+	signupService         *signup.Service
+	roleService           *role.Service
+	metaRepo              repository.MetaRepository
+	userRepo              repository.UserRepository
+	abuseRepo             repository.AbuseReportRepository
+	modLogService         *moderationlog.Service
+	emojiRepo             repository.EmojiRepository
+	driveFileRepo         repository.DriveFileRepository
+	adminDB               *gorm.DB
+	userIPRepo            repository.UserIPRepository
+	queueInspector        QueueInspector
+	queueRedis            QueueRedisInfoProvider
+	emojiEnqueuer         EmojiImportEnqueuer
+	emojiImageFetcher     EmojiImageFetcher
+	relayService          RelayService
+	abuseForwarder        AbuseForwarder
+	deleteAccountEnqueuer DeleteAccountEnqueuer
+	systemWebhookRepo     repository.SystemWebhookRepository
+	recipientRepo         repository.AbuseReportNotificationRecipientRepository
+	// systemWebhookDispatcher は resolve-abuse-user-report 時に
+	// abuseReportResolved system webhook を発火するための dispatcher
+	// (*core/webhook.Service)。nil なら発火しない (#1723)。
+	systemWebhookDispatcher SystemWebhookDispatcher
 	adRepo                  repository.AdRepository
 	avatarDecoRepo          repository.AvatarDecorationRepository
 	inviteRepo              repository.RegistrationTicketRepository
@@ -282,6 +287,20 @@ func (h *Handler) SetUnfollowEnqueuer(e UnfollowEnqueuer) {
 // admin/abuse-report/notification-recipient/*.
 func (h *Handler) SetRecipientRepo(r repository.AbuseReportNotificationRecipientRepository) {
 	h.recipientRepo = r
+}
+
+// SystemWebhookDispatcher fans a system-level event out to subscribed system
+// webhooks, optionally excluding specific webhook IDs. Implemented by
+// *core/webhook.Service. Used to fire abuseReportResolved on report resolution
+// (#1723).
+type SystemWebhookDispatcher interface {
+	DispatchSystemExcluding(eventType string, body any, excludes []string)
+}
+
+// SetSystemWebhookDispatcher wires the system webhook dispatcher used to emit
+// abuseReportResolved. nil disables firing (DB update still happens).
+func (h *Handler) SetSystemWebhookDispatcher(d SystemWebhookDispatcher) {
+	h.systemWebhookDispatcher = d
 }
 
 // SetAdRepo attaches an AdRepository for admin/ad/*.
@@ -2673,36 +2692,43 @@ func (h *Handler) AbuseReports(c echo.Context) error {
 	profByID := h.abuseUserProfiles(reports)
 	out := make([]packedAbuseReport, 0, len(reports))
 	for _, r := range reports {
-		p := packedAbuseReport{
-			ID:             r.ID,
-			Comment:        r.Comment,
-			Resolved:       r.Resolved,
-			ReporterID:     r.ReporterID,
-			TargetUserID:   r.TargetUserID,
-			AssigneeID:     r.AssigneeID,
-			Forwarded:      r.Forwarded,
-			ResolvedAs:     r.ResolvedAs,
-			ModerationNote: r.ModerationNote,
-			// 生 model.User を inline すると usernameLower / inbox 等の内部
-			// field が漏れ、UserDetailedNotMe 固有 field も欠ける。UserDetailed
-			// で pack する。
-			Reporter:   h.packAbuseUser(r.Reporter, profByID),
-			TargetUser: h.packAbuseUser(r.TargetUser, profByID),
-			Assignee:   h.packAbuseUser(r.Assignee, profByID),
-		}
-		if s, err := aidxCreatedAtString(h.idGen, r.ID); err == nil {
-			p.CreatedAt = s
-		} else if !errors.Is(err, ErrIDGenMissing) {
-			// idGen は wired されているのに parse 失敗した場合のみログに残す。
-			// 非 aidx 形式の legacy ID 等で createdAt が出せない時に frontend
-			// 側で「日時の解析が失敗しました。」が出る原因を後追いできるように
-			// する (ShowModerationLogs と同 pattern)。
-			slog.DebugContext(c.Request().Context(), "abuseReport: createdAt derive failed",
-				"reportId", r.ID, "err", err)
-		}
-		out = append(out, p)
+		out = append(out, h.packAbuseReport(c.Request().Context(), r, profByID))
 	}
 	return c.JSON(http.StatusOK, out)
+}
+
+// packAbuseReport converts an abuse report into the wire shape shared by
+// admin/abuse-user-reports (list) and the abuseReportResolved system webhook
+// body (#1723). profByID は abuseUserProfiles で batch 解決した profile map。
+func (h *Handler) packAbuseReport(ctx context.Context, r *model.AbuseUserReport, profByID map[string]*model.UserProfile) packedAbuseReport {
+	p := packedAbuseReport{
+		ID:             r.ID,
+		Comment:        r.Comment,
+		Resolved:       r.Resolved,
+		ReporterID:     r.ReporterID,
+		TargetUserID:   r.TargetUserID,
+		AssigneeID:     r.AssigneeID,
+		Forwarded:      r.Forwarded,
+		ResolvedAs:     r.ResolvedAs,
+		ModerationNote: r.ModerationNote,
+		// 生 model.User を inline すると usernameLower / inbox 等の内部
+		// field が漏れ、UserDetailedNotMe 固有 field も欠ける。UserDetailed
+		// で pack する。
+		Reporter:   h.packAbuseUser(r.Reporter, profByID),
+		TargetUser: h.packAbuseUser(r.TargetUser, profByID),
+		Assignee:   h.packAbuseUser(r.Assignee, profByID),
+	}
+	if s, err := aidxCreatedAtString(h.idGen, r.ID); err == nil {
+		p.CreatedAt = s
+	} else if !errors.Is(err, ErrIDGenMissing) {
+		// idGen は wired されているのに parse 失敗した場合のみログに残す。
+		// 非 aidx 形式の legacy ID 等で createdAt が出せない時に frontend
+		// 側で「日時の解析が失敗しました。」が出る原因を後追いできるように
+		// する (ShowModerationLogs と同 pattern)。
+		slog.DebugContext(ctx, "abuseReport: createdAt derive failed",
+			"reportId", r.ID, "err", err)
+	}
+	return p
 }
 
 // abuseUserProfiles batch-fetches the profiles of every reporter / targetUser /
@@ -2815,8 +2841,6 @@ func (h *Handler) ResolveAbuseReport(c echo.Context) error {
 	// fix と同方針: 既存 row の resolvedAs が意図せず書き換わる silent
 	// corruption を防ぐ)。
 	// upstream は resolve 時に assigneeId=moderator.id を記録する。
-	// (notifySystemWebhook('abuseReportResolved') は notification-recipient
-	// service 配線が要るため後続スライスで対応)。
 	fields := map[string]any{"resolved": true}
 	if me := middleware.GetUser(c); me != nil {
 		fields["assigneeId"] = me.ID
@@ -2838,7 +2862,51 @@ func (h *Handler) ResolveAbuseReport(c echo.Context) error {
 	if err := h.abuseRepo.UpdateFields(req.ReportID, fields); err != nil {
 		return c.JSON(http.StatusNotFound, apierr.ErrorWithKind("NO_SUCH_ABUSE_REPORT", "No such abuse report.", "ac3794dd-2ce4-d878-e546-73c60c06b398", apierr.KindServer))
 	}
+	// upstream AbuseReportService.resolve は notifySystemWebhook('abuseReportResolved')
+	// を呼ぶ。best-effort: DB 更新は済んでいるので発火失敗は握り潰す (#1723)。
+	h.notifyAbuseReportResolved(c.Request().Context(), req.ReportID)
 	return c.NoContent(http.StatusNoContent)
+}
+
+// notifyAbuseReportResolved fires the abuseReportResolved system webhook for a
+// resolved report. 本家 AbuseReportNotificationService.notifySystemWebhook 相当:
+// inactive な notification recipient (method=webhook) が指す systemWebhookId を
+// excludes に渡し、残りの active system webhook へ packed report を配送する。
+// dispatcher / abuseRepo 未配線時は no-op (#1723)。
+func (h *Handler) notifyAbuseReportResolved(ctx context.Context, reportID string) {
+	if h.systemWebhookDispatcher == nil || h.abuseRepo == nil {
+		return
+	}
+	report, err := h.abuseRepo.FindByID(reportID)
+	if err != nil {
+		slog.WarnContext(ctx, "abuseReportResolved: load report failed", "reportId", reportID, "err", err)
+		return
+	}
+	profByID := h.abuseUserProfiles([]*model.AbuseUserReport{report})
+	body := h.packAbuseReport(ctx, report, profByID)
+	h.systemWebhookDispatcher.DispatchSystemExcluding(
+		corewebhook.SystemEventAbuseReportResolved, body, h.inactiveAbuseWebhookIDs())
+}
+
+// inactiveAbuseWebhookIDs returns the systemWebhookId values of inactive
+// abuse-report-notification recipients (method=webhook). 本家 notifySystemWebhook
+// の withoutWebhookIds 相当 (= 無効化された recipient 宛は配送しない)。recipientRepo
+// 未配線 / 取得失敗時は nil (= excludes 無し)。
+func (h *Handler) inactiveAbuseWebhookIDs() []string {
+	if h.recipientRepo == nil {
+		return nil
+	}
+	recipients, err := h.recipientRepo.List()
+	if err != nil {
+		return nil
+	}
+	var excludes []string
+	for _, r := range recipients {
+		if r.Method == "webhook" && !r.IsActive && r.SystemWebhookID != nil {
+			excludes = append(excludes, *r.SystemWebhookID)
+		}
+	}
+	return excludes
 }
 
 // ShowModerationLogs handles POST /api/admin/show-moderation-logs.

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -1777,6 +1777,80 @@ func TestAbuseReports_WithRepo(t *testing.T) {
 	assert.Len(t, resp, 1)
 }
 
+// stubSystemWebhookDispatcher records DispatchSystemExcluding calls for the
+// abuseReportResolved webhook tests (#1723).
+type stubSystemWebhookDispatcher struct {
+	calls []struct {
+		eventType string
+		body      any
+		excludes  []string
+	}
+}
+
+func (s *stubSystemWebhookDispatcher) DispatchSystemExcluding(eventType string, body any, excludes []string) {
+	s.calls = append(s.calls, struct {
+		eventType string
+		body      any
+		excludes  []string
+	}{eventType, body, excludes})
+}
+
+// resolve は abuseReportResolved system webhook を発火し、inactive な
+// notification recipient (method=webhook) の systemWebhookId を excludes に渡す
+// (#1723, upstream notifySystemWebhook)。
+func TestResolveAbuseReport_FiresResolvedWebhook(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	abuseRepo := testutil.NewMockAbuseReportRepository()
+	abuseRepo.Reports["r1"] = &model.AbuseUserReport{ID: "r1", ReporterID: "rep1", TargetUserID: "tgt1"}
+	h.SetAbuseRepo(abuseRepo)
+
+	recipientRepo := testutil.NewMockAbuseReportNotificationRecipientRepository()
+	inactiveID := "wh_inactive"
+	activeID := "wh_active"
+	emailInactiveID := "wh_email"
+	require.NoError(t, recipientRepo.Create(&model.AbuseReportNotificationRecipient{
+		ID: "rc1", Method: "webhook", IsActive: false, SystemWebhookID: &inactiveID,
+	}))
+	require.NoError(t, recipientRepo.Create(&model.AbuseReportNotificationRecipient{
+		ID: "rc2", Method: "webhook", IsActive: true, SystemWebhookID: &activeID,
+	}))
+	require.NoError(t, recipientRepo.Create(&model.AbuseReportNotificationRecipient{
+		ID: "rc3", Method: "email", IsActive: false, SystemWebhookID: &emailInactiveID,
+	}))
+	h.SetRecipientRepo(recipientRepo)
+
+	disp := &stubSystemWebhookDispatcher{}
+	h.SetSystemWebhookDispatcher(disp)
+
+	rec := doPost(h.ResolveAbuseReport, `{"reportId":"r1"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Len(t, disp.calls, 1)
+	call := disp.calls[0]
+	assert.Equal(t, "abuseReportResolved", call.eventType)
+	// excludes は inactive な webhook recipient のみ (active webhook / email は除外しない)。
+	assert.Equal(t, []string{inactiveID}, call.excludes)
+	// body は packedAbuseReport。wire shape (JSON) で id / resolved を検証する
+	// (packedAbuseReport は unexported のため JSON 経由で assert)。
+	raw, err := json.Marshal(call.body)
+	require.NoError(t, err)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(raw, &body))
+	assert.Equal(t, "r1", body["id"])
+	assert.Equal(t, true, body["resolved"])
+}
+
+// dispatcher 未配線時は webhook を発火しないが resolve 自体は成功する (#1723)。
+func TestResolveAbuseReport_NoDispatcherStillResolves(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	abuseRepo := testutil.NewMockAbuseReportRepository()
+	abuseRepo.Reports["r1"] = &model.AbuseUserReport{ID: "r1"}
+	h.SetAbuseRepo(abuseRepo)
+
+	rec := doPost(h.ResolveAbuseReport, `{"reportId":"r1"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.True(t, abuseRepo.Reports["r1"].Resolved)
+}
+
 func TestResolveAbuseReport_WithRepo(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	abuseRepo := testutil.NewMockAbuseReportRepository()

--- a/internal/core/webhook/service.go
+++ b/internal/core/webhook/service.go
@@ -150,6 +150,15 @@ func (s *Service) DispatchUserTest(webhookID, userID, eventType string, body any
 // DispatchSystem mirrors DispatchUser for system webhooks (admin-level
 // events such as abuseReport / userCreated). 本家 SystemWebhookService.enqueueSystemWebhook 相当。
 func (s *Service) DispatchSystem(eventType string, body any) {
+	s.DispatchSystemExcluding(eventType, body, nil)
+}
+
+// DispatchSystemExcluding is DispatchSystem but skips any active system webhook
+// whose ID appears in excludes. 本家 enqueueSystemWebhook の opts.excludes 相当:
+// abuse-report-notification の resolve 通知では、inactive な notification
+// recipient が指す systemWebhookId を excludes に渡して配送対象から外す
+// (#1723、AbuseReportNotificationService.notifySystemWebhook)。
+func (s *Service) DispatchSystemExcluding(eventType string, body any, excludes []string) {
 	if s == nil || s.enqueuer == nil || s.systemRepo == nil {
 		return
 	}
@@ -162,6 +171,9 @@ func (s *Service) DispatchSystem(eventType string, body any) {
 	now := time.Now().UnixMilli()
 	for _, h := range hooks {
 		if !slices.Contains([]string(h.On), eventType) {
+			continue
+		}
+		if slices.Contains(excludes, h.ID) {
 			continue
 		}
 		raw, _ := json.Marshal(Envelope{

--- a/internal/core/webhook/service_test.go
+++ b/internal/core/webhook/service_test.go
@@ -235,3 +235,29 @@ func TestDispatchSystem_NilSafe(t *testing.T) {
 	svc = webhook.NewService(nil, nil, nil, "")
 	svc.DispatchSystem("userCreated", nil)
 }
+
+// DispatchSystemExcluding は excludes に含まれる webhook ID へは配送しない
+// (本家 enqueueSystemWebhook opts.excludes 相当、#1723)。
+func TestDispatchSystemExcluding_SkipsExcluded(t *testing.T) {
+	enq := &fakeEnqueuer{}
+	repo := &fakeSystemWebhookRepo{hooks: map[string]*model.SystemWebhook{
+		"h1": {ID: "h1", IsActive: true, On: pq.StringArray{"abuseReportResolved"}},
+		"h2": {ID: "h2", IsActive: true, On: pq.StringArray{"abuseReportResolved"}},
+	}}
+	svc := webhook.NewService(enq, nil, repo, "https://example.com")
+	svc.DispatchSystemExcluding(webhook.SystemEventAbuseReportResolved, map[string]any{"id": "r1"}, []string{"h2"})
+	require.Len(t, enq.systemCalls, 1)
+	assert.Equal(t, "h1", enq.systemCalls[0].WebhookID, "excludes の h2 は配送されない")
+}
+
+// excludes が nil の場合は DispatchSystem と同じ全 active 配送。
+func TestDispatchSystemExcluding_NilExcludesDeliversAll(t *testing.T) {
+	enq := &fakeEnqueuer{}
+	repo := &fakeSystemWebhookRepo{hooks: map[string]*model.SystemWebhook{
+		"h1": {ID: "h1", IsActive: true, On: pq.StringArray{"abuseReportResolved"}},
+		"h2": {ID: "h2", IsActive: true, On: pq.StringArray{"abuseReportResolved"}},
+	}}
+	svc := webhook.NewService(enq, nil, repo, "https://example.com")
+	svc.DispatchSystemExcluding(webhook.SystemEventAbuseReportResolved, nil, nil)
+	assert.Len(t, enq.systemCalls, 2)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2221,6 +2221,9 @@ func (s *Server) setupRoutes() {
 	// + forward proxy 経由にする (#638)。
 	adminHandler.SetWebhookTestClient(s.outboundClient(10 * time.Second))
 	adminHandler.SetRecipientRepo(recipientRepo)
+	// resolve-abuse-user-report 時に abuseReportResolved system webhook を発火
+	// する dispatcher (#1723)。
+	adminHandler.SetSystemWebhookDispatcher(webhookService)
 	adminHandler.SetAdRepo(repository.NewAdRepository(s.db))
 	adminHandler.SetAvatarDecorationRepo(repository.NewAvatarDecorationRepository(s.db))
 	adminHandler.SetInviteRepo(repository.NewRegistrationTicketRepository(s.db))


### PR DESCRIPTION
## Summary

`admin/resolve-abuse-user-report` (abuse report の resolve) で upstream `AbuseReportService.resolve` 相当の `notifySystemWebhook('abuseReportResolved')` を実装する。従来は `SystemEventAbuseReportResolved` 定数が定義済なのに呼び出し元がゼロで、resolve しても system webhook が飛ばない parity 差分があった (`#1545` MEDIUM 項目の派生)。assigneeId の記録は `#1545` 本体で対応済。

## upstream 挙動との整合

`AbuseReportNotificationService.notifySystemWebhook` の semantics に揃えた:

- packed report (reporter / targetUser / assignee を `UserDetailed` で pack) を webhook body にする。
- **inactive** な abuse-report-notification-recipient (method=webhook) が指す `systemWebhookId` を `excludes` に渡し、配送対象から外す (active な system webhook であっても無効化された recipient 宛は飛ばさない)。

## 主な変更点

- **`internal/core/webhook/service.go`**: `DispatchSystemExcluding(eventType, body, excludes)` を追加。`excludes` に含まれる active system webhook をスキップする (本家 `enqueueSystemWebhook` の `opts.excludes` 相当)。`DispatchSystem` は `nil` excludes で委譲するよう薄くリファクタ。
- **`internal/api/admin/handler.go`**:
  - `SystemWebhookDispatcher` interface + `SetSystemWebhookDispatcher` setter を追加。
  - `ResolveAbuseReport` は DB 更新後に `notifyAbuseReportResolved` を best-effort で発火 (発火失敗は握り潰す = DB 更新は確定済)。
  - `inactiveAbuseWebhookIDs` で excludes (inactive webhook recipient の systemWebhookId) を計算。
  - `AbuseReports` の report packing を `packAbuseReport` ヘルパーに抽出し、webhook body と list response で共有。
- **`internal/server/router.go`**: `adminHandler.SetSystemWebhookDispatcher(webhookService)` を配線。

## テスト

- `internal/core/webhook`: `TestDispatchSystemExcluding_SkipsExcluded` (excludes の webhook を飛ばさない) / `TestDispatchSystemExcluding_NilExcludesDeliversAll` (nil で全 active 配送)。
- `internal/api/admin`: `TestResolveAbuseReport_FiresResolvedWebhook` (eventType=abuseReportResolved / excludes=inactive webhook recipient のみ / body の id・resolved) / `TestResolveAbuseReport_NoDispatcherStillResolves` (dispatcher 未配線でも resolve は成功)。
- 実行: `go test ./internal/api/admin/... ./internal/core/webhook/... -count=1`
- カバレッジ: webhook 93.8% / admin 89.3% (gate 維持)。

## Closes

Closes #1723

🤖 Generated with [Claude Code](https://claude.com/claude-code)