### PR TITLE
Fix hashtags parity: list sort/attachedTo フィルタ + search 前方一致 + show 正規化 (#1544)

### DIFF
--- a/internal/api/hashtags/handler.go
+++ b/internal/api/hashtags/handler.go
@@ -3,6 +3,7 @@ package hashtags
 import (
 	"net/http"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -26,33 +27,50 @@ func NewHandler(db *gorm.DB) *Handler {
 	return &Handler{db: db}
 }
 
-// validListSorts は upstream Misskey TS hashtags/list paramDef enum と一致 (#925)。
-var validListSorts = map[string]struct{}{
-	"+mentionedUsers": {}, "-mentionedUsers": {},
-	"+mentionedLocalUsers": {}, "-mentionedLocalUsers": {},
-	"+mentionedRemoteUsers": {}, "-mentionedRemoteUsers": {},
-	"+attachedUsers": {}, "-attachedUsers": {},
-	"+attachedLocalUsers": {}, "-attachedLocalUsers": {},
-	"+attachedRemoteUsers": {}, "-attachedRemoteUsers": {},
+// listSortOrders は upstream Misskey TS hashtags/list paramDef enum を、
+// 対応する order by 句に対応付ける (#925, #1544)。+ が DESC、- が ASC
+// (upstream の符号付けと同じ)。キー集合が paramDef enum の妥当値も兼ねる。
+var listSortOrders = map[string]string{
+	"+mentionedUsers": `"mentionedUsersCount" DESC`, "-mentionedUsers": `"mentionedUsersCount" ASC`,
+	"+mentionedLocalUsers": `"mentionedLocalUsersCount" DESC`, "-mentionedLocalUsers": `"mentionedLocalUsersCount" ASC`,
+	"+mentionedRemoteUsers": `"mentionedRemoteUsersCount" DESC`, "-mentionedRemoteUsers": `"mentionedRemoteUsersCount" ASC`,
+	"+attachedUsers": `"attachedUsersCount" DESC`, "-attachedUsers": `"attachedUsersCount" ASC`,
+	"+attachedLocalUsers": `"attachedLocalUsersCount" DESC`, "-attachedLocalUsers": `"attachedLocalUsersCount" ASC`,
+	"+attachedRemoteUsers": `"attachedRemoteUsersCount" DESC`, "-attachedRemoteUsers": `"attachedRemoteUsersCount" ASC`,
 }
 
 // List handles POST /api/hashtags/list.
 func (h *Handler) List(c echo.Context) error {
 	var req struct {
-		Limit  int    `json:"limit"`
-		Sort   string `json:"sort"`
-		Offset int    `json:"offset"`
+		Limit                    int    `json:"limit"`
+		Sort                     string `json:"sort"`
+		Offset                   int    `json:"offset"`
+		AttachedToUserOnly       bool   `json:"attachedToUserOnly"`
+		AttachedToLocalUserOnly  bool   `json:"attachedToLocalUserOnly"`
+		AttachedToRemoteUserOnly bool   `json:"attachedToRemoteUserOnly"`
 	}
 	if err := c.Bind(&req); err != nil || req.Sort == "" {
 		// upstream Misskey TS は paramDef で sort を required にしている (#925)。
 		// mk-go も同 shape に揃え、permissive な挙動を弾く。
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	if _, ok := validListSorts[req.Sort]; !ok {
+	order, ok := listSortOrders[req.Sort]
+	if !ok {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "sort must be one of upstream-defined enum.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
-	q := h.db.Model(&model.Hashtag{}).Order("\"mentionedUsersCount\" DESC").Limit(req.Limit)
+	// upstream list.ts: attachedTo* で attachedUsersCount 系が != 0 の tag のみに絞る。
+	q := h.db.Model(&model.Hashtag{})
+	if req.AttachedToUserOnly {
+		q = q.Where(`"attachedUsersCount" != 0`)
+	}
+	if req.AttachedToLocalUserOnly {
+		q = q.Where(`"attachedLocalUsersCount" != 0`)
+	}
+	if req.AttachedToRemoteUserOnly {
+		q = q.Where(`"attachedRemoteUsersCount" != 0`)
+	}
+	q = q.Order(order).Limit(req.Limit)
 	if req.Offset > 0 {
 		q = q.Offset(req.Offset)
 	}
@@ -70,15 +88,26 @@ func (h *Handler) List(c echo.Context) error {
 // Search handles POST /api/hashtags/search.
 func (h *Handler) Search(c echo.Context) error {
 	var req struct {
-		Query string `json:"query"`
-		Limit int    `json:"limit"`
+		Query  string `json:"query"`
+		Limit  int    `json:"limit"`
+		Offset int    `json:"offset"`
 	}
 	if err := c.Bind(&req); err != nil || req.Query == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "query is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
+	// upstream search.ts: name LIKE sqlLikeEscape(query.toLowerCase())+'%' (前方一致)
+	// を mentionedLocalUsersCount DESC で並べ offset を適用する。hashtag.name は
+	// normalizeForSearch 済 (lowercase) で格納されるため小文字化で一致する。
+	q := h.db.Model(&model.Hashtag{}).
+		Where(`"name" LIKE ? ESCAPE '\'`, escapeLike(strings.ToLower(req.Query))+"%").
+		Order(`"mentionedLocalUsersCount" DESC`).
+		Limit(req.Limit)
+	if req.Offset > 0 {
+		q = q.Offset(req.Offset)
+	}
 	var tags []*model.Hashtag
-	if err := h.db.Where("name ILIKE ?", "%"+req.Query+"%").Limit(req.Limit).Find(&tags).Error; err != nil {
+	if err := q.Find(&tags).Error; err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	names := make([]string, 0, len(tags))
@@ -96,8 +125,11 @@ func (h *Handler) Show(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.Tag == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "tag is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
+	// upstream show.ts: hashtags.findOneBy({name: normalizeForSearch(tag)})。
+	// hashtag.name は normalizeForSearch (NFKC+lowercase) 済で格納されるため、
+	// 入力も同じく正規化して一致させる ('Misskey' → 'misskey')。
 	var tag model.Hashtag
-	if err := h.db.Where("name = ?", req.Tag).First(&tag).Error; err != nil {
+	if err := h.db.Where("name = ?", searchnorm.Normalize(req.Tag)).First(&tag).Error; err != nil {
 		// HTTP semantics 的には not-found = 404 が望ましいが、upstream
 		// Misskey TS は ApiError の既定動作で 400 を返している (#925)。
 		// drop-in 互換を優先して 400 + NO_SUCH_HASHTAG body に揃える。
@@ -373,6 +405,16 @@ func (h *Handler) Users(c echo.Context) error {
 		out = append(out, entity.PackUserDetailed(u, profByID[u.ID], gen))
 	}
 	return c.JSON(http.StatusOK, out)
+}
+
+// escapeLike escapes LIKE metacharacters so user input matches literally
+// (upstream sqlLikeEscape 相当)。PostgreSQL の既定 escape 文字は backslash
+// なので \ 自身もエスケープする。
+func escapeLike(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
 }
 
 func packTag(t *model.Hashtag) map[string]any {

--- a/internal/api/hashtags/handler_test.go
+++ b/internal/api/hashtags/handler_test.go
@@ -97,6 +97,60 @@ func TestList_DBError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, doPost(brokenHandler().List, `{"sort":"+mentionedUsers"}`).Code)
 }
 
+// decodeTagNames は list/search レスポンスを順序保持で tag 名配列に変換する。
+func decodeListTagNames(t *testing.T, rec *httptest.ResponseRecorder) []string {
+	t.Helper()
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r["tag"].(string))
+	}
+	return out
+}
+
+// TestList_SortHonored: sort 値に応じて order by が切り替わること (#1544)。
+// 旧実装は常に mentionedUsersCount DESC 固定だった。
+func TestList_SortHonored(t *testing.T) {
+	cleanup()
+	defer cleanup()
+	testDB.Create(&model.Hashtag{ID: "ht_s1", Name: "alpha", MentionedUsersCount: 1, AttachedUsersCount: 9})
+	testDB.Create(&model.Hashtag{ID: "ht_s2", Name: "bravo", MentionedUsersCount: 9, AttachedUsersCount: 1})
+
+	// +mentionedUsers DESC → bravo(9) が先頭。
+	got := decodeListTagNames(t, doPost(newHandler().List, `{"sort":"+mentionedUsers"}`))
+	require.Len(t, got, 2)
+	assert.Equal(t, "bravo", got[0])
+
+	// -mentionedUsers ASC → alpha(1) が先頭。
+	got = decodeListTagNames(t, doPost(newHandler().List, `{"sort":"-mentionedUsers"}`))
+	require.Len(t, got, 2)
+	assert.Equal(t, "alpha", got[0])
+
+	// +attachedUsers DESC → alpha(9) が先頭 (列が切り替わる)。
+	got = decodeListTagNames(t, doPost(newHandler().List, `{"sort":"+attachedUsers"}`))
+	require.Len(t, got, 2)
+	assert.Equal(t, "alpha", got[0])
+}
+
+// TestList_AttachedToFilters: attachedTo* で count!=0 の tag のみ返す (#1544)。
+func TestList_AttachedToFilters(t *testing.T) {
+	cleanup()
+	defer cleanup()
+	testDB.Create(&model.Hashtag{ID: "ht_a1", Name: "withlocal", AttachedUsersCount: 3, AttachedLocalUsersCount: 3, AttachedRemoteUsersCount: 0})
+	testDB.Create(&model.Hashtag{ID: "ht_a2", Name: "withremote", AttachedUsersCount: 2, AttachedLocalUsersCount: 0, AttachedRemoteUsersCount: 2})
+	testDB.Create(&model.Hashtag{ID: "ht_a3", Name: "noattach", AttachedUsersCount: 0})
+
+	got := decodeListTagNames(t, doPost(newHandler().List, `{"sort":"+mentionedUsers","attachedToUserOnly":true}`))
+	assert.ElementsMatch(t, []string{"withlocal", "withremote"}, got)
+
+	got = decodeListTagNames(t, doPost(newHandler().List, `{"sort":"+mentionedUsers","attachedToLocalUserOnly":true}`))
+	assert.ElementsMatch(t, []string{"withlocal"}, got)
+
+	got = decodeListTagNames(t, doPost(newHandler().List, `{"sort":"+mentionedUsers","attachedToRemoteUserOnly":true}`))
+	assert.ElementsMatch(t, []string{"withremote"}, got)
+}
+
 // --- Search ---
 
 func TestSearch_Success(t *testing.T) {
@@ -114,6 +168,63 @@ func TestSearch_InvalidParam(t *testing.T) {
 
 func TestSearch_DBError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, doPost(brokenHandler().Search, `{"query":"x"}`).Code)
+}
+
+// decodeSearchNames は search レスポンス (string 配列) を順序保持で返す。
+func decodeSearchNames(t *testing.T, rec *httptest.ResponseRecorder) []string {
+	t.Helper()
+	var names []string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &names))
+	return names
+}
+
+// TestSearch_PrefixMatch: upstream は前方一致 (name LIKE query+'%')。部分一致では
+// ない。query="go" は "golang" に一致するが "mygolang" には一致しない (#1544)。
+func TestSearch_PrefixMatch(t *testing.T) {
+	cleanup()
+	defer cleanup()
+	testDB.Create(&model.Hashtag{ID: "ht_p1", Name: "golang"})
+	testDB.Create(&model.Hashtag{ID: "ht_p2", Name: "mygolang"})
+
+	names := decodeSearchNames(t, doPost(newHandler().Search, `{"query":"go"}`))
+	assert.Contains(t, names, "golang")
+	assert.NotContains(t, names, "mygolang", "部分一致ではなく前方一致")
+}
+
+// TestSearch_CaseInsensitivePrefix: query は lowercase 化されて前方一致する。
+func TestSearch_CaseInsensitivePrefix(t *testing.T) {
+	cleanup()
+	defer cleanup()
+	testDB.Create(&model.Hashtag{ID: "ht_ci", Name: "misskey"})
+	names := decodeSearchNames(t, doPost(newHandler().Search, `{"query":"Miss"}`))
+	assert.Contains(t, names, "misskey")
+}
+
+// TestSearch_OrderAndOffset: mentionedLocalUsersCount DESC で並び offset を適用する。
+func TestSearch_OrderAndOffset(t *testing.T) {
+	cleanup()
+	defer cleanup()
+	testDB.Create(&model.Hashtag{ID: "ht_o1", Name: "golow", MentionedLocalUsersCount: 1})
+	testDB.Create(&model.Hashtag{ID: "ht_o2", Name: "gohigh", MentionedLocalUsersCount: 9})
+
+	names := decodeSearchNames(t, doPost(newHandler().Search, `{"query":"go"}`))
+	require.Len(t, names, 2)
+	assert.Equal(t, "gohigh", names[0], "mentionedLocalUsersCount DESC")
+
+	// offset=1 で先頭 (gohigh) を飛ばす。
+	names = decodeSearchNames(t, doPost(newHandler().Search, `{"query":"go","offset":1}`))
+	require.Len(t, names, 1)
+	assert.Equal(t, "golow", names[0])
+}
+
+// TestSearch_EscapesWildcards: query 内の LIKE メタ文字 (% _) はリテラル扱い。
+func TestSearch_EscapesWildcards(t *testing.T) {
+	cleanup()
+	defer cleanup()
+	testDB.Create(&model.Hashtag{ID: "ht_w1", Name: "abc"})
+	// "%" を前方一致リテラルとして扱うため、"%" は "abc" に一致しない。
+	names := decodeSearchNames(t, doPost(newHandler().Search, `{"query":"%"}`))
+	assert.NotContains(t, names, "abc")
 }
 
 // --- Show ---
@@ -140,6 +251,23 @@ func TestShow_BadRequestForUnknownTag(t *testing.T) {
 
 func TestShow_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, doPost(newHandler().Show, `{}`).Code)
+}
+
+// TestShow_NormalizesTag: upstream は normalizeForSearch (NFKC+lowercase) で
+// 引くため、大文字や全角入力でも格納名 (lowercase) に一致する (#1544)。
+// 旧実装は exact match で 'Misskey' が 'misskey' にヒットせず NO_SUCH_HASHTAG。
+func TestShow_NormalizesTag(t *testing.T) {
+	cleanup()
+	defer cleanup()
+	testDB.Create(&model.Hashtag{ID: "ht_n1", Name: "misskey"})
+
+	rec := doPost(newHandler().Show, `{"tag":"Misskey"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "misskey")
+
+	// 全角 (NFKC で半角化) でも一致する。
+	rec = doPost(newHandler().Show, `{"tag":"ＭＩＳＳＫＥＹ"}`)
+	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
 // --- Trend ---


### PR DESCRIPTION
## Summary

`#1544` (federation+antennas+hashtags+roles parity 監査) の **hashtags 4 項目**を解消する。`#1544` は複数ドメインにまたがるため、本 PR は hashtags ドメインのみを対象とし issue は close しない (`Refs #1544`)。

## 主な変更点 (`internal/api/hashtags/handler.go`)

- **hashtags/list — sort 反映**: sort パラメータが並び順に反映されず常に `mentionedUsersCount DESC` 固定だったのを、upstream `list.ts` の enum (`+/-mentionedUsers/Local/Remote`, `attachedUsers/Local/Remote`) に応じた order by 切替に修正。
- **hashtags/list — attachedTo フィルタ**: `attachedToUserOnly` / `attachedToLocalUserOnly` / `attachedToRemoteUserOnly` を実装 (`attachedUsersCount` 系 `!= 0` で絞る)。
- **hashtags/search — 前方一致・順序・offset**: 部分一致 `ILIKE '%q%'` + 無ソート + offset 無視だったのを、upstream `search.ts` に揃えて `name LIKE lower(q)+'%'` (前方一致) + `mentionedLocalUsersCount DESC` + offset 適用に修正。LIKE メタ文字 (`% _ \`) は `escapeLike` でリテラル化。
- **hashtags/show — 正規化**: exact match で `'Misskey'` 等がヒットしなかったのを、`searchnorm.Normalize` (NFKC+lowercase) で正規化してから引くよう修正 (upstream `normalizeForSearch` 相当)。

## テスト

- `TestList_SortHonored` (sort 値で order 切替) / `TestList_AttachedToFilters` (3 フィルタ)
- `TestSearch_PrefixMatch` (部分一致でないこと) / `TestSearch_CaseInsensitivePrefix` / `TestSearch_OrderAndOffset` / `TestSearch_EscapesWildcards`
- `TestShow_NormalizesTag` (大文字・全角入力でヒット)
- 実行: `go test ./internal/api/hashtags/... -count=1`
- カバレッジ: 91.0% (gate 維持)、List/Search/Show/escapeLike 各 100%。

## Refs

Refs #1544 (hashtags ドメイン分。残りの federation/antennas/roles は別 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)