### PR TITLE
Fix antennas parity: EMPTY_KEYWORD / NO_SUCH_USER_LIST / excludeNotesInSensitiveChannel (#1544)

### DIFF
--- a/internal/api/antennas/handler.go
+++ b/internal/api/antennas/handler.go
@@ -125,17 +125,18 @@ func (h *Handler) emojiLookup() entity.EmojiLookup {
 
 // CreateRequest is the request body for antennas/create.
 type CreateRequest struct {
-	Name            string              `json:"name"`
-	Src             model.AntennaSource `json:"src"`
-	UserListID      *string             `json:"userListId"`
-	Users           []string            `json:"users"`
-	Keywords        [][]string          `json:"keywords"`
-	ExcludeKeywords [][]string          `json:"excludeKeywords"`
-	CaseSensitive   bool                `json:"caseSensitive"`
-	ExcludeBots     bool                `json:"excludeBots"`
-	WithReplies     bool                `json:"withReplies"`
-	WithFile        bool                `json:"withFile"`
-	LocalOnly       bool                `json:"localOnly"`
+	Name                           string              `json:"name"`
+	Src                            model.AntennaSource `json:"src"`
+	UserListID                     *string             `json:"userListId"`
+	Users                          []string            `json:"users"`
+	Keywords                       [][]string          `json:"keywords"`
+	ExcludeKeywords                [][]string          `json:"excludeKeywords"`
+	CaseSensitive                  bool                `json:"caseSensitive"`
+	ExcludeBots                    bool                `json:"excludeBots"`
+	WithReplies                    bool                `json:"withReplies"`
+	WithFile                       bool                `json:"withFile"`
+	LocalOnly                      bool                `json:"localOnly"`
+	ExcludeNotesInSensitiveChannel bool                `json:"excludeNotesInSensitiveChannel"`
 }
 
 // Create handles POST /api/antennas/create.
@@ -145,25 +146,33 @@ func (h *Handler) Create(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.Name == "" {
 		return apierr.JSONInvalidParam(c)
 	}
+	// upstream create.ts: keywords と excludeKeywords が両方とも空なら EMPTY_KEYWORD。
+	if coreantenna.AllKeywordsEmpty(req.Keywords) && coreantenna.AllKeywordsEmpty(req.ExcludeKeywords) {
+		return c.JSON(http.StatusBadRequest, apierr.Error("EMPTY_KEYWORD", "Either keywords or excludeKeywords is required.", "53ee222e-1ddd-4f9a-92e5-9fb82ddb463a"))
+	}
 	a, err := h.svc.Create(coreantenna.CreateInput{
-		OwnerID:         user.ID,
-		Name:            req.Name,
-		Src:             req.Src,
-		UserListID:      req.UserListID,
-		Users:           req.Users,
-		Keywords:        req.Keywords,
-		ExcludeKeywords: req.ExcludeKeywords,
-		CaseSensitive:   req.CaseSensitive,
-		ExcludeBots:     req.ExcludeBots,
-		WithReplies:     req.WithReplies,
-		WithFile:        req.WithFile,
-		LocalOnly:       req.LocalOnly,
+		OwnerID:                        user.ID,
+		Name:                           req.Name,
+		Src:                            req.Src,
+		UserListID:                     req.UserListID,
+		Users:                          req.Users,
+		Keywords:                       req.Keywords,
+		ExcludeKeywords:                req.ExcludeKeywords,
+		CaseSensitive:                  req.CaseSensitive,
+		ExcludeBots:                    req.ExcludeBots,
+		WithReplies:                    req.WithReplies,
+		WithFile:                       req.WithFile,
+		LocalOnly:                      req.LocalOnly,
+		ExcludeNotesInSensitiveChannel: req.ExcludeNotesInSensitiveChannel,
 	})
 	if err != nil {
-		// Name は事前 invalidParam で弾いているため、ここに来るのは
-		// ErrInvalidSource か repo エラー、または antennaLimit 超過のみ。
+		// Name / EMPTY_KEYWORD は事前に弾いているため、ここに来るのは
+		// ErrInvalidSource / NO_SUCH_USER_LIST / antennaLimit / repo エラー。
 		if errors.Is(err, coreantenna.ErrInvalidSource) {
 			return apierr.JSONInvalidParam(c)
+		}
+		if errors.Is(err, coreantenna.ErrNoSuchUserList) {
+			return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_USER_LIST", "No such user list.", "95063e93-a283-4b8b-9aa5-bcdb8df69a7f"))
 		}
 		if errors.Is(err, coreantenna.ErrTooManyAntennas) {
 			return apierr.JSONTooManyAntennas(c)
@@ -198,19 +207,20 @@ func (h *Handler) Show(c echo.Context) error {
 
 // UpdateRequest is the request body for antennas/update.
 type UpdateRequest struct {
-	AntennaID       string               `json:"antennaId"`
-	Name            *string              `json:"name"`
-	Src             *model.AntennaSource `json:"src"`
-	UserListID      *string              `json:"userListId"`
-	Users           *[]string            `json:"users"`
-	Keywords        *[][]string          `json:"keywords"`
-	ExcludeKeywords *[][]string          `json:"excludeKeywords"`
-	CaseSensitive   *bool                `json:"caseSensitive"`
-	ExcludeBots     *bool                `json:"excludeBots"`
-	WithReplies     *bool                `json:"withReplies"`
-	WithFile        *bool                `json:"withFile"`
-	LocalOnly       *bool                `json:"localOnly"`
-	IsActive        *bool                `json:"isActive"`
+	AntennaID                      string               `json:"antennaId"`
+	Name                           *string              `json:"name"`
+	Src                            *model.AntennaSource `json:"src"`
+	UserListID                     *string              `json:"userListId"`
+	Users                          *[]string            `json:"users"`
+	Keywords                       *[][]string          `json:"keywords"`
+	ExcludeKeywords                *[][]string          `json:"excludeKeywords"`
+	CaseSensitive                  *bool                `json:"caseSensitive"`
+	ExcludeBots                    *bool                `json:"excludeBots"`
+	WithReplies                    *bool                `json:"withReplies"`
+	WithFile                       *bool                `json:"withFile"`
+	LocalOnly                      *bool                `json:"localOnly"`
+	IsActive                       *bool                `json:"isActive"`
+	ExcludeNotesInSensitiveChannel *bool                `json:"excludeNotesInSensitiveChannel"`
 }
 
 // Update handles POST /api/antennas/update.
@@ -220,19 +230,26 @@ func (h *Handler) Update(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.AntennaID == "" {
 		return apierr.JSONInvalidParam(c)
 	}
+	// upstream update.ts: keywords/excludeKeywords が両方指定され、かつ両方とも
+	// 空なら EMPTY_KEYWORD (片方のみ指定の場合は検査しない)。
+	if req.Keywords != nil && req.ExcludeKeywords != nil &&
+		coreantenna.AllKeywordsEmpty(*req.Keywords) && coreantenna.AllKeywordsEmpty(*req.ExcludeKeywords) {
+		return c.JSON(http.StatusBadRequest, apierr.Error("EMPTY_KEYWORD", "Either keywords or excludeKeywords is required.", "721aaff6-4e1b-4d88-8de6-877fae9f68c4"))
+	}
 	a, err := h.svc.Update(user.ID, req.AntennaID, coreantenna.UpdateInput{
-		Name:            req.Name,
-		Src:             req.Src,
-		UserListID:      req.UserListID,
-		Users:           req.Users,
-		Keywords:        req.Keywords,
-		ExcludeKeywords: req.ExcludeKeywords,
-		CaseSensitive:   req.CaseSensitive,
-		ExcludeBots:     req.ExcludeBots,
-		WithReplies:     req.WithReplies,
-		WithFile:        req.WithFile,
-		LocalOnly:       req.LocalOnly,
-		IsActive:        req.IsActive,
+		Name:                           req.Name,
+		Src:                            req.Src,
+		UserListID:                     req.UserListID,
+		Users:                          req.Users,
+		Keywords:                       req.Keywords,
+		ExcludeKeywords:                req.ExcludeKeywords,
+		CaseSensitive:                  req.CaseSensitive,
+		ExcludeBots:                    req.ExcludeBots,
+		WithReplies:                    req.WithReplies,
+		WithFile:                       req.WithFile,
+		LocalOnly:                      req.LocalOnly,
+		IsActive:                       req.IsActive,
+		ExcludeNotesInSensitiveChannel: req.ExcludeNotesInSensitiveChannel,
 	})
 	if err != nil {
 		switch {
@@ -240,6 +257,8 @@ func (h *Handler) Update(c echo.Context) error {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANTENNA", "No such antenna.", "10c673ac-8852-48eb-aa1f-f5b67f069290"))
 		case errors.Is(err, coreantenna.ErrAccessDenied):
 			return apierr.JSONAccessDenied(c)
+		case errors.Is(err, coreantenna.ErrNoSuchUserList):
+			return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_USER_LIST", "No such user list.", "1c6b35c9-943e-48c2-81e4-2844989407f7"))
 		case errors.Is(err, coreantenna.ErrAntennaNameRequired),
 			errors.Is(err, coreantenna.ErrInvalidSource):
 			return apierr.JSONInvalidParam(c)

--- a/internal/api/antennas/handler_test.go
+++ b/internal/api/antennas/handler_test.go
@@ -123,7 +123,7 @@ func TestCreate_NameRequired(t *testing.T) {
 
 func TestCreate_InvalidSource(t *testing.T) {
 	h, _, _ := newHandler(t)
-	c, rec := newReq(t, `{"name":"alpha","src":"bogus"}`)
+	c, rec := newReq(t, `{"name":"alpha","src":"bogus","keywords":[["foo"]]}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Create(c))
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
@@ -141,10 +141,88 @@ func TestCreate_RepoError(t *testing.T) {
 	repo := &failingAntennaRepo{MockAntennaRepository: mock}
 	svc := coreantenna.NewService(repo, testutil.NewMockUserRepository(), testRedis.Client, idGen)
 	h := NewHandler(svc, testutil.NewMockNoteRepository(), idGen)
-	c, rec := newReq(t, `{"name":"alpha","src":"all"}`)
+	c, rec := newReq(t, `{"name":"alpha","src":"all","keywords":[["foo"]]}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Create(c))
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// newHandlerWithUserList は userListRepo を配線した handler を返す
+// (NO_SUCH_USER_LIST 検証用)。
+func newHandlerWithUserList(t *testing.T) (*Handler, *testutil.MockAntennaRepository, *testutil.MockUserListRepository) {
+	t.Helper()
+	testRedis.FlushAll(context.Background())
+	repo := testutil.NewMockAntennaRepository()
+	lists := testutil.NewMockUserListRepository()
+	svc := coreantenna.NewService(repo, testutil.NewMockUserRepository(), testRedis.Client, idGen)
+	svc.SetUserListRepo(lists)
+	return NewHandler(svc, testutil.NewMockNoteRepository(), idGen), repo, lists
+}
+
+// upstream create.ts: keywords と excludeKeywords が両方空なら EMPTY_KEYWORD (#1544)。
+func TestCreate_EmptyKeyword(t *testing.T) {
+	h, _, _ := newHandler(t)
+	// keywords/excludeKeywords 未指定 → 両方空扱いで EMPTY_KEYWORD。
+	c, rec := newReq(t, `{"name":"alpha","src":"all"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "EMPTY_KEYWORD")
+
+	// 空文字のみの DNF も空扱い。
+	c, rec = newReq(t, `{"name":"alpha","src":"all","keywords":[[""]],"excludeKeywords":[[""]]}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// excludeKeywords のみ指定なら EMPTY_KEYWORD にはならない。
+func TestCreate_ExcludeKeywordOnlySatisfies(t *testing.T) {
+	h, _, _ := newHandler(t)
+	c, rec := newReq(t, `{"name":"alpha","src":"all","excludeKeywords":[["spam"]]}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// upstream create.ts: src=list で userListId が自分の list でないなら NO_SUCH_USER_LIST。
+func TestCreate_NoSuchUserList(t *testing.T) {
+	h, _, lists := newHandlerWithUserList(t)
+	// 他人 (bob) 所有の list を alice が参照 → NO_SUCH_USER_LIST。
+	require.NoError(t, lists.Create(&model.UserList{ID: "ul1", UserID: "bob", Name: "theirs"}))
+	c, rec := newReq(t, `{"name":"alpha","src":"list","userListId":"ul1","keywords":[["foo"]]}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_USER_LIST")
+
+	// 存在しない list も同様。
+	c, rec = newReq(t, `{"name":"alpha","src":"list","userListId":"ghost","keywords":[["foo"]]}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// 自分の list を参照する src=list は成功する。
+func TestCreate_OwnedUserListAccepted(t *testing.T) {
+	h, _, lists := newHandlerWithUserList(t)
+	require.NoError(t, lists.Create(&model.UserList{ID: "ul1", UserID: "alice", Name: "mine"}))
+	c, rec := newReq(t, `{"name":"alpha","src":"list","userListId":"ul1","keywords":[["foo"]]}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// excludeNotesInSensitiveChannel が永続化されレスポンスに反映される (#1544)。
+func TestCreate_ExcludeNotesInSensitiveChannelPersisted(t *testing.T) {
+	h, _, _ := newHandler(t)
+	c, rec := newReq(t, `{"name":"alpha","src":"all","keywords":[["foo"]],"excludeNotesInSensitiveChannel":true}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["excludeNotesInSensitiveChannel"])
 }
 
 // --- Show ------------------------------------------------------------------
@@ -260,6 +338,52 @@ func TestUpdate_RepoError(t *testing.T) {
 	setUser(c, "alice")
 	require.NoError(t, h.Update(c))
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// upstream update.ts: keywords/excludeKeywords が両方指定され両方空なら EMPTY_KEYWORD (#1544)。
+func TestUpdate_EmptyKeyword(t *testing.T) {
+	h, repo, _ := newHandler(t)
+	repo.Antennas["a1"] = &model.Antenna{ID: "a1", UserID: "alice", Name: "alpha"}
+	c, rec := newReq(t, `{"antennaId":"a1","keywords":[[""]],"excludeKeywords":[]}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Update(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "EMPTY_KEYWORD")
+}
+
+// keywords のみ指定 (excludeKeywords 未指定) なら EMPTY_KEYWORD 検査しない。
+func TestUpdate_OneSidedKeywordsNotChecked(t *testing.T) {
+	h, repo, _ := newHandler(t)
+	repo.Antennas["a1"] = &model.Antenna{ID: "a1", UserID: "alice", Name: "alpha"}
+	c, rec := newReq(t, `{"antennaId":"a1","keywords":[[""]]}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Update(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// upstream update.ts: 既存 src=list で userListId が自分の list でないなら NO_SUCH_USER_LIST。
+func TestUpdate_NoSuchUserList(t *testing.T) {
+	h, repo, lists := newHandlerWithUserList(t)
+	repo.Antennas["a1"] = &model.Antenna{ID: "a1", UserID: "alice", Name: "alpha", Src: model.AntennaSourceList}
+	require.NoError(t, lists.Create(&model.UserList{ID: "ul1", UserID: "bob", Name: "theirs"}))
+	c, rec := newReq(t, `{"antennaId":"a1","userListId":"ul1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Update(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_USER_LIST")
+}
+
+// excludeNotesInSensitiveChannel を update で更新できる (#1544)。
+func TestUpdate_ExcludeNotesInSensitiveChannelPersisted(t *testing.T) {
+	h, repo, _ := newHandler(t)
+	repo.Antennas["a1"] = &model.Antenna{ID: "a1", UserID: "alice", Name: "alpha"}
+	c, rec := newReq(t, `{"antennaId":"a1","excludeNotesInSensitiveChannel":true}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Update(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["excludeNotesInSensitiveChannel"])
 }
 
 // --- Delete ----------------------------------------------------------------

--- a/internal/core/antenna/antenna_service.go
+++ b/internal/core/antenna/antenna_service.go
@@ -34,7 +34,38 @@ var (
 	ErrAccessDenied = errors.New("not the owner of this antenna")
 	// ErrInvalidSource is returned when src is not a known antenna source.
 	ErrInvalidSource = errors.New("invalid antenna source")
+	// ErrNoSuchUserList is returned when src=list references a user list the
+	// caller does not own / does not exist (upstream noSuchUserList、#1544)。
+	ErrNoSuchUserList = errors.New("no such user list")
 )
+
+// AllKeywordsEmpty reports whether every entry of a DNF keyword set is the
+// empty string (= upstream `keywords.flat().every(x => x === ”)`)。空配列も
+// vacuously true を返す。EMPTY_KEYWORD 検査 (endpoint 層) で用いる。
+func AllKeywordsEmpty(kw [][]string) bool {
+	for _, row := range kw {
+		for _, s := range row {
+			if s != "" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// validateUserList enforces the upstream noSuchUserList check: when src=list
+// references a userListId, the list must exist and be owned by ownerID.
+// userListRepo 未配線時は skip (= list source を使わない構成)。
+func (s *Service) validateUserList(ownerID string, userListID *string) error {
+	if s.userListRepo == nil || userListID == nil || *userListID == "" {
+		return nil
+	}
+	list, err := s.userListRepo.FindByID(*userListID)
+	if err != nil || list == nil || list.UserID != ownerID {
+		return ErrNoSuchUserList
+	}
+	return nil
+}
 
 // MaxNotesPerAntenna caps how many notes are kept per antenna in the Redis
 // stream. 古いものから XADD MAXLEN ~ で削除される。
@@ -142,18 +173,19 @@ func (s *Service) SetClock(now func() time.Time) {
 
 // CreateInput is the parameter set for Service.Create.
 type CreateInput struct {
-	OwnerID         string
-	Name            string
-	Src             model.AntennaSource
-	UserListID      *string
-	Users           []string
-	Keywords        [][]string
-	ExcludeKeywords [][]string
-	CaseSensitive   bool
-	ExcludeBots     bool
-	WithReplies     bool
-	WithFile        bool
-	LocalOnly       bool
+	OwnerID                        string
+	Name                           string
+	Src                            model.AntennaSource
+	UserListID                     *string
+	Users                          []string
+	Keywords                       [][]string
+	ExcludeKeywords                [][]string
+	CaseSensitive                  bool
+	ExcludeBots                    bool
+	WithReplies                    bool
+	WithFile                       bool
+	LocalOnly                      bool
+	ExcludeNotesInSensitiveChannel bool
 }
 
 // Create persists a new antenna and returns it.
@@ -180,26 +212,33 @@ func (s *Service) Create(in CreateInput) (*model.Antenna, error) {
 			}
 		}
 	}
+	// upstream create.ts: src='list' で userListId 指定時、自分が所有する list か検証。
+	if in.Src == model.AntennaSourceList {
+		if err := s.validateUserList(in.OwnerID, in.UserListID); err != nil {
+			return nil, err
+		}
+	}
 	// Marshal of [][]string never fails, so we ignore the error.
 	keywords, _ := json.Marshal(normalizeKeywords(in.Keywords))
 	exclude, _ := json.Marshal(normalizeKeywords(in.ExcludeKeywords))
 	now := s.clock()
 	a := &model.Antenna{
-		ID:              s.idGen.Generate(now),
-		LastUsedAt:      now,
-		UserID:          in.OwnerID,
-		Name:            in.Name,
-		Src:             in.Src,
-		UserListID:      in.UserListID,
-		Users:           in.Users,
-		Keywords:        keywords,
-		ExcludeKeywords: exclude,
-		CaseSensitive:   in.CaseSensitive,
-		ExcludeBots:     in.ExcludeBots,
-		WithReplies:     in.WithReplies,
-		WithFile:        in.WithFile,
-		LocalOnly:       in.LocalOnly,
-		IsActive:        true,
+		ID:                             s.idGen.Generate(now),
+		LastUsedAt:                     now,
+		UserID:                         in.OwnerID,
+		Name:                           in.Name,
+		Src:                            in.Src,
+		UserListID:                     in.UserListID,
+		Users:                          in.Users,
+		Keywords:                       keywords,
+		ExcludeKeywords:                exclude,
+		CaseSensitive:                  in.CaseSensitive,
+		ExcludeBots:                    in.ExcludeBots,
+		WithReplies:                    in.WithReplies,
+		WithFile:                       in.WithFile,
+		LocalOnly:                      in.LocalOnly,
+		ExcludeNotesInSensitiveChannel: in.ExcludeNotesInSensitiveChannel,
+		IsActive:                       true,
 	}
 	if err := s.repo.Create(a); err != nil {
 		return nil, err
@@ -222,18 +261,19 @@ func (s *Service) Show(ownerID, antennaID string) (*model.Antenna, error) {
 // UpdateInput holds the editable fields of an antenna. nil の field は更新
 // されない。
 type UpdateInput struct {
-	Name            *string
-	Src             *model.AntennaSource
-	UserListID      *string
-	Users           *[]string
-	Keywords        *[][]string
-	ExcludeKeywords *[][]string
-	CaseSensitive   *bool
-	ExcludeBots     *bool
-	WithReplies     *bool
-	WithFile        *bool
-	LocalOnly       *bool
-	IsActive        *bool
+	Name                           *string
+	Src                            *model.AntennaSource
+	UserListID                     *string
+	Users                          *[]string
+	Keywords                       *[][]string
+	ExcludeKeywords                *[][]string
+	CaseSensitive                  *bool
+	ExcludeBots                    *bool
+	WithReplies                    *bool
+	WithFile                       *bool
+	LocalOnly                      *bool
+	IsActive                       *bool
+	ExcludeNotesInSensitiveChannel *bool
 }
 
 // Update applies the non-nil fields to an antenna owned by ownerID.
@@ -244,6 +284,13 @@ func (s *Service) Update(ownerID, antennaID string, in UpdateInput) (*model.Ante
 	}
 	if a.UserID != ownerID {
 		return nil, ErrAccessDenied
+	}
+	// upstream update.ts: 新 src か既存 src が list で userListId 指定時、
+	// 自分が所有する list か検証する。
+	if (in.Src != nil && *in.Src == model.AntennaSourceList) || a.Src == model.AntennaSourceList {
+		if err := s.validateUserList(ownerID, in.UserListID); err != nil {
+			return nil, err
+		}
 	}
 	fields := map[string]any{}
 	if in.Name != nil {
@@ -292,6 +339,9 @@ func (s *Service) Update(ownerID, antennaID string, in UpdateInput) (*model.Ante
 	}
 	if in.LocalOnly != nil {
 		fields["localOnly"] = *in.LocalOnly
+	}
+	if in.ExcludeNotesInSensitiveChannel != nil {
+		fields["excludeNotesInSensitiveChannel"] = *in.ExcludeNotesInSensitiveChannel
 	}
 	// 本家 update.ts は編集のたびに isActive=true へ復帰させる (deactivate された
 	// antenna は編集で再び有効化される)。mk-go は isActive をユーザー param として

--- a/internal/core/antenna/antenna_service_test.go
+++ b/internal/core/antenna/antenna_service_test.go
@@ -93,6 +93,32 @@ func TestCreate_ListSourceAccepted(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestAllKeywordsEmpty(t *testing.T) {
+	assert.True(t, AllKeywordsEmpty(nil))
+	assert.True(t, AllKeywordsEmpty([][]string{}))
+	assert.True(t, AllKeywordsEmpty([][]string{{""}, {"", ""}}))
+	assert.False(t, AllKeywordsEmpty([][]string{{""}, {"foo"}}))
+	assert.False(t, AllKeywordsEmpty([][]string{{"bar"}}))
+}
+
+// src=list で他人所有 / 不在の list を参照すると ErrNoSuchUserList。
+func TestCreate_ListSource_NoSuchUserList(t *testing.T) {
+	svc, _ := newSvc(t)
+	lists := testutil.NewMockUserListRepository()
+	svc.SetUserListRepo(lists)
+	require.NoError(t, lists.Create(&model.UserList{ID: "ul1", UserID: "other", Name: "theirs"}))
+
+	// 他人所有の list。
+	notMine := "ul1"
+	_, err := svc.Create(CreateInput{OwnerID: "u1", Name: "alpha", Src: model.AntennaSourceList, UserListID: &notMine})
+	assert.ErrorIs(t, err, ErrNoSuchUserList)
+
+	// 存在しない list。
+	ghost := "ghost"
+	_, err = svc.Create(CreateInput{OwnerID: "u1", Name: "alpha", Src: model.AntennaSourceList, UserListID: &ghost})
+	assert.ErrorIs(t, err, ErrNoSuchUserList)
+}
+
 func TestCreate_RepoError(t *testing.T) {
 	svc, repo := newSvc(t)
 	repo.CreateErr = errors.New("boom")

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -4457,6 +4457,10 @@ func applyAntennaFields(a *model.Antenna, fields map[string]any) {
 			if b, ok := v.(bool); ok {
 				a.LocalOnly = b
 			}
+		case "excludeNotesInSensitiveChannel":
+			if b, ok := v.(bool); ok {
+				a.ExcludeNotesInSensitiveChannel = b
+			}
 		case "lastUsedAt":
 			if t, ok := v.(time.Time); ok {
 				a.LastUsedAt = t


### PR DESCRIPTION
## Summary

`#1544` (parity 監査) の **antennas 3 項目**を解消する。`#1544` は複数ドメインにまたがるため本 PR は antennas ドメインのみ対象とし issue は close しない (`Refs #1544`)。

なお当初監査の 5 項目目「prohibitMoved 未強制」は再検証で **解消済 (STALE)** だった (`router.go` で `middleware.RequireNotMoved()` が create/update に配線済)。

## 主な変更点

- **EMPTY_KEYWORD (create/update)**: `keywords` と `excludeKeywords` が両方とも空なら upstream の `emptyKeyword` (code `EMPTY_KEYWORD`) を返す。endpoint 層の param validation のため handler で検査する (既存の name 必須チェックと同列)。`core/antenna` の `matchNote` 系テストが keyword 無し antenna を作る前提を壊さないよう、検査は handler に置き `AllKeywordsEmpty` ヘルパーを service と共有。
- **NO_SUCH_USER_LIST (create/update)**: `src=list` で `userListId` を指定した際、自分が所有する list か検証し、不在/他人所有なら `NO_SUCH_USER_LIST` を返す (`service.validateUserList`)。update は新 src か既存 src が list のときに検査 (upstream `update.ts` と同条件)。`userListRepo` 未配線時は skip。
- **excludeNotesInSensitiveChannel (create/update)**: パラメータを受け取り永続化する (model 列は既存、これまで API から更新不可だった)。

error id は upstream golden と一致 (create: `53ee222e...` / `95063e93...`、update: `721aaff6...` / `1c6b35c9...`)。

## テスト

- handler: `TestCreate_EmptyKeyword` / `TestCreate_ExcludeKeywordOnlySatisfies` / `TestCreate_NoSuchUserList` / `TestCreate_OwnedUserListAccepted` / `TestCreate_ExcludeNotesInSensitiveChannelPersisted`、`TestUpdate_EmptyKeyword` / `TestUpdate_OneSidedKeywordsNotChecked` / `TestUpdate_NoSuchUserList` / `TestUpdate_ExcludeNotesInSensitiveChannelPersisted`
- service: `TestAllKeywordsEmpty` / `TestCreate_ListSource_NoSuchUserList`
- 既存の keyword 無し Create テスト 2 件 (`TestCreate_InvalidSource` / `TestCreate_RepoError`) に keyword を補って意図どおりの経路を通す。
- mock の `applyAntennaFields` に `excludeNotesInSensitiveChannel` を追加。
- 実行: `go test ./internal/api/antennas/... ./internal/core/antenna/... -count=1`
- カバレッジ: antennas handler 91.9% / core/antenna 95.3% (gate 維持)。

## Refs

Refs #1544 (antennas ドメイン分。残りの federation/roles は別 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)