### PR TITLE
Fix roles parity: roles/users 割当ユーザー一覧 + roles/notes の expiresAt 除外 (#1544)

### DIFF
--- a/internal/api/roles/handler.go
+++ b/internal/api/roles/handler.go
@@ -155,17 +155,91 @@ func (h *Handler) Show(c echo.Context) error {
 }
 
 // Users handles POST /api/roles/users.
+//
+// upstream users.ts: isPublic かつ isExplorable な role の roleAssignments を
+// 期限有効分だけ取得し id cursor でページングして [{id, user:UserDetailed}] を
+// 返す。!isPublic / !isExplorable は NO_SUCH_ROLE 扱い (#1544)。
 func (h *Handler) Users(c echo.Context) error {
 	var req struct {
-		RoleID string `json:"roleId"`
+		RoleID    string `json:"roleId"`
+		Limit     int    `json:"limit"`
+		SinceID   string `json:"sinceId"`
+		UntilID   string `json:"untilId"`
+		SinceDate *int64 `json:"sinceDate"`
+		UntilDate *int64 `json:"untilDate"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoleID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roleId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	if _, err := h.roleService.Show(req.RoleID); err != nil {
+	r, err := h.roleService.Show(req.RoleID)
+	if err != nil || !r.IsPublic || !r.IsExplorable {
+		// upstream は findOneBy({id, isPublic:true, isExplorable:true}) が null
+		// なら NO_SUCH_ROLE。!isPublic / !isExplorable も同じ扱い。
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROLE", "No such role.", "30aaaee3-4792-48dc-ab0d-cf501a575ac5"))
 	}
-	return c.JSON(http.StatusOK, []any{})
+
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	// sinceDate / untilDate を aidx prefix に正規化 (Notes と同 pattern、#1173)。
+	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	assigns, err := h.roleService.ListByRole(req.RoleID, untilID, sinceID, limit)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+
+	// reporter/assignee と同様に user_profile を 1 batch で解決して UserDetailed を
+	// pack する (N+1 回避)。userRepo 未配線時は profile なしで pack する。
+	profByID := h.assignmentProfiles(assigns)
+	out := make([]any, 0, len(assigns))
+	for _, a := range assigns {
+		if a.User == nil {
+			// preload 失敗 (user 削除等) は upstream では userId fallback だが、
+			// UserDetailed を組めないため skip する (defensive)。
+			continue
+		}
+		out = append(out, map[string]any{
+			"id":   a.ID,
+			"user": entity.PackUserDetailed(a.User, profByID[a.UserID], h.idGen),
+		})
+	}
+	return c.JSON(http.StatusOK, out)
+}
+
+// assignmentProfiles batch-fetches the user_profile rows of the assignees so
+// roles/users can pack UserDetailed without N+1 (#1544)。userRepo 未配線時は nil。
+func (h *Handler) assignmentProfiles(assigns []*model.RoleAssignment) map[string]*model.UserProfile {
+	if h.userRepo == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(assigns))
+	seen := map[string]struct{}{}
+	for _, a := range assigns {
+		if a.User == nil {
+			continue
+		}
+		if _, ok := seen[a.UserID]; ok {
+			continue
+		}
+		seen[a.UserID] = struct{}{}
+		ids = append(ids, a.UserID)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	profiles, err := h.userRepo.FindProfilesByUserIDs(ids)
+	if err != nil {
+		return nil
+	}
+	byID := make(map[string]*model.UserProfile, len(profiles))
+	for _, p := range profiles {
+		byID[p.UserID] = p
+	}
+	return byID
 }
 
 // Notes handles POST /api/roles/notes.

--- a/internal/api/roles/handler_test.go
+++ b/internal/api/roles/handler_test.go
@@ -201,9 +201,113 @@ func TestShow_InvalidParam(t *testing.T) {
 
 func TestUsers_Success(t *testing.T) {
 	h, roleRepo := newTestHandler(t)
-	roleRepo.Roles["r1"] = &model.Role{ID: "r1", IsPublic: true}
+	// upstream は isPublic かつ isExplorable な role のみ対象 (#1544)。
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", IsPublic: true, IsExplorable: true}
 	rec := doPost(h.Users, `{"roleId":"r1"}`)
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// newUsersTestHandler は roleRepo / assignRepo (UserRepo 紐付け済) / userRepo を
+// 露出した handler を返す (roles/users の割当ユーザー一覧テスト用)。
+func newUsersTestHandler(t *testing.T) (*roles.Handler, *testutil.MockRoleRepository, *testutil.MockRoleAssignmentRepository, *testutil.MockUserRepository) {
+	t.Helper()
+	roleRepo := testutil.NewMockRoleRepository()
+	assignRepo := testutil.NewMockRoleAssignmentRepository(roleRepo)
+	userRepo := testutil.NewMockUserRepository()
+	assignRepo.UserRepo = userRepo
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "x"}
+	idGen, _ := id.NewGenerator("aidx")
+	svc := corerole.NewService(roleRepo, assignRepo, metaRepo, idGen)
+	h := roles.NewHandler(svc, idGen)
+	h.SetUserRepo(userRepo)
+	return h, roleRepo, assignRepo, userRepo
+}
+
+// upstream users.ts: 割り当てユーザーを [{id, user:UserDetailed}] で返す (#1544)。
+func TestUsers_ReturnsAssignedUsers(t *testing.T) {
+	h, roleRepo, assignRepo, userRepo := newUsersTestHandler(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", IsPublic: true, IsExplorable: true}
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	require.NoError(t, assignRepo.Create(&model.RoleAssignment{ID: "ra1", RoleID: "r1", UserID: "alice"}))
+
+	rec := doPost(h.Users, `{"roleId":"r1"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "ra1", resp[0]["id"])
+	user, ok := resp[0]["user"].(map[string]any)
+	require.True(t, ok, "user は UserDetailed object")
+	assert.Equal(t, "alice", user["id"])
+}
+
+// 期限切れの割当 (expiresAt <= now) はユーザー一覧に現れない (#1544)。
+func TestUsers_ExpiredAssignmentExcluded(t *testing.T) {
+	h, roleRepo, assignRepo, userRepo := newUsersTestHandler(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", IsPublic: true, IsExplorable: true}
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	past := time.Now().Add(-time.Hour)
+	require.NoError(t, assignRepo.Create(&model.RoleAssignment{ID: "ra1", RoleID: "r1", UserID: "alice", ExpiresAt: &past}))
+
+	rec := doPost(h.Users, `{"roleId":"r1"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Empty(t, resp, "期限切れ割当は除外される")
+}
+
+// userRepo 未配線でも user は packed される (profile なし)。
+func TestUsers_NilUserRepoPacksWithoutProfile(t *testing.T) {
+	roleRepo := testutil.NewMockRoleRepository()
+	assignRepo := testutil.NewMockRoleAssignmentRepository(roleRepo)
+	userRepo := testutil.NewMockUserRepository()
+	assignRepo.UserRepo = userRepo // assignment.User の preload 用
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "x"}
+	idGen, _ := id.NewGenerator("aidx")
+	svc := corerole.NewService(roleRepo, assignRepo, metaRepo, idGen)
+	h := roles.NewHandler(svc, idGen) // SetUserRepo は呼ばない (profile lookup 無効)
+
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", IsPublic: true, IsExplorable: true}
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	require.NoError(t, assignRepo.Create(&model.RoleAssignment{ID: "ra1", RoleID: "r1", UserID: "alice"}))
+
+	rec := doPost(h.Users, `{"roleId":"r1"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "alice", resp[0]["user"].(map[string]any)["id"])
+}
+
+// assignment.User が nil (preload 失敗) の割当は skip され一覧に出ない。
+func TestUsers_NilUserSkipped(t *testing.T) {
+	h, roleRepo, assignRepo, _ := newUsersTestHandler(t)
+	// assignRepo.UserRepo に対応 user を入れない → a.User が nil のまま。
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", IsPublic: true, IsExplorable: true}
+	require.NoError(t, assignRepo.Create(&model.RoleAssignment{ID: "ra1", RoleID: "r1", UserID: "ghostuser"}))
+
+	rec := doPost(h.Users, `{"roleId":"r1"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Empty(t, resp, "User preload できなかった割当は skip")
+}
+
+// isPublic でも !isExplorable なら NO_SUCH_ROLE (#1544)。
+func TestUsers_NotExplorableIsNotFound(t *testing.T) {
+	h, roleRepo := newTestHandler(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", IsPublic: true, IsExplorable: false}
+	rec := doPost(h.Users, `{"roleId":"r1"}`)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestUsers_NotPublicIsNotFound(t *testing.T) {
+	h, roleRepo := newTestHandler(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", IsPublic: false, IsExplorable: true}
+	rec := doPost(h.Users, `{"roleId":"r1"}`)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
 func TestUsers_NotFound(t *testing.T) {

--- a/internal/repository/role_notes_query.go
+++ b/internal/repository/role_notes_query.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"time"
+
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/gorm"
 )
@@ -19,9 +21,13 @@ func NewRoleNotesQuery(db *gorm.DB) *RoleNotesQuery {
 func (q *RoleNotesQuery) ListByRole(roleID string, limit int, sinceID, untilID string) ([]*model.Note, error) {
 	// preloadNoteRelations で User + Renote/Reply (+User) を preload し、
 	// note.go 側の他の list 系クエリと同一の embed 方針に揃える (#416)。
+	// upstream notes.ts は fanout timeline 経由で「現に role を持つ user」だけを
+	// 対象にする。mk-go は role_assignment を JOIN するため、失効済み割当
+	// (expiresAt <= now) の user の note が漏れないよう expiresAt を除外する (#1544)。
 	query := preloadNoteRelations(q.db).Model(&model.Note{}).
 		Joins(`JOIN "role_assignment" ON "role_assignment"."userId" = "note"."userId"`).
 		Where(`"role_assignment"."roleId" = ?`, roleID).
+		Where(`("role_assignment"."expiresAt" IS NULL OR "role_assignment"."expiresAt" > ?)`, time.Now()).
 		Where(`"note"."visibility" = 'public'`).
 		Order(paginationOrder(sinceID, untilID, `"note"."id"`)).
 		Limit(limit)

--- a/internal/repository/role_notes_query_test.go
+++ b/internal/repository/role_notes_query_test.go
@@ -2,9 +2,12 @@ package repository
 
 import (
 	"testing"
+	"time"
 
+	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
 )
 
 // RoleNotesQueryはrole_assignment経由でnoteを拾うJOINクエリ。本テストでは
@@ -22,4 +25,48 @@ func TestRoleNotesQuery_ListByRole(t *testing.T) {
 	notes, err = q.ListByRole("nonexistent_role", 5, "since_dummy", "until_dummy")
 	require.NoError(t, err)
 	assert.Empty(t, notes)
+}
+
+// TestRoleNotesQuery_ListByRole_ExcludesExpiredAssignment は #1544 の
+// regression guard: role_assignment.expiresAt が失効した user の note は
+// roles/notes に漏れないこと。
+func TestRoleNotesQuery_ListByRole_ExcludesExpiredAssignment(t *testing.T) {
+	q := NewRoleNotesQuery(testDB)
+	roleRepo := NewRoleRepository(testDB)
+	assignRepo := NewRoleAssignmentRepository(testDB)
+	noteRepo := NewNoteRepository(testDB)
+
+	now := time.Now()
+	role := &model.Role{
+		ID: "role_rnq_exp", UpdatedAt: now, LastUsedAt: now, Name: "RNQExp",
+		Target: model.RoleTargetManual, Policies: datatypes.JSON([]byte("{}")),
+		CondFormula: datatypes.JSON([]byte("{}")),
+	}
+	require.NoError(t, roleRepo.Create(role))
+	defer cleanupRole(t, role.ID)
+
+	createTestUser(t, "rnq_active")
+	createTestUser(t, "rnq_expired")
+	defer cleanupUser(t, "rnq_active")
+	defer cleanupUser(t, "rnq_expired")
+
+	past := now.Add(-time.Hour)
+	require.NoError(t, assignRepo.Create(&model.RoleAssignment{ID: "rnq_a_active", UserID: "rnq_active", RoleID: role.ID}))
+	require.NoError(t, assignRepo.Create(&model.RoleAssignment{ID: "rnq_a_expired", UserID: "rnq_expired", RoleID: role.ID, ExpiresAt: &past}))
+
+	activeNote := &model.Note{ID: "rnq_n_active", UserID: "rnq_active", Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}"))}
+	expiredNote := &model.Note{ID: "rnq_n_expired", UserID: "rnq_expired", Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}"))}
+	require.NoError(t, noteRepo.Create(activeNote))
+	require.NoError(t, noteRepo.Create(expiredNote))
+	defer cleanupNote(t, activeNote.ID)
+	defer cleanupNote(t, expiredNote.ID)
+
+	notes, err := q.ListByRole(role.ID, 50, "", "")
+	require.NoError(t, err)
+	ids := make(map[string]bool, len(notes))
+	for _, n := range notes {
+		ids[n.ID] = true
+	}
+	assert.True(t, ids["rnq_n_active"], "有効な割当の note は含まれる")
+	assert.False(t, ids["rnq_n_expired"], "失効した割当の note は除外される")
 }


### PR DESCRIPTION
## Summary

`#1544` (parity 監査) の **roles 2 項目**を解消する。`#1544` は複数ドメインにまたがるため本 PR は roles ドメインのみ対象とし issue は close しない (`Refs #1544`)。

## 主な変更点

### roles/users — 割当ユーザー一覧の実装 (HIGH)
常に空配列を返すスタブだったのを、upstream `users.ts` に揃えて実装:
- `isPublic` かつ `isExplorable` な role のみ対象 (それ以外は `NO_SUCH_ROLE`)。
- `roleAssignments` を期限有効分のみ取得し id cursor (`sinceId`/`untilId`/`sinceDate`/`untilDate`/`limit`) でページング。
- `[{id, user: UserDetailed}]` を返す。`user_profile` は 1 batch で解決して N+1 を回避。

データ層 (`core/role.ListByRole` + `repository.ListByRole`) は既に `expiresAt` 除外 + cursor + `User` preload を備えていたが handler が未配線だった。

### roles/notes — expiresAt 除外 (MEDIUM, partial fix の残り)
`isExplorable` ガード + mute/block/channel-mute フィルタは既に実装済だったが、`role_notes_query` が `role_assignment` を JOIN する際に `expiresAt` を見ておらず、失効済み割当の user の note が漏れていた。`expiresAt IS NULL OR expiresAt > now` で除外する (upstream の fanout timeline 相当の「現に role を持つ user」のみ)。GORM の Where AND/OR 優先順位の罠を避けるため OR を明示括弧で囲む。

## テスト

- roles/users: `TestUsers_ReturnsAssignedUsers` / `TestUsers_ExpiredAssignmentExcluded` / `TestUsers_NotExplorableIsNotFound` / `TestUsers_NotPublicIsNotFound` / `TestUsers_NilUserRepoPacksWithoutProfile` / `TestUsers_NilUserSkipped`、既存 `TestUsers_Success` に `IsExplorable` を補う。
- roles/notes: `TestRoleNotesQuery_ListByRole_ExcludesExpiredAssignment` (repository 層の DB テスト、失効割当の note が除外されること)。
- 実行: `go test ./internal/api/roles/... ./internal/repository/... -count=1`
- カバレッジ: roles handler 93.9% (gate 維持)。

## Refs

Refs #1544 (roles ドメイン分。残りの federation は別 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)