### PR TITLE
Fix federation parity: users を UserDetailedNotMe で返す + stats の other 算出/クランプ修正 (#1544)

### DIFF
--- a/internal/api/federation/host_listings.go
+++ b/internal/api/federation/host_listings.go
@@ -77,19 +77,40 @@ func (h *Handler) Users(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	out := make([]map[string]any, 0, len(users))
+	// upstream users.ts は packMany(users, me, {schema:'UserDetailedNotMe'}) を
+	// 返す。旧実装は id/username/host/name/avatarUrl の最小 map のみで
+	// createdAt/notesCount/followersCount/description/fields/roles 等が欠落して
+	// いた (#1544)。UserDetailed で pack して shape を揃える。user_profile は
+	// 1 batch で解決して N+1 を回避。
+	profByID := h.userProfiles(users)
+	out := make([]entity.UserDetailed, 0, len(users))
 	for _, u := range users {
-		out = append(out, map[string]any{
-			"id":       u.ID,
-			"username": u.Username,
-			"host":     u.Host,
-			"name":     u.Name,
-			// リモートユーザーのアバターは proxy 経由にする (issue #1529)。
-			// IdenticonURL が avatar mode proxy 化と identicon fallback を担う。
-			"avatarUrl": entity.IdenticonURL(u),
-		})
+		out = append(out, entity.PackUserDetailed(u, profByID[u.ID], h.idGen))
 	}
 	return c.JSON(http.StatusOK, out)
+}
+
+// userProfiles batch-loads the user_profile rows for the given users keyed by
+// userId (N+1 回避)。userRepo 未配線 / 取得失敗時は nil。
+func (h *Handler) userProfiles(users []*model.User) map[string]*model.UserProfile {
+	if h.userRepo == nil || len(users) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(users))
+	for _, u := range users {
+		ids = append(ids, u.ID)
+	}
+	profiles, err := h.userRepo.FindProfilesByUserIDs(ids)
+	if err != nil {
+		return nil
+	}
+	byID := make(map[string]*model.UserProfile, len(profiles))
+	for _, p := range profiles {
+		if p != nil {
+			byID[p.UserID] = p
+		}
+	}
+	return byID
 }
 
 // parseHostPage parses + validates the common per-host page request. Returns

--- a/internal/api/federation/host_listings_test.go
+++ b/internal/api/federation/host_listings_test.go
@@ -193,6 +193,33 @@ func TestUsers_NoRepoReturnsEmpty(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// upstream users.ts は UserDetailedNotMe を返す。旧実装の最小 map では欠けて
+// いた createdAt / notesCount 等の UserDetailed field が含まれること (#1544)。
+func TestUsers_ReturnsUserDetailedShape(t *testing.T) {
+	h, _ := newHandler(t)
+	userRepo := testutil.NewMockUserRepository()
+	remote := "remote.example"
+	idGen, _ := id.NewGenerator("aidx")
+	uid := idGen.Generate(time.Now())
+	userRepo.Users[uid] = &model.User{ID: uid, Username: "alice", Host: &remote}
+	userRepo.Profiles[uid] = &model.UserProfile{UserID: uid, Description: strPtr("hello")}
+	h.SetUserRepo(userRepo)
+
+	rec := postBody(h.Users, `{"host":"remote.example"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.GreaterOrEqual(t, len(rows), 1)
+	row := rows[0]
+	// UserDetailed 固有 field (最小 map には無かった) が存在すること。
+	assert.Contains(t, row, "createdAt")
+	assert.Contains(t, row, "notesCount")
+	assert.Contains(t, row, "followersCount")
+	assert.Equal(t, "alice", row["username"])
+}
+
+func strPtr(s string) *string { return &s }
+
 // bindHostPage の limit clamp 分岐 (>100) カバー
 func TestFollowers_LimitClampedAt100(t *testing.T) {
 	h, _ := newHandler(t)

--- a/internal/api/federation/stats.go
+++ b/internal/api/federation/stats.go
@@ -34,16 +34,23 @@ func (h *Handler) Stats(c echo.Context) error {
 
 	// "+" 接頭辞が DESC (= 上位順) なので、followers / following の多い順を
 	// 取るには +followers / +following を渡す (repository の sort の向きを本家
-	// TS の federation/instances に合わせたため)。
-	subs, err := h.svc.List(model.InstanceListFilter{SortBy: "+followers", Limit: req.Limit})
+	// TS の federation/instances に合わせたため)。upstream stats.ts は
+	// followersCount>0 / followingCount>0 で絞るので Subscribing / Publishing を
+	// 立てる (= instance.go の followersCount>0 / followingCount>0 フィルタ、#1544)。
+	yes := true
+	subs, err := h.svc.List(model.InstanceListFilter{Subscribing: &yes, SortBy: "+followers", Limit: req.Limit})
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	pubs, err := h.svc.List(model.InstanceListFilter{SortBy: "+following", Limit: req.Limit})
+	pubs, err := h.svc.List(model.InstanceListFilter{Publishing: &yes, SortBy: "+following", Limit: req.Limit})
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	totalFollowers, totalFollowing, err := totalCounts(h.svc)
+	// upstream stats.ts は following テーブルを count する (allSubCount =
+	// followeeHost not null, allPubCount = followerHost not null)。旧実装は
+	// instance テーブルの followersCount/followingCount 全行合算で semantics が
+	// 異なっていた (#1544)。followingRepo 未配線時は 0 (= other は 0 クランプ)。
+	allSubCount, allPubCount, err := h.remoteFollowCounts()
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
@@ -73,38 +80,35 @@ func (h *Handler) Stats(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, map[string]any{
-		"topSubInstances":     topSub,
-		"otherFollowersCount": totalFollowers - topSubFollowers,
+		"topSubInstances": topSub,
+		// upstream: Math.max(0, allSubCount - gotSubCount)。負値クランプを揃える。
+		"otherFollowersCount": maxInt(0, int(allSubCount)-topSubFollowers),
 		"topPubInstances":     topPub,
-		"otherFollowingCount": totalFollowing - topPubFollowing,
+		"otherFollowingCount": maxInt(0, int(allPubCount)-topPubFollowing),
 	})
 }
 
-// totalCounts sums followersCount / followingCount across every instance row.
-// Scans the whole instance table in pages; OK for current scale (a few
-// thousand rows) and matches upstream Misskey's aggregation approach.
-func totalCounts(svc interface {
-	List(filter model.InstanceListFilter) ([]*model.Instance, error)
-}) (int, int, error) {
-	totalFollowers := 0
-	totalFollowing := 0
-	offset := 0
-	for {
-		page, err := svc.List(model.InstanceListFilter{Limit: 100, Offset: offset})
-		if err != nil {
-			return 0, 0, err
-		}
-		if len(page) == 0 {
-			break
-		}
-		for _, inst := range page {
-			totalFollowers += inst.FollowersCount
-			totalFollowing += inst.FollowingCount
-		}
-		if len(page) < 100 {
-			break
-		}
-		offset += 100
+// remoteFollowCounts returns (allSubCount, allPubCount) from the following
+// table: allSubCount = rows with followeeHost not null, allPubCount = rows with
+// followerHost not null. followingRepo 未配線時は (0, 0)。
+func (h *Handler) remoteFollowCounts() (int64, int64, error) {
+	if h.followingRepo == nil {
+		return 0, 0, nil
 	}
-	return totalFollowers, totalFollowing, nil
+	sub, err := h.followingRepo.CountRemoteFollowees()
+	if err != nil {
+		return 0, 0, err
+	}
+	pub, err := h.followingRepo.CountRemoteFollowers()
+	if err != nil {
+		return 0, 0, err
+	}
+	return sub, pub, nil
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/internal/api/federation/stats_test.go
+++ b/internal/api/federation/stats_test.go
@@ -3,9 +3,11 @@ package federation
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,6 +34,12 @@ func TestStats_WithTopInstances(t *testing.T) {
 	_ = instRepo.Create(&model.Instance{ID: "inst-2", Host: "beta.example", FollowersCount: 8, FollowingCount: 20})
 	_ = instRepo.Create(&model.Instance{ID: "inst-3", Host: "gamma.example", FollowersCount: 2, FollowingCount: 3})
 
+	// upstream stats.ts: allSubCount = following(followeeHost not null), allPubCount =
+	// following(followerHost not null)。following テーブルを seed して count を作る。
+	// allSubCount=20 (top 18 → other 2), allPubCount=28 (top 25 → other 3)。
+	followRepo := seedFollowCounts(t, 20, 28)
+	h.SetFollowingRepo(followRepo)
+
 	rec := postBody(h.Stats, `{"limit":2}`)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	var body map[string]any
@@ -42,14 +50,48 @@ func TestStats_WithTopInstances(t *testing.T) {
 	topPub, ok := body["topPubInstances"].([]any)
 	require.True(t, ok)
 	assert.Len(t, topPub, 2)
-	// topSubInstances は followers 上位 2 件 = 10 + 8 = 18
-	// 合計 followers = 20、other = 2
+	// topSubInstances は followers 上位 2 件 = 10 + 8 = 18、allSubCount=20、other=2
 	assert.EqualValues(t, 2, body["otherFollowersCount"])
-	// topPubInstances は following 上位 2 件 = 20 + 5 = 25
-	// 合計 following = 28、other = 3
+	// topPubInstances は following 上位 2 件 = 20 + 5 = 25、allPubCount=28、other=3
 	assert.EqualValues(t, 3, body["otherFollowingCount"])
 	// host 順 (alpha/beta/gamma) と following 順 (beta/alpha/gamma) は食い違う。
 	// topPub 先頭が beta であることで +following DESC の sort が実際に効いて
 	// いる (= host 順に素通りしていない) ことを担保する。
 	assert.Equal(t, "beta.example", topPub[0].(map[string]any)["host"])
+}
+
+// seedFollowCounts builds a following mock with sub rows (followeeHost set) and
+// pub rows (followerHost set) so CountRemoteFollowees/Followers return the given
+// counts (#1544 stats)。
+func seedFollowCounts(t *testing.T, sub, pub int) *testutil.MockFollowingRepository {
+	t.Helper()
+	repo := testutil.NewMockFollowingRepository()
+	host := "remote.example"
+	n := 0
+	for i := 0; i < sub; i++ {
+		n++
+		require.NoError(t, repo.Create(&model.Following{ID: "fsub" + itoa(n), FolloweeHost: &host}))
+	}
+	for i := 0; i < pub; i++ {
+		n++
+		require.NoError(t, repo.Create(&model.Following{ID: "fpub" + itoa(n), FollowerHost: &host}))
+	}
+	return repo
+}
+
+func itoa(n int) string { return strconv.Itoa(n) }
+
+// otherX は負にならず max(0, allX - topSum) でクランプされる (#1544)。
+func TestStats_OtherCountClampedToZero(t *testing.T) {
+	h, instRepo := newHandler(t)
+	_ = instRepo.Create(&model.Instance{ID: "inst-1", Host: "alpha.example", FollowersCount: 10, FollowingCount: 10})
+	// following テーブルは空 → allSub=allPub=0、top sum > 0 でも other は 0 にクランプ。
+	h.SetFollowingRepo(testutil.NewMockFollowingRepository())
+
+	rec := postBody(h.Stats, `{"limit":10}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.EqualValues(t, 0, body["otherFollowersCount"])
+	assert.EqualValues(t, 0, body["otherFollowingCount"])
 }

--- a/internal/repository/following.go
+++ b/internal/repository/following.go
@@ -46,6 +46,15 @@ type FollowingRepository interface {
 	// ユーザーがフォローしている = follower 側がそのホスト) ので、列は
 	// followerHost。
 	ListFollowingByHost(host string, limit, offset int) ([]*model.Following, error)
+	// CountRemoteFollowees returns the number of Following rows whose
+	// followeeHost is non-NULL (= remote users being followed by anyone).
+	// federation/stats の allSubCount (upstream count where followeeHost is
+	// not null) に対応 (#1544)。
+	CountRemoteFollowees() (int64, error)
+	// CountRemoteFollowers returns the number of Following rows whose
+	// followerHost is non-NULL (= remote users following anyone). stats の
+	// allPubCount (upstream count where followerHost is not null) に対応 (#1544)。
+	CountRemoteFollowers() (int64, error)
 	// UpdateRelation applies partial updates to a Following row identified
 	// by (followerID, followeeID). Used by following/update.
 	UpdateRelation(followerID, followeeID string, fields map[string]any) error
@@ -230,6 +239,24 @@ func (r *followingRepository) ListFollowingByHost(host string, limit, offset int
 		return nil, err
 	}
 	return rows, nil
+}
+
+func (r *followingRepository) CountRemoteFollowees() (int64, error) {
+	var n int64
+	if err := r.db.Model(&model.Following{}).
+		Where(`"followeeHost" IS NOT NULL`).Count(&n).Error; err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+func (r *followingRepository) CountRemoteFollowers() (int64, error) {
+	var n int64
+	if err := r.db.Model(&model.Following{}).
+		Where(`"followerHost" IS NOT NULL`).Count(&n).Error; err != nil {
+		return 0, err
+	}
+	return n, nil
 }
 
 // UpdateRelation applies a partial field update to a single (follower, followee)

--- a/internal/repository/following_test.go
+++ b/internal/repository/following_test.go
@@ -47,6 +47,42 @@ func TestFollowingRepository_FindByPair_NotFound(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// CountRemoteFollowees / CountRemoteFollowers は federation/stats の
+// allSubCount / allPubCount に対応 (#1544)。グローバル count なので baseline
+// からの delta を検証する。
+func TestFollowingRepository_CountRemoteFollows(t *testing.T) {
+	repo := NewFollowingRepository(testDB)
+	a := insertTestUser(t, "u_crf_a", "crfa")
+	b := insertTestUser(t, "u_crf_b", "crfb")
+	cc := insertTestUser(t, "u_crf_c", "crfc")
+	d := insertTestUser(t, "u_crf_d", "crfd")
+	defer cleanupUser(t, a.ID)
+	defer cleanupUser(t, b.ID)
+	defer cleanupUser(t, cc.ID)
+	defer cleanupUser(t, d.ID)
+
+	baseSub, err := repo.CountRemoteFollowees()
+	require.NoError(t, err)
+	basePub, err := repo.CountRemoteFollowers()
+	require.NoError(t, err)
+
+	remote := "remote.example"
+	// a→b: followeeHost set (remote followee = allSubCount)
+	subRow := &model.Following{ID: "crf_sub", FollowerID: a.ID, FolloweeID: b.ID, FolloweeHost: &remote}
+	// c→d: followerHost set (remote follower = allPubCount)
+	pubRow := &model.Following{ID: "crf_pub", FollowerID: cc.ID, FolloweeID: d.ID, FollowerHost: &remote}
+	require.NoError(t, repo.Create(subRow))
+	require.NoError(t, repo.Create(pubRow))
+	defer testDB.Exec(`DELETE FROM "following" WHERE id IN (?, ?)`, subRow.ID, pubRow.ID)
+
+	sub, err := repo.CountRemoteFollowees()
+	require.NoError(t, err)
+	assert.Equal(t, baseSub+1, sub, "followeeHost not null が 1 件増える")
+	pub, err := repo.CountRemoteFollowers()
+	require.NoError(t, err)
+	assert.Equal(t, basePub+1, pub, "followerHost not null が 1 件増える")
+}
+
 func TestFollowingRepository_Exists(t *testing.T) {
 	repo := NewFollowingRepository(testDB)
 	follower := insertTestUser(t, "u_fl_3", "follower3")

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -5222,6 +5222,26 @@ func (m *MockFollowingRepository) ListFollowingByHost(host string, limit, offset
 	return paginate(rows, limit, offset), nil
 }
 
+func (m *MockFollowingRepository) CountRemoteFollowees() (int64, error) {
+	var n int64
+	for _, f := range m.Followings {
+		if f.FolloweeHost != nil {
+			n++
+		}
+	}
+	return n, nil
+}
+
+func (m *MockFollowingRepository) CountRemoteFollowers() (int64, error) {
+	var n int64
+	for _, f := range m.Followings {
+		if f.FollowerHost != nil {
+			n++
+		}
+	}
+	return n, nil
+}
+
 func (m *MockFollowingRepository) UpdateRelation(followerID, followeeID string, fields map[string]any) error {
 	for _, f := range m.Followings {
 		if f.FollowerID == followerID && f.FolloweeID == followeeID {


### PR DESCRIPTION
## Summary

`#1544` (parity 監査) の **federation のうち自己完結する 2 項目**を解消する。`#1544` は複数ドメインにまたがるため本 PR は issue を close しない (`Refs #1544`)。

## 主な変更点

### federation/users — UserDetailedNotMe を返す (HIGH)
`{id, username, host, name, avatarUrl}` の最小 map を返していたのを、upstream `users.ts` に揃えて `UserDetailed` (UserDetailedNotMe schema) で pack する。`createdAt` / `notesCount` / `followersCount` / `description` / `fields` / `roles` 等の欠落を解消。`user_profile` は 1 batch で解決して N+1 を回避。

### federation/stats — other 算出/クランプ/フィルタ (MEDIUM)
`otherFollowersCount` / `otherFollowingCount` の算出を upstream `stats.ts` に揃える:
- `topSubInstances` / `topPubInstances` を `followersCount>0` / `followingCount>0` で絞る (`InstanceListFilter.Subscribing` / `Publishing`)。
- `allSubCount` / `allPubCount` を instance テーブル全行合算ではなく `following` テーブルの count (`followeeHost` not null / `followerHost` not null) で求める (新規 repo メソッド `CountRemoteFollowees` / `CountRemoteFollowers`)。
- `other = max(0, allX - topSum)` で負値クランプを追加。

## テスト

- `TestUsers_ReturnsUserDetailedShape` (UserDetailed 固有 field の存在)
- `TestStats_WithTopInstances` (following seed で top/other 算出を検証) / `TestStats_OtherCountClampedToZero` (0 クランプ)
- `TestFollowingRepository_CountRemoteFollows` (repository 層、delta 検証)
- 実行: `go test ./internal/api/federation/... ./internal/repository/... -count=1`
- カバレッジ: federation 91.3% / repository 90.2% (gate 維持)。

## 残項目について (別 follow-up issue に切り出し予定)

同 issue の federation 残 3 項目は cross-cutting / 要判断のため本 PR には含めず follow-up にする:
- [MEDIUM] followers/following/users の cursor pagination (`sinceId`/`untilId`/`sinceDate`/`untilDate`) — 共有の `ListUsers` / repo interface に跨る変更。
- [LOW] `isSuspended`/`suspensionState` の `softwareSuspended` 判定 — blocked-software の meta config 新設が必要。
- [LOW] `update-remote-user` の認証 (TS は `requireCredential:false`、mk-go は moderator 必須) — mk-go 側の意図的な hardening で要判断。

## Refs

Refs #1544 (federation ドメインの自己完結分)

🤖 Generated with [Claude Code](https://claude.com/claude-code)