### PR TITLE
Fix federation parity: followers/following/users に cursor pagination を実装 (#1732)

### DIFF
--- a/internal/api/federation/host_listings.go
+++ b/internal/api/federation/host_listings.go
@@ -7,15 +7,24 @@ import (
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
 	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 )
 
 // hostPageRequest is the common request body for the three per-host listing
 // endpoints (federation/followers, federation/following, federation/users).
 type hostPageRequest struct {
-	Host   string `json:"host"`
-	Limit  int    `json:"limit"`
-	Offset int    `json:"offset"`
+	Host      string `json:"host"`
+	Limit     int    `json:"limit"`
+	Offset    int    `json:"offset"`
+	SinceID   string `json:"sinceId"`
+	UntilID   string `json:"untilId"`
+	SinceDate *int64 `json:"sinceDate"`
+	UntilDate *int64 `json:"untilDate"`
+	// sinceID / untilID は parseHostPage が sinceDate/untilDate を aidx prefix に
+	// 正規化して埋める cursor 値 (#1732、upstream makePaginationQuery 互換)。
+	sinceID string
+	untilID string
 }
 
 // Followers handles POST /api/federation/followers.
@@ -30,7 +39,7 @@ func (h *Handler) Followers(c echo.Context) error {
 	if h.followingRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
-	rows, err := h.followingRepo.ListFollowersByHost(req.Host, req.Limit, req.Offset)
+	rows, err := h.followingRepo.ListFollowersByHostCursor(req.Host, req.sinceID, req.untilID, req.Limit)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
@@ -49,7 +58,7 @@ func (h *Handler) Following(c echo.Context) error {
 	if h.followingRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
-	rows, err := h.followingRepo.ListFollowingByHost(req.Host, req.Limit, req.Offset)
+	rows, err := h.followingRepo.ListFollowingByHostCursor(req.Host, req.sinceID, req.untilID, req.Limit)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
@@ -60,19 +69,20 @@ func (h *Handler) Following(c echo.Context) error {
 //
 // 指定リモートホストに属するユーザーの一覧を返す。
 func (h *Handler) Users(c echo.Context) error {
-	var req hostPageRequest
-	if err := c.Bind(&req); err != nil || req.Host == "" {
+	req, ok := parseHostPage(c)
+	if !ok {
 		return apierr.JSONInvalidParam(c)
 	}
 	if h.userRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
-	limit := pagination.ClampLimit(req.Limit, 10, 100)
 	users, err := h.userRepo.ListUsers(model.UserListFilter{
 		Origin:   "remote",
 		Hostname: req.Host,
-		Limit:    limit,
+		Limit:    req.Limit,
 		Offset:   req.Offset,
+		SinceID:  req.sinceID,
+		UntilID:  req.untilID,
 	})
 	if err != nil {
 		return apierr.JSONInternalError(c)
@@ -122,6 +132,9 @@ func parseHostPage(c echo.Context) (hostPageRequest, bool) {
 		return req, false
 	}
 	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
+	// sinceDate / untilDate を aidx prefix に正規化して cursor 値に落とす
+	// (#1732、upstream makePaginationQuery 互換)。
+	req.sinceID, req.untilID = id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
 	return req, true
 }
 

--- a/internal/api/federation/host_listings_test.go
+++ b/internal/api/federation/host_listings_test.go
@@ -156,6 +156,67 @@ func TestFollowing_PackShape(t *testing.T) {
 	assert.False(t, hasFollowee, "missing followee user must leave followee absent")
 }
 
+// upstream followers.ts は makePaginationQuery で id cursor を使う。untilId で
+// それ以前の行のみ返ること (#1732)。
+func TestFollowers_CursorUntilID(t *testing.T) {
+	h, _ := newHandler(t)
+	repo := testutil.NewMockFollowingRepository()
+	remote := "remote.example"
+	repo.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "l1", FolloweeID: "r1", FolloweeHost: &remote}
+	repo.Followings["f2"] = &model.Following{ID: "f2", FollowerID: "l2", FolloweeID: "r2", FolloweeHost: &remote}
+	repo.Followings["f3"] = &model.Following{ID: "f3", FollowerID: "l3", FolloweeID: "r3", FolloweeHost: &remote}
+	h.SetFollowingRepo(repo)
+
+	// untilId=f3 → f3 より小さい id (f1, f2) のみ、DESC で [f2, f1]。
+	rec := postBody(h.Followers, `{"host":"remote.example","untilId":"f3"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 2)
+	assert.Equal(t, "f2", rows[0]["id"])
+	assert.Equal(t, "f1", rows[1]["id"])
+}
+
+// sinceId 指定時は ASC で それ以降の行を返す (#1732)。
+func TestFollowing_CursorSinceID(t *testing.T) {
+	h, _ := newHandler(t)
+	repo := testutil.NewMockFollowingRepository()
+	remote := "remote.example"
+	repo.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "r1", FollowerHost: &remote, FolloweeID: "l1"}
+	repo.Followings["f2"] = &model.Following{ID: "f2", FollowerID: "r2", FollowerHost: &remote, FolloweeID: "l2"}
+	repo.Followings["f3"] = &model.Following{ID: "f3", FollowerID: "r3", FollowerHost: &remote, FolloweeID: "l3"}
+	h.SetFollowingRepo(repo)
+
+	// sinceId=f1 → f1 より大きい id (f2, f3) を ASC で [f2, f3]。
+	rec := postBody(h.Following, `{"host":"remote.example","sinceId":"f1"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 2)
+	assert.Equal(t, "f2", rows[0]["id"])
+	assert.Equal(t, "f3", rows[1]["id"])
+}
+
+// federation/users も id cursor (untilId) を受け付ける (#1732)。
+func TestUsers_CursorUntilID(t *testing.T) {
+	h, _ := newHandler(t)
+	userRepo := testutil.NewMockUserRepository()
+	remote := "remote.example"
+	for _, uid := range []string{"u1", "u2", "u3"} {
+		userRepo.Users[uid] = &model.User{ID: uid, Username: uid, Host: &remote}
+	}
+	h.SetUserRepo(userRepo)
+
+	// untilId=u3 → u1, u2 のみ DESC で [u2, u1]。
+	rec := postBody(h.Users, `{"host":"remote.example","untilId":"u3"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 2)
+	assert.Equal(t, "u2", rows[0]["id"])
+	assert.Equal(t, "u1", rows[1]["id"])
+}
+
 func TestUsers_FiltersByHost(t *testing.T) {
 	h, _ := newHandler(t)
 	userRepo := testutil.NewMockUserRepository()

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -80,4 +80,9 @@ type UserListFilter struct {
 	Sort     string // "+createdAt", "-createdAt", "+updatedAt", "-updatedAt", etc.
 	Limit    int
 	Offset   int
+	// Cursor pagination (federation/users 等の makePaginationQuery 互換、#1732)。
+	// 非空のときは Sort/Offset を無視して id cursor で絞る。sinceID のみ指定時は
+	// id ASC、それ以外は id DESC。
+	SinceID string
+	UntilID string
 }

--- a/internal/repository/following.go
+++ b/internal/repository/following.go
@@ -46,6 +46,14 @@ type FollowingRepository interface {
 	// ユーザーがフォローしている = follower 側がそのホスト) ので、列は
 	// followerHost。
 	ListFollowingByHost(host string, limit, offset int) ([]*model.Following, error)
+	// ListFollowersByHostCursor is ListFollowersByHost with id cursor pagination
+	// (sinceID/untilID) instead of offset. Used by federation/followers to match
+	// upstream makePaginationQuery (#1732)。sinceID のみ指定時は id ASC、
+	// それ以外は id DESC。
+	ListFollowersByHostCursor(host, sinceID, untilID string, limit int) ([]*model.Following, error)
+	// ListFollowingByHostCursor is ListFollowingByHost with id cursor pagination.
+	// Used by federation/following (#1732)。
+	ListFollowingByHostCursor(host, sinceID, untilID string, limit int) ([]*model.Following, error)
 	// CountRemoteFollowees returns the number of Following rows whose
 	// followeeHost is non-NULL (= remote users being followed by anyone).
 	// federation/stats の allSubCount (upstream count where followeeHost is
@@ -236,6 +244,52 @@ func (r *followingRepository) ListFollowingByHost(host string, limit, offset int
 	var rows []*model.Following
 	if err := r.db.Where(`"followerHost" = ?`, host).
 		Order("id DESC").Limit(limit).Offset(offset).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// ListFollowersByHostCursor is the cursor-paginated variant of
+// ListFollowersByHost (federation/followers, #1732)。
+func (r *followingRepository) ListFollowersByHostCursor(host, sinceID, untilID string, limit int) ([]*model.Following, error) {
+	if limit <= 0 {
+		limit = 30
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	q := r.db.Where(`"followeeHost" = ?`, host)
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	var rows []*model.Following
+	if err := q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// ListFollowingByHostCursor is the cursor-paginated variant of
+// ListFollowingByHost (federation/following, #1732)。
+func (r *followingRepository) ListFollowingByHostCursor(host, sinceID, untilID string, limit int) ([]*model.Following, error) {
+	if limit <= 0 {
+		limit = 30
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	q := r.db.Where(`"followerHost" = ?`, host)
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	var rows []*model.Following
+	if err := q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit).Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil

--- a/internal/repository/following_test.go
+++ b/internal/repository/following_test.go
@@ -47,6 +47,79 @@ func TestFollowingRepository_FindByPair_NotFound(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// ListFollowersByHostCursor / ListFollowingByHostCursor は federation の
+// followers/following を id cursor でページングする (#1732)。
+func TestFollowingRepository_ListByHostCursor(t *testing.T) {
+	repo := NewFollowingRepository(testDB)
+	// following は (followerId, followeeId) が unique なので各行を別 pair にする。
+	la := insertTestUser(t, "u_hc_la", "hcla")
+	lb := insertTestUser(t, "u_hc_lb", "hclb")
+	lc := insertTestUser(t, "u_hc_lc", "hclc")
+	ru := insertTestUser(t, "u_hc_ru", "hcru")
+	defer cleanupUser(t, la.ID)
+	defer cleanupUser(t, lb.ID)
+	defer cleanupUser(t, lc.ID)
+	defer cleanupUser(t, ru.ID)
+
+	host := "hostcursor.example"
+	// followeeHost=host の 3 行 (federation/followers 対象)。id は昇順 a<b<c、
+	// pair は (la→ru), (lb→ru), (lc→ru) で distinct。
+	followers := []struct{ id, follower string }{
+		{"hc_fee_a", la.ID}, {"hc_fee_b", lb.ID}, {"hc_fee_c", lc.ID},
+	}
+	for _, r := range followers {
+		row := &model.Following{ID: r.id, FollowerID: r.follower, FolloweeID: ru.ID, FolloweeHost: &host}
+		require.NoError(t, repo.Create(row))
+		defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, r.id)
+	}
+
+	// untilID=hc_fee_c → a, b のみ DESC で [b, a]。
+	rows, err := repo.ListFollowersByHostCursor(host, "", "hc_fee_c", 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "hc_fee_b", rows[0].ID)
+	assert.Equal(t, "hc_fee_a", rows[1].ID)
+
+	// sinceID=hc_fee_a → b, c のみ ASC で [b, c]。
+	rows, err = repo.ListFollowersByHostCursor(host, "hc_fee_a", "", 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "hc_fee_b", rows[0].ID)
+	assert.Equal(t, "hc_fee_c", rows[1].ID)
+
+	// followerHost 版 (federation/following) も動くこと (default id DESC)。
+	// pair は (ru→la), (ru→lb) で distinct。
+	host2 := "hostcursor2.example"
+	following := []struct{ id, followee string }{
+		{"hc_fer_a", la.ID}, {"hc_fer_b", lb.ID},
+	}
+	for _, r := range following {
+		row := &model.Following{ID: r.id, FollowerID: ru.ID, FollowerHost: &host2, FolloweeID: r.followee}
+		require.NoError(t, repo.Create(row))
+		defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, r.id)
+	}
+	rows, err = repo.ListFollowingByHostCursor(host2, "", "", 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "hc_fer_b", rows[0].ID, "default は id DESC")
+
+	// following 版の sinceID / untilID 分岐 + limit<=0 のデフォルト適用も通す。
+	rows, err = repo.ListFollowingByHostCursor(host2, "hc_fer_a", "", 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "hc_fer_b", rows[0].ID, "sinceID 指定 + limit<=0 デフォルト")
+
+	rows, err = repo.ListFollowingByHostCursor(host2, "", "hc_fer_b", 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "hc_fer_a", rows[0].ID, "untilID 指定")
+
+	// followers 版も limit<=0 デフォルト適用を通す (全 3 行返る)。
+	rows, err = repo.ListFollowersByHostCursor(host, "", "", 0)
+	require.NoError(t, err)
+	assert.Len(t, rows, 3)
+}
+
 // CountRemoteFollowees / CountRemoteFollowers は federation/stats の
 // allSubCount / allPubCount に対応 (#1544)。グローバル count なので baseline
 // からの delta を検証する。

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -463,7 +463,28 @@ func (r *userRepository) ListUsers(filter model.UserListFilter) ([]*model.User, 
 	case "-follower":
 		q = q.Order(`"followersCount" ASC`)
 	default:
-		q = q.Order("id ASC")
+		// cursor 指定時は下で id order を付けるので default order は付けない。
+		if filter.SinceID == "" && filter.UntilID == "" {
+			q = q.Order("id ASC")
+		}
+	}
+
+	// cursor pagination (federation/users 等、#1732)。非空のときは Sort/Offset を
+	// 無視して id cursor で絞る (makePaginationQuery 互換)。
+	cursor := filter.SinceID != "" || filter.UntilID != ""
+	if filter.SinceID != "" {
+		q = q.Where(`"id" > ?`, filter.SinceID)
+	}
+	if filter.UntilID != "" {
+		q = q.Where(`"id" < ?`, filter.UntilID)
+	}
+	if cursor {
+		// sinceId のみ指定時は ASC、それ以外は DESC (Misskey keyset 互換)。
+		if filter.SinceID != "" && filter.UntilID == "" {
+			q = q.Order("id ASC")
+		} else {
+			q = q.Order("id DESC")
+		}
 	}
 
 	limit := filter.Limit
@@ -474,7 +495,7 @@ func (r *userRepository) ListUsers(filter model.UserListFilter) ([]*model.User, 
 		limit = 100
 	}
 	q = q.Limit(limit)
-	if filter.Offset > 0 {
+	if !cursor && filter.Offset > 0 {
 		q = q.Offset(filter.Offset)
 	}
 

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -976,6 +976,42 @@ func TestUserRepository_ListUsers_RemoteOrigin(t *testing.T) {
 	assert.NotNil(t, users)
 }
 
+// ListUsers の id cursor (federation/users 等、#1732)。SinceID/UntilID 指定時は
+// Offset を無視し id 順に絞る。一意な host で seed して決定的に検証する。
+func TestUserRepository_ListUsers_Cursor(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	host := "lucursor.example"
+	tok := func(s string) *string { return &s }
+	hostP := host
+	for _, uid := range []string{"lu_cur_a", "lu_cur_b", "lu_cur_c"} {
+		u := &model.User{
+			ID: uid, Username: uid, UsernameLower: uid, Host: &hostP,
+			Token: tok("tok_" + uid), AvatarDecorations: datatypes.JSON([]byte("[]")),
+		}
+		require.NoError(t, testDB.Create(u).Error)
+		defer cleanupUser(t, uid)
+	}
+
+	f := model.UserListFilter{Origin: "remote", Hostname: host, Limit: 10}
+
+	// untilID=lu_cur_c → a, b のみ DESC で [b, a]。
+	f.UntilID = "lu_cur_c"
+	users, err := repo.ListUsers(f)
+	require.NoError(t, err)
+	require.Len(t, users, 2)
+	assert.Equal(t, "lu_cur_b", users[0].ID)
+	assert.Equal(t, "lu_cur_a", users[1].ID)
+
+	// sinceID=lu_cur_a → b, c のみ ASC で [b, c]。
+	f.UntilID = ""
+	f.SinceID = "lu_cur_a"
+	users, err = repo.ListUsers(f)
+	require.NoError(t, err)
+	require.Len(t, users, 2)
+	assert.Equal(t, "lu_cur_b", users[0].ID)
+	assert.Equal(t, "lu_cur_c", users[1].ID)
+}
+
 func TestUserRepository_ListUsers_AliveState(t *testing.T) {
 	repo := NewUserRepository(testDB)
 	users, err := repo.ListUsers(model.UserListFilter{State: "alive", Limit: 10})

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -298,6 +298,30 @@ func (m *MockUserRepository) ListUsers(filter model.UserListFilter) ([]*model.Us
 	if limit <= 0 {
 		limit = 10
 	}
+	// cursor pagination (federation/users 等、#1732)。SinceID/UntilID 指定時は
+	// id cursor で絞り Offset を無視し、production の paginationOrder に揃えて
+	// sinceID-only は ASC、それ以外は DESC で並べる。
+	if filter.SinceID != "" || filter.UntilID != "" {
+		var filtered []*model.User
+		for _, u := range result {
+			if filter.SinceID != "" && u.ID <= filter.SinceID {
+				continue
+			}
+			if filter.UntilID != "" && u.ID >= filter.UntilID {
+				continue
+			}
+			filtered = append(filtered, u)
+		}
+		if filter.SinceID != "" && filter.UntilID == "" {
+			sort.SliceStable(filtered, func(i, j int) bool { return filtered[i].ID < filtered[j].ID })
+		} else {
+			sort.SliceStable(filtered, func(i, j int) bool { return filtered[i].ID > filtered[j].ID })
+		}
+		if len(filtered) > limit {
+			filtered = filtered[:limit]
+		}
+		return filtered, nil
+	}
 	offset := filter.Offset
 	if offset >= len(result) {
 		return nil, nil
@@ -5224,6 +5248,51 @@ func (m *MockFollowingRepository) ListFollowingByHost(host string, limit, offset
 		}
 	}
 	return paginate(rows, limit, offset), nil
+}
+
+// hostCursorPage filters followings by a host-column selector with id cursor
+// pagination, mirroring paginationOrder (sinceID-only ASC, else DESC) (#1732)。
+func (m *MockFollowingRepository) hostCursorPage(match func(*model.Following) bool, sinceID, untilID string, limit int) []*model.Following {
+	if limit <= 0 {
+		limit = 30
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	var rows []*model.Following
+	for _, f := range m.Followings {
+		if !match(f) {
+			continue
+		}
+		if sinceID != "" && f.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && f.ID >= untilID {
+			continue
+		}
+		rows = append(rows, f)
+	}
+	if sinceID != "" && untilID == "" {
+		sort.SliceStable(rows, func(i, j int) bool { return rows[i].ID < rows[j].ID })
+	} else {
+		sort.SliceStable(rows, func(i, j int) bool { return rows[i].ID > rows[j].ID })
+	}
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	return rows
+}
+
+func (m *MockFollowingRepository) ListFollowersByHostCursor(host, sinceID, untilID string, limit int) ([]*model.Following, error) {
+	return m.hostCursorPage(func(f *model.Following) bool {
+		return f.FolloweeHost != nil && *f.FolloweeHost == host
+	}, sinceID, untilID, limit), nil
+}
+
+func (m *MockFollowingRepository) ListFollowingByHostCursor(host, sinceID, untilID string, limit int) ([]*model.Following, error) {
+	return m.hostCursorPage(func(f *model.Following) bool {
+		return f.FollowerHost != nil && *f.FollowerHost == host
+	}, sinceID, untilID, limit), nil
 }
 
 func (m *MockFollowingRepository) CountRemoteFollowees() (int64, error) {


### PR DESCRIPTION
## Summary

`#1732` (federation 残差分) の **cursor pagination 項目**を解消する。残 2 項目 (softwareSuspended / update-remote-user 認証) は別途扱うため本 PR は issue を close しない (`Refs #1732`)。

federation/followers・following・users は offset のみで `sinceId`/`untilId`/`sinceDate`/`untilDate` を受け付けず、frontend (`MkPagination`) が送る `untilId` を無視して末尾検知できず無限ロードになる upstream 不整合があった (`#487` 等と同種)。upstream の `makePaginationQuery` に揃えて id cursor 対応する。

## 主な変更点

- **`hostPageRequest`**: `sinceId`/`untilId`/`sinceDate`/`untilDate` を追加し、`parseHostPage` で `id.NormalizeCursor` により `sinceDate`/`untilDate` を aidx prefix に正規化。
- **following repo**: `ListFollowersByHostCursor` / `ListFollowingByHostCursor` を追加 (既存の offset 版は admin の bulk 経路が使うため温存)。`sinceID` のみ ASC、それ以外 DESC の keyset (`paginationOrder`)。
- **`UserListFilter`**: `SinceID`/`UntilID` を追加し `ListUsers` で cursor 適用 (非空時は `Sort`/`Offset` を無視して id 順)。admin/show-users 等は cursor 未指定で従来動作のまま (後方互換)。
- **federation/users**: `parseHostPage` 経由に統一し `ListUsers` に cursor を渡す。

## テスト

- handler: `TestFollowers_CursorUntilID` / `TestFollowing_CursorSinceID` / `TestUsers_CursorUntilID`
- repository: `TestFollowingRepository_ListByHostCursor` (since/until/limit 分岐) / `TestUserRepository_ListUsers_Cursor`
- mock の `MockFollowingRepository` に cursor メソッド、`MockUserRepository.ListUsers` に cursor 分岐を追加。
- 実行: `go test ./internal/api/federation/... ./internal/repository/... -count=1`
- カバレッジ: federation 91.3% / repository 90.2% (gate 維持)。

## Refs

Refs #1732 (cursor pagination 分。残り softwareSuspended / update-remote-user 認証は別対応)

🤖 Generated with [Claude Code](https://claude.com/claude-code)