### PR TITLE
Fix federation parity: instances/show-instance/stats に softwareSuspended 判定を反映 (#1732)

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/server/middleware"
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
@@ -1223,6 +1224,9 @@ func (h *Handler) UpdateMeta(c echo.Context) error {
 	// すべての varchar[] 列に影響していたバグで、admin が whitelist 連合や
 	// host ブロックを保存しても永続化されない原因だった。
 	coerceMetaArrayFields(fields)
+	// jsonb 列 (deliverSuspendedSoftware) は decoded []any を []byte に marshal
+	// しないと UPDATE が型不一致で失敗する (#1732)。
+	coerceMetaJSONBFields(fields)
 
 	// VAPID 鍵 auto-generate (#492): Service Worker 有効化時に
 	// swPublicKey / swPrivateKey が両方空のとき backend で生成して詰める。
@@ -1453,6 +1457,34 @@ func coerceMetaArrayFields(fields map[string]any) {
 		}
 		// pq.StringArray / []string が来ているケースは driver.Valuer 互換
 		// なのでそのまま real repo に流す。
+	}
+}
+
+// metaJSONBColumns lists meta jsonb columns whose update-meta payload arrives as
+// a decoded []any / map[string]any and must be json.Marshal された []byte に
+// 変換しないと jsonb 列の UPDATE が型不一致で失敗する (#1732 deliverSuspendedSoftware)。
+var metaJSONBColumns = map[string]struct{}{
+	"deliverSuspendedSoftware": {},
+}
+
+// coerceMetaJSONBFields marshals decoded JSON values for known jsonb meta
+// columns into datatypes.JSON ([]byte) so GORM/pgx can write them. nil は
+// 空配列扱い、既に []byte/string のものはそのまま流す。
+func coerceMetaJSONBFields(fields map[string]any) {
+	for k, v := range fields {
+		if _, ok := metaJSONBColumns[k]; !ok {
+			continue
+		}
+		switch v.(type) {
+		case nil:
+			fields[k] = datatypes.JSON([]byte("[]"))
+		case []byte, string, datatypes.JSON:
+			// 既に raw JSON。そのまま流す。
+		default:
+			if raw, err := json.Marshal(v); err == nil {
+				fields[k] = datatypes.JSON(raw)
+			}
+		}
 	}
 }
 

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -639,6 +639,20 @@ func TestUpdateMeta_SwPublickeyAliasIsTranslated(t *testing.T) {
 	assert.Equal(t, "KEY", *metaRepo.Meta.SwPublicKey)
 }
 
+// deliverSuspendedSoftware は jsonb 列。JSON decode された []any を
+// coerceMetaJSONBFields が []byte に marshal して永続化できること (#1732)。
+func TestUpdateMeta_DeliverSuspendedSoftware(t *testing.T) {
+	h, _, metaRepo, _ := newTestHandler(t)
+	rec := doPost(h.UpdateMeta, `{"deliverSuspendedSoftware":[{"software":"mastodon","versionRange":"*"}]}`, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.NotEmpty(t, metaRepo.Meta.DeliverSuspendedSoftware, "jsonb 列が永続化される")
+	var entries []model.SuspendedSoftwareEntry
+	require.NoError(t, json.Unmarshal(metaRepo.Meta.DeliverSuspendedSoftware, &entries))
+	require.Len(t, entries, 1)
+	assert.Equal(t, "mastodon", entries[0].Software)
+	assert.Equal(t, "*", entries[0].VersionRange)
+}
+
 // JSON で送られてくる array は []any{...} に decode されるが、そのまま
 // repo.Update に流すと lib/pq が varchar[] 列に書けず "expression is of
 // type record" で UPDATE 全体が落ちる。handler 側の coerceMetaArrayFields

--- a/internal/api/federation/handler.go
+++ b/internal/api/federation/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
+	corefederation "github.com/shiroha-a/mk/internal/core/federation"
 	coreinstance "github.com/shiroha-a/mk/internal/core/instance"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -206,6 +207,16 @@ func instanceToMap(inst *model.Instance, hosts coreinstance.FederationHostSets, 
 	if showModerationNote {
 		moderationNote = inst.ModerationNote
 	}
+	// softwareSuspended: meta.deliverSuspendedSoftware に該当する software なら
+	// 配送停止扱い。upstream InstanceEntityService は
+	// isSuspended = suspensionState!=='none' || softwareSuspended、
+	// suspensionState は none かつ softwareSuspended なら 'softwareSuspended' (#1732)。
+	softwareSuspended := corefederation.MatchSuspendedSoftware(inst.SoftwareName, inst.SoftwareVersion, hosts.SuspendedSoftware)
+	isSuspended := inst.SuspensionState != model.SuspensionStateNone || softwareSuspended
+	var suspensionState any = inst.SuspensionState
+	if inst.SuspensionState == model.SuspensionStateNone && softwareSuspended {
+		suspensionState = "softwareSuspended"
+	}
 	return map[string]any{
 		"id":                      inst.ID,
 		"firstRetrievedAt":        inst.FirstRetrievedAt,
@@ -220,8 +231,8 @@ func instanceToMap(inst *model.Instance, hosts coreinstance.FederationHostSets, 
 		"latestRequestReceivedAt": inst.LatestRequestReceivedAt,
 		"isNotResponding":         inst.IsNotResponding,
 		"notRespondingSince":      inst.NotRespondingSince,
-		"isSuspended":             inst.SuspensionState != model.SuspensionStateNone,
-		"suspensionState":         inst.SuspensionState,
+		"isSuspended":             isSuspended,
+		"suspensionState":         suspensionState,
 		"isBlocked":               coreinstance.HostMatchesAny(hosts.Blocked, inst.Host),
 		"isSilenced":              coreinstance.HostMatchesAny(hosts.Silenced, inst.Host),
 		"isMediaSilenced":         coreinstance.HostMatchesAny(hosts.MediaSilenced, inst.Host),

--- a/internal/api/federation/handler_test.go
+++ b/internal/api/federation/handler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
 )
 
 func newHandler(t *testing.T) (*Handler, *testutil.MockInstanceRepository) {
@@ -120,6 +121,68 @@ func TestShowInstance_ModerationNoteVisibleToModerator(t *testing.T) {
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Equal(t, "secret moderator memo", resp["moderationNote"])
+}
+
+// softwareSuspended: meta.deliverSuspendedSoftware に該当する software の
+// instance は isSuspended=true、suspensionState='softwareSuspended' を返す (#1732)。
+func TestShowInstance_SoftwareSuspended(t *testing.T) {
+	h, repo, metaRepo := newHandlerWithMeta(t)
+	metaRepo.Meta = &model.Meta{
+		DeliverSuspendedSoftware: datatypes.JSON([]byte(`[{"software":"mastodon","versionRange":"*"}]`)),
+	}
+	inst := seedInstance(t, repo, "masto.example")
+	name := "mastodon"
+	ver := "4.2.0"
+	inst.SoftwareName = &name
+	inst.SoftwareVersion = &ver
+
+	c, rec := newReq(t, `{"host":"masto.example"}`)
+	require.NoError(t, h.ShowInstance(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["isSuspended"])
+	assert.Equal(t, "softwareSuspended", resp["suspensionState"])
+}
+
+// 該当しない software の instance は従来どおり isSuspended=false / state=none。
+func TestShowInstance_SoftwareNotSuspended(t *testing.T) {
+	h, repo, metaRepo := newHandlerWithMeta(t)
+	metaRepo.Meta = &model.Meta{
+		DeliverSuspendedSoftware: datatypes.JSON([]byte(`[{"software":"mastodon","versionRange":"*"}]`)),
+	}
+	inst := seedInstance(t, repo, "mk.example")
+	name := "misskey"
+	inst.SoftwareName = &name
+
+	c, rec := newReq(t, `{"host":"mk.example"}`)
+	require.NoError(t, h.ShowInstance(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["isSuspended"])
+	assert.Equal(t, "none", resp["suspensionState"])
+}
+
+// 手動 suspend 済みの instance は softwareSuspended に関わらず元の state を保つ。
+func TestShowInstance_ManualSuspensionStatePreserved(t *testing.T) {
+	h, repo, metaRepo := newHandlerWithMeta(t)
+	metaRepo.Meta = &model.Meta{
+		DeliverSuspendedSoftware: datatypes.JSON([]byte(`[{"software":"mastodon","versionRange":"*"}]`)),
+	}
+	inst := seedInstance(t, repo, "masto2.example")
+	name := "mastodon"
+	inst.SoftwareName = &name
+	inst.SuspensionState = model.SuspensionStateManuallySuspended
+
+	c, rec := newReq(t, `{"host":"masto2.example"}`)
+	require.NoError(t, h.ShowInstance(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["isSuspended"])
+	// none ではないので 'softwareSuspended' で上書きせず元の状態を返す。
+	assert.Equal(t, "manuallySuspended", resp["suspensionState"])
 }
 
 // 認証済みでも moderator でなければ moderationNote は隠す。

--- a/internal/core/federation/suspended.go
+++ b/internal/core/federation/suspended.go
@@ -9,9 +9,40 @@ import (
 )
 
 // SuspendedSoftwareEntry represents one entry in meta.deliverSuspendedSoftware.
-type SuspendedSoftwareEntry struct {
-	Software     string `json:"software"`
-	VersionRange string `json:"versionRange"`
+// 型は model に置き、display (federation/instances 等) と deliver gate で共有
+// する。マッチ判定は MatchSuspendedSoftware に集約する (#1732)。
+type SuspendedSoftwareEntry = model.SuspendedSoftwareEntry
+
+// MatchSuspendedSoftware reports whether an instance running softwareName /
+// softwareVersion matches any deliverSuspendedSoftware entry. 本家
+// UtilityService.isDeliverSuspendedSoftware 相当で、softwareName を
+// case-insensitive 比較し、versionRange が "*" なら全バージョン一致、
+// softwareVersion が nil なら "*" 以外はマッチしない。バージョン比較は簡易
+// semver (完全一致 / "1.2" は "1.2.3" や "1.2-rc" にマッチ) で行う。federation/
+// instances 等の display と deliver gate の双方が使う。
+func MatchSuspendedSoftware(softwareName, softwareVersion *string, entries []SuspendedSoftwareEntry) bool {
+	if len(entries) == 0 || softwareName == nil {
+		return false
+	}
+	name := strings.ToLower(*softwareName)
+	for _, e := range entries {
+		if strings.ToLower(e.Software) != name {
+			continue
+		}
+		if e.VersionRange == "*" {
+			return true
+		}
+		if softwareVersion == nil {
+			continue
+		}
+		ver := *softwareVersion
+		if ver == e.VersionRange ||
+			strings.HasPrefix(ver, e.VersionRange+".") ||
+			strings.HasPrefix(ver, e.VersionRange+"-") {
+			return true
+		}
+	}
+	return false
 }
 
 // SuspendedChecker determines whether delivery to an instance should be
@@ -41,32 +72,5 @@ func (c *SuspendedChecker) IsSuspended(host string) bool {
 		return false
 	}
 
-	return matchesSuspendedSoftware(inst, c.entries)
-}
-
-func matchesSuspendedSoftware(inst *model.Instance, entries []SuspendedSoftwareEntry) bool {
-	if inst.SoftwareName == nil {
-		return false
-	}
-	name := strings.ToLower(*inst.SoftwareName)
-
-	for _, e := range entries {
-		if strings.ToLower(e.Software) != name {
-			continue
-		}
-		// versionRange が "*" なら全バージョンマッチ
-		if e.VersionRange == "*" {
-			return true
-		}
-		// softwareVersion が nil なら "*" 以外ではマッチしない
-		if inst.SoftwareVersion == nil {
-			continue
-		}
-		// 完全一致 or プレフィックスマッチ (簡易 semver — "1.2" は "1.2.3" にマッチ)
-		ver := *inst.SoftwareVersion
-		if ver == e.VersionRange || strings.HasPrefix(ver, e.VersionRange+".") || strings.HasPrefix(ver, e.VersionRange+"-") {
-			return true
-		}
-	}
-	return false
+	return MatchSuspendedSoftware(inst.SoftwareName, inst.SoftwareVersion, c.entries)
 }

--- a/internal/core/federation/suspended_test.go
+++ b/internal/core/federation/suspended_test.go
@@ -4,74 +4,40 @@ import (
 	"testing"
 
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestMatchesSuspendedSoftware_WildcardVersion(t *testing.T) {
-	name := "mastodon"
-	ver := "4.2.0"
-	inst := &model.Instance{SoftwareName: &name, SoftwareVersion: &ver}
-	entries := []SuspendedSoftwareEntry{{Software: "Mastodon", VersionRange: "*"}}
-	assert.True(t, matchesSuspendedSoftware(inst, entries))
-}
+func strp(s string) *string { return &s }
 
-func TestMatchesSuspendedSoftware_ExactVersion(t *testing.T) {
-	name := "pixelfed"
-	ver := "0.12.4"
-	inst := &model.Instance{SoftwareName: &name, SoftwareVersion: &ver}
-	entries := []SuspendedSoftwareEntry{{Software: "Pixelfed", VersionRange: "0.12.4"}}
-	assert.True(t, matchesSuspendedSoftware(inst, entries))
-}
-
-func TestMatchesSuspendedSoftware_PrefixMatch(t *testing.T) {
-	name := "pleroma"
-	ver := "2.6.3-beta1"
-	inst := &model.Instance{SoftwareName: &name, SoftwareVersion: &ver}
-	entries := []SuspendedSoftwareEntry{{Software: "Pleroma", VersionRange: "2.6.3"}}
-	assert.True(t, matchesSuspendedSoftware(inst, entries))
-}
-
-func TestMatchesSuspendedSoftware_NoMatch(t *testing.T) {
-	name := "mastodon"
-	ver := "4.3.0"
-	inst := &model.Instance{SoftwareName: &name, SoftwareVersion: &ver}
+// MatchSuspendedSoftware のマッチ判定を網羅する (display + deliver gate 共有)。
+func TestMatchSuspendedSoftware(t *testing.T) {
 	entries := []SuspendedSoftwareEntry{{Software: "Mastodon", VersionRange: "4.2.0"}}
-	assert.False(t, matchesSuspendedSoftware(inst, entries))
-}
-
-func TestMatchesSuspendedSoftware_DifferentSoftware(t *testing.T) {
-	name := "misskey"
-	ver := "2024.1.0"
-	inst := &model.Instance{SoftwareName: &name, SoftwareVersion: &ver}
-	entries := []SuspendedSoftwareEntry{{Software: "Mastodon", VersionRange: "*"}}
-	assert.False(t, matchesSuspendedSoftware(inst, entries))
-}
-
-func TestMatchesSuspendedSoftware_NilSoftwareName(t *testing.T) {
-	inst := &model.Instance{SoftwareName: nil}
-	entries := []SuspendedSoftwareEntry{{Software: "Mastodon", VersionRange: "*"}}
-	assert.False(t, matchesSuspendedSoftware(inst, entries))
-}
-
-func TestMatchesSuspendedSoftware_NilVersion_Wildcard(t *testing.T) {
-	name := "mastodon"
-	inst := &model.Instance{SoftwareName: &name, SoftwareVersion: nil}
-	entries := []SuspendedSoftwareEntry{{Software: "Mastodon", VersionRange: "*"}}
-	assert.True(t, matchesSuspendedSoftware(inst, entries))
-}
-
-func TestMatchesSuspendedSoftware_NilVersion_Specific(t *testing.T) {
-	name := "mastodon"
-	inst := &model.Instance{SoftwareName: &name, SoftwareVersion: nil}
-	entries := []SuspendedSoftwareEntry{{Software: "Mastodon", VersionRange: "4.2.0"}}
-	assert.False(t, matchesSuspendedSoftware(inst, entries))
-}
-
-func TestMatchesSuspendedSoftware_EmptyEntries(t *testing.T) {
-	name := "mastodon"
-	ver := "4.2.0"
-	inst := &model.Instance{SoftwareName: &name, SoftwareVersion: &ver}
-	assert.False(t, matchesSuspendedSoftware(inst, nil))
+	wildcard := []SuspendedSoftwareEntry{{Software: "Mastodon", VersionRange: "*"}}
+	tests := []struct {
+		name    string
+		swName  *string
+		swVer   *string
+		entries []SuspendedSoftwareEntry
+		want    bool
+	}{
+		{"wildcard version", strp("mastodon"), strp("4.2.0"), wildcard, true},
+		{"exact version", strp("pixelfed"), strp("0.12.4"), []SuspendedSoftwareEntry{{Software: "Pixelfed", VersionRange: "0.12.4"}}, true},
+		{"prefix dot match", strp("pleroma"), strp("2.6.3-beta1"), []SuspendedSoftwareEntry{{Software: "Pleroma", VersionRange: "2.6.3"}}, true},
+		{"prefix sub match", strp("akkoma"), strp("3.10.4"), []SuspendedSoftwareEntry{{Software: "Akkoma", VersionRange: "3.10"}}, true},
+		{"no version match", strp("mastodon"), strp("4.3.0"), entries, false},
+		{"different software", strp("misskey"), strp("2024.1.0"), wildcard, false},
+		{"nil software name", nil, strp("4.2.0"), wildcard, false},
+		{"nil version + wildcard", strp("mastodon"), nil, wildcard, true},
+		{"nil version + specific", strp("mastodon"), nil, entries, false},
+		{"empty entries", strp("mastodon"), strp("4.2.0"), nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, MatchSuspendedSoftware(tt.swName, tt.swVer, tt.entries))
+		})
+	}
 }
 
 func TestNewSuspendedChecker_InvalidJSON(t *testing.T) {
@@ -87,4 +53,20 @@ func TestSuspendedChecker_EmptyHost(t *testing.T) {
 func TestSuspendedChecker_EmptyEntries(t *testing.T) {
 	c := NewSuspendedChecker([]byte(`[]`), nil)
 	assert.False(t, c.IsSuspended("example.com"))
+}
+
+// IsSuspended は host の instance を引いて software をマッチさせる。
+func TestSuspendedChecker_IsSuspended_MatchAndMiss(t *testing.T) {
+	repo := testutil.NewMockInstanceRepository()
+	name := "mastodon"
+	ver := "4.2.0"
+	require.NoError(t, repo.Create(&model.Instance{ID: "i1", Host: "blocked.example", SoftwareName: &name, SoftwareVersion: &ver}))
+	other := "misskey"
+	require.NoError(t, repo.Create(&model.Instance{ID: "i2", Host: "ok.example", SoftwareName: &other, SoftwareVersion: &ver}))
+
+	c := NewSuspendedChecker([]byte(`[{"software":"mastodon","versionRange":"*"}]`), repo)
+	assert.True(t, c.IsSuspended("blocked.example"), "mastodon は suspend 対象")
+	assert.False(t, c.IsSuspended("ok.example"), "misskey は対象外")
+	// instance レコードが無い host は false (FindByHost error)。
+	assert.False(t, c.IsSuspended("unknown.example"))
 }

--- a/internal/core/instance/instance_service.go
+++ b/internal/core/instance/instance_service.go
@@ -3,6 +3,7 @@
 package instance
 
 import (
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"strings"
@@ -363,6 +364,9 @@ type FederationHostSets struct {
 	Blocked       []string
 	Silenced      []string
 	MediaSilenced []string
+	// SuspendedSoftware は meta.deliverSuspendedSoftware をパースしたもの。
+	// federation/instances 等の softwareSuspended 表示判定に使う (#1732)。
+	SuspendedSoftware []model.SuspendedSoftwareEntry
 }
 
 // FederationHostLists returns the blocked / silenced / media-silenced host
@@ -379,10 +383,17 @@ func (s *Service) FederationHostLists() (FederationHostSets, error) {
 	if err != nil {
 		return FederationHostSets{}, err
 	}
+	// deliverSuspendedSoftware (jsonb) を softwareSuspended 判定用に parse する
+	// (#1732)。不正な JSON は空扱い (best-effort)。
+	var suspended []model.SuspendedSoftwareEntry
+	if len(meta.DeliverSuspendedSoftware) > 0 {
+		_ = json.Unmarshal(meta.DeliverSuspendedSoftware, &suspended)
+	}
 	return FederationHostSets{
-		Blocked:       meta.BlockedHosts,
-		Silenced:      meta.SilencedHosts,
-		MediaSilenced: meta.MediaSilencedHosts,
+		Blocked:           meta.BlockedHosts,
+		Silenced:          meta.SilencedHosts,
+		MediaSilenced:     meta.MediaSilencedHosts,
+		SuspendedSoftware: suspended,
 	}, nil
 }
 

--- a/internal/model/software_suspension.go
+++ b/internal/model/software_suspension.go
@@ -1,0 +1,10 @@
+package model
+
+// SuspendedSoftwareEntry is one entry of meta.deliverSuspendedSoftware:
+// federation delivery to instances running the matching software (+ version
+// range) is suspended. Misskey TS の SoftwareSuspension に対応。マッチ判定は
+// core/federation.MatchSuspendedSoftware が行う (#1732)。
+type SuspendedSoftwareEntry struct {
+	Software     string `json:"software"`
+	VersionRange string `json:"versionRange"`
+}

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
@@ -2520,6 +2521,15 @@ func (m *MockMetaRepository) Update(fields map[string]any) error {
 			setStrArr(&m.Meta.FederationHosts, k, v)
 		case "blockedHosts":
 			setStrArr(&m.Meta.BlockedHosts, k, v)
+		case "deliverSuspendedSoftware":
+			// jsonb 列。handler の coerceMetaJSONBFields で []byte/datatypes.JSON
+			// に正規化済みのものを反映する (#1732)。
+			switch b := v.(type) {
+			case datatypes.JSON:
+				m.Meta.DeliverSuspendedSoftware = b
+			case []byte:
+				m.Meta.DeliverSuspendedSoftware = datatypes.JSON(b)
+			}
 		case "silencedHosts":
 			setStrArr(&m.Meta.SilencedHosts, k, v)
 		case "mediaSilencedHosts":


### PR DESCRIPTION
## Summary

`#1732` (federation 残差分) の **softwareSuspended 項目**を解消する。残る update-remote-user 認証は別途扱うため本 PR は issue を close しない (`Refs #1732`)。

### 再検証で判明した STALE
`#1732` の audit は「softwareSuspended 系のコードは mk-go 全体に存在しない」としていたが、再検証の結果これは **STALE** だった。`meta.deliverSuspendedSoftware` (jsonb 列, migration 000029)・deliver queue gate (`SuspendedChecker`, router 配線済)・admin/meta の read は既に存在する。**欠けていたのは federation/instances・show-instance・stats の `isSuspended`/`suspensionState` 表示への反映のみ**だった。

## 主な変更点

- **マッチ判定の集約**: `core/federation.MatchSuspendedSoftware` を新設し、display (federation packing) と deliver gate (`SuspendedChecker`) で共有。重複していた matcher を削除。型は `model.SuspendedSoftwareEntry`。
- **`core/instance.FederationHostSets`**: `SuspendedSoftware` を追加し、`FederationHostLists` が `meta.deliverSuspendedSoftware` を parse する。instances/show-instance/stats は同一経路で hosts を取得するため 3 エンドポイントすべてに反映される。
- **`instanceToMap`**: `softwareSuspended` を算出し、upstream `InstanceEntityService` に揃える。`isSuspended = suspensionState!=='none' || softwareSuspended`、`suspensionState` は none かつ softwareSuspended なら `'softwareSuspended'`。
- **admin/update-meta**: `deliverSuspendedSoftware` (jsonb) を `coerceMetaJSONBFields` で `[]byte` に marshal して書き込めるようにする (従来は read のみで API から write 不可だった)。これで設定→表示→配送 gate が end-to-end で機能する。

## テスト

- `core/federation`: `MatchSuspendedSoftware` の網羅 (wildcard/exact/prefix/nil version 等) + `SuspendedChecker` の host lookup 経路。
- `api/federation`: `TestShowInstance_SoftwareSuspended` / `SoftwareNotSuspended` / `ManualSuspensionStatePreserved`。
- `api/admin`: `TestUpdateMeta_DeliverSuspendedSoftware` (jsonb round-trip)。
- mock の meta Update に `deliverSuspendedSoftware` を追加。
- 実行: `go test ./internal/api/federation/... ./internal/core/federation/... ./internal/core/instance/... ./internal/api/admin/... -count=1`
- カバレッジ: federation 91.5% / core/federation 90.4% / core/instance 92.7% / admin 89.2% (gate 維持)。`model` は型のみ追加で test 不要 (gate 非対象維持)。

## Refs

Refs #1732 (softwareSuspended 分。残り update-remote-user 認証は別対応)

🤖 Generated with [Claude Code](https://claude.com/claude-code)