### PR TITLE
Fix admin/emoji parity: name-only update + list の DESC 既定/:name:/aliases/category 検索 (#1543)

### DIFF
--- a/internal/api/admin/drive_emoji_test.go
+++ b/internal/api/admin/drive_emoji_test.go
@@ -1275,6 +1275,33 @@ func TestEmojiUpdate_SelfRenameOk(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
+// upstream paramDef は {name} のみでの更新も許す。id 無し name 指定時は
+// local emoji を name で解決して他フィールドを更新する (#1543)。
+func TestEmojiUpdate_NameOnly(t *testing.T) {
+	h, emojiRepo := setupEmojiHandler(t, &model.Emoji{ID: "e1", Name: "smile"})
+	rec := doPost(h.EmojiUpdate, `{"name":"smile","category":"faces"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	got, err := emojiRepo.FindByNameAndHost("smile", nil)
+	require.NoError(t, err)
+	require.NotNil(t, got.Category)
+	assert.Equal(t, "faces", *got.Category, "name で解決した emoji の category が更新される")
+}
+
+// name のみ指定で該当 local emoji が無ければ NO_SUCH_EMOJI (#1543)。
+func TestEmojiUpdate_NameOnly_NotFound(t *testing.T) {
+	h, _ := setupEmojiHandler(t, &model.Emoji{ID: "e1", Name: "smile"})
+	rec := doPost(h.EmojiUpdate, `{"name":"ghost","category":"x"}`, adminUser)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_EMOJI")
+}
+
+// id も name も無ければ INVALID_PARAM (#1543)。
+func TestEmojiUpdate_NeitherIDNorName(t *testing.T) {
+	h, _ := setupEmojiHandler(t, &model.Emoji{ID: "e1", Name: "smile"})
+	rec := doPost(h.EmojiUpdate, `{"category":"x"}`, adminUser)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
 func TestEmojiUpdate_UnsupportedFileType(t *testing.T) {
 	h, _ := setupEmojiHandler(t, &model.Emoji{ID: "e1", Name: "smile"})
 	dr := testutil.NewMockDriveFileRepository()

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -2302,8 +2302,10 @@ func (h *Handler) EmojiUpdate(c echo.Context) error {
 		LocalOnly   *bool    `json:"localOnly"`
 		RoleIDs     []string `json:"roleIdsThatCanBeUsedThisEmojiAsReaction"`
 	}
-	if err := c.Bind(&req); err != nil || req.ID == "" {
-		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "id is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	// upstream update.ts paramDef は allOf+anyOf で {id} または {name} の
+	// どちらか必須。id 無し name 指定時は local emoji を name で解決する (#1543)。
+	if err := c.Bind(&req); err != nil || (req.ID == "" && (req.Name == nil || *req.Name == "")) {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "id or name is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 	if h.emojiRepo == nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
@@ -2311,15 +2313,25 @@ func (h *Handler) EmojiUpdate(c echo.Context) error {
 	// before snapshot for moderation log (also used to gate NO_SUCH_EMOJI when
 	// the row is missing — UpdateFields の RowsAffected==0 経路は repo 側で
 	// ErrRecordNotFound に昇格済み (#650 問題 2)).
-	before, err := h.emojiRepo.FindByID(req.ID)
-	if err != nil {
+	// id 指定があれば id 解決、無ければ name で local emoji を解決する。upstream
+	// CustomEmojiService.update は `data.id ? getEmojiById : getEmojiByName` (#1543)。
+	var before *model.Emoji
+	var err error
+	if req.ID != "" {
+		before, err = h.emojiRepo.FindByID(req.ID)
+	} else {
+		before, err = h.emojiRepo.FindByNameAndHost(*req.Name, nil)
+	}
+	if err != nil || before == nil {
 		// #729: 再現報告のため request 側 id と原因 (find vs update path) を
 		// log に残す。frontend 側で stale id を握っているのか、repo 側で
 		// 何か起きているのか切り分けに使う。
-		slog.WarnContext(c.Request().Context(), "EmojiUpdate: NO_SUCH_EMOJI on FindByID",
+		slog.WarnContext(c.Request().Context(), "EmojiUpdate: NO_SUCH_EMOJI on lookup",
 			"id", req.ID, "err", err)
 		return c.JSON(http.StatusNotFound, apierr.NoSuchEmoji())
 	}
+	// 以降の UpdateFields / moderation log は解決済み id を使う。
+	req.ID = before.ID
 	fields := map[string]any{}
 	if req.Name != nil {
 		// リネーム時は同名 local emoji の重複を弾く (SAME_NAME_EMOJI_EXISTS)。

--- a/internal/repository/emoji.go
+++ b/internal/repository/emoji.go
@@ -2,10 +2,31 @@ package repository
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/gorm"
 )
+
+// emojiNameTokenRe extracts `:name:` tokens from an admin/emoji/list query,
+// mirroring upstream list.ts の `/\:([a-z0-9_]*)\:/g` (#1543)。
+var emojiNameTokenRe = regexp.MustCompile(`:([a-z0-9_]*):`)
+
+// extractEmojiNameTokens returns the inner names of all `:xxx:` tokens in query
+// (空トークンは除外)。1 つ以上見つかれば admin/emoji/list は完全一致集合で絞る。
+func extractEmojiNameTokens(query string) []string {
+	matches := emojiNameTokenRe.FindAllStringSubmatch(query, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(matches))
+	for _, m := range matches {
+		if m[1] != "" {
+			names = append(names, m[1])
+		}
+	}
+	return names
+}
 
 // EmojiRepository provides data access for the `emoji` table.
 type EmojiRepository interface {
@@ -160,12 +181,22 @@ func (r *emojiRepository) ListRemoteWithFilter(query, host, sinceID, untilID str
 }
 
 func (r *emojiRepository) ListWithFilter(query, category string, local bool, sinceID, untilID string, limit, offset int) ([]*model.Emoji, error) {
-	q := r.db.Order("id ASC")
+	// upstream list.ts は makePaginationQuery を使うため、カーソル無し時は
+	// id DESC (最新が先頭)、sinceId のみ指定時は id ASC で並べる (#1543)。
+	q := r.db.Order(paginationOrder(sinceID, untilID, "id"))
 	if local {
 		q = q.Where("host IS NULL")
 	}
 	if query != "" {
-		q = q.Where("name ILIKE ?", "%"+query+"%")
+		// upstream list.ts: query が :name: 形式を含むなら該当 emoji 名の完全一致
+		// 集合で絞り、そうでなければ name / aliases / category のいずれかに部分
+		// 一致する emoji を返す (#1543)。
+		if names := extractEmojiNameTokens(query); len(names) > 0 {
+			q = q.Where("name IN ?", names)
+		} else {
+			like := "%" + escapeLike(query) + "%"
+			q = q.Where(`name ILIKE ? ESCAPE '\' OR array_to_string(aliases, ',') ILIKE ? ESCAPE '\' OR category ILIKE ? ESCAPE '\'`, like, like, like)
+		}
 	}
 	if category != "" {
 		q = q.Where("category = ?", category)

--- a/internal/repository/emoji_test.go
+++ b/internal/repository/emoji_test.go
@@ -142,6 +142,81 @@ func TestEmojiRepository_ListWithFilter(t *testing.T) {
 	assert.LessOrEqual(t, len(emojis), 1)
 }
 
+// upstream list.ts は makePaginationQuery で id DESC (最新が先頭)。mk-go も
+// カーソル無し時は DESC で並べる (#1543)。
+func TestEmojiRepository_ListWithFilter_DefaultOrderDesc(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+	e1 := &model.Emoji{ID: "e_ord_1", Name: "ordone", OriginalURL: "https://example.com/1.png"}
+	e2 := &model.Emoji{ID: "e_ord_2", Name: "ordtwo", OriginalURL: "https://example.com/2.png"}
+	require.NoError(t, repo.Create(e1))
+	require.NoError(t, repo.Create(e2))
+	defer cleanupEmoji(t, e1.ID)
+	defer cleanupEmoji(t, e2.ID)
+
+	emojis, err := repo.ListWithFilter("", "", true, "", "", 100, 0)
+	require.NoError(t, err)
+	// id DESC なので e_ord_2 が e_ord_1 より前に来る。
+	var i1, i2 = -1, -1
+	for i, e := range emojis {
+		if e.ID == "e_ord_1" {
+			i1 = i
+		}
+		if e.ID == "e_ord_2" {
+			i2 = i
+		}
+	}
+	require.NotEqual(t, -1, i1)
+	require.NotEqual(t, -1, i2)
+	assert.Less(t, i2, i1, "id DESC: e_ord_2 が先")
+}
+
+// query が :name: 形式なら該当名の完全一致集合で絞る (#1543)。
+func TestEmojiRepository_ListWithFilter_ColonNameExactMatch(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+	exact := &model.Emoji{ID: "e_cn_exact", Name: "alpha", OriginalURL: "https://example.com/a.png"}
+	prefixed := &model.Emoji{ID: "e_cn_prefixed", Name: "alphabet", OriginalURL: "https://example.com/ab.png"}
+	require.NoError(t, repo.Create(exact))
+	require.NoError(t, repo.Create(prefixed))
+	defer cleanupEmoji(t, exact.ID)
+	defer cleanupEmoji(t, prefixed.ID)
+
+	// ":alpha:" は alpha のみ完全一致 (部分一致の alphabet は含めない)。
+	emojis, err := repo.ListWithFilter(":alpha:", "", true, "", "", 100, 0)
+	require.NoError(t, err)
+	ids := map[string]bool{}
+	for _, e := range emojis {
+		ids[e.ID] = true
+	}
+	assert.True(t, ids["e_cn_exact"])
+	assert.False(t, ids["e_cn_prefixed"], ":name: は完全一致のみ")
+}
+
+// query が :name: 形式でなければ name / aliases / category の部分一致で絞る (#1543)。
+func TestEmojiRepository_ListWithFilter_AliasAndCategoryMatch(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+	byAlias := &model.Emoji{ID: "e_q_alias", Name: "nomatch1", Aliases: pq.StringArray{"zzqterm"}, OriginalURL: "https://example.com/al.png"}
+	byCategory := &model.Emoji{ID: "e_q_cat", Name: "nomatch2", Category: strPtrEmoji("zzqterm-cat"), OriginalURL: "https://example.com/c.png"}
+	unrelated := &model.Emoji{ID: "e_q_none", Name: "nomatch3", OriginalURL: "https://example.com/n.png"}
+	require.NoError(t, repo.Create(byAlias))
+	require.NoError(t, repo.Create(byCategory))
+	require.NoError(t, repo.Create(unrelated))
+	defer cleanupEmoji(t, byAlias.ID)
+	defer cleanupEmoji(t, byCategory.ID)
+	defer cleanupEmoji(t, unrelated.ID)
+
+	emojis, err := repo.ListWithFilter("zzqterm", "", true, "", "", 100, 0)
+	require.NoError(t, err)
+	ids := map[string]bool{}
+	for _, e := range emojis {
+		ids[e.ID] = true
+	}
+	assert.True(t, ids["e_q_alias"], "aliases 部分一致")
+	assert.True(t, ids["e_q_cat"], "category 部分一致")
+	assert.False(t, ids["e_q_none"], "無関係は除外")
+}
+
+func strPtrEmoji(s string) *string { return &s }
+
 func TestEmojiRepository_ListWithFilter_DefaultLimit(t *testing.T) {
 	repo := NewEmojiRepository(testDB)
 	emojis, err := repo.ListWithFilter("", "", true, "", "", 0, 0) // limit=0 → default 50


### PR DESCRIPTION
## Summary

`#1543` (admin/emoji + avatar-decorations parity 監査) の **emoji 3 項目**を解消する。残る avatar-decorations 2 項目は別 PR で扱うため本 PR は issue を close しない (`Refs #1543`)。

なお emoji/update の `SAME_NAME_EMOJI_EXISTS` rename 重複チェックは再検証の結果 **既に実装済 (STALE)** で、欠けていたのは name-only update のみだった。

## 主な変更点

- **admin/emoji/update — name-only update**: `id` 必須だったのを upstream paramDef (allOf+anyOf で `{id}` または `{name}`) に揃え、`id` 無し `name` 指定時は local emoji を name で解決して他フィールドを更新できるようにする (`CustomEmojiService.update` の `data.id ? getEmojiById : getEmojiByName` 相当)。`id`/`name` 両方欠如時は INVALID_PARAM。
- **admin/emoji/list — 既定の並び順**: `id ASC` だったのを upstream `makePaginationQuery` に揃えて **`id DESC`** (最新が先頭、`sinceId` のみ指定時は ASC) に修正。
- **admin/emoji/list — query 検索**: `name` 部分一致のみだったのを upstream `list.ts` に揃え、`:name:` 形式なら該当名の **完全一致集合**で絞り、そうでなければ **name / aliases / category** のいずれかへの部分一致で絞るよう修正。LIKE メタ文字は `escapeLike` でリテラル化。

## テスト

- handler: `TestEmojiUpdate_NameOnly` / `TestEmojiUpdate_NameOnly_NotFound` / `TestEmojiUpdate_NeitherIDNorName`
- repository: `TestEmojiRepository_ListWithFilter_DefaultOrderDesc` / `ColonNameExactMatch` / `AliasAndCategoryMatch`
- 既存の emoji/update・list テストは回帰なし。
- 実行: `go test ./internal/api/admin/... ./internal/repository/... -count=1`
- カバレッジ: admin 89.3% / repository 90.2% (gate 維持)。

## Refs

Refs #1543 (emoji ドメイン分。残り avatar-decorations は別 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)