### PR TITLE
Fix avatar-decorations parity: get-avatar-decorations の roleIds 絞り込み + list の param 受理 (#1543)

### DIFF
--- a/internal/api/admin/ad_invite_promo_test.go
+++ b/internal/api/admin/ad_invite_promo_test.go
@@ -331,6 +331,27 @@ func TestAvatarDecorationsList_WithRepo(t *testing.T) {
 	assert.Len(t, rows, 2)
 }
 
+// upstream list.ts は limit/sinceId/untilId/sinceDate/untilDate/userId を受けるが
+// getAll(true) で全件返す。mk-go も params を受理しつつ全件返す (#1543)。
+func TestAvatarDecorationsList_AcceptsParamsReturnsAll(t *testing.T) {
+	h, _ := setupAvatarDecorationHandler(t,
+		&model.AvatarDecoration{ID: "d1", Name: "a"},
+		&model.AvatarDecoration{ID: "d2", Name: "b"},
+	)
+	// limit=1 を送っても TS 同様に全件 (2 件) 返る。
+	rec := doPost(h.AvatarDecorationsList, `{"limit":1,"sinceId":"x","userId":"u1"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []model.AvatarDecoration
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	assert.Len(t, rows, 2, "params を受理しても全件返す (TS getAll(true) 互換)")
+}
+
+func TestAvatarDecorationsList_InvalidJSON(t *testing.T) {
+	h, _ := setupAvatarDecorationHandler(t)
+	rec := doPost(h.AvatarDecorationsList, `{not`, adminUser)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
 func TestAvatarDecorationsUpdate_Success(t *testing.T) {
 	h, repo := setupAvatarDecorationHandler(t,
 		&model.AvatarDecoration{ID: "d1", Name: "old", URL: "u"},

--- a/internal/api/admin/avatar_decorations.go
+++ b/internal/api/admin/avatar_decorations.go
@@ -97,6 +97,20 @@ func (h *Handler) AvatarDecorationsDelete(c echo.Context) error {
 
 // AvatarDecorationsList handles POST /api/admin/avatar-decorations/list.
 func (h *Handler) AvatarDecorationsList(c echo.Context) error {
+	// upstream list.ts paramDef は limit/sinceId/untilId/sinceDate/untilDate/userId
+	// を受け取るが、実装は avatarDecorationService.getAll(true) で全件返す。mk-go も
+	// これに揃えて全件返す。params は受理するが結果には影響しない (#1543)。
+	var req struct {
+		Limit     int     `json:"limit"`
+		SinceID   string  `json:"sinceId"`
+		UntilID   string  `json:"untilId"`
+		SinceDate *int64  `json:"sinceDate"`
+		UntilDate *int64  `json:"untilDate"`
+		UserID    *string `json:"userId"`
+	}
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("Invalid parameters."))
+	}
 	if h.avatarDecoRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}

--- a/internal/core/role/role_service.go
+++ b/internal/core/role/role_service.go
@@ -1042,6 +1042,34 @@ func (s *Service) List() ([]*model.Role, error) {
 	return s.roleRepo.List()
 }
 
+// ExistingRoleIDSet returns the set of all current role ids. get-avatar-
+// decorations / get-emoji 系が削除済ロール ID を除去するために使う (#1543)。
+func (s *Service) ExistingRoleIDSet() (map[string]bool, error) {
+	roles, err := s.roleRepo.List()
+	if err != nil {
+		return nil, err
+	}
+	set := make(map[string]bool, len(roles))
+	for _, r := range roles {
+		set[r.ID] = true
+	}
+	return set, nil
+}
+
+// FilterExistingRoleIDs returns the subset of ids that exist in `existing`,
+// preserving input order. 戻り値は常に非 nil (空でも []) なので JSON では null
+// ではなく [] になる。upstream get-avatar-decorations.ts は roleIds を現存ロール
+// で filter して削除済ロール ID を除去する (#1543)。
+func FilterExistingRoleIDs(ids []string, existing map[string]bool) []string {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if existing[id] {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
 // ListByRole returns role assignments (with User preloaded) for the given
 // role, paginated by untilID/sinceID (assignment.id keyset). Misskey TS の
 // admin/roles/users 互換 envelope ({id, createdAt, user}) を組み立てるため

--- a/internal/core/role/role_service_test.go
+++ b/internal/core/role/role_service_test.go
@@ -24,6 +24,37 @@ func newTestService(t *testing.T) (*role.Service, *testutil.MockRoleRepository, 
 	return svc, roleRepo, assignRepo, metaRepo
 }
 
+// FilterExistingRoleIDs は existing に含まれる id だけを順序保持で返し、
+// 戻り値は常に非 nil (#1543)。
+func TestFilterExistingRoleIDs(t *testing.T) {
+	existing := map[string]bool{"r1": true, "r3": true}
+	got := role.FilterExistingRoleIDs([]string{"r1", "r2", "r3"}, existing)
+	assert.Equal(t, []string{"r1", "r3"}, got, "r2 (非存在) は除去")
+
+	// 全て非存在 → 空でも非 nil ([])。
+	got = role.FilterExistingRoleIDs([]string{"gone"}, existing)
+	assert.NotNil(t, got)
+	assert.Empty(t, got)
+
+	// nil 入力でも非 nil の空 slice。
+	got = role.FilterExistingRoleIDs(nil, existing)
+	assert.NotNil(t, got)
+	assert.Empty(t, got)
+}
+
+// ExistingRoleIDSet は全ロールの id 集合を返す (#1543)。
+func TestExistingRoleIDSet(t *testing.T) {
+	svc, roleRepo, _, _ := newTestService(t)
+	roleRepo.Roles["a"] = &model.Role{ID: "a", Name: "A"}
+	roleRepo.Roles["b"] = &model.Role{ID: "b", Name: "B"}
+
+	set, err := svc.ExistingRoleIDSet()
+	require.NoError(t, err)
+	assert.True(t, set["a"])
+	assert.True(t, set["b"])
+	assert.False(t, set["ghost"])
+}
+
 func TestGetUserRoles_NoRoles(t *testing.T) {
 	svc, _, _, _ := newTestService(t)
 	roles, err := svc.GetUserRoles("user1")

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2571,14 +2571,24 @@ func (s *Server) setupRoutes() {
 		if err := s.db.Find(&decorations).Error; err != nil {
 			return c.JSON(http.StatusOK, []any{})
 		}
+		// upstream get-avatar-decorations.ts は roleIdsThatCanBeUsedThisDecoration を
+		// 現存ロールのみに filter して削除済ロール ID を除去する (#1543)。meta は
+		// 1 度だけ引いて使い回す。取得失敗時は空集合 (= 全 roleId を除去) ではなく
+		// nil 扱いで filter すると全件落ちるため、エラー時は filter を skip して
+		// 旧挙動 (verbatim) にフォールバックする。
+		existingRoles, roleErr := roleService.ExistingRoleIDSet()
 		out := make([]map[string]any, 0, len(decorations))
 		for _, d := range decorations {
+			roleIDs := []string(d.RoleIDs)
+			if roleErr == nil {
+				roleIDs = corerole.FilterExistingRoleIDs(roleIDs, existingRoles)
+			}
 			out = append(out, map[string]any{
 				"id":                                 d.ID,
 				"name":                               d.Name,
 				"description":                        d.Description,
 				"url":                                d.URL,
-				"roleIdsThatCanBeUsedThisDecoration": d.RoleIDs,
+				"roleIdsThatCanBeUsedThisDecoration": roleIDs,
 				// upstream Misskey #17034 (= 2026.5.0) で追加された category field
 				// もここで返す。nullable なので null のままも許容。
 				"category": d.Category,


### PR DESCRIPTION
## Summary

`#1543` (admin/emoji + avatar-decorations parity 監査) の **avatar-decorations 2 項目**を解消する。emoji 3 項目は別 PR (#1735) で対応済。本 PR マージ + #1735 マージで `#1543` を close する。

## 主な変更点

- **get-avatar-decorations — roleIds 現存ロール絞り込み (MEDIUM)**: `roleIdsThatCanBeUsedThisDecoration` を verbatim で返していたのを、upstream `get-avatar-decorations.ts` に揃えて現存ロールのみに filter する (削除済ロール ID を除去)。`core/role` に `ExistingRoleIDSet` / `FilterExistingRoleIDs` を追加し、inline handler は role 集合を 1 度引いて各 decoration を filter する。role 取得失敗時は filter を skip して旧挙動 (verbatim) にフォールバック。
- **admin/avatar-decorations/list — param 受理 (LOW)**: `limit`/`sinceId`/`untilId`/`sinceDate`/`untilDate`/`userId` を bind するよう修正。ただし upstream 実装も `getAll(true)` で全件返すため、mk-go も params を受理しつつ全件返す挙動を維持する (結果は TS と一致、param で絞ると逆に divergence になる)。

## テスト

- `core/role`: `TestFilterExistingRoleIDs` / `TestExistingRoleIDSet`
- `api/admin`: `TestAvatarDecorationsList_AcceptsParamsReturnsAll` / `TestAvatarDecorationsList_InvalidJSON`
- get-avatar-decorations の filter wiring は `internal/server` (router inline handler、e2e/drop-in 検証対象) のため、filter ロジックは `core/role` helper の test で担保する。
- 実行: `go test ./internal/core/role/... ./internal/api/admin/... -count=1`
- カバレッジ: core/role 94.9% / admin 80%+ (gate 維持)。

## Refs

Refs #1543 (avatar-decorations ドメイン分。emoji 分は #1735)

🤖 Generated with [Claude Code](https://claude.com/claude-code)