### PR TITLE
Fix admin/system-webhook parity: test の NO_SUCH_WEBHOOK/override/配送形 + create/update の on enum/required (#1542)

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -135,11 +135,6 @@ type Handler struct {
 	// log type 分岐をテストするため、`adminDB` 直叩きから repository 経由
 	// に剥がしている。未配線時は `adminDB` フォールバックは持たず no-op。
 	instanceRepo repository.InstanceRepository
-	// webhookTestClient は admin/system-webhook/test の fire-and-forget POST
-	// に使う SSRF-safe HTTP client。router.go で safehttp.WithProxy など共通
-	// outbound 設定を適用したものを差し込む (#638)。nil のときは default の
-	// 10s timeout client にフォールバックする (テスト容易性のため)。
-	webhookTestClient *http.Client
 	// userTokenInvalidator は admin が他 user を suspend / unsuspend /
 	// 論理削除した直後に target user の全 tokenCache entry を即時失効する
 	// ために使う (#965)。i/regenerate-token (#884) や i/update (#960) と
@@ -236,14 +231,6 @@ func (h *Handler) SetSystemWebhookRepo(r repository.SystemWebhookRepository) {
 	h.systemWebhookRepo = r
 }
 
-// SetWebhookTestClient attaches an SSRF-safe HTTP client used by
-// admin/system-webhook/test to POST a fire-and-forget probe request.
-// Typically wired with the server-wide outbound transport (forward proxy,
-// outgoing address, allowedPrivateNetworks 等を反映、#638)。
-func (h *Handler) SetWebhookTestClient(c *http.Client) {
-	h.webhookTestClient = c
-}
-
 // SetInstanceMetadataFetcher attaches the fetcher used by
 // admin/federation/refresh-remote-instance-metadata to re-fetch nodeinfo +
 // icon for a specific host on demand.
@@ -296,6 +283,9 @@ func (h *Handler) SetRecipientRepo(r repository.AbuseReportNotificationRecipient
 // (#1723).
 type SystemWebhookDispatcher interface {
 	DispatchSystemExcluding(eventType string, body any, excludes []string)
+	// DispatchSystemTest enqueues a single test delivery to a system webhook
+	// (admin/system-webhook/test, #1542). overrideURL/Secret が非空ならそちらへ。
+	DispatchSystemTest(webhookID, eventType string, body any, overrideURL, overrideSecret string)
 }
 
 // SetSystemWebhookDispatcher wires the system webhook dispatcher used to emit

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -1799,6 +1799,13 @@ type stubSystemWebhookDispatcher struct {
 		body      any
 		excludes  []string
 	}
+	testCalls []struct {
+		webhookID      string
+		eventType      string
+		body           any
+		overrideURL    string
+		overrideSecret string
+	}
 }
 
 func (s *stubSystemWebhookDispatcher) DispatchSystemExcluding(eventType string, body any, excludes []string) {
@@ -1807,6 +1814,16 @@ func (s *stubSystemWebhookDispatcher) DispatchSystemExcluding(eventType string, 
 		body      any
 		excludes  []string
 	}{eventType, body, excludes})
+}
+
+func (s *stubSystemWebhookDispatcher) DispatchSystemTest(webhookID, eventType string, body any, overrideURL, overrideSecret string) {
+	s.testCalls = append(s.testCalls, struct {
+		webhookID      string
+		eventType      string
+		body           any
+		overrideURL    string
+		overrideSecret string
+	}{webhookID, eventType, body, overrideURL, overrideSecret})
 }
 
 // resolve は abuseReportResolved system webhook を発火し、inactive な

--- a/internal/api/admin/system_webhook.go
+++ b/internal/api/admin/system_webhook.go
@@ -1,10 +1,7 @@
 package admin
 
 import (
-	"fmt"
-	"log/slog"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -15,37 +12,53 @@ import (
 	"github.com/shiroha-a/mk/internal/model"
 )
 
-// sendWebhookTest sends a test webhook POST request.
-//
-// Misskey 本家の admin/system-webhook/test 互換。シークレットがあれば
-// X-Misskey-Hook-Secret ヘッダに平文を載せる (本家も同仕様)。
-//
-// client は SSRF-safe transport + forward proxy 経由を期待した HTTP client。
-// nil なら 10s timeout の素の Client にフォールバックする (#638)。
-func sendWebhookTest(client *http.Client, url, secret, eventType string) {
-	body := fmt.Sprintf(`{"type":"%s","body":{"test":true},"createdAt":"%s"}`,
-		eventType, time.Now().UTC().Format(time.RFC3339))
+// systemWebhookEventTypes is the allow-list of system webhook `on` event types,
+// mirroring upstream models/SystemWebhook.ts systemWebhookEventTypes (#1542)。
+var systemWebhookEventTypes = map[string]bool{
+	"abuseReport":                             true,
+	"abuseReportResolved":                     true,
+	"userCreated":                             true,
+	"inactiveModeratorsWarning":               true,
+	"inactiveModeratorsInvitationOnlyChanged": true,
+}
 
-	req, err := http.NewRequest("POST", url, strings.NewReader(body))
-	if err != nil {
-		slog.Warn("webhook test: request creation failed", "error", err)
-		return
+// validSystemWebhookEvents reports whether every entry of `on` is a known event
+// type. 空配列も valid (= required 検証は別途行う)。
+func validSystemWebhookEvents(on []string) bool {
+	for _, e := range on {
+		if !systemWebhookEventTypes[e] {
+			return false
+		}
 	}
-	req.Header.Set("Content-Type", "application/json")
-	if secret != "" {
-		req.Header.Set("X-Misskey-Hook-Secret", secret)
-	}
+	return true
+}
 
-	if client == nil {
-		client = &http.Client{Timeout: 10 * time.Second}
+// dummySystemWebhookBody builds a representative test payload per system event
+// type, matching upstream WebhookTestService の type 別 dummy 相当 (#1542)。
+func dummySystemWebhookBody(eventType string) map[string]any {
+	dummyUser := map[string]any{
+		"id":       "dummy-user-1",
+		"username": "dummy",
+		"host":     nil,
 	}
-	resp, err := client.Do(req)
-	if err != nil {
-		slog.Warn("webhook test: request failed", "error", err)
-		return
+	switch eventType {
+	case "abuseReport", "abuseReportResolved":
+		return map[string]any{
+			"id":           "dummy-report-1",
+			"comment":      "This is a dummy abuse report for testing purposes.",
+			"resolved":     eventType == "abuseReportResolved",
+			"reporterId":   "dummy-user-1",
+			"targetUserId": "dummy-user-2",
+			"reporter":     dummyUser,
+			"targetUser":   dummyUser,
+			"assignee":     nil,
+		}
+	case "userCreated":
+		return dummyUser
+	default:
+		// inactiveModeratorsWarning / inactiveModeratorsInvitationOnlyChanged 等。
+		return map[string]any{}
 	}
-	_ = resp.Body.Close()
-	slog.Info("webhook test sent", "url", url, "status", resp.StatusCode)
 }
 
 // SystemWebhookCreate handles POST /api/admin/system-webhook/create.
@@ -54,26 +67,28 @@ func (h *Handler) SystemWebhookCreate(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)
 	}
 	var req struct {
-		Name     string   `json:"name"`
-		URL      string   `json:"url"`
-		Secret   string   `json:"secret"`
-		On       []string `json:"on"`
-		IsActive *bool    `json:"isActive"`
+		Name   string `json:"name"`
+		URL    string `json:"url"`
+		Secret string `json:"secret"`
+		// upstream create.ts required:[isActive,name,on,url]。欠落を 400 で弾く
+		// ため On/IsActive はポインタで「未送出 (nil)」を判別する (#1542)。
+		On       *[]string `json:"on"`
+		IsActive *bool     `json:"isActive"`
 	}
-	if err := c.Bind(&req); err != nil || req.Name == "" || req.URL == "" {
+	if err := c.Bind(&req); err != nil || req.Name == "" || req.URL == "" || req.On == nil || req.IsActive == nil {
 		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("Invalid parameters."))
 	}
-	isActive := true
-	if req.IsActive != nil {
-		isActive = *req.IsActive
+	// on は systemWebhookEventTypes enum のみ受理する (upstream create.ts)。
+	if !validSystemWebhookEvents(*req.On) {
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("on contains an unknown event type."))
 	}
 	sw := &model.SystemWebhook{
 		ID:        h.idGen.Generate(time.Now()),
 		Name:      req.Name,
 		URL:       req.URL,
 		Secret:    req.Secret,
-		On:        req.On,
-		IsActive:  isActive,
+		On:        *req.On,
+		IsActive:  *req.IsActive,
 		UpdatedAt: time.Now(),
 	}
 	if err := h.systemWebhookRepo.Create(sw); err != nil {
@@ -140,22 +155,38 @@ func (h *Handler) SystemWebhookShow(c echo.Context) error {
 }
 
 // SystemWebhookTest handles POST /api/admin/system-webhook/test.
+//
+// upstream test.ts: webhook 不在なら NO_SUCH_WEBHOOK、override.url/secret を受け、
+// 配送 processor 経由で type 別 dummy payload を送る。mk-go も DispatchSystemTest
+// で real delivery (queue) を経由させ、header/envelope を本配送と一致させる (#1542)。
 func (h *Handler) SystemWebhookTest(c echo.Context) error {
 	var req struct {
 		WebhookID string `json:"webhookId"`
 		Type      string `json:"type"`
+		Override  *struct {
+			URL    string `json:"url"`
+			Secret string `json:"secret"`
+		} `json:"override"`
 	}
-	_ = c.Bind(&req)
-	if req.WebhookID == "" || h.systemWebhookRepo == nil {
-		return c.NoContent(http.StatusNoContent)
+	if err := c.Bind(&req); err != nil || req.WebhookID == "" {
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("webhookId is required."))
+	}
+	if h.systemWebhookRepo == nil {
+		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 	}
 	sw, err := h.systemWebhookRepo.FindByID(req.WebhookID)
 	if err != nil {
+		return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_WEBHOOK", "No such webhook.", "0c52149c-e913-18f8-5dc7-74870bfe0cf9"))
+	}
+	if h.systemWebhookDispatcher == nil {
+		// dispatcher 未配線時は no-op (DB lookup の NO_SUCH_WEBHOOK 検証は通す)。
 		return c.NoContent(http.StatusNoContent)
 	}
-	// テスト送信(非同期)。配送結果は latestStatus 系カラムに反映されないが、
-	// Misskey 本家の /system-webhook/test も fire-and-forget 挙動なので整合。
-	go sendWebhookTest(h.webhookTestClient, sw.URL, sw.Secret, req.Type)
+	var overrideURL, overrideSecret string
+	if req.Override != nil {
+		overrideURL, overrideSecret = req.Override.URL, req.Override.Secret
+	}
+	h.systemWebhookDispatcher.DispatchSystemTest(sw.ID, req.Type, dummySystemWebhookBody(req.Type), overrideURL, overrideSecret)
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -195,6 +226,10 @@ func (h *Handler) SystemWebhookUpdate(c echo.Context) error {
 		fields["secret"] = *req.Secret
 	}
 	if req.On != nil {
+		// on は systemWebhookEventTypes enum のみ受理 (upstream update.ts、#1542)。
+		if !validSystemWebhookEvents(*req.On) {
+			return c.JSON(http.StatusBadRequest, apierr.InvalidParam("on contains an unknown event type."))
+		}
 		// pq.StringArray でラップしないと GORM Updates(map) が空 string[] を
 		// NULL 化して NOT NULL 制約違反になる (#932、#931 / #896 と同 class)。
 		fields["on"] = pq.StringArray(*req.On)

--- a/internal/api/admin/system_webhook_test.go
+++ b/internal/api/admin/system_webhook_test.go
@@ -3,7 +3,6 @@ package admin_test
 import (
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -22,7 +21,7 @@ func TestSystemWebhookCreate_Success(t *testing.T) {
 	h.SetSystemWebhookRepo(repo)
 
 	rec := doPost(h.SystemWebhookCreate,
-		`{"name":"hook1","url":"https://example.com/hook","secret":"s","on":["abuseReport"]}`,
+		`{"name":"hook1","url":"https://example.com/hook","secret":"s","on":["abuseReport"],"isActive":true}`,
 		adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
@@ -45,12 +44,43 @@ func TestSystemWebhookCreate_MissingFields(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// upstream create.ts required:[isActive,name,on,url]。on / isActive 欠落は 400 (#1542)。
+func TestSystemWebhookCreate_RequiredOnIsActive(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetSystemWebhookRepo(testutil.NewMockSystemWebhookRepository())
+	// on 欠落
+	assert.Equal(t, http.StatusBadRequest,
+		doPost(h.SystemWebhookCreate, `{"name":"x","url":"https://x","isActive":true}`, adminUser).Code)
+	// isActive 欠落
+	assert.Equal(t, http.StatusBadRequest,
+		doPost(h.SystemWebhookCreate, `{"name":"x","url":"https://x","on":["abuseReport"]}`, adminUser).Code)
+}
+
+// on は systemWebhookEventTypes enum のみ受理。未知値は 400 (#1542)。
+func TestSystemWebhookCreate_InvalidEventType(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetSystemWebhookRepo(testutil.NewMockSystemWebhookRepository())
+	rec := doPost(h.SystemWebhookCreate,
+		`{"name":"x","url":"https://x","on":["bogusEvent"],"isActive":true}`, adminUser)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// update も on の enum を検証する (#1542)。
+func TestSystemWebhookUpdate_InvalidEventType(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockSystemWebhookRepository()
+	require.NoError(t, repo.Create(&model.SystemWebhook{ID: "w1", Name: "x", URL: "https://x"}))
+	h.SetSystemWebhookRepo(repo)
+	rec := doPost(h.SystemWebhookUpdate, `{"id":"w1","on":["bogusEvent"]}`, adminUser)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
 func TestSystemWebhookCreate_RepoError(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	repo := testutil.NewMockSystemWebhookRepository()
 	repo.CreateErr = assertError{}
 	h.SetSystemWebhookRepo(repo)
-	rec := doPost(h.SystemWebhookCreate, `{"name":"x","url":"https://x"}`, adminUser)
+	rec := doPost(h.SystemWebhookCreate, `{"name":"x","url":"https://x","on":["abuseReport"],"isActive":true}`, adminUser)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
@@ -151,44 +181,38 @@ func TestSystemWebhookTest_WithRepo(t *testing.T) {
 	repo := testutil.NewMockSystemWebhookRepository()
 	require.NoError(t, repo.Create(&model.SystemWebhook{ID: "w1", URL: "https://127.0.0.1:1"}))
 	h.SetSystemWebhookRepo(repo)
+	disp := &stubSystemWebhookDispatcher{}
+	h.SetSystemWebhookDispatcher(disp)
 
-	// webhookId 空は 204
-	assert.Equal(t, http.StatusNoContent, doPost(h.SystemWebhookTest, `{}`, adminUser).Code)
-	// 存在しない webhookId も 204
-	assert.Equal(t, http.StatusNoContent,
-		doPost(h.SystemWebhookTest, `{"webhookId":"missing"}`, adminUser).Code)
-	// 正常系も 204 (fire-and-forget)
+	// webhookId 空は 400 (required, #1542)。
+	assert.Equal(t, http.StatusBadRequest, doPost(h.SystemWebhookTest, `{}`, adminUser).Code)
+	// 存在しない webhookId は NO_SUCH_WEBHOOK (400)。
+	rec := doPost(h.SystemWebhookTest, `{"webhookId":"missing"}`, adminUser)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_WEBHOOK")
+	// 正常系は 204 + dispatcher 呼び出し。
 	assert.Equal(t, http.StatusNoContent,
 		doPost(h.SystemWebhookTest, `{"webhookId":"w1","type":"abuseReport"}`, adminUser).Code)
+	require.Len(t, disp.testCalls, 1)
+	assert.Equal(t, "w1", disp.testCalls[0].webhookID)
+	assert.Equal(t, "abuseReport", disp.testCalls[0].eventType)
 }
 
-// SetWebhookTestClient で渡した *http.Client が SystemWebhookTest 経由で
-// 実際に使われ、fire-and-forget の goroutine が POST を打つことを確認 (#638)。
-func TestSystemWebhookTest_UsesInjectedClient(t *testing.T) {
+// override.url / override.secret を受け取り dispatcher にそのまま渡す (#1542)。
+func TestSystemWebhookTest_Override(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
-
-	hit := make(chan *http.Request, 1)
-	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		hit <- r
-	}))
-	defer srv.Close()
-
 	repo := testutil.NewMockSystemWebhookRepository()
-	require.NoError(t, repo.Create(&model.SystemWebhook{ID: "w-inject", URL: srv.URL, Secret: "topsecret"}))
+	require.NoError(t, repo.Create(&model.SystemWebhook{ID: "w1", URL: "https://saved.example", Secret: "saved"}))
 	h.SetSystemWebhookRepo(repo)
-	h.SetWebhookTestClient(srv.Client())
+	disp := &stubSystemWebhookDispatcher{}
+	h.SetSystemWebhookDispatcher(disp)
 
-	rec := doPost(h.SystemWebhookTest, `{"webhookId":"w-inject","type":"abuseReport"}`, adminUser)
-	assert.Equal(t, http.StatusNoContent, rec.Code)
-
-	select {
-	case req := <-hit:
-		assert.Equal(t, http.MethodPost, req.Method)
-		assert.Equal(t, "topsecret", req.Header.Get("X-Misskey-Hook-Secret"))
-		assert.Equal(t, "application/json", req.Header.Get("Content-Type"))
-	case <-time.After(2 * time.Second):
-		t.Fatal("injected client was not used: webhook POST never reached the test server")
-	}
+	rec := doPost(h.SystemWebhookTest,
+		`{"webhookId":"w1","type":"userCreated","override":{"url":"https://override.example","secret":"ovsecret"}}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Len(t, disp.testCalls, 1)
+	assert.Equal(t, "https://override.example", disp.testCalls[0].overrideURL)
+	assert.Equal(t, "ovsecret", disp.testCalls[0].overrideSecret)
 }
 
 // --- thin nil-repo smoke tests ---
@@ -219,7 +243,10 @@ func TestSystemWebhookShow(t *testing.T) {
 
 func TestSystemWebhookTest(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
-	assert.Equal(t, http.StatusNoContent, doPost(h.SystemWebhookTest, `{}`, adminUser).Code)
+	// 空 webhookId は 400 (required, #1542)。
+	assert.Equal(t, http.StatusBadRequest, doPost(h.SystemWebhookTest, `{}`, adminUser).Code)
+	// nil repo + webhookId 指定は 500 (lookup 不能)。
+	assert.Equal(t, http.StatusInternalServerError, doPost(h.SystemWebhookTest, `{"webhookId":"x"}`, adminUser).Code)
 }
 
 func TestSystemWebhookUpdate(t *testing.T) {
@@ -234,7 +261,7 @@ func TestSystemWebhookCreate_WritesModerationLog(t *testing.T) {
 	h.SetSystemWebhookRepo(testutil.NewMockSystemWebhookRepository())
 	repo := attachModLog(t, h)
 
-	rec := doPost(h.SystemWebhookCreate, `{"name":"hook","url":"https://x"}`, adminUser)
+	rec := doPost(h.SystemWebhookCreate, `{"name":"hook","url":"https://x","on":["abuseReport"],"isActive":true}`, adminUser)
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
 	assert.Equal(t, "createSystemWebhook", repo.Snapshot()[0].Type)

--- a/internal/core/webhook/service.go
+++ b/internal/core/webhook/service.go
@@ -147,6 +147,34 @@ func (s *Service) DispatchUserTest(webhookID, userID, eventType string, body any
 	}
 }
 
+// DispatchSystemTest enqueues a single system webhook test delivery for
+// admin/system-webhook/test (#1542)。DispatchUserTest の system 版で、UserID は
+// 持たず、overrideURL/Secret が非空ならそちらへ送る。real delivery (processor) を
+// 経由するため header / envelope は本配送と完全に一致する。
+func (s *Service) DispatchSystemTest(webhookID, eventType string, body any, overrideURL, overrideSecret string) {
+	if s == nil || s.enqueuer == nil {
+		return
+	}
+	raw, _ := json.Marshal(Envelope{
+		Server:    s.server,
+		HookID:    webhookID,
+		EventID:   uuid.NewString(),
+		CreatedAt: time.Now().UnixMilli(),
+		Type:      eventType,
+		Body:      body,
+	})
+	if err := s.enqueuer.EnqueueSystemWebhook(context.Background(), queue.WebhookPayload{
+		WebhookID:      webhookID,
+		EventType:      eventType,
+		Body:           raw,
+		OverrideURL:    overrideURL,
+		OverrideSecret: overrideSecret,
+	}); err != nil {
+		slog.Warn("webhook: enqueue system test webhook failed",
+			"hookId", webhookID, "event", eventType, "err", err)
+	}
+}
+
 // DispatchSystem mirrors DispatchUser for system webhooks (admin-level
 // events such as abuseReport / userCreated). 本家 SystemWebhookService.enqueueSystemWebhook 相当。
 func (s *Service) DispatchSystem(eventType string, body any) {

--- a/internal/core/webhook/service_test.go
+++ b/internal/core/webhook/service_test.go
@@ -250,6 +250,26 @@ func TestDispatchSystemExcluding_SkipsExcluded(t *testing.T) {
 	assert.Equal(t, "h1", enq.systemCalls[0].WebhookID, "excludes の h2 は配送されない")
 }
 
+// DispatchSystemTest は webhookID 1 件に test 配送を enqueue し、override を
+// payload に載せる (#1542)。
+func TestDispatchSystemTest_EnqueuesWithOverride(t *testing.T) {
+	enq := &fakeEnqueuer{}
+	svc := webhook.NewService(enq, nil, nil, "https://example.com")
+	svc.DispatchSystemTest("w1", webhook.SystemEventAbuseReport, map[string]any{"id": "r1"}, "https://override.example", "ovsecret")
+	require.Len(t, enq.systemCalls, 1)
+	assert.Equal(t, "w1", enq.systemCalls[0].WebhookID)
+	assert.Equal(t, "https://override.example", enq.systemCalls[0].OverrideURL)
+	assert.Equal(t, "ovsecret", enq.systemCalls[0].OverrideSecret)
+	assert.Empty(t, enq.systemCalls[0].UserID, "system webhook は UserID を持たない")
+}
+
+func TestDispatchSystemTest_NilSafe(t *testing.T) {
+	var svc *webhook.Service
+	svc.DispatchSystemTest("w1", "abuseReport", nil, "", "")
+	svc = webhook.NewService(nil, nil, nil, "")
+	svc.DispatchSystemTest("w1", "abuseReport", nil, "", "")
+}
+
 // excludes が nil の場合は DispatchSystem と同じ全 active 配送。
 func TestDispatchSystemExcluding_NilExcludesDeliversAll(t *testing.T) {
 	enq := &fakeEnqueuer{}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2217,9 +2217,9 @@ func (s *Server) setupRoutes() {
 	adminHandler.SetEmojiImageFetcher(apiadmin.NewEmojiImageFetcher(s.outboundClient(10*time.Second), driveService, s.config.UserAgent))
 	adminHandler.SetRelayService(relaySvc)
 	adminHandler.SetSystemWebhookRepo(systemWebhookRepo)
-	// admin/system-webhook/test の fire-and-forget POST も SSRF-safe transport
-	// + forward proxy 経由にする (#638)。
-	adminHandler.SetWebhookTestClient(s.outboundClient(10 * time.Second))
+	// admin/system-webhook/test は webhookService.DispatchSystemTest で real
+	// delivery (queue) を経由する。SSRF-safe transport は配送 processor 側
+	// (NewWebhookProcessor) で適用済 (#1542、旧 SetWebhookTestClient を廃止)。
 	adminHandler.SetRecipientRepo(recipientRepo)
 	// resolve-abuse-user-report 時に abuseReportResolved system webhook を発火
 	// する dispatcher (#1723)。


### PR DESCRIPTION
## Summary

`#1542` の **admin/system-webhook 項目**を解消する。`#1542` は複数領域にまたがるため本 PR は issue を close しない (`Refs #1542`)。

## 主な変更点

### admin/system-webhook/test
- **NO_SUCH_WEBHOOK**: webhook 不在で 204 を silent に返していたのを `NO_SUCH_WEBHOOK` (400, `0c52149c-...`) に修正。`webhookId` 欠落は 400 (required)。
- **override**: `override.url` / `override.secret` を受理し、指定時はそちらへ配送する。
- **配送形 (header/payload)**: 固定 body + 不足 header (`X-Misskey-Hook-Id` / `X-Misskey-Host` / `User-Agent`、`server`/`hookId`/`eventId` 欠落) だったのを、**real delivery (queue) を経由する `DispatchSystemTest`** に置き換え、本配送 (processor) と同一の header/envelope + type 別 dummy payload で送るよう修正。これにより test 送信が実配送と必ず一致する。ad-hoc な `sendWebhookTest` / `webhookTestClient` を廃止し、配送 processor の SSRF-safe transport を共用。

### admin/system-webhook/create, /update
- **on enum**: `on` を `systemWebhookEventTypes` enum で検証し未知値を 400 で弾く。
- **required (create)**: `required:[isActive,name,on,url]` に揃え、`on`/`isActive` 欠落を 400 にする (従来は `on` 欠落=空配列 / `isActive` 欠落=true default)。

`core/webhook` に `DispatchSystemTest` を追加 (`DispatchUserTest` の system 版、override 対応)。

## 再検証メモ
同 issue の system webhook event dispatch のうち `abuseReportResolved` / `userCreated` / `inactiveModeratorsWarning` / `inactiveModeratorsInvitationOnlyChanged` は **既に配送済** (audit の「userCreated 以外 fire されない」は STALE)。残る `abuseReport` (report 作成時) の配送のみ未対応で、users handler 側のため**別 PR**で対応する。

## テスト

- test: `TestSystemWebhookTest_WithRepo` (NO_SUCH_WEBHOOK + dispatcher 呼び出し) / `TestSystemWebhookTest_Override`
- create/update: `TestSystemWebhookCreate_RequiredOnIsActive` / `TestSystemWebhookCreate_InvalidEventType` / `TestSystemWebhookUpdate_InvalidEventType`
- core/webhook: `TestDispatchSystemTest_EnqueuesWithOverride` / `TestDispatchSystemTest_NilSafe`
- 既存 create/test テストに必須 `on`/`isActive` を補完。
- 実行: `go test ./internal/api/admin/... ./internal/core/webhook/... -count=1`
- カバレッジ: core/webhook 93.0% / admin (gate 80) 維持。

## Refs

Refs #1542 (system-webhook admin 分。roles は #1737、abuseReport dispatch は別 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)