### PR TITLE
Fix system-webhook parity: report-abuse 時に abuseReport system webhook を発火 (#1542)

### DIFF
--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -81,6 +81,25 @@ type Handler struct {
 	// featuredRanking は users/featured-notes の per-user engagement ランキング
 	// (#1687)。nil 時 (= 未配線 / test) は SQL count-DESC fallback を使う。
 	featuredRanking FeaturedRankingReader
+	// systemWebhookDispatcher / recipientRepo は users/report-abuse 時に
+	// abuseReport system webhook を発火するために使う (#1542)。未配線なら発火しない。
+	systemWebhookDispatcher SystemWebhookDispatcher
+	recipientRepo           repository.AbuseReportNotificationRecipientRepository
+}
+
+// SystemWebhookDispatcher fires a system webhook event to subscribed webhooks,
+// excluding given ids. Implemented by *core/webhook.Service. report-abuse の
+// abuseReport 発火に使う (#1542)。
+type SystemWebhookDispatcher interface {
+	DispatchSystemExcluding(eventType string, body any, excludes []string)
+}
+
+// SetAbuseReportWebhook wires the system webhook dispatcher + notification
+// recipient repo so users/report-abuse fires the abuseReport system webhook
+// (#1542). nil dispatcher disables firing.
+func (h *Handler) SetAbuseReportWebhook(d SystemWebhookDispatcher, recipientRepo repository.AbuseReportNotificationRecipientRepository) {
+	h.systemWebhookDispatcher = d
+	h.recipientRepo = recipientRepo
 }
 
 // FeaturedRankingReader reads the per-user engagement ranking for

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -16,6 +16,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/pagination"
 	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	"github.com/shiroha-a/mk/internal/core/reaction"
+	corewebhook "github.com/shiroha-a/mk/internal/core/webhook"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -202,7 +203,87 @@ func (h *Handler) ReportAbuse(c echo.Context) error {
 	// 各 moderator/admin の admin stream へ newAbuseUserReport を配信する
 	// (#1549, upstream AbuseReportNotificationService)。best-effort。
 	h.notifyModeratorsOfAbuseReport(report)
+	// abuseReport system webhook を発火する (#1542, upstream
+	// AbuseReportService.report → notifySystemWebhook(reports, 'abuseReport'))。
+	// best-effort。
+	h.fireAbuseReportWebhook(report, me, target)
 	return c.NoContent(http.StatusNoContent)
+}
+
+// fireAbuseReportWebhook dispatches the abuseReport system webhook on report
+// creation, mirroring upstream notifySystemWebhook (#1542)。inactive な
+// notification recipient (method=webhook) が指す systemWebhookId を excludes に
+// 渡す。dispatcher 未配線時は no-op。
+func (h *Handler) fireAbuseReportWebhook(report *model.AbuseUserReport, reporter, target *model.User) {
+	if h.systemWebhookDispatcher == nil {
+		return
+	}
+	// reporter / targetUser を UserDetailed で pack する (assignee は作成時点では
+	// 常に nil)。profile は 1 batch で解決する。
+	var profByID map[string]*model.UserProfile
+	if h.userRepo != nil {
+		ids := make([]string, 0, 2)
+		if reporter != nil {
+			ids = append(ids, reporter.ID)
+		}
+		if target != nil {
+			ids = append(ids, target.ID)
+		}
+		if profiles, err := h.userRepo.FindProfilesByUserIDs(ids); err == nil {
+			profByID = make(map[string]*model.UserProfile, len(profiles))
+			for _, p := range profiles {
+				profByID[p.UserID] = p
+			}
+		}
+	}
+	packUser := func(u *model.User) any {
+		if u == nil {
+			return nil
+		}
+		d := entity.PackUserDetailed(u, profByID[u.ID], h.idGen)
+		return &d
+	}
+	createdAt := ""
+	if t, err := h.idGen.ParseTime(report.ID); err == nil {
+		createdAt = t.UTC().Format("2006-01-02T15:04:05.000Z")
+	}
+	// admin/abuse-user-reports の packedAbuseReport と同 shape (#1542)。
+	body := map[string]any{
+		"id":             report.ID,
+		"createdAt":      createdAt,
+		"comment":        report.Comment,
+		"resolved":       false,
+		"reporterId":     report.ReporterID,
+		"targetUserId":   report.TargetUserID,
+		"assigneeId":     nil,
+		"reporter":       packUser(reporter),
+		"targetUser":     packUser(target),
+		"assignee":       nil,
+		"forwarded":      false,
+		"resolvedAs":     nil,
+		"moderationNote": "",
+	}
+	h.systemWebhookDispatcher.DispatchSystemExcluding(corewebhook.SystemEventAbuseReport, body, h.inactiveAbuseWebhookIDs())
+}
+
+// inactiveAbuseWebhookIDs returns the systemWebhookId values of inactive
+// abuse-report-notification recipients (method=webhook). 本家 notifySystemWebhook
+// の withoutWebhookIds 相当 (#1542)。recipientRepo 未配線 / 取得失敗時は nil。
+func (h *Handler) inactiveAbuseWebhookIDs() []string {
+	if h.recipientRepo == nil {
+		return nil
+	}
+	recipients, err := h.recipientRepo.List()
+	if err != nil {
+		return nil
+	}
+	var excludes []string
+	for _, r := range recipients {
+		if r.Method == "webhook" && !r.IsActive && r.SystemWebhookID != nil {
+			excludes = append(excludes, *r.SystemWebhookID)
+		}
+	}
+	return excludes
 }
 
 // notifyModeratorsOfAbuseReport publishes a newAbuseUserReport admin stream

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -228,6 +228,60 @@ func TestReportAbuse_NotifiesModerators(t *testing.T) {
 		[]string{notifier.calls[0].userID, notifier.calls[1].userID})
 }
 
+// #1542: report-abuse は abuseReport system webhook を発火し、inactive な
+// notification recipient (method=webhook) の systemWebhookId を excludes に渡す。
+type stubSysWebhookDispatcher struct {
+	calls []struct {
+		eventType string
+		body      any
+		excludes  []string
+	}
+}
+
+func (s *stubSysWebhookDispatcher) DispatchSystemExcluding(eventType string, body any, excludes []string) {
+	s.calls = append(s.calls, struct {
+		eventType string
+		body      any
+		excludes  []string
+	}{eventType, body, excludes})
+}
+
+func TestReportAbuse_FiresSystemWebhook(t *testing.T) {
+	h, userRepo, _ := newExtraHandler(t)
+	h.SetUserRepo(userRepo)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "reporter"}
+	userRepo.Users["u2"] = &model.User{ID: "u2", Username: "target"}
+
+	disp := &stubSysWebhookDispatcher{}
+	recip := testutil.NewMockAbuseReportNotificationRecipientRepository()
+	inactiveID := "wh_inactive"
+	require.NoError(t, recip.Create(&model.AbuseReportNotificationRecipient{
+		ID: "rc1", Method: "webhook", IsActive: false, SystemWebhookID: &inactiveID,
+	}))
+	h.SetAbuseReportWebhook(disp, recip)
+
+	rec := postExtra(h.ReportAbuse, `{"userId":"u2","comment":"spam"}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Len(t, disp.calls, 1)
+	assert.Equal(t, "abuseReport", disp.calls[0].eventType)
+	assert.Equal(t, []string{inactiveID}, disp.calls[0].excludes, "inactive webhook recipient は excludes に")
+	body, ok := disp.calls[0].body.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "u1", body["reporterId"])
+	assert.Equal(t, "u2", body["targetUserId"])
+	assert.Equal(t, false, body["resolved"])
+	assert.Nil(t, body["assignee"])
+}
+
+// dispatcher 未配線でも report 自体は成功する (#1542)。
+func TestReportAbuse_NoDispatcherStillSucceeds(t *testing.T) {
+	h, userRepo, _ := newExtraHandler(t)
+	h.SetUserRepo(userRepo)
+	userRepo.Users["u2"] = &model.User{ID: "u2", Username: "target"}
+	rec := postExtra(h.ReportAbuse, `{"userId":"u2","comment":"spam"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
 // --- Reactions ---
 
 func TestReactions_Success(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2168,6 +2168,9 @@ func (s *Server) setupRoutes() {
 	abuseReportRepo := repository.NewAbuseReportRepository(s.db)
 	modLogRepo := repository.NewModerationLogRepository(s.db)
 	recipientRepo := repository.NewAbuseReportNotificationRecipientRepository(s.db)
+	// users/report-abuse 時に abuseReport system webhook を発火する (#1542)。
+	// recipientRepo がここで揃うため本箇所で配線する。
+	usersHandler.SetAbuseReportWebhook(webhookService, recipientRepo)
 	adminHandler := apiadmin.NewHandler(signupService, roleService, metaRepo, userRepo, idGen)
 	// admin/suspend-user / admin/unsuspend-user / admin/accounts/delete が
 	// target user の全 token cache entry を即時 invalidate するために、


### PR DESCRIPTION
## Summary

`#1542` の **system webhook event dispatch** 残項目 (`abuseReport` on report 作成時) を解消する。`#1542` は複数領域にまたがるため本 PR は issue を close しない (`Refs #1542`)。

upstream `AbuseReportService.report` は `notifyAdminStream` / `notifyMail` に加えて `notifySystemWebhook(reports, 'abuseReport')` を発火するが、mk-go の users/report-abuse は `abuseRepo.Create` + admin stream (`newAbuseUserReport`, #1549) のみで system webhook を発火していなかった。`#1723` の `abuseReportResolved` (resolve 時) と対になる **creation 側**を実装する。

## 主な変更点

- users Handler に `SystemWebhookDispatcher` (`DispatchSystemExcluding`) + `recipientRepo` を配線する `SetAbuseReportWebhook` を追加。
- `ReportAbuse` 成功後に `fireAbuseReportWebhook` を best-effort で呼び、packed report (reporter/targetUser を `UserDetailed`、assignee は作成時 nil) を body に `abuseReport` を発火。inactive な notification recipient (method=webhook) の `systemWebhookId` を excludes に渡す (upstream `notifySystemWebhook` の `withoutWebhookIds` 相当)。
- router で `webhookService` + `recipientRepo` を配線。

これで system webhook の **5 event** (`abuseReport` / `abuseReportResolved` / `userCreated` / `inactiveModeratorsWarning` / `inactiveModeratorsInvitationOnlyChanged`) すべてが実イベントで配送される。

## テスト

- `TestReportAbuse_FiresSystemWebhook` (excludes 計算 + body shape) / `TestReportAbuse_NoDispatcherStillSucceeds`
- 実行: `go test ./internal/api/users/... -count=1`
- カバレッジ: users 90.6% (gate 維持)、ReportAbuse 100% / fireAbuseReportWebhook 91.3%。

## Refs

Refs #1542 (system webhook event dispatch の abuseReport 分)

🤖 Generated with [Claude Code](https://claude.com/claude-code)