### PR TITLE
Fix meta parity: meta 更新の cross-worker cache invalidation (policiesUpdated 相当) (#1740)

### DIFF
--- a/internal/core/event/pubsub_test.go
+++ b/internal/core/event/pubsub_test.go
@@ -6,9 +6,12 @@ import (
 	"log"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -184,4 +187,56 @@ func TestPubSubService_Publish_MarshalError(t *testing.T) {
 	// chanがJSONにmarshalできない
 	err := svc.Publish(ctx, "ch", make(chan int))
 	assert.Error(t, err)
+}
+
+// crossWorkerFakeMeta is a minimal MetaRepository inner used to count DB fetches
+// in the cross-worker invalidation e2e (#1740).
+type crossWorkerFakeMeta struct {
+	fetchCount atomic.Int32
+	meta       *model.Meta
+}
+
+func (r *crossWorkerFakeMeta) Fetch() (*model.Meta, error) {
+	r.fetchCount.Add(1)
+	return r.meta, nil
+}
+func (r *crossWorkerFakeMeta) Update(map[string]any) error { return nil }
+func (r *crossWorkerFakeMeta) EnsureInitial(string) error  { return nil }
+
+// TestPubSubService_CrossWorkerMetaInvalidation は #1740 の核となる合成を検証する:
+// worker A が meta を更新すると internal:metaUpdated が publish され、worker B が
+// 受信して自プロセスの CachedMetaRepository を invalidate し、次の Fetch で
+// 再取得する (= cross-worker で default policy 変更等が伝播する)。
+func TestPubSubService_CrossWorkerMetaInvalidation(t *testing.T) {
+	ctx := context.Background()
+	innerA := &crossWorkerFakeMeta{meta: &model.Meta{ID: "m1"}}
+	innerB := &crossWorkerFakeMeta{meta: &model.Meta{ID: "m1"}}
+	cachedA := repository.NewCachedMetaRepositoryWithTTL(innerA, time.Hour)
+	cachedB := repository.NewCachedMetaRepositoryWithTTL(innerB, time.Hour)
+
+	psA := NewPubSubService(testRedis.Client, "internal_e2e:")
+	psB := NewPubSubService(testRedis.Client, "internal_e2e:")
+	defer psA.Close()
+	defer psB.Close()
+
+	// worker A は更新時に metaUpdated を publish する。
+	cachedA.SetInvalidationHook(func() { _ = psA.Publish(ctx, "metaUpdated", struct{}{}) })
+	// 両 worker が購読し、受信で自 cache を invalidate する。
+	psA.Subscribe(ctx, "metaUpdated", func([]byte) { cachedA.Invalidate() })
+	psB.Subscribe(ctx, "metaUpdated", func([]byte) { cachedB.Invalidate() })
+	time.Sleep(100 * time.Millisecond) // subscription 登録待ち
+
+	// 両 cache を温める。
+	_, _ = cachedA.Fetch()
+	_, _ = cachedB.Fetch()
+	require.Equal(t, int32(1), innerB.fetchCount.Load())
+
+	// worker A が更新 → publish → worker B が invalidate。
+	require.NoError(t, cachedA.Update(map[string]any{"name": "x"}))
+
+	// B は受信後 cache が drop され、次の Fetch で再取得する。
+	require.Eventually(t, func() bool {
+		_, _ = cachedB.Fetch()
+		return innerB.fetchCount.Load() > 1
+	}, 3*time.Second, 20*time.Millisecond, "worker B should re-fetch after cross-worker metaUpdated")
 }

--- a/internal/repository/meta_cached.go
+++ b/internal/repository/meta_cached.go
@@ -18,6 +18,12 @@ type CachedMetaRepository struct {
 	mu  sync.RWMutex
 	val *model.Meta
 	at  time.Time
+
+	// onUpdate は Update / EnsureInitial 成功時に呼ばれる post-update hook。
+	// cross-worker cache invalidation のため、自プロセスのローカル invalidate に
+	// 加えて他 worker へ metaUpdated を publish するのに使う (#1740)。nil 安全。
+	// repository 層が event/redis に直接依存しないよう func で受け取る。
+	onUpdate func()
 }
 
 // NewCachedMetaRepository creates a cached wrapper with a 5-minute TTL.
@@ -28,6 +34,20 @@ func NewCachedMetaRepository(inner MetaRepository) MetaRepository {
 // NewCachedMetaRepositoryWithTTL creates a cached wrapper with a custom TTL.
 func NewCachedMetaRepositoryWithTTL(inner MetaRepository, ttl time.Duration) *CachedMetaRepository {
 	return &CachedMetaRepository{inner: inner, ttl: ttl}
+}
+
+// SetInvalidationHook registers a callback fired after a successful Update /
+// EnsureInitial (in addition to the local cache invalidation). Used to publish
+// a cross-worker metaUpdated event so other processes invalidate their caches
+// (#1740). nil-safe.
+func (c *CachedMetaRepository) SetInvalidationHook(fn func()) {
+	c.onUpdate = fn
+}
+
+// Invalidate clears the cached meta. Exported so a cross-worker subscriber can
+// drop this process's cache on a remote metaUpdated event (#1740).
+func (c *CachedMetaRepository) Invalidate() {
+	c.invalidate()
 }
 
 // Fetch returns the cached meta if still valid, otherwise fetches from DB.
@@ -62,6 +82,7 @@ func (c *CachedMetaRepository) Update(fields map[string]any) error {
 	err := c.inner.Update(fields)
 	if err == nil {
 		c.invalidate()
+		c.notifyUpdate()
 	}
 	return err
 }
@@ -71,8 +92,15 @@ func (c *CachedMetaRepository) EnsureInitial(id string) error {
 	err := c.inner.EnsureInitial(id)
 	if err == nil {
 		c.invalidate()
+		c.notifyUpdate()
 	}
 	return err
+}
+
+func (c *CachedMetaRepository) notifyUpdate() {
+	if c.onUpdate != nil {
+		c.onUpdate()
+	}
 }
 
 func (c *CachedMetaRepository) invalidate() {

--- a/internal/repository/meta_cached_test.go
+++ b/internal/repository/meta_cached_test.go
@@ -91,6 +91,48 @@ func TestCachedMetaRepository_UpdateInvalidates(t *testing.T) {
 	assert.Equal(t, int32(2), inner.fetchCount.Load())
 }
 
+// SetInvalidationHook は Update / EnsureInitial 成功時に呼ばれる (#1740)。
+func TestCachedMetaRepository_InvalidationHookFires(t *testing.T) {
+	inner := &countingMetaRepo{meta: &model.Meta{ID: "m1"}}
+	cached := repository.NewCachedMetaRepositoryWithTTL(inner, 1*time.Minute)
+	var hookCount atomic.Int32
+	cached.SetInvalidationHook(func() { hookCount.Add(1) })
+
+	require.NoError(t, cached.Update(map[string]any{"name": "new"}))
+	assert.Equal(t, int32(1), hookCount.Load(), "Update success fires hook")
+
+	require.NoError(t, cached.EnsureInitial("m1"))
+	assert.Equal(t, int32(2), hookCount.Load(), "EnsureInitial success fires hook")
+}
+
+// Update 失敗時は hook を呼ばない (#1740)。
+func TestCachedMetaRepository_InvalidationHookNotFiredOnError(t *testing.T) {
+	inner := &countingMetaRepo{meta: &model.Meta{ID: "m1"}, updateErr: errors.New("boom")}
+	cached := repository.NewCachedMetaRepositoryWithTTL(inner, 1*time.Minute)
+	var hookCount atomic.Int32
+	cached.SetInvalidationHook(func() { hookCount.Add(1) })
+
+	require.Error(t, cached.Update(map[string]any{"name": "new"}))
+	assert.Equal(t, int32(0), hookCount.Load(), "failed Update must not fire hook")
+}
+
+// Invalidate() は cache を drop し次の Fetch を再取得させる (cross-worker
+// subscriber が remote metaUpdated で呼ぶ経路、#1740)。
+func TestCachedMetaRepository_InvalidateDropsCache(t *testing.T) {
+	inner := &countingMetaRepo{meta: &model.Meta{ID: "m1"}}
+	cached := repository.NewCachedMetaRepositoryWithTTL(inner, 1*time.Minute)
+
+	_, err := cached.Fetch()
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), inner.fetchCount.Load())
+
+	cached.Invalidate()
+
+	_, err = cached.Fetch()
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), inner.fetchCount.Load(), "Invalidate forces re-fetch")
+}
+
 func TestCachedMetaRepository_EnsureInitialInvalidates(t *testing.T) {
 	inner := &countingMetaRepo{meta: &model.Meta{ID: "m1"}}
 	cached := repository.NewCachedMetaRepositoryWithTTL(inner, 1*time.Minute)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -135,7 +135,10 @@ func (s *Server) setupRoutes() {
 	// 時の invalidate が両方に反映される (#300 3-3)。
 	userRepo := s.userRepo
 	noteRepo := repository.NewNoteRepository(s.db)
-	metaRepo := repository.NewCachedMetaRepository(repository.NewMetaRepository(s.db))
+	// cross-worker cache invalidation (#1740) のため concrete *CachedMetaRepository
+	// を保持する。internal event bus との配線は streamPubSub 生成箇所で行う。
+	cachedMeta := repository.NewCachedMetaRepositoryWithTTL(repository.NewMetaRepository(s.db), 5*time.Minute)
+	var metaRepo repository.MetaRepository = cachedMeta
 	// Seed the singleton meta row on first boot so that fresh installs
 	// can run /api/admin/accounts/create (initial setup) without tripping
 	// over a missing meta row.
@@ -1867,6 +1870,21 @@ func (s *Server) setupRoutes() {
 	// 1. Redis pubsub bus (核となる publish/subscribe チャンネル)
 	streamPubSub := event.NewPubSubService(s.redis.Pubsub, "stream:")
 	streamBus := stream.NewEventPubSubBus(streamPubSub)
+
+	// #1740: meta 更新の cross-worker cache invalidation。更新した worker は
+	// internal:metaUpdated を publish し、各 worker は受信して自プロセスの
+	// CachedMetaRepository を invalidate する。upstream の
+	// globalEventService.publishInternalEvent('metaUpdated'/'policiesUpdated') 相当で、
+	// update-meta / update-default-policies 等あらゆる meta 更新を 1 箇所で伝播する。
+	internalPubSub := event.NewPubSubService(s.redis.Pubsub, "internal:")
+	cachedMeta.SetInvalidationHook(func() {
+		if err := internalPubSub.Publish(context.Background(), "metaUpdated", struct{}{}); err != nil {
+			slog.Warn("meta: publish metaUpdated failed", "err", err)
+		}
+	})
+	internalPubSub.Subscribe(context.Background(), "metaUpdated", func([]byte) {
+		cachedMeta.Invalidate()
+	})
 
 	// pollVoted / reacted / unreacted / deleted を noteStream:<id> に publish
 	// する共通 publisher。subNote / sn メッセージで購読しているクライアントへ


### PR DESCRIPTION
## Summary

`#1542` 派生の `#1740` を解消する。`admin/roles/update-default-policies` 等の meta 更新は、更新を行った worker 内では `CachedMetaRepository.Update` が即時 invalidate するものの、他 worker (別プロセス) は独立の 5min TTL cache を持つため最大 5 分 stale だった。upstream の `globalEventService.publishInternalEvent('metaUpdated'/'policiesUpdated')` (Redis pub/sub) に相当する cross-worker invalidation が mk-go に無かった。

policies に限らず**全 meta 更新に共通の問題**なので、単一の choke point (`CachedMetaRepository.Update` / `EnsureInitial`) で伝播する形で解消する (policies-only ではなく根本対応)。

## 主な変更点

- **`CachedMetaRepository`**: `SetInvalidationHook` (post-update callback) と `Invalidate()` を追加。repository 層が event/redis に直接依存しないよう hook は `func()` で受ける。
- **router**: `internal:` prefix の `PubSubService` を生成し、hook で `metaUpdated` を publish、各 worker が購読して自プロセスの cache を `Invalidate` する。`update-meta` / `update-default-policies` 等あらゆる meta 更新を 1 箇所で cross-worker 伝播する。

既存の Redis pub/sub bus (`core/event.PubSubService`、streaming で使用) を再利用し、新インフラ・migration・config は不要。

## テスト

- 単体 (`internal/repository`): `TestCachedMetaRepository_InvalidationHookFires` (Update/EnsureInitial 成功時のみ発火) / `_InvalidationHookNotFiredOnError` / `_InvalidateDropsCache`
- e2e (`internal/core/event`, 実 Redis): `TestPubSubService_CrossWorkerMetaInvalidation` — 2 worker (`CachedMetaRepository` + `PubSubService`) で worker A の更新が worker B の cache を invalidate し再取得させることを検証。
- 実行: `go test ./internal/repository/... ./internal/core/event/... -count=1`
- カバレッジ: repository 90.2% (gate 維持)、meta_cached の新 symbol 全て 100%。

## Closes

Closes #1740

🤖 Generated with [Claude Code](https://claude.com/claude-code)