### PR TITLE
Fix chat parity: messages/react の emoji 検証 + own/others/member guard + 100-reaction 上限 (#1541)

### DIFF
--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -742,8 +742,11 @@ func TestReactionsCreate(t *testing.T) {
 	h, repo := newHandlerWithService(t)
 	// missing params → 400
 	assert.Equal(t, http.StatusBadRequest, post(h.ReactionsCreate, `{}`, u1).Code)
-	// #1549: React は service 経由で message を引くので seed が要る。
-	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "sender", Reads: pq.StringArray{}, Reactions: pq.StringArray{}}
+	// #1549/#1541: React は service 経由で message を引くので seed が要る。
+	// #1541 で react guard が入ったため、reactor (u1) が受信者である DM にする
+	// (own-message でも others-message でもない有効な react)。
+	to := u1.ID
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "sender", ToUserID: &to, Reads: pq.StringArray{}, Reactions: pq.StringArray{}}
 	rec := post(h.ReactionsCreate, `{"messageId":"m1","reaction":"👍"}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }

--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -45,7 +46,28 @@ var (
 	// blocked the sender. Mirrors upstream ChatService's 'blocked' error
 	// (YOU_HAVE_BEEN_BLOCKED).
 	ErrChatBlocked = errors.New("you have been blocked by the recipient")
+	// ErrCannotReact is returned by React when the actor may not react to the
+	// target message: it is their own message, a 1-on-1 message not addressed to
+	// them, or a room message in a room they are not a member of. Mirrors
+	// upstream ChatService.react's 'cannot react to own/others message' (plain
+	// Error -> generic 500).
+	ErrCannotReact = errors.New("cannot react to this message")
+	// ErrTooManyReactions is returned by React when the message already has the
+	// maximum number of reactions (upstream MAX_REACTIONS_PER_MESSAGE).
+	ErrTooManyReactions = errors.New("too many reactions")
+	// ErrNoSuchEmoji is returned by React when a custom emoji reaction references
+	// a local emoji that does not exist (upstream 'no such emoji').
+	ErrNoSuchEmoji = errors.New("no such emoji")
 )
+
+// maxReactionsPerMessage caps the reactions on a single chat message
+// (upstream MAX_REACTIONS_PER_MESSAGE = 100).
+const maxReactionsPerMessage = 100
+
+// chatCustomEmojiPattern matches a local custom-emoji reaction (`:name:` or the
+// canonical `:name@.:` form). upstream isCustomEmojiRegexp は local emoji だけを
+// 対象とするため host 付き (`:name@host:`) は unicode として扱う。
+var chatCustomEmojiPattern = regexp.MustCompile(`^:([\w+\-]+)(?:@\.)?:$`)
 
 // StreamingPublisher is the Redis pub/sub dispatch interface the service uses
 // to broadcast chat events. Implementations live in internal/stream so the
@@ -109,6 +131,10 @@ type Service struct {
 	// invitationNotifier: AP 経由で受け取った招待を local invitee へ通知する
 	// (#1559)。未配線なら通知しない。
 	invitationNotifier ChatInvitationNotifier
+	// emojiRepo: React で custom emoji (`:name:`) reaction の存在検証に使う
+	// (#1541)。nil の場合は custom emoji を検証せず `:name:` をそのまま採用する
+	// (legacy/test path)。
+	emojiRepo repository.EmojiRepository
 }
 
 // ChatInvitationNotifier records a 'chatRoomInvitationReceived' notification on
@@ -121,6 +147,12 @@ type ChatInvitationNotifier interface {
 // notify local invitees of inbound (federated) chat room invitations (#1559)。
 func (s *Service) SetInvitationNotifier(n ChatInvitationNotifier) {
 	s.invitationNotifier = n
+}
+
+// SetEmojiRepo wires the emoji repository so React can validate custom-emoji
+// reactions against the local emoji table (#1541). nil disables the check.
+func (s *Service) SetEmojiRepo(r repository.EmojiRepository) {
+	s.emojiRepo = r
 }
 
 // NewService constructs a chat Service.
@@ -1014,15 +1046,70 @@ func (s *Service) MarkReadByMessageID(ctx context.Context, userID, messageID str
 // upstream ChatService.react)。reaction は reactor.ID+"/"+emoji で永続化し、
 // stream event には raw emoji + reactor (UserLite) を載せる。
 func (s *Service) React(ctx context.Context, messageID string, reactor *model.User, emoji string) error {
+	// upstream ChatService.react は emoji の正規化/存在検証を最初に行い、未存在の
+	// custom emoji は 'no such emoji' を投げる (message 検索より前)。
+	reaction, err := s.normalizeChatReaction(emoji)
+	if err != nil {
+		return err
+	}
 	msg, err := s.repo.FindMessageByID(messageID)
 	if err != nil {
 		return ErrNotFound
 	}
-	if err := s.repo.AddReaction(messageID, reactor.ID+"/"+emoji); err != nil {
+	// 自分のメッセージには react できない。
+	if msg.FromUserID == reactor.ID {
+		return ErrCannotReact
+	}
+	// 1-on-1 で自分が受信者でないメッセージには react できない
+	// (upstream: toRoomId === null && toUserId !== userId)。
+	if msg.ToRoomID == nil {
+		if msg.ToUserID == nil || *msg.ToUserID != reactor.ID {
+			return ErrCannotReact
+		}
+	}
+	// reaction 上限 (upstream MAX_REACTIONS_PER_MESSAGE)。
+	if len(msg.Reactions) >= maxReactionsPerMessage {
+		return ErrTooManyReactions
+	}
+	// room メッセージは member でなければ react できない。
+	if msg.ToRoomID != nil && *msg.ToRoomID != "" {
+		room, err := s.repo.FindRoomByID(*msg.ToRoomID)
+		if err != nil {
+			return ErrNotFound
+		}
+		isMember, err := s.isRoomMemberWith(room, reactor.ID, *msg.ToRoomID)
+		if err != nil {
+			return err
+		}
+		if !isMember {
+			return ErrCannotReact
+		}
+	}
+	if err := s.repo.AddReaction(messageID, reactor.ID+"/"+reaction); err != nil {
 		return fmt.Errorf("add reaction: %w", err)
 	}
-	s.publishReaction(ctx, msg, EventReact, reactor, emoji)
+	s.publishReaction(ctx, msg, EventReact, reactor, reaction)
 	return nil
+}
+
+// normalizeChatReaction validates and canonicalises a chat reaction string,
+// mirroring upstream ChatService.react: a `:name:` custom-emoji reaction is
+// looked up in the local emoji table (ErrNoSuchEmoji if absent) and stored as
+// `:name:`, while anything else is treated as a unicode emoji with its
+// variation selector (U+FE0F) stripped. emojiRepo 未配線時は custom emoji を
+// 検証せず `:name:` をそのまま採用する (legacy/test path)。
+func (s *Service) normalizeChatReaction(raw string) (string, error) {
+	if m := chatCustomEmojiPattern.FindStringSubmatch(raw); m != nil {
+		name := m[1]
+		if s.emojiRepo != nil {
+			if _, err := s.emojiRepo.FindByNameAndHost(name, nil); err != nil {
+				return "", ErrNoSuchEmoji
+			}
+		}
+		return ":" + name + ":", nil
+	}
+	// variation selector (U+FE0F) を strip して upstream の canonical form に揃える。
+	return strings.ReplaceAll(raw, "\ufe0f", ""), nil
 }
 
 // Unreact removes a reaction and publishes an `unreact` stream event (#1549)。

--- a/internal/core/chat/service_test.go
+++ b/internal/core/chat/service_test.go
@@ -597,7 +597,8 @@ func TestReact_DMPublishesReact(t *testing.T) {
 	svc, repo, pub := newSvc(t)
 	to := "bob"
 	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "carol", ToUserID: &to}
-	reactor := &model.User{ID: "alice", Username: "alice"}
+	// upstream は 1-on-1 で受信者 (toUserId) だけが react できる。
+	reactor := &model.User{ID: "bob", Username: "bob"}
 	require.NoError(t, svc.React(context.Background(), "m1", reactor, "👍"))
 	require.Len(t, pub.userCalls, 1)
 	assert.Equal(t, corechat.EventReact, pub.userCalls[0].eventType)
@@ -611,6 +612,8 @@ func TestReact_DMPublishesReact(t *testing.T) {
 func TestReact_RoomPublishesReact(t *testing.T) {
 	svc, repo, pub := newSvc(t)
 	room := "r1"
+	// reactor は room member でなければ react できない (owner = member 扱い)。
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
 	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "carol", ToRoomID: &room}
 	require.NoError(t, svc.React(context.Background(), "m1", &model.User{ID: "alice"}, "👍"))
 	require.Len(t, pub.roomCalls, 1)
@@ -638,6 +641,90 @@ func TestUnreact_MessageNotFound(t *testing.T) {
 	err := svc.Unreact(context.Background(), "ghost", &model.User{ID: "alice"}, "👍")
 	assert.ErrorIs(t, err, corechat.ErrNotFound)
 }
+
+// --- #1541: React validation (own/others/member/limit/emoji) ---
+
+// 自分のメッセージには react できない。
+func TestReact_OwnMessage(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	to := "bob"
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "alice", ToUserID: &to}
+	err := svc.React(context.Background(), "m1", &model.User{ID: "alice"}, "👍")
+	assert.ErrorIs(t, err, corechat.ErrCannotReact)
+}
+
+// 1-on-1 で受信者でない第三者は react できない。
+func TestReact_OthersMessage1on1(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	to := "bob"
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "carol", ToUserID: &to}
+	err := svc.React(context.Background(), "m1", &model.User{ID: "dave"}, "👍")
+	assert.ErrorIs(t, err, corechat.ErrCannotReact)
+}
+
+// room メッセージは member でなければ react できない。
+func TestReact_RoomNotMember(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	room := "r1"
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "alice"}
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "carol", ToRoomID: &room}
+	err := svc.React(context.Background(), "m1", &model.User{ID: "dave"}, "👍")
+	assert.ErrorIs(t, err, corechat.ErrCannotReact)
+}
+
+// 100 reaction を超えると拒否する。
+func TestReact_TooManyReactions(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	to := "bob"
+	reactions := make([]string, maxReactionsForTest)
+	for i := range reactions {
+		reactions[i] = "u/x"
+	}
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "carol", ToUserID: &to, Reactions: reactions}
+	err := svc.React(context.Background(), "m1", &model.User{ID: "bob"}, "👍")
+	assert.ErrorIs(t, err, corechat.ErrTooManyReactions)
+}
+
+// 存在しない custom emoji は ErrNoSuchEmoji。
+func TestReact_NoSuchEmoji(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	emojiRepo := testutil.NewMockEmojiRepository()
+	svc.SetEmojiRepo(emojiRepo)
+	to := "bob"
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "carol", ToUserID: &to}
+	err := svc.React(context.Background(), "m1", &model.User{ID: "bob"}, ":ghost:")
+	assert.ErrorIs(t, err, corechat.ErrNoSuchEmoji)
+}
+
+// 存在する local custom emoji は ":name:" に正規化されて publish される。
+func TestReact_CustomEmojiOK(t *testing.T) {
+	svc, repo, pub := newSvc(t)
+	emojiRepo := testutil.NewMockEmojiRepository()
+	emojiRepo.Emojis["party@"] = &model.Emoji{Name: "party"}
+	svc.SetEmojiRepo(emojiRepo)
+	to := "bob"
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "carol", ToUserID: &to}
+	require.NoError(t, svc.React(context.Background(), "m1", &model.User{ID: "bob"}, ":party:"))
+	require.Len(t, pub.userCalls, 1)
+	body, ok := pub.userCalls[0].body.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, ":party:", body["reaction"], "custom emoji は :name: 形式に正規化される")
+}
+
+// unicode reaction は variation selector (U+FE0F) を strip して publish される。
+func TestReact_UnicodeStripsVariationSelector(t *testing.T) {
+	svc, repo, pub := newSvc(t)
+	to := "bob"
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "carol", ToUserID: &to}
+	require.NoError(t, svc.React(context.Background(), "m1", &model.User{ID: "bob"}, "❤️"))
+	require.Len(t, pub.userCalls, 1)
+	body, ok := pub.userCalls[0].body.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "❤", body["reaction"], "U+FE0F が除去される")
+}
+
+// maxReactionsForTest mirrors the service-internal cap for the limit test.
+const maxReactionsForTest = 100
 
 // ReadUserChat / ReadRoomChat は会話全体既読 (repo へ委譲、no-error)。
 func TestReadUserChat_NoError(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2047,6 +2047,8 @@ func (s *Server) setupRoutes() {
 	// 1-on-1 DM で recipient が sender を block している場合に弾く
 	// (upstream YOU_HAVE_BEEN_BLOCKED 互換)。
 	chatService.SetBlockingRepo(blockingRepo)
+	// React で custom emoji (:name:) reaction の存在検証に使う (#1541)。
+	chatService.SetEmojiRepo(emojiRepo)
 	streamRegistry.Register("chatRoom", channels.NewChatRoomFactory(chatService).New)
 	streamRegistry.Register("chatUser", channels.NewChatUserFactory(chatService).New)
 	// Phase 9.7: federation processor / reversi handler に reversi 依存を注入。


### PR DESCRIPTION
## Summary

chat/* parity issue #1541 の HIGH 項目。upstream `ChatService.react` は reaction を受理する前に複数の検証を行うが、mk-go の `React` は `FindMessageByID` 後に無条件で `AddReaction` していた。upstream と同じ検証を同じ順序で実装する。

## 主な変更点 (`internal/core/chat/service.go`)

`React` を以下の順 (upstream `ChatService.react` 準拠) に書き換え:

1. **emoji 正規化/検証** (message 検索より前): custom emoji `:name:` は local emoji table (`emojiRepo.FindByNameAndHost(name, nil)`) で存在検証し、未存在なら `ErrNoSuchEmoji`。それ以外は unicode として variation selector (U+FE0F) を strip。`emojiRepo` 未配線時 (test/legacy) は検証 skip。
2. **own-message guard**: `msg.FromUserID == reactor.ID` を拒否。
3. **others-message guard** (1-on-1): `toRoomId == null && toUserId != reactor` を拒否。
4. **100-reaction 上限**: `len(reactions) >= MAX_REACTIONS_PER_MESSAGE(100)` を拒否。
5. **room-member guard**: room メッセージは member でなければ拒否。

これらの soft-reject は upstream で plain `Error` (= generic 500) のため、handler は従来通り全エラーを 500 にマップする (message-not-found も upstream `findOneByOrFail` の `EntityNotFoundError -> 500` と一致するため据え置き、vestigial な `noSuchMessage` golden には追従しない)。`internal/server/router.go` で `chatService.SetEmojiRepo(emojiRepo)` を配線。

## テスト

`internal/core/chat` に own / others-1on1 / room-not-member / too-many(100) / no-such-emoji / custom-emoji-ok / unicode-strip を追加。既存の DM/room react テストは guard を満たす fixture (受信者 / room owner) に更新。

実行: `go test ./internal/core/chat/...` (coverage: 91.0%)

## 関連

Refs #1541 (chat/* parity の一部。残項目は後続 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)