### PR TITLE
Fix chat parity: rooms/invitations/outbox の response shape (createdAt + room) (#1541)

### DIFF
--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -1350,19 +1350,20 @@ func (h *Handler) InvitationsOutbox(c echo.Context) error {
 	// 自分が所有するルームの招待一覧を返す
 	room, err := h.repo.FindRoomByID(req.RoomID)
 	if err != nil || room.OwnerID != user.ID {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "b3926861-29ef-4df6-98b5-a7c640ad2b5a"))
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "a3c6b309-9717-4316-ae94-a69b53437237"))
 	}
 	rows, err := h.repo.ListInvitationsByRoom(req.RoomID)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
+	// upstream packRoomInvitation は {id, createdAt, roomId, room, userId, user} を
+	// 返す。旧 mk-go は createdAt と room を欠いていた (#1541)。ListInvitationsByRoom は
+	// User を Preload 済み、room は上で取得済みなので各 inv に詰めて
+	// packInvitationDetailed (createdAt + room + user) で pack する。
 	out := make([]map[string]any, 0, len(rows))
 	for _, inv := range rows {
-		entry := map[string]any{"id": inv.ID, "roomId": inv.RoomID, "userId": inv.UserID}
-		if inv.User != nil {
-			entry["user"] = packUser(inv.User)
-		}
-		out = append(out, entry)
+		inv.Room = room
+		out = append(out, h.packInvitationDetailed(inv, user.ID))
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -1263,6 +1263,37 @@ func TestInvitationsOutbox(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, post(h.InvitationsOutbox, `{"roomId":"r1"}`, u2).Code)
 }
 
+// #1541: outbox の各 invitation は upstream packRoomInvitation 同様
+// createdAt と room を含む。
+func TestInvitationsOutbox_ShapeIncludesCreatedAtAndRoom(t *testing.T) {
+	h, repo := newTestHandler()
+	idGen, _ := id.NewGenerator("aidx")
+	invID := idGen.Generate(time.Now())
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u1.ID, Name: "room"}
+	require.NoError(t, repo.CreateInvitation(&model.ChatRoomInvitation{ID: invID, UserID: u2.ID, RoomID: "r1"}))
+	rec := post(h.InvitationsOutbox, `{"roomId":"r1"}`, u1)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	entry := resp[0]
+	assert.Equal(t, "r1", entry["roomId"])
+	assert.Equal(t, u2.ID, entry["userId"])
+	assert.NotEmpty(t, entry["createdAt"], "createdAt は invitation id から導出される")
+	room, ok := entry["room"].(map[string]any)
+	require.True(t, ok, "room (ChatRoom) を含む")
+	assert.Equal(t, "r1", room["id"])
+	assert.Equal(t, "room", room["name"])
+}
+
+// #1541: outbox の NO_SUCH_ROOM は upstream の golden id を返す。
+func TestInvitationsOutbox_NoSuchRoomGoldenID(t *testing.T) {
+	h, _ := newTestHandler()
+	rec := post(h.InvitationsOutbox, `{"roomId":"ghost"}`, u1)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assertErrorCode(t, rec, "NO_SUCH_ROOM", "a3c6b309-9717-4316-ae94-a69b53437237")
+}
+
 func TestRoomsJoin(t *testing.T) {
 	h, repo := newTestHandler()
 	// invalid param

--- a/internal/testutil/mock_chat.go
+++ b/internal/testutil/mock_chat.go
@@ -327,8 +327,16 @@ func (m *MockChatRepository) ListInvitationsByUser(_ string, _ bool) ([]*model.C
 	return nil, nil
 }
 
-func (m *MockChatRepository) ListInvitationsByRoom(_ string) ([]*model.ChatRoomInvitation, error) {
-	return nil, nil
+func (m *MockChatRepository) ListInvitationsByRoom(roomID string) ([]*model.ChatRoomInvitation, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var rows []*model.ChatRoomInvitation
+	for _, inv := range m.Invitations {
+		if inv.RoomID == roomID {
+			rows = append(rows, inv)
+		}
+	}
+	return rows, nil
 }
 
 // --- Read tracking / unread count ---


### PR DESCRIPTION
## Summary

chat/* parity issue #1541 の MEDIUM 項目。upstream `packRoomInvitation` は `{id, createdAt, roomId, room, userId, user}` を返すが、mk-go の `InvitationsOutbox` は `{id, roomId, userId}` (+ optional user) のみで **createdAt と room を欠いていた**。

## 主な変更点

- `InvitationsOutbox` を既存の `packInvitationDetailed` (createdAt は invitation id から導出 + room + user) を通すよう書き換え。`ListInvitationsByRoom` は `User` を Preload 済み、room は owner-check で取得済みのため、各 invitation に room を詰めて pack する。
- 併せて outbox の **NO_SUCH_ROOM golden id が誤っていた** (旧 `b3926861-...`) のを upstream golden (`a3c6b309-9717-4316-ae94-a69b53437237`) に修正 (同 endpoint の隣接バグ)。
- `testutil.MockChatRepository.ListInvitationsByRoom` が `nil` 固定だったのを roomId で filter して返すよう faithful 化 (response shape を test 可能にするため。呼び出し元は `InvitationsOutbox` のみ)。

## テスト

`internal/api/chat` に outbox response が createdAt + room を含むこと / NO_SUCH_ROOM golden id を追加。

実行: `go test ./internal/api/chat/... ./internal/testutil/...` (coverage: api/chat 94.6%)

## 関連

Refs #1541 (chat/* parity の一部。残項目は後続 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)