### PR TITLE
Fix chat parity: messages/search の userId/roomId scope + NO_SUCH_ROOM + user-timeline NO_SUCH_USER (#1541)

### DIFF
--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -967,13 +967,24 @@ func (h *Handler) Messages(c echo.Context) error {
 func (h *Handler) MessagesSearch(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req struct {
-		Query string `json:"query"`
-		Limit int    `json:"limit"`
+		Query  string `json:"query"`
+		Limit  int    `json:"limit"`
+		UserID string `json:"userId"`
+		RoomID string `json:"roomId"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
-	msgs, _ := h.repo.SearchMessages(user.ID, req.Query, req.Limit)
+	// roomId 指定時は upstream search.ts と同じく room が存在し、かつ自分が member
+	// (owner 含む) でなければ NO_SUCH_ROOM を返す (存在しない room も非 member も
+	// 同じ code)。
+	if req.RoomID != "" {
+		room, err := h.repo.FindRoomByID(req.RoomID)
+		if err != nil || !h.isRoomMember(room, user.ID) {
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "460b3669-81b0-4dc9-a997-44442141bf83"))
+		}
+	}
+	msgs, _ := h.repo.SearchMessages(user.ID, req.Query, req.Limit, req.UserID, req.RoomID)
 	result := make([]map[string]any, len(msgs))
 	for i, m := range msgs {
 		result[i] = h.packMessageDetailed(m, user.ID)
@@ -1229,6 +1240,13 @@ func (h *Handler) UserTimeline(c echo.Context) error {
 	}
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return apierr.JSONInvalidParam(c)
+	}
+	// upstream user-timeline.ts は getUser(userId) で相手を解決し、不在なら
+	// NO_SUCH_USER を返す。userRepo 未配線 (legacy test) は検証 skip。
+	if h.userRepo != nil {
+		if _, err := h.userRepo.FindByID(req.UserID); err != nil {
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "11795c64-40ea-4198-b06e-3c873ed9039d"))
+		}
 	}
 	if req.Limit <= 0 {
 		req.Limit = 10

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -375,7 +375,7 @@ type mockMsgRepo struct{ *testutil.MockChatRepository }
 func (m *mockMsgRepo) ListMessagesByRoom(_ string, _ int) ([]*model.ChatMessage, error) {
 	return []*model.ChatMessage{{ID: "m1", FromUserID: "u1", Reads: pq.StringArray{}, Reactions: pq.StringArray{}}}, nil
 }
-func (m *mockMsgRepo) SearchMessages(_, _ string, _ int) ([]*model.ChatMessage, error) {
+func (m *mockMsgRepo) SearchMessages(_, _ string, _ int, _, _ string) ([]*model.ChatMessage, error) {
 	return []*model.ChatMessage{{ID: "m1", FromUserID: "u1", Reads: pq.StringArray{}, Reactions: pq.StringArray{}}}, nil
 }
 
@@ -738,6 +738,54 @@ func TestMessagesSearch(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// #1541: roomId 指定で存在しない room は NO_SUCH_ROOM。
+func TestMessagesSearch_RoomNotFound(t *testing.T) {
+	h, _ := newTestHandler()
+	rec := post(h.MessagesSearch, `{"query":"x","roomId":"ghost"}`, u1)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assertErrorCode(t, rec, "NO_SUCH_ROOM", "460b3669-81b0-4dc9-a997-44442141bf83")
+}
+
+// #1541: roomId 指定で非 member の room も NO_SUCH_ROOM。
+func TestMessagesSearch_RoomNotMember(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u2.ID}
+	rec := post(h.MessagesSearch, `{"query":"x","roomId":"r1"}`, u1)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assertErrorCode(t, rec, "NO_SUCH_ROOM", "460b3669-81b0-4dc9-a997-44442141bf83")
+}
+
+// #1541: member であれば roomId scope で検索でき、その room のメッセージを返す。
+func TestMessagesSearch_RoomScoped(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u1.ID}
+	roomID := "r1"
+	txt := "hello room"
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "u2", ToRoomID: &roomID, Text: &txt, Reads: pq.StringArray{}, Reactions: pq.StringArray{}}
+	rec := post(h.MessagesSearch, `{"query":"hello","roomId":"r1"}`, u1)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp, 1)
+}
+
+// #1541: userId scope は相手との 1-on-1 のみを返す。
+func TestMessagesSearch_UserScoped(t *testing.T) {
+	h, repo := newTestHandler()
+	to := "u2"
+	txt := "hi bob"
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: u1.ID, ToUserID: &to, Text: &txt, Reads: pq.StringArray{}, Reactions: pq.StringArray{}}
+	// 別人との DM はヒットしない。
+	other := "u3"
+	txt2 := "hi carol"
+	repo.Messages["m2"] = &model.ChatMessage{ID: "m2", FromUserID: u1.ID, ToUserID: &other, Text: &txt2, Reads: pq.StringArray{}, Reactions: pq.StringArray{}}
+	rec := post(h.MessagesSearch, `{"query":"hi","userId":"u2"}`, u1)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp, 1)
+}
+
 func TestReactionsCreate(t *testing.T) {
 	h, repo := newHandlerWithService(t)
 	// missing params → 400
@@ -1062,6 +1110,25 @@ func TestUserTimeline_MarksReadOnOpen(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "u1", spy.markFromUserCalled.reader)
 	assert.Equal(t, "u_other", spy.markFromUserCalled.fromUser)
+}
+
+// #1541: userRepo 配線時、存在しない userId は NO_SUCH_USER を返す。
+func TestUserTimeline_NoSuchUser(t *testing.T) {
+	h, _ := newTestHandler()
+	h.SetUserRepo(testutil.NewMockUserRepository()) // 空 (u_ghost 未登録)
+	rec := post(h.UserTimeline, `{"userId":"u_ghost"}`, u1)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assertErrorCode(t, rec, "NO_SUCH_USER", "11795c64-40ea-4198-b06e-3c873ed9039d")
+}
+
+// #1541: userId が存在すれば従来どおり 200。
+func TestUserTimeline_UserExists(t *testing.T) {
+	h, _ := newTestHandler()
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["u2"] = u2
+	h.SetUserRepo(userRepo)
+	rec := post(h.UserTimeline, `{"userId":"u2"}`, u1)
+	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
 func TestRoomTimeline_MarksReadOnOpen(t *testing.T) {

--- a/internal/repository/chat.go
+++ b/internal/repository/chat.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"strings"
+
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/gorm"
 )
@@ -27,7 +29,7 @@ type ChatRepository interface {
 	// file, newest-first, with id-cursor pagination. Used by
 	// drive/files/attached-chat-messages.
 	ListMessagesByFileID(fileID, untilID, sinceID string, limit int) ([]*model.ChatMessage, error)
-	SearchMessages(userID, query string, limit int) ([]*model.ChatMessage, error)
+	SearchMessages(meID, query string, limit int, userID, roomID string) ([]*model.ChatMessage, error)
 
 	// Membership operations
 	CreateMembership(m *model.ChatRoomMembership) error
@@ -211,14 +213,38 @@ func (r *chatRepository) ListMessagesByUser(userID, otherUserID string, limit in
 	return msgs, nil
 }
 
-func (r *chatRepository) SearchMessages(userID, query string, limit int) ([]*model.ChatMessage, error) {
+// SearchMessages mirrors upstream ChatService.searchMessages: when userID is
+// set it scopes to the 1-on-1 conversation with that user, when roomID is set
+// it scopes to that room, and otherwise it covers every message the viewer can
+// see (own 1-on-1 messages + rooms they are a member of or own). The membership
+// + NO_SUCH_ROOM gate for roomID is enforced by the handler before this is
+// reached (upstream search.ts).
+func (r *chatRepository) SearchMessages(meID, query string, limit int, userID, roomID string) ([]*model.ChatMessage, error) {
 	if limit <= 0 {
-		limit = 20
+		limit = 10
 	}
+	if limit > 100 {
+		limit = 100
+	}
+	q := r.db.Preload("FromUser").Preload("ToUser").Preload("ToRoom").Preload("ToRoom.Owner").Preload("File")
+	switch {
+	case userID != "":
+		q = q.Where(`("fromUserId" = ? AND "toUserId" = ?) OR ("fromUserId" = ? AND "toUserId" = ?)`,
+			meID, userID, userID, meID)
+	case roomID != "":
+		q = q.Where(`"toRoomId" = ?`, roomID)
+	default:
+		// 自分の 1-on-1 + 所属 / 所有 room のメッセージを対象にする
+		// (upstream の membership / owned-room サブクエリ相当)。
+		memberSub := r.db.Model(&model.ChatRoomMembership{}).Select(`"roomId"`).Where(`"userId" = ?`, meID)
+		ownedSub := r.db.Model(&model.ChatRoom{}).Select(`"id"`).Where(`"ownerId" = ?`, meID)
+		q = q.Where(`"fromUserId" = ? OR "toUserId" = ? OR "toRoomId" IN (?) OR "toRoomId" IN (?)`,
+			meID, meID, memberSub, ownedSub)
+	}
+	// LIKE metacharacter を escape して literal 一致にする (upstream sqlLikeEscape)。
+	q = q.Where(`LOWER("text") LIKE ?`, "%"+escapeLike(strings.ToLower(query))+"%")
 	var msgs []*model.ChatMessage
-	if err := r.db.Preload("FromUser").Preload("File").
-		Where(`("fromUserId" = ? OR "toUserId" = ?) AND "text" ILIKE ?`, userID, userID, "%"+query+"%").
-		Order(`"id" DESC`).Limit(limit).Find(&msgs).Error; err != nil {
+	if err := q.Order(`"id" DESC`).Limit(limit).Find(&msgs).Error; err != nil {
 		return nil, err
 	}
 	return msgs, nil

--- a/internal/repository/chat_test.go
+++ b/internal/repository/chat_test.go
@@ -110,15 +110,30 @@ func TestChatRepository_Messages(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, dms2, 1)
 
-	// SearchMessages
-	results, err := repo.SearchMessages(user1.ID, "dm", 10)
+	// SearchMessages - default scope (own 1-on-1 + member/owned rooms)
+	results, err := repo.SearchMessages(user1.ID, "dm", 10, "", "")
 	require.NoError(t, err)
 	assert.Len(t, results, 1)
 
 	// SearchMessages - default limit
-	results2, err := repo.SearchMessages(user1.ID, "dm", 0)
+	results2, err := repo.SearchMessages(user1.ID, "dm", 0, "", "")
 	require.NoError(t, err)
 	assert.Len(t, results2, 1)
+
+	// SearchMessages - userId scope (1-on-1 with user2)
+	byUser, err := repo.SearchMessages(user1.ID, "dm", 10, user2.ID, "")
+	require.NoError(t, err)
+	assert.Len(t, byUser, 1)
+
+	// SearchMessages - roomId scope (room message "hello")
+	byRoom, err := repo.SearchMessages(user1.ID, "hello", 10, "", room.ID)
+	require.NoError(t, err)
+	assert.Len(t, byRoom, 1)
+
+	// SearchMessages - default scope finds the owned-room message too
+	byOwned, err := repo.SearchMessages(user1.ID, "hello", 10, "", "")
+	require.NoError(t, err)
+	assert.Len(t, byOwned, 1)
 
 	// MarkRead
 	require.NoError(t, repo.MarkRead(user2.ID, "cm_2"))

--- a/internal/repository/coverage_complete_test.go
+++ b/internal/repository/coverage_complete_test.go
@@ -158,7 +158,7 @@ func TestErrorPaths_CancelledContext(t *testing.T) {
 	assert.Error(t, err)
 	_, err = cr.ListMessagesByUser("x", "y", 10)
 	assert.Error(t, err)
-	_, err = cr.SearchMessages("x", "q", 10)
+	_, err = cr.SearchMessages("x", "q", 10, "", "")
 	assert.Error(t, err)
 	_, err = cr.ListMembersByRoom("x")
 	assert.Error(t, err)

--- a/internal/testutil/mock_chat.go
+++ b/internal/testutil/mock_chat.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/shiroha-a/mk/internal/model"
@@ -208,8 +209,49 @@ func (m *MockChatRepository) ListMessagesByFileID(fileID, untilID, sinceID strin
 	return out, nil
 }
 
-func (m *MockChatRepository) SearchMessages(_, _ string, _ int) ([]*model.ChatMessage, error) {
-	return nil, nil
+func (m *MockChatRepository) SearchMessages(meID, query string, limit int, userID, roomID string) ([]*model.ChatMessage, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if limit <= 0 {
+		limit = 10
+	}
+	q := strings.ToLower(query)
+	var out []*model.ChatMessage
+	for _, msg := range m.Messages {
+		if msg.Text == nil || !strings.Contains(strings.ToLower(*msg.Text), q) {
+			continue
+		}
+		match := false
+		switch {
+		case userID != "":
+			match = (msg.FromUserID == meID && msg.ToUserID != nil && *msg.ToUserID == userID) ||
+				(msg.FromUserID == userID && msg.ToUserID != nil && *msg.ToUserID == meID)
+		case roomID != "":
+			match = msg.ToRoomID != nil && *msg.ToRoomID == roomID
+		default:
+			switch {
+			case msg.FromUserID == meID:
+				match = true
+			case msg.ToUserID != nil && *msg.ToUserID == meID:
+				match = true
+			case msg.ToRoomID != nil:
+				if _, ok := m.Memberships[membershipKey(meID, *msg.ToRoomID)]; ok {
+					match = true
+				} else if r, ok := m.Rooms[*msg.ToRoomID]; ok && r.OwnerID == meID {
+					match = true
+				}
+			}
+		}
+		if match {
+			cp := *msg
+			out = append(out, &cp)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID > out[j].ID })
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
 }
 
 // --- Memberships ---


### PR DESCRIPTION
## Summary

chat/* parity issue #1541 の MEDIUM (messages/search) + LOW (user-timeline) を解消する。

## 主な変更点

### messages/search (#1541 MEDIUM)
旧 `SearchMessages` は `userId`/`roomId` を無視し `(fromUserId=me OR toUserId=me)` の 1-on-1 のみを検索していた。upstream `ChatService.searchMessages` + `search.ts` に揃える:

- **userId 指定**: 相手との 1-on-1 のみ。
- **roomId 指定**: その room のメッセージ。handler 側で room 存在 + member (owner 含む) gate を行い、不在/非 member は `NO_SUCH_ROOM` (`460b3669-...`) を返す (upstream `search.ts` と同じく両ケース同 code)。
- **無指定 (default)**: 自分の 1-on-1 + 所属/所有 room のメッセージ (membership / owned-room サブクエリ相当)。
- LIKE metacharacter は `escapeLike` で literal 化、`LOWER` 比較で case-insensitive。
- `SearchMessages` シグネチャに `meID` と `userId`/`roomId` を追加 (repository interface 変更につき mock / 統合テスト呼び出しも更新)。

### messages/user-timeline (#1541 LOW)
未存在の `userId` に対し upstream は `getUser -> NO_SUCH_USER` (`11795c64-...`) を返すが、mk-go は空配列を返していた。`userRepo` 配線時に存在検証を追加。

## テスト

- 統合 (`internal/repository`): search の userId / roomId / default scope (own 1-on-1 + owned room) を実 DB で検証。
- 単体 (`internal/api/chat`): NO_SUCH_ROOM (不在/非 member) / room-scoped / user-scoped / user-timeline NO_SUCH_USER + 存在時 200。

実行: `go test ./internal/repository/... ./internal/api/chat/...` (coverage: repository 90.2% / api/chat 94.6%)

## 関連

Refs #1541 (chat/* parity の一部。残項目は後続 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)