### PR TITLE
Fix chat parity: rooms/delete を moderator にも許可 + deleteChatRoom 監査ログ (#1541)

### DIFF
--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	corechat "github.com/shiroha-a/mk/internal/core/chat"
+	"github.com/shiroha-a/mk/internal/core/moderationlog"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -39,6 +41,10 @@ type Handler struct {
 	// invitationNotifier は invitations/create で被招待ユーザーへ
 	// 'chatRoomInvitationReceived' 通知を送る (#1559)。未配線なら通知しない。
 	invitationNotifier ChatInvitationNotifier
+	// modLog は moderator が他人の room を削除した際に監査ログを残すために使う
+	// (#1541, upstream ChatService.deleteRoom の moderationLog.log)。未配線なら
+	// 記録を skip する。
+	modLog ModLogger
 }
 
 // maxRoomMembers mirrors upstream ChatService.MAX_ROOM_MEMBERS。join /
@@ -72,6 +78,16 @@ type ChatInvitationNotifier interface {
 // SetInvitationNotifier wires the notifier used by invitations/create to send a
 // 'chatRoomInvitationReceived' notification (upstream ChatService の招待作成)。
 func (h *Handler) SetInvitationNotifier(n ChatInvitationNotifier) { h.invitationNotifier = n }
+
+// ModLogger records a moderation action. Satisfied by *core/moderationlog.Service.
+// nil 配線時は記録を skip する (#1541)。
+type ModLogger interface {
+	Log(ctx context.Context, moderatorID string, t moderationlog.LogType, info map[string]any)
+}
+
+// SetModLog wires the moderation-log writer used when a moderator deletes
+// another user's chat room (#1541)。
+func (h *Handler) SetModLog(m ModLogger) { h.modLog = m }
 
 // PackInvitationByID loads an invitation by ID (with room + invitee user) and
 // packs it for the given viewer, returning false when it no longer exists. Used
@@ -602,10 +618,27 @@ func (h *Handler) RoomsDelete(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	room, err := h.repo.FindRoomByID(req.RoomID)
-	if err != nil || room.OwnerID != user.ID {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "6ab4d7df-5043-57b9-bd5d-ff9908288473"))
+	if err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "d4e3753d-97bf-4a19-ab8e-21080fbc0f4b"))
+	}
+	// upstream hasPermissionToDeleteRoom は owner OR moderator を許可する。
+	// 旧 mk-go は owner-only だったため moderator が他人の room を削除できなかった。
+	isOwner := room.OwnerID == user.ID
+	isMod := h.isModerator(user.ID)
+	if !isOwner && !isMod {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "d4e3753d-97bf-4a19-ab8e-21080fbc0f4b"))
 	}
 	_ = h.repo.DeleteRoom(req.RoomID)
+	// upstream deleteRoom は deleter が moderator なら deleteChatRoom を監査ログに残す
+	// (owner かどうかに依らず moderator なら記録する)。
+	if isMod && h.modLog != nil {
+		h.modLog.Log(c.Request().Context(), user.ID, moderationlog.LogDeleteChatRoom, map[string]any{
+			"roomId": room.ID,
+			"room": map[string]any{
+				"id": room.ID, "name": room.Name, "ownerId": room.OwnerID, "description": room.Description,
+			},
+		})
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
 	corechat "github.com/shiroha-a/mk/internal/core/chat"
+	"github.com/shiroha-a/mk/internal/core/moderationlog"
 	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -20,6 +22,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// stubModLog records moderation-log calls for chat room delete tests (#1541).
+type stubModLog struct {
+	types    []moderationlog.LogType
+	lastInfo map[string]any
+}
+
+func (s *stubModLog) Log(_ context.Context, _ string, t moderationlog.LogType, info map[string]any) {
+	s.types = append(s.types, t)
+	s.lastInfo = info
+}
 
 var errMock = assert.AnError
 
@@ -198,6 +211,46 @@ func TestRoomsDelete_NotOwner(t *testing.T) {
 	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "other"}
 	rec := post(h.RoomsDelete, `{"roomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+	// #1541: delete の NO_SUCH_ROOM golden id。
+	assertErrorCode(t, rec, "NO_SUCH_ROOM", "d4e3753d-97bf-4a19-ab8e-21080fbc0f4b")
+}
+
+// #1541: moderator は他人の room を削除でき、deleteChatRoom を監査ログに残す。
+func TestRoomsDelete_ModeratorDeletesOthersRoom(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "other", Name: "victim"}
+	h.SetModeratorChecker(fakeModeratorChecker{mods: map[string]bool{u1.ID: true}})
+	modLog := &stubModLog{}
+	h.SetModLog(modLog)
+	rec := post(h.RoomsDelete, `{"roomId":"r1"}`, u1)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	_, ok := repo.Rooms["r1"]
+	assert.False(t, ok, "room is deleted")
+	require.Len(t, modLog.types, 1)
+	assert.Equal(t, moderationlog.LogDeleteChatRoom, modLog.types[0])
+	assert.Equal(t, "r1", modLog.lastInfo["roomId"])
+}
+
+// #1541: owner (非 moderator) の削除は監査ログを残さない。
+func TestRoomsDelete_OwnerNoModLog(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u1.ID}
+	modLog := &stubModLog{}
+	h.SetModLog(modLog)
+	rec := post(h.RoomsDelete, `{"roomId":"r1"}`, u1)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Empty(t, modLog.types, "owner delete must not write a moderation log")
+}
+
+// #1541: 非 owner かつ非 moderator は削除できない。
+func TestRoomsDelete_NonOwnerNonModerator(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "other"}
+	h.SetModeratorChecker(fakeModeratorChecker{mods: map[string]bool{}})
+	rec := post(h.RoomsDelete, `{"roomId":"r1"}`, u1)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	_, ok := repo.Rooms["r1"]
+	assert.True(t, ok, "room must not be deleted by a non-owner non-moderator")
 }
 
 func TestRoomsOwned(t *testing.T) {

--- a/internal/core/moderationlog/types.go
+++ b/internal/core/moderationlog/types.go
@@ -90,6 +90,7 @@ const (
 	// Content deletion by moderators
 	LogDeleteGalleryPost LogType = "deleteGalleryPost"
 	LogDeleteFlash       LogType = "deleteFlash"
+	LogDeleteChatRoom    LogType = "deleteChatRoom"
 
 	// Misc
 	LogUpdateProxyAccountDescription LogType = "updateProxyAccountDescription"

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2467,6 +2467,7 @@ func (s *Server) setupRoutes() {
 	chatHandler.SetDriveFileRepo(driveFileRepo)
 	chatHandler.SetModeratorChecker(roleService)
 	chatHandler.SetUserRepo(userRepo)
+	chatHandler.SetModLog(modLogService) // #1541: moderator による chat room 削除の監査ログ
 	// chatRoomInvitationReceived 通知 (#1559): 招待作成 (local handler / AP service)
 	// で発火し、entity 側で read 時に packed invitation へ解決する。lookup は
 	// 招待削除済なら (nil,false)。chatHandler が PackInvitationByID を提供する


### PR DESCRIPTION
## Summary

chat/* parity issue #1541 の LOW 項目。upstream `hasPermissionToDeleteRoom` は owner OR moderator を許可し、`deleteRoom` は deleter が moderator のとき `deleteChatRoom` を `moderationLog` に残すが、mk-go の `RoomsDelete` は **owner-only** で監査ログも無かった。

## 主な変更点

- `RoomsDelete` を **owner OR moderator** 許可に変更 (`moderatorChecker` は配線済み)。
- moderator が削除した場合 (owner かどうかに依らず、upstream と同条件) `deleteChatRoom` を監査ログに残す。flash/gallery と同じ `ModLogger` interface (`Log`) + `SetModLog` で受け、router で `modLogService` を配線。`moderationlog` に `LogDeleteChatRoom` 定数を追加。
- 併せて delete の **NO_SUCH_ROOM golden id** が show/update と同一の誤った id (`6ab4d7df-...`) だったのを upstream golden (`d4e3753d-97bf-4a19-ab8e-21080fbc0f4b`) に修正 (同 endpoint の隣接バグ)。

## テスト

`internal/api/chat`: moderator が他人 room を削除でき監査ログを残す / owner 削除は監査ログ無し / 非 owner 非 moderator は 404 / delete の NO_SUCH_ROOM golden id。

実行: `go test ./internal/api/chat/...` (coverage: 94.5%)

## 関連

Refs #1541 (chat/* parity の一部。残項目は後続 PR / follow-up issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)