### PR TITLE
Fix chat parity: 1-on-1 DM の chatApproval bypass + 送信後 approval 挿入 (#1748)

### DIFF
--- a/internal/core/chat/ap_delivery_test.go
+++ b/internal/core/chat/ap_delivery_test.go
@@ -361,3 +361,90 @@ func TestFederateInvitation_DeliveryFailureIsSwallowed(t *testing.T) {
 	svc.FederateInvitation("room1", "bob")
 	assert.Equal(t, 1, deliverer.called)
 }
+
+// --- #1748: chatApproval bypass ---
+
+// fakeApprovalRepo is an in-memory repository.ChatApprovalRepository for the
+// chatApproval bypass tests.
+type fakeApprovalRepo struct {
+	approvals   map[string]bool // key: userID+"/"+otherID
+	createCount int
+	createErr   error
+}
+
+func newFakeApprovalRepo() *fakeApprovalRepo {
+	return &fakeApprovalRepo{approvals: map[string]bool{}}
+}
+
+func (f *fakeApprovalRepo) Create(a *model.ChatApproval) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	f.createCount++
+	f.approvals[a.UserID+"/"+a.OtherID] = true
+	return nil
+}
+func (f *fakeApprovalRepo) Delete(userID, otherID string) error {
+	delete(f.approvals, userID+"/"+otherID)
+	return nil
+}
+func (f *fakeApprovalRepo) Exists(userID, otherID string) (bool, error) {
+	return f.approvals[userID+"/"+otherID], nil
+}
+func (f *fakeApprovalRepo) ListByUser(string) ([]*model.ChatApproval, error) { return nil, nil }
+
+// 相手 (bob) が過去に自分 (alice) へ送っていれば (otherApprovedMe)、bob の
+// chatScope=followers でも alice→bob を許可する。
+func TestCreateMessageToUser_ApprovalBypassesScope(t *testing.T) {
+	svc, userRepo, _ := newScopeService(t)
+	approvalRepo := newFakeApprovalRepo()
+	svc.SetApprovalRepo(approvalRepo)
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", ChatScope: "followers"}
+
+	// approval 無し: alice は follower でないので reject。
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "x", "")
+	require.ErrorIs(t, err, corechat.ErrChatScopeViolation)
+
+	// bob が過去に alice へ送った = approval{bob, alice}。otherApprovedMe で bypass。
+	approvalRepo.approvals["bob/alice"] = true
+	_, err = svc.CreateMessageToUser(context.Background(), "alice", "bob", "ok", "")
+	require.NoError(t, err)
+}
+
+// 送信成功後、自分→相手の approval が記録される。
+func TestCreateMessageToUser_RecordsApprovalAfterSend(t *testing.T) {
+	svc, userRepo, _ := newScopeService(t)
+	approvalRepo := newFakeApprovalRepo()
+	svc.SetApprovalRepo(approvalRepo)
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", ChatScope: "everyone"}
+
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
+	require.NoError(t, err)
+	ok, _ := approvalRepo.Exists("alice", "bob")
+	assert.True(t, ok, "approval{alice, bob} must be recorded after send")
+}
+
+// 既に approval{alice, bob} があれば重複挿入しない (idempotent)。
+func TestCreateMessageToUser_ApprovalIdempotent(t *testing.T) {
+	svc, userRepo, _ := newScopeService(t)
+	approvalRepo := newFakeApprovalRepo()
+	svc.SetApprovalRepo(approvalRepo)
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", ChatScope: "everyone"}
+	approvalRepo.approvals["alice/bob"] = true
+
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "hi", "")
+	require.NoError(t, err)
+	assert.Equal(t, 0, approvalRepo.createCount, "既存 approval があれば Create を呼ばない")
+}
+
+// approvalRepo 未配線なら従来どおり scope のみで判定する (regression)。
+func TestCreateMessageToUser_NoApprovalRepoScopeEnforced(t *testing.T) {
+	svc, userRepo, _ := newScopeService(t)
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", ChatScope: "followers"}
+	_, err := svc.CreateMessageToUser(context.Background(), "alice", "bob", "x", "")
+	require.ErrorIs(t, err, corechat.ErrChatScopeViolation)
+}

--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -135,6 +135,10 @@ type Service struct {
 	// (#1541)。nil の場合は custom emoji を検証せず `:name:` をそのまま採用する
 	// (legacy/test path)。
 	emojiRepo repository.EmojiRepository
+	// approvalRepo: 1-on-1 DM の chatApproval bypass に使う (#1748)。相手が過去に
+	// 自分へ送ってきている (otherApprovedMe) なら chatScope チェックを skip し、
+	// 送信後に自分→相手の approval を挿入する。nil なら従来どおり scope のみで判定。
+	approvalRepo repository.ChatApprovalRepository
 }
 
 // ChatInvitationNotifier records a 'chatRoomInvitationReceived' notification on
@@ -153,6 +157,14 @@ func (s *Service) SetInvitationNotifier(n ChatInvitationNotifier) {
 // reactions against the local emoji table (#1541). nil disables the check.
 func (s *Service) SetEmojiRepo(r repository.EmojiRepository) {
 	s.emojiRepo = r
+}
+
+// SetApprovalRepo wires the chat-approval repository so CreateMessageToUser can
+// apply the upstream chatApproval bypass: skip the chatScope check when the
+// recipient previously messaged the sender, and record an approval after a
+// successful send (#1748). nil disables the bypass (scope-only behaviour).
+func (s *Service) SetApprovalRepo(r repository.ChatApprovalRepository) {
+	s.approvalRepo = r
 }
 
 // NewService constructs a chat Service.
@@ -310,6 +322,27 @@ func (s *Service) canChat(sender, recipient *model.User) error {
 	return nil
 }
 
+// recordChatApproval records a (fromUserID -> toUserID) chat approval after a
+// successful 1-on-1 send so the recipient can later reply regardless of the
+// sender's chatScope (upstream ChatService.createMessageToUser の送信後 approval
+// 挿入)。冪等: 既に存在すれば挿入しない。best-effort で error はログのみ (#1748)。
+func (s *Service) recordChatApproval(fromUserID, toUserID string) {
+	if s.approvalRepo == nil {
+		return
+	}
+	// iApprovedOther: 自分が既に相手を許可済みなら重複挿入しない。
+	if ok, err := s.approvalRepo.Exists(fromUserID, toUserID); err != nil || ok {
+		return
+	}
+	if err := s.approvalRepo.Create(&model.ChatApproval{
+		ID:      s.idGen.Generate(time.Now()),
+		UserID:  fromUserID,
+		OtherID: toUserID,
+	}); err != nil {
+		slog.Warn("chat: failed to record chat approval", "from", fromUserID, "to", toUserID, "err", err)
+	}
+}
+
 // --- Message lifecycle ---
 
 // CreateMessageToUser persists a direct-message row and fires the
@@ -323,7 +356,16 @@ func (s *Service) CreateMessageToUser(ctx context.Context, fromUserID, toUserID,
 	if fromUserID == "" || toUserID == "" {
 		return nil, ErrInvalidTarget
 	}
-	if s.userRepo != nil {
+	// upstream は scope チェックの前に chatApprovals を見て、相手 (toUser) が過去に
+	// 自分 (fromUser) へ送ってきている (otherApprovedMe) 場合は chatScope を bypass
+	// する (#1748)。approvalRepo 未配線なら従来どおり scope のみで判定する。
+	otherApprovedMe := false
+	if s.approvalRepo != nil {
+		if ok, err := s.approvalRepo.Exists(toUserID, fromUserID); err == nil {
+			otherApprovedMe = ok
+		}
+	}
+	if !otherApprovedMe && s.userRepo != nil {
 		recipient, err := s.userRepo.FindByID(toUserID)
 		if err == nil {
 			sender, err := s.userRepo.FindByID(fromUserID)
@@ -362,6 +404,10 @@ func (s *Service) CreateMessageToUser(ctx context.Context, fromUserID, toUserID,
 	if err := s.repo.CreateMessage(msg); err != nil {
 		return nil, fmt.Errorf("create user message: %w", err)
 	}
+	// upstream は送信後、自分が相手をまだ許可していなければ (iApprovedOther でなければ)
+	// 自分→相手の approval を挿入する (= 以降、相手は自分へ scope に依らず返信できる)。
+	// best-effort: 失敗してもメッセージ送信は成功扱い (#1748)。
+	s.recordChatApproval(fromUserID, toUserID)
 	if s.publisher != nil {
 		s.publisher.PublishUserMessage(ctx, fromUserID, toUserID, EventMessage, s.packMessageStream(msg))
 	}
@@ -629,7 +675,15 @@ func (s *Service) CreateMessageViaAP(ctx context.Context, uri string, fromUser *
 			return existing, nil
 		}
 	}
-	if s.userRepo != nil {
+	// inbound でも chatApproval bypass を適用する: local recipient が過去に remote
+	// sender へ送っていれば (otherApprovedMe) scope チェックを skip する (#1748)。
+	otherApprovedMe := false
+	if s.approvalRepo != nil {
+		if ok, err := s.approvalRepo.Exists(toUserID, fromUser.ID); err == nil {
+			otherApprovedMe = ok
+		}
+	}
+	if !otherApprovedMe && s.userRepo != nil {
 		if recipient, err := s.userRepo.FindByID(toUserID); err == nil && recipient.IsLocal() {
 			if err := s.canChat(fromUser, recipient); err != nil {
 				return nil, err
@@ -662,6 +716,9 @@ func (s *Service) CreateMessageViaAP(ctx context.Context, uri string, fromUser *
 	if err := s.repo.CreateMessage(msg); err != nil {
 		return nil, fmt.Errorf("create AP message: %w", err)
 	}
+	// inbound 受信後、remote sender -> local recipient の approval を記録する
+	// (= 以降 local recipient は scope に依らず remote sender へ返信できる、#1748)。
+	s.recordChatApproval(fromUser.ID, toUserID)
 	if s.publisher != nil {
 		s.publisher.PublishUserMessage(ctx, fromUser.ID, toUserID, EventMessage, packMessage(msg))
 	}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2049,6 +2049,8 @@ func (s *Server) setupRoutes() {
 	chatService.SetBlockingRepo(blockingRepo)
 	// React で custom emoji (:name:) reaction の存在検証に使う (#1541)。
 	chatService.SetEmojiRepo(emojiRepo)
+	// 1-on-1 DM の chatApproval bypass + 送信後 approval 挿入に使う (#1748)。
+	chatService.SetApprovalRepo(repository.NewChatApprovalRepository(s.db))
 	streamRegistry.Register("chatRoom", channels.NewChatRoomFactory(chatService).New)
 	streamRegistry.Register("chatUser", channels.NewChatUserFactory(chatService).New)
 	// Phase 9.7: federation processor / reversi handler に reversi 依存を注入。


### PR DESCRIPTION
## Summary

#1541 から分離した chatApproval 対応。upstream `ChatService.createMessageToUser` は chatScope 判定の前に `chatApprovals` を参照し、相手が過去に自分へ送ってきている (`otherApprovedMe`) 場合は scope チェックを skip し、送信後に自分→相手の approval を挿入する。mk-go は `chat_approval` テーブル / repository を持つが create 経路から **未参照** だったため、followers/none scope の相手から先に話しかけられても返信が弾かれていた。

## 主な変更点

- `core/chat.Service` に `approvalRepo` (`ChatApprovalRepository`) + `SetApprovalRepo` を追加。
- `CreateMessageToUser`: scope チェック前に `Exists(toUser, fromUser)` で `otherApprovedMe` を判定し、true なら `canChat` を skip。送信成功後に `recordChatApproval(fromUser, toUser)` で approval を冪等挿入 (`iApprovedOther` なら skip、失敗は best-effort log)。
- `CreateMessageViaAP` (inbound 連合 DM) でも同じ bypass + 記録を適用し、remote sender → local recipient の approval を残して local 側が scope に依らず返信できるようにする。
- router で `NewChatApprovalRepository` を配線。`approvalRepo` 未配線時は従来どおり scope のみで判定 (nil 安全)。

## テスト

`internal/core/chat`: approval による scope bypass / 送信後の approval 記録 / 既存 approval での冪等性 / `approvalRepo` 未配線時の scope 維持。

実行: `go test ./internal/core/chat/...` (coverage: 90.7%)

Closes #1748

🤖 Generated with [Claude Code](https://claude.com/claude-code)