### PR TITLE
Fix channels parity: channels/show (detailed) の pinnedNotes + viewer 時 hasUnreadNote (#1540)

### DIFF
--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -2,6 +2,7 @@
 package channels
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -34,6 +35,21 @@ type Handler struct {
 	// bannerResolver は channel の bannerId を drive file に解決して bannerUrl
 	// を埋める (#1280)。未配線なら bannerUrl は null で出す。
 	bannerResolver ChannelBannerResolver
+	// pinnedNoteRepo は channels/show (detailed) の pinnedNotes 展開に使う
+	// (#1540)。未配線なら pinnedNotes は空配列で出す。
+	pinnedNoteRepo ChannelPinnedNoteRepo
+}
+
+// ChannelPinnedNoteRepo fetches the notes for the detailed channels/show
+// pinnedNotes field (#1540). The returned notes follow the order of `ids`.
+type ChannelPinnedNoteRepo interface {
+	FindManyByIDsWithUser(ids []string) ([]*model.Note, error)
+}
+
+// SetPinnedNoteRepo wires the note repository used to expand pinnedNoteIds into
+// pinnedNotes (Note[]) on the detailed channels/show response (#1540).
+func (h *Handler) SetPinnedNoteRepo(r ChannelPinnedNoteRepo) {
+	h.pinnedNoteRepo = r
 }
 
 // ChannelBannerResolver covers the drive-file lookups the channels handler
@@ -205,7 +221,38 @@ func (h *Handler) Show(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CHANNEL", "No such channel.", "6f6c314b-7486-4897-8966-c04a66a02923"))
 	}
-	return c.JSON(http.StatusOK, h.channelToMapForViewer(ch, middleware.GetUser(c)))
+	viewer := middleware.GetUser(c)
+	out := h.channelToMapForViewer(ch, viewer)
+	// upstream show.ts は pack(channel, me, detailed=true) を呼び、detailed 時のみ
+	// pinnedNotes (展開済 Note[]、pinnedNoteIds 順) を返す (#1540)。
+	out["pinnedNotes"] = h.packPinnedNotes(c.Request().Context(), ch, viewer)
+	return c.JSON(http.StatusOK, out)
+}
+
+// packPinnedNotes expands ch.PinnedNoteIDs into packed Note entities in
+// pinnedNoteIds order for the detailed channels/show response (#1540).
+// FindManyByIDsWithUser preserves the requested order, so no re-sort is needed
+// (upstream re-sorts because findBy does not). Returns an empty slice when there
+// are no pinned notes or the note repo / field resolver is unwired.
+func (h *Handler) packPinnedNotes(ctx context.Context, ch *model.Channel, viewer *model.User) []any {
+	out := make([]any, 0)
+	ids := []string(ch.PinnedNoteIDs)
+	if len(ids) == 0 || h.pinnedNoteRepo == nil {
+		return out
+	}
+	notes, err := h.pinnedNoteRepo.FindManyByIDsWithUser(ids)
+	if err != nil || len(notes) == 0 {
+		return out
+	}
+	entities := entity.PackNotes(ctx, notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
+	if h.fieldRes != nil {
+		h.fieldRes.Apply(entities, viewer)
+	}
+	notehide.HideEmbeds(viewer, entities)
+	for _, pn := range entities {
+		out = append(out, pn)
+	}
+	return out
 }
 
 // UpdateRequest is the request body for channels/update.
@@ -577,6 +624,9 @@ func (h *Handler) channelToMapForViewer(ch *model.Channel, viewer *model.User) m
 	if viewer == nil {
 		return out
 	}
+	// upstream は me がある時 hasUnreadNote:false を後方互換で必ず付ける
+	// (ChannelEntityService、#1540)。mk-go は未読判定を持たないため常に false。
+	out["hasUnreadNote"] = false
 	if h.followingRepo != nil {
 		if ok, err := h.followingRepo.Exists(viewer.ID, ch.ID); err == nil {
 			out["isFollowing"] = ok

--- a/internal/api/channels/handler_test.go
+++ b/internal/api/channels/handler_test.go
@@ -170,6 +170,70 @@ func TestShow_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
+// #1540: show は detailed=true 相当で pinnedNotes (展開済 Note[]) を pinnedNoteIds 順で返す。
+func TestShow_DetailedPinnedNotes(t *testing.T) {
+	h, repo, _, noteRepo := newHandler(t)
+	h.SetPinnedNoteRepo(noteRepo)
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "alice"}
+	noteRepo.Notes["n2"] = &model.Note{ID: "n2", UserID: "alice"}
+	// shapetest の createdAt (aidx 派生) のため channel id は valid aidx を使う。
+	idGen, _ := id.NewGenerator("aidx")
+	cid := idGen.Generate(time.Now())
+	repo.Channels[cid] = &model.Channel{ID: cid, Name: "alpha", PinnedNoteIDs: []string{"n2", "n1"}}
+	c, rec := newReq(t, `{"channelId":"`+cid+`"}`)
+	require.NoError(t, h.Show(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	pn, ok := resp["pinnedNotes"].([]any)
+	require.True(t, ok, "pinnedNotes must be present")
+	require.Len(t, pn, 2)
+	// pinnedNoteIds の順 (n2, n1) を保つ
+	assert.Equal(t, "n2", pn[0].(map[string]any)["id"])
+	assert.Equal(t, "n1", pn[1].(map[string]any)["id"])
+	shapetest.Assert(t, "Channel", resp) // L3: detailed Channel (pinnedNotes 込み)
+}
+
+// pinnedNotes は detailed では常に存在し、ピン無しでも空配列を返す。
+func TestShow_PinnedNotesEmptyArray(t *testing.T) {
+	h, repo, _, noteRepo := newHandler(t)
+	h.SetPinnedNoteRepo(noteRepo)
+	repo.Channels["c1"] = &model.Channel{ID: "c1", Name: "alpha"}
+	c, rec := newReq(t, `{"channelId":"c1"}`)
+	require.NoError(t, h.Show(c))
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	pn, ok := resp["pinnedNotes"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, pn)
+}
+
+// #1540: viewer がある時 hasUnreadNote:false を必ず付ける (後方互換)。
+func TestShow_HasUnreadNoteWhenViewer(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	repo.Channels["c1"] = &model.Channel{ID: "c1", Name: "alpha"}
+	c, rec := newReq(t, `{"channelId":"c1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Show(c))
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	val, ok := resp["hasUnreadNote"]
+	require.True(t, ok, "hasUnreadNote must be present when viewer exists")
+	assert.Equal(t, false, val)
+}
+
+// viewer が無い時は hasUnreadNote を出さない (upstream は me 無しで省略)。
+func TestShow_NoHasUnreadNoteWithoutViewer(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	repo.Channels["c1"] = &model.Channel{ID: "c1", Name: "alpha"}
+	c, rec := newReq(t, `{"channelId":"c1"}`)
+	require.NoError(t, h.Show(c))
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	_, ok := resp["hasUnreadNote"]
+	assert.False(t, ok, "hasUnreadNote must be absent without viewer")
+}
+
 // --- Update ----------------------------------------------------------------
 
 func TestUpdate_Success(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1799,6 +1799,7 @@ func (s *Server) setupRoutes() {
 	channelsHandler.SetReactionReader(reactionCountWriter)
 	channelsHandler.SetNoteFieldResolver(noteFieldResolver)
 	channelsHandler.SetUserRepo(userRepo)
+	channelsHandler.SetPinnedNoteRepo(noteRepo) // #1540: channels/show (detailed) の pinnedNotes 展開
 
 	// Antennas endpoints (Phase 4.3)
 	antennasHandler := antennas.NewHandler(antennaService, noteRepo, idGen)


### PR DESCRIPTION
## Summary

#1540 (channels/* parity) の HIGH + MEDIUM 項目。

## 主な変更点

### channels/show pinnedNotes (#1540 HIGH)
upstream `show.ts` は `pack(channel, me, detailed=true)` を呼び、detailed 時のみ `pinnedNotes` (展開済 Note[]、pinnedNoteIds 順) を返すが、mk-go の `Show` は `channelToMapForViewer` を呼ぶだけで `pinnedNotes` を埋めていなかった。

- handler に `ChannelPinnedNoteRepo` (`FindManyByIDsWithUser`) + `SetPinnedNoteRepo` を追加し、router で `noteRepo` を配線。
- Timeline と同じ packing path (`entity.PackNotes` + `NoteFieldResolver.Apply` + `HideEmbeds`) を再利用。`FindManyByIDsWithUser` が id 順を保つため `pinnedNoteIds` 順がそのまま得られる (upstream は `findBy` 後に再 sort するが mk-go は不要)。detailed では常に `pinnedNotes` を含め、ピン無しは空配列。

### Channel entity hasUnreadNote (#1540 MEDIUM)
upstream は `me` がある時 `hasUnreadNote:false` を後方互換で必ず付ける。`channelToMapForViewer` で viewer present 時に `hasUnreadNote:false` を出すよう追加 (mk-go は未読判定を持たないため常に false)。

## テスト

`internal/api/channels`: pinnedNotes の順序 / ピン無しの空配列 / hasUnreadNote の有無 (viewer 有/無) + detailed Channel の L3 shapetest。

実行: `go test ./internal/api/channels/...` (coverage: 93.0%)

## 関連

Refs #1540 (channels/* parity の一部。残項目は後続 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)