### PR TITLE
Fix channels parity: owned/search/featured の絞り込み・並び順を upstream に揃える (#1540)

### DIFF
--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -355,14 +355,17 @@ func (h *Handler) Owned(c echo.Context) error {
 }
 
 // Featured handles POST /api/channels/featured.
+//
+// upstream featured.ts は pagination param を持たず、lastNotedAt IS NOT NULL かつ
+// isArchived=FALSE の channel を lastNotedAt DESC で固定 10 件返す (#1540)。
+// cursor / limit は無視する (service が固定条件で返す) が、malformed JSON は
+// upstream のフレームワーク同様 400 で弾くため bind 検証だけ残す。
 func (h *Handler) Featured(c echo.Context) error {
 	var req PaginatedListRequest
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
-	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
-	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
-	rows, err := h.svc.ListFeatured(sinceID, untilID, req.Limit, req.Offset)
+	rows, err := h.svc.ListFeatured()
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/core/channel/channel_service.go
+++ b/internal/core/channel/channel_service.go
@@ -296,24 +296,30 @@ func (s *Service) ListFollowed(userID, sinceID, untilID string, limit, offset in
 // ListOwned returns channels owned by the user with cursor (sinceID/untilID)
 // or offset pagination.
 func (s *Service) ListOwned(userID, sinceID, untilID string, limit, offset int) ([]*model.Channel, error) {
+	// upstream owned.ts は isArchived=FALSE を AND し、cursor 無し時は id DESC で
+	// 並べる (makePaginationQuery, #1540)。
+	notArchived := false
 	return s.repo.List(model.ChannelListFilter{
-		OwnerID: userID,
-		Limit:   limit,
-		Offset:  offset,
-		SinceID: sinceID,
-		UntilID: untilID,
+		OwnerID:    userID,
+		IsArchived: &notArchived,
+		SortBy:     "-id",
+		Limit:      limit,
+		Offset:     offset,
+		SinceID:    sinceID,
+		UntilID:    untilID,
 	})
 }
 
-// ListFeatured returns the most active channels (notes count desc), or by
-// id when cursor is supplied (frontend Paginator対応)。
-func (s *Service) ListFeatured(sinceID, untilID string, limit, offset int) ([]*model.Channel, error) {
+// ListFeatured returns the upstream channels/featured set: channels that have
+// been posted to (lastNotedAt IS NOT NULL) and are not archived, ordered by
+// lastNotedAt DESC, capped at a fixed 10. featured には pagination が無い (#1540)。
+func (s *Service) ListFeatured() ([]*model.Channel, error) {
+	notArchived := false
 	return s.repo.List(model.ChannelListFilter{
-		SortBy:  "-notesCount",
-		Limit:   limit,
-		Offset:  offset,
-		SinceID: sinceID,
-		UntilID: untilID,
+		IsArchived:         &notArchived,
+		LastNotedAtNotNull: true,
+		SortBy:             "-lastNotedAt",
+		Limit:              10,
 	})
 }
 
@@ -321,12 +327,14 @@ func (s *Service) ListFeatured(sinceID, untilID string, limit, offset int) ([]*m
 // Search finds channels by name (and description when searchType is
 // "nameAndDescription", the upstream default). "nameOnly" matches name only.
 func (s *Service) Search(query, searchType, sinceID, untilID string, limit, offset int) ([]*model.Channel, error) {
-	// upstream channels/search は常に isArchived=FALSE を AND する。
+	// upstream channels/search は常に isArchived=FALSE を AND し、cursor 無し時は
+	// id DESC で並べる (makePaginationQuery, #1540)。
 	notArchived := false
 	return s.repo.List(model.ChannelListFilter{
 		Query:             query,
 		SearchDescription: searchType != "nameOnly",
 		IsArchived:        &notArchived,
+		SortBy:            "-id",
 		Limit:             limit,
 		Offset:            offset,
 		SinceID:           sinceID,

--- a/internal/core/channel/channel_service_test.go
+++ b/internal/core/channel/channel_service_test.go
@@ -438,12 +438,31 @@ func TestListOwned(t *testing.T) {
 	assert.Len(t, rows, 2)
 }
 
+// #1540: owned は isArchived=FALSE を AND する (archived な自分の channel は出ない)。
+func TestListOwned_ExcludesArchived(t *testing.T) {
+	svc, repo, _, _ := newSvc(t)
+	owner := "u1"
+	repo.Channels["c1"] = &model.Channel{ID: "c1", UserID: &owner}
+	repo.Channels["c2"] = &model.Channel{ID: "c2", UserID: &owner, IsArchived: true}
+	rows, err := svc.ListOwned("u1", "", "", 10, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "c1", rows[0].ID)
+}
+
 func TestListFeatured(t *testing.T) {
 	svc, repo, _, _ := newSvc(t)
-	repo.Channels["c1"] = &model.Channel{ID: "c1"}
-	rows, err := svc.ListFeatured("", "", 10, 0)
+	now := time.Now()
+	// 投稿のある非アーカイブ channel のみ featured に出る (#1540)。
+	repo.Channels["c1"] = &model.Channel{ID: "c1", LastNotedAt: &now}
+	// lastNotedAt が無い channel は除外される。
+	repo.Channels["c2"] = &model.Channel{ID: "c2"}
+	// archived channel も除外される。
+	repo.Channels["c3"] = &model.Channel{ID: "c3", LastNotedAt: &now, IsArchived: true}
+	rows, err := svc.ListFeatured()
 	require.NoError(t, err)
-	assert.Len(t, rows, 1)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "c1", rows[0].ID)
 }
 
 func TestSearch(t *testing.T) {

--- a/internal/model/channel.go
+++ b/internal/model/channel.go
@@ -44,10 +44,13 @@ type ChannelListFilter struct {
 	// SearchDescription: true で Query を name OR description にマッチさせる
 	// (upstream channels/search type=nameAndDescription, 既定)。false は name のみ。
 	SearchDescription bool
-	IsArchived        *bool  // archived 状態で絞る
-	SortBy            string // "+lastNotedAt" / "-lastNotedAt" / "+name" / "-notesCount" 等
-	Limit             int
-	Offset            int
+	IsArchived        *bool // archived 状態で絞る
+	// LastNotedAtNotNull: true で lastNotedAt IS NOT NULL を AND する
+	// (upstream channels/featured: 一度も投稿の無い channel を除外, #1540)。
+	LastNotedAtNotNull bool
+	SortBy             string // "+lastNotedAt" / "-lastNotedAt" / "+id" / "-id" / "+name" / "-notesCount" 等
+	Limit              int
+	Offset             int
 	// Cursor pagination (frontend Paginator). 指定時は SortBy を id 順に
 	// 上書きして cursor 一貫性を保つ。Offset は無視する。
 	SinceID string

--- a/internal/repository/channel.go
+++ b/internal/repository/channel.go
@@ -84,6 +84,9 @@ func (r *channelRepository) List(filter model.ChannelListFilter) ([]*model.Chann
 	if filter.IsArchived != nil {
 		q = q.Where("\"isArchived\" = ?", *filter.IsArchived)
 	}
+	if filter.LastNotedAtNotNull {
+		q = q.Where("\"lastNotedAt\" IS NOT NULL")
+	}
 	cursor := filter.SinceID != "" || filter.UntilID != ""
 	if filter.SinceID != "" {
 		q = q.Where("id > ?", filter.SinceID)
@@ -99,6 +102,10 @@ func (r *channelRepository) List(filter model.ChannelListFilter) ([]*model.Chann
 			q = q.Order("\"lastNotedAt\" ASC NULLS LAST")
 		case "-lastNotedAt":
 			q = q.Order("\"lastNotedAt\" DESC NULLS LAST")
+		case "+id":
+			q = q.Order("id ASC")
+		case "-id":
+			q = q.Order("id DESC")
 		case "+name":
 			q = q.Order("name ASC")
 		case "-name":

--- a/internal/repository/channel_test.go
+++ b/internal/repository/channel_test.go
@@ -189,12 +189,42 @@ func TestChannelRepository_List_Sort(t *testing.T) {
 
 	for _, sortBy := range []string{
 		"+lastNotedAt", "-lastNotedAt", "+name", "-name",
-		"+notesCount", "-notesCount", "+usersCount", "-usersCount", "",
+		"+notesCount", "-notesCount", "+usersCount", "-usersCount", "+id", "-id", "",
 	} {
 		rows, err := repo.List(model.ChannelListFilter{Query: "sort-", SortBy: sortBy, Limit: 10})
 		require.NoError(t, err)
 		assert.Len(t, rows, 2)
 	}
+}
+
+// #1540: owned/search の cursor 無し default は id DESC、featured は
+// lastNotedAt IS NOT NULL で絞る。
+func TestChannelRepository_List_IDSortAndLastNotedAtFilter(t *testing.T) {
+	repo := NewChannelRepository(testDB)
+	uid := insertTestUser(t, "u_chr_ids", "channeluserids").ID
+	defer cleanupUser(t, uid)
+
+	now := time.Now()
+	a := newTestChannel("ch_ids_a", "ids-a", &uid) // lastNotedAt なし
+	b := newTestChannel("ch_ids_b", "ids-b", &uid)
+	b.LastNotedAt = &now
+	for _, ch := range []*model.Channel{a, b} {
+		require.NoError(t, repo.Create(ch))
+		defer cleanupChannel(t, ch.ID)
+	}
+
+	// SortBy "-id" は id 降順 (ch_ids_b > ch_ids_a)。
+	rows, err := repo.List(model.ChannelListFilter{Query: "ids-", SortBy: "-id", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "ch_ids_b", rows[0].ID)
+	assert.Equal(t, "ch_ids_a", rows[1].ID)
+
+	// LastNotedAtNotNull は lastNotedAt の無い channel を除外する。
+	rows, err = repo.List(model.ChannelListFilter{Query: "ids-", LastNotedAtNotNull: true, SortBy: "-lastNotedAt", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "ch_ids_b", rows[0].ID)
 }
 
 func TestChannelRepository_List_LimitClamp(t *testing.T) {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -4593,6 +4593,9 @@ func (m *MockChannelRepository) List(filter model.ChannelListFilter) ([]*model.C
 		if filter.IsArchived != nil && c.IsArchived != *filter.IsArchived {
 			continue
 		}
+		if filter.LastNotedAtNotNull && c.LastNotedAt == nil {
+			continue
+		}
 		rows = append(rows, c)
 	}
 	for i := 0; i < len(rows); i++ {


### PR DESCRIPTION
## Summary

#1540 (channels/* parity) の list 系 query 差分をまとめて解消する。

## 主な変更点

- **channels/owned**: upstream `owned.ts` は `isArchived=FALSE` を AND するが mk-go は未設定で archived channel も返していた。`ListOwned` に `IsArchived=FALSE` を追加。
- **channels/featured**: upstream `featured.ts` は `lastNotedAt IS NOT NULL` かつ `isArchived=FALSE` を `lastNotedAt DESC` で固定 10 件返すが、mk-go は `notesCount DESC` で絞り込み無し・limit も呼び出し側依存だった。`ChannelListFilter` に `LastNotedAtNotNull` を追加し、`ListFeatured` を固定条件 (lastNotedAt not null + 非archived + lastNotedAt DESC + limit 10、pagination 無し) に書き換え。Featured handler は cursor/limit を無視 (malformed JSON の 400 検証のみ残す)。
- **channels/owned + channels/search default sort**: upstream は `makePaginationQuery` で cursor 無し時 `id DESC` で並ぶが、mk-go repo の default は `lastNotedAt DESC` だった。repo の sort switch に `+id`/`-id` を追加し、`ListOwned`/`Search` に `SortBy=-id` を明示。repo の default は他用途のため `lastNotedAt` のまま維持。
- **channels/favorite** の冪等性 (既お気に入りで 204) は mk-go の方が堅牢で互換影響軽微のため**据え置き** (issue 本文の disposition に記載)。

## テスト

- 単体 (`internal/core/channel`): owned の archived 除外 / featured の lastNotedAt-not-null + archived 除外。
- 統合 (`internal/repository`): repo の `-id` sort 降順 + `LastNotedAtNotNull` filter。
- mock `List` に `LastNotedAtNotNull` を反映。

実行: `go test ./internal/core/channel/... ./internal/api/channels/... ./internal/repository/...` (coverage: core/channel 95.3% / api/channels 93.2%)

## 関連

Refs #1540 (channels/* parity の一部。残項目は後続 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)