### PR TITLE
Fix channels parity: mute/create ALREADY_MUTING_CHANNEL + mute/delete NO_SUCH_CHANNEL/NOT_MUTING_CHANNEL (#1540)

### DIFF
--- a/internal/api/channels/mute.go
+++ b/internal/api/channels/mute.go
@@ -35,12 +35,12 @@ func (h *Handler) MuteCreate(c echo.Context) error {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CHANNEL", "No such channel.", "7174361e-d58f-31d6-2e7c-6fb830786a3f"))
 	}
 	// 本家 create.ts は alreadyMuting → expiresAt-past の順でチェックする。
-	// 既ミュート済みなら 204 を返す既存挙動 (#1540) を先に短絡させ、本家の順序に
-	// 揃える。これにより「既ミュート済み + 過去 expiresAt」で 400 を返す不整合も
-	// 解消する。Exists は期限切れを除外するため (#1603)、ここで true=能動的mute。
+	// 本家 create.ts は alreadyMuting → expiresAt-past の順でチェックする。既ミュート
+	// 済みは ALREADY_MUTING_CHANNEL を返す (#1540)。Exists は期限切れを除外するため
+	// (#1603)、ここで true=能動的 mute。
 	already, _ := h.mutingRepo.Exists(user.ID, req.ChannelID)
 	if already {
-		return c.NoContent(http.StatusNoContent)
+		return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_MUTING_CHANNEL", "You are already muting that channel.", "5a251978-769a-da44-3e89-3931e43bb592"))
 	}
 	// 本家 create.ts: `ps.expiresAt && ps.expiresAt <= Date.now()` で過去なら
 	// EXPIRES_AT_IS_PAST。0 は JS で falsy のため無期限 (nil) として扱う。
@@ -75,6 +75,14 @@ func (h *Handler) MuteDelete(c echo.Context) error {
 	}
 	if h.mutingRepo == nil {
 		return c.NoContent(http.StatusNoContent)
+	}
+	// 本家 delete.ts は channel 不在 → NO_SUCH_CHANNEL、未ミュート → NOT_MUTING_CHANNEL
+	// の順でチェックしてから削除する (#1540)。
+	if _, err := h.svc.Show(req.ChannelID); err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CHANNEL", "No such channel.", "e7998769-6e94-d9c2-6b8f-94a527314aba"))
+	}
+	if muting, _ := h.mutingRepo.Exists(user.ID, req.ChannelID); !muting {
+		return c.JSON(http.StatusBadRequest, apierr.Error("NOT_MUTING_CHANNEL", "You are not muting that channel.", "14d55962-6ea8-d990-1333-d6bef78dc2ab"))
 	}
 	if err := h.mutingRepo.Delete(user.ID, req.ChannelID); err != nil {
 		return apierr.JSONInternalError(c)

--- a/internal/api/channels/mute_test.go
+++ b/internal/api/channels/mute_test.go
@@ -61,15 +61,18 @@ func TestMuteCreate_ZeroExpiresAtIsIndefinite(t *testing.T) {
 	assert.Nil(t, mut.ExpiresAt, "expiresAt=0 は無期限 (nil) として保存")
 }
 
-func TestMuteCreate_AlreadyMutedPastExpiresAtReturns204(t *testing.T) {
+func TestMuteCreate_AlreadyMutedPastExpiresAtReturnsAlreadyMuting(t *testing.T) {
 	h, chRepo, _, mutRepo := newStubHandler(t)
 	chRepo.Channels["ch1"] = &model.Channel{ID: "ch1", Name: "test"}
 	mutRepo.Mutings["u1:ch1"] = &model.ChannelMuting{ID: "m1", UserID: "u1", ChannelID: "ch1"}
-	// 既ミュート済みなら過去 expiresAt でも EXPIRES_AT_IS_PAST(400) ではなく
-	// 204 (本家順序: alreadyMuting を先にチェック)。
+	// 既ミュート済みなら過去 expiresAt でも EXPIRES_AT_IS_PAST ではなく
+	// ALREADY_MUTING_CHANNEL (本家順序: alreadyMuting を先にチェック, #1540)。
 	past := time.Now().Add(-time.Hour).UnixMilli()
 	rec := postStubWithBody(t, h.MuteCreate, fmt.Sprintf(`{"channelId":"ch1","expiresAt":%d}`, past), "u1")
-	assert.Equal(t, http.StatusNoContent, rec.Code)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "ALREADY_MUTING_CHANNEL", resp["error"].(map[string]any)["code"])
 }
 
 func TestMuteCreate_MissingChannelID(t *testing.T) {
@@ -89,13 +92,19 @@ func TestMuteCreate_AlreadyMuted(t *testing.T) {
 	chRepo.Channels["ch1"] = &model.Channel{ID: "ch1", Name: "test"}
 	mutRepo.Mutings["u1:ch1"] = &model.ChannelMuting{ID: "m1", UserID: "u1", ChannelID: "ch1"}
 	rec := postStubWithBody(t, h.MuteCreate, `{"channelId":"ch1"}`, "u1")
-	assert.Equal(t, http.StatusNoContent, rec.Code)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj := resp["error"].(map[string]any)
+	assert.Equal(t, "ALREADY_MUTING_CHANNEL", errObj["code"])
+	assert.Equal(t, "5a251978-769a-da44-3e89-3931e43bb592", errObj["id"])
 }
 
 // --- MuteDelete ---
 
 func TestMuteDelete_Success(t *testing.T) {
-	h, _, _, mutRepo := newStubHandler(t)
+	h, chRepo, _, mutRepo := newStubHandler(t)
+	chRepo.Channels["ch1"] = &model.Channel{ID: "ch1", Name: "test"}
 	mutRepo.Mutings["u1:ch1"] = &model.ChannelMuting{ID: "m1", UserID: "u1", ChannelID: "ch1"}
 	rec := postStubWithBody(t, h.MuteDelete, `{"channelId":"ch1"}`, "u1")
 	assert.Equal(t, http.StatusNoContent, rec.Code)
@@ -107,6 +116,32 @@ func TestMuteDelete_MissingChannelID(t *testing.T) {
 	h, _, _, _ := newStubHandler(t)
 	rec := postStubWithBody(t, h.MuteDelete, `{}`, "u1")
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// #1540: delete は channel 不在で NO_SUCH_CHANNEL。
+func TestMuteDelete_ChannelNotFound(t *testing.T) {
+	h, _, _, mutRepo := newStubHandler(t)
+	mutRepo.Mutings["u1:ch1"] = &model.ChannelMuting{ID: "m1", UserID: "u1", ChannelID: "ch1"}
+	rec := postStubWithBody(t, h.MuteDelete, `{"channelId":"ch1"}`, "u1")
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj := resp["error"].(map[string]any)
+	assert.Equal(t, "NO_SUCH_CHANNEL", errObj["code"])
+	assert.Equal(t, "e7998769-6e94-d9c2-6b8f-94a527314aba", errObj["id"])
+}
+
+// #1540: delete は未ミュートで NOT_MUTING_CHANNEL。
+func TestMuteDelete_NotMuting(t *testing.T) {
+	h, chRepo, _, _ := newStubHandler(t)
+	chRepo.Channels["ch1"] = &model.Channel{ID: "ch1", Name: "test"}
+	rec := postStubWithBody(t, h.MuteDelete, `{"channelId":"ch1"}`, "u1")
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj := resp["error"].(map[string]any)
+	assert.Equal(t, "NOT_MUTING_CHANNEL", errObj["code"])
+	assert.Equal(t, "14d55962-6ea8-d990-1333-d6bef78dc2ab", errObj["id"])
 }
 
 // --- MuteList ---


### PR DESCRIPTION
## Summary

#1540 (channels/* parity) の mute エラー差分を解消する。

## 主な変更点

- **channels/mute/create**: 既ミュート済みは 204 を返していたが、upstream は `ALREADY_MUTING_CHANNEL` (`5a251978-...`) を throw する。本家順 (alreadyMuting → expiresAt-past) を保ったまま 204 を `ALREADY_MUTING_CHANNEL` (400) に変更。
- **channels/mute/delete**: channel 存在も muting 有無も確認せず常に削除して 204 だったが、upstream は channel 不在で `NO_SUCH_CHANNEL` (`e7998769-...`)、未ミュートで `NOT_MUTING_CHANNEL` (`14d55962-...`) を throw する。`Show` + `Exists` で順に検証してから削除する。

(`EXPIRES_AT_IS_PAST` / mute/create の `NO_SUCH_CHANNEL` は #1603 で実装済み。)

## テスト

`internal/api/channels`: mute/create の `ALREADY_MUTING_CHANNEL` (既ミュート / 既ミュート+過去expiresAt) / mute/delete の `NO_SUCH_CHANNEL`・`NOT_MUTING_CHANNEL` を追加。既存の 204 期待 test を更新。

実行: `go test ./internal/api/channels/...` (coverage: 93.3%)

## 関連

Refs #1540 (channels/* parity の一部。残項目は後続 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)