### PR TITLE
Fix admin parity: send-email/promo の必須param検証 + reset-password の root guard (#1539)

### DIFF
--- a/internal/api/admin/ad_invite_promo_test.go
+++ b/internal/api/admin/ad_invite_promo_test.go
@@ -631,6 +631,15 @@ func TestPromoCreate_MissingNoteID(t *testing.T) {
 		doPost(h.PromoCreate, `{}`, adminUser).Code)
 }
 
+// #1539: expiresAt 欠落は upstream required により 400 (旧 mk-go は epoch 0 で保存)。
+func TestPromoCreate_MissingExpiresAt(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	h.SetPromoNoteRepo(&stubPromoRepo{})
+	h.SetNoteFinder(&stubNoteFinder{})
+	assert.Equal(t, http.StatusBadRequest,
+		doPost(h.PromoCreate, `{"noteId":"n1"}`, adminUser).Code)
+}
+
 func TestPromoCreate_NoSuchNote(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	h.SetPromoNoteRepo(&stubPromoRepo{})

--- a/internal/api/admin/email.go
+++ b/internal/api/admin/email.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/misc/smtp"
 )
 
@@ -19,8 +20,11 @@ func (h *Handler) SendEmail(c echo.Context) error {
 		Subject string `json:"subject"`
 		Text    string `json:"text"`
 	}
-	if err := c.Bind(&req); err != nil || req.To == "" {
-		return c.NoContent(http.StatusNoContent)
+	// upstream send-email.ts は paramDef required:['to','subject','text']。欠落は
+	// schema validation 段で 400 になるため、いずれか欠ければ INVALID_PARAM を返す
+	// (旧 mk-go は to のみ確認し subject/text 欠落でも 204 だった、#1539)。
+	if err := c.Bind(&req); err != nil || req.To == "" || req.Subject == "" || req.Text == "" {
+		return apierr.JSONInvalidParam(c)
 	}
 	if h.metaRepo != nil {
 		sender := smtp.SubjectBodySenderFromMeta(h.metaRepo, h.smtpProxyURL)

--- a/internal/api/admin/email_test.go
+++ b/internal/api/admin/email_test.go
@@ -9,5 +9,14 @@ import (
 
 func TestSendEmail(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
-	assert.Equal(t, http.StatusNoContent, doPost(h.SendEmail, `{}`, adminUser).Code)
+	// to/subject/text すべて揃えば 204 (#1539)。
+	assert.Equal(t, http.StatusNoContent, doPost(h.SendEmail, `{"to":"a@example.com","subject":"s","text":"t"}`, adminUser).Code)
+}
+
+// #1539: subject / text 欠落は upstream required により 400。
+func TestSendEmail_MissingSubjectOrText(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	assert.Equal(t, http.StatusBadRequest, doPost(h.SendEmail, `{}`, adminUser).Code)
+	assert.Equal(t, http.StatusBadRequest, doPost(h.SendEmail, `{"to":"a@example.com"}`, adminUser).Code)
+	assert.Equal(t, http.StatusBadRequest, doPost(h.SendEmail, `{"to":"a@example.com","subject":"s"}`, adminUser).Code)
 }

--- a/internal/api/admin/password_reset.go
+++ b/internal/api/admin/password_reset.go
@@ -30,6 +30,14 @@ func (h *Handler) ResetPassword(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
+	// upstream reset-password.ts は rootUserId===target で 'cannot reset password
+	// of root' を投げる。mk-go は他の admin guard (suspend-user) と揃えて root を
+	// ACCESS_DENIED で弾く (#1539)。userRepo 未配線時は guard を skip。
+	if h.userRepo != nil {
+		if user, err := h.userRepo.FindByID(req.UserID); err == nil && user.IsRoot {
+			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Cannot reset the password of a root account.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
+		}
+	}
 	if sent := h.sendPasswordResetEmail(req.UserID); sent {
 		h.logUserAction(c, moderationlog.LogResetPassword, req.UserID)
 		return c.JSON(http.StatusOK, map[string]any{"sent": true})

--- a/internal/api/admin/password_reset_test.go
+++ b/internal/api/admin/password_reset_test.go
@@ -90,6 +90,15 @@ func TestResetPasswordAdmin_Success(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "password")
 }
 
+// #1539: root アカウントのパスワードはリセットできない (upstream root guard)。
+func TestResetPasswordAdmin_RootRejected(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["root1"] = &model.User{ID: "root1", Username: "admin", IsRoot: true}
+	rec := doPost(h.ResetPassword, `{"userId":"root1"}`, adminUser)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "ACCESS_DENIED")
+}
+
 func TestResetPasswordAdmin_VerifiedEmailSendsResetLink(t *testing.T) {
 	h, userRepo, _, _ := newTestHandler(t)
 	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "testuser"}

--- a/internal/api/admin/promo.go
+++ b/internal/api/admin/promo.go
@@ -15,11 +15,13 @@ func (h *Handler) PromoCreate(c echo.Context) error {
 		return c.NoContent(http.StatusNoContent)
 	}
 	var req struct {
-		NoteID    string `json:"noteId"`
-		ExpiresAt int64  `json:"expiresAt"`
+		NoteID string `json:"noteId"`
+		// upstream promo/create.ts は required:['noteId','expiresAt']。欠落を 0 (=epoch)
+		// で保存しないよう pointer で受け、nil を弾く (#1539)。
+		ExpiresAt *int64 `json:"expiresAt"`
 	}
-	if err := c.Bind(&req); err != nil || req.NoteID == "" {
-		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "noteId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
+	if err := c.Bind(&req); err != nil || req.NoteID == "" || req.ExpiresAt == nil {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "noteId and expiresAt are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
 	// noteFinder 未配線時は visibility 検証ができないため fail-closed で
@@ -60,7 +62,7 @@ func (h *Handler) PromoCreate(c echo.Context) error {
 
 	promo := &model.PromoNote{
 		NoteID:    req.NoteID,
-		ExpiresAt: time.UnixMilli(req.ExpiresAt),
+		ExpiresAt: time.UnixMilli(*req.ExpiresAt),
 		UserID:    targetUserID,
 	}
 	if err := h.promoNoteRepo.Create(promo); err != nil {


### PR DESCRIPTION
## Summary

#1539 (admin/* singletons) の request-side validation / guard 差分を解消する。

## 主な変更点

- **admin/send-email** (#1539 LOW): upstream paramDef `required:['to','subject','text']`。mk-go は `to` のみ確認し subject/text 欠落でも 204 を返していた。いずれか欠ければ `INVALID_PARAM` (400)。
- **admin/promo/create** (#1539 LOW): upstream `required:['noteId','expiresAt']`。mk-go は expiresAt 欠落時に 0 (=epoch) で保存していた。expiresAt を `*int64` で受け、nil を 400 で弾く。
- **admin/reset-password** (#1539 MEDIUM): upstream は `rootUserId===target` で `'cannot reset password of root'`。mk-go に root guard が無かった。他の admin guard (suspend-user) と揃えて root を `ACCESS_DENIED` (403) で弾く。`{sent:true}` の email フロー (#186) と fallback の temp password 長は**意図的な mk-go 設計**のため据え置き (root guard のみ追加、issue 本文 disposition に記載)。

## テスト

`internal/api/admin`: send-email の subject/text 欠落 400 + 全部揃って 204 / promo の expiresAt 欠落 400 / reset-password の root 拒否 403 を追加。

実行: `go test ./internal/api/admin/...` (coverage 89.5%, gate 80%)

## 関連

Refs #1539 (admin/* singletons の一部。残項目は後続 PR / follow-up issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)