### PR TITLE
Fix admin parity: show-moderation-logs の cursor/type/userId/search 絞り込み + user packing (#1539)

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -2986,17 +2986,37 @@ func (h *Handler) inactiveAbuseWebhookIDs() []string {
 // と同じく "2006-01-02T15:04:05.000Z" 形式 (Misskey の標準)。
 func (h *Handler) ShowModerationLogs(c echo.Context) error {
 	var req struct {
-		Limit  int `json:"limit"`
-		Offset int `json:"offset"`
+		Limit     int    `json:"limit"`
+		SinceID   string `json:"sinceId"`
+		UntilID   string `json:"untilId"`
+		SinceDate *int64 `json:"sinceDate"`
+		UntilDate *int64 `json:"untilDate"`
+		Type      string `json:"type"`
+		UserID    string `json:"userId"`
+		Search    string `json:"search"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "Invalid parameters.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
-	logs, err := h.modLogService.List(req.Limit, req.Offset)
+	// sinceDate/untilDate を aidx prefix に正規化し、type/userId/search で絞る
+	// (upstream show-moderation-logs.ts, #1539)。
+	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	logs, err := h.modLogService.List(model.ModerationLogFilter{
+		Limit:   pagination.ClampLimit(req.Limit, 10, 100),
+		SinceID: sinceID,
+		UntilID: untilID,
+		Type:    req.Type,
+		UserID:  req.UserID,
+		Search:  req.Search,
+	})
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	// upstream は user を UserDetailedNotMe (optional:false) で pack する。生 model.User
+	// を埋めると usernameLower/inbox 等の内部列が漏れ avatarUrl 等 packed field も欠ける。
+	// actor (moderator) の profile は重複が多いので distinct user で 1 度だけ fetch して
+	// pack する (#1539)。
+	profileByUser := map[string]*model.UserProfile{}
 	out := make([]map[string]any, 0, len(logs))
 	for _, l := range logs {
 		m := map[string]any{
@@ -3015,7 +3035,14 @@ func (h *Handler) ShowModerationLogs(c echo.Context) error {
 				"logId", l.ID, "err", err)
 		}
 		if l.User != nil {
-			m["user"] = l.User
+			prof, ok := profileByUser[l.UserID]
+			if !ok {
+				if h.userRepo != nil {
+					prof, _ = h.userRepo.FindProfileByUserID(l.UserID)
+				}
+				profileByUser[l.UserID] = prof
+			}
+			m["user"] = entity.PackUserDetailed(l.User, prof, h.idGen)
 		}
 		out = append(out, m)
 	}

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -2069,6 +2069,53 @@ func TestShowModerationLogs_Empty(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// #1539: user は生 model.User でなく packed (UserDetailed) で返す。
+func TestShowModerationLogs_PacksUser(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	modLogRepo := testutil.NewMockModerationLogRepository()
+	require.NoError(t, modLogRepo.Create(&model.ModerationLog{
+		ID: "l1", UserID: "mod1", Type: "suspend", User: &model.User{ID: "mod1", Username: "modu"},
+	}))
+	gen, _ := id.NewGenerator("aidx")
+	h.SetModLogService(moderationlog.New(modLogRepo, gen))
+	userRepo.Profiles["mod1"] = &model.UserProfile{UserID: "mod1"}
+
+	rec := doPost(h.ShowModerationLogs, `{}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	user, ok := resp[0]["user"].(map[string]any)
+	require.True(t, ok, "user must be a packed object, not raw model.User")
+	assert.Equal(t, "mod1", user["id"])
+	assert.Contains(t, user, "avatarUrl", "packed UserDetailed exposes avatarUrl")
+}
+
+// #1539: type / userId / search の絞り込み。
+func TestShowModerationLogs_Filters(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	modLogRepo := testutil.NewMockModerationLogRepository()
+	require.NoError(t, modLogRepo.Create(&model.ModerationLog{ID: "l1", UserID: "a", Type: "suspend", Info: []byte(`{"x":"findme"}`)}))
+	require.NoError(t, modLogRepo.Create(&model.ModerationLog{ID: "l2", UserID: "b", Type: "deleteNote", Info: []byte(`{}`)}))
+	gen, _ := id.NewGenerator("aidx")
+	h.SetModLogService(moderationlog.New(modLogRepo, gen))
+
+	listIDs := func(body string) []string {
+		rec := doPost(h.ShowModerationLogs, body, nil)
+		require.Equal(t, http.StatusOK, rec.Code)
+		var resp []map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		ids := make([]string, 0, len(resp))
+		for _, m := range resp {
+			ids = append(ids, m["id"].(string))
+		}
+		return ids
+	}
+	assert.Equal(t, []string{"l1"}, listIDs(`{"type":"suspend"}`))
+	assert.Equal(t, []string{"l2"}, listIDs(`{"userId":"b"}`))
+	assert.Equal(t, []string{"l1"}, listIDs(`{"search":"findme"}`))
+}
+
 type failingAbuseListRepo struct {
 	*testutil.MockAbuseReportRepository
 }
@@ -2417,7 +2464,7 @@ type failingModLogListRepo struct {
 	*testutil.MockModerationLogRepository
 }
 
-func (f *failingModLogListRepo) List(_ int, _ int) ([]*model.ModerationLog, error) {
+func (f *failingModLogListRepo) List(_ model.ModerationLogFilter) ([]*model.ModerationLog, error) {
 	return nil, assert.AnError
 }
 

--- a/internal/core/moderationlog/service.go
+++ b/internal/core/moderationlog/service.go
@@ -153,11 +153,11 @@ func (s *Service) LogMany(ctx context.Context, moderatorID string, entries []Ent
 // not `[]`, and the frontend expects a JSON array). Nil receiver /
 // nil repo also returns an empty slice so the read endpoint degrades
 // gracefully when the service has not been wired.
-func (s *Service) List(limit, offset int) ([]*model.ModerationLog, error) {
+func (s *Service) List(filter model.ModerationLogFilter) ([]*model.ModerationLog, error) {
 	if s == nil || s.repo == nil {
 		return []*model.ModerationLog{}, nil
 	}
-	logs, err := s.repo.List(limit, offset)
+	logs, err := s.repo.List(filter)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/moderationlog/service_test.go
+++ b/internal/core/moderationlog/service_test.go
@@ -43,18 +43,19 @@ func (s *spyRepo) CreateMany(logs []*model.ModerationLog) error {
 	return nil
 }
 
-func (s *spyRepo) List(limit, offset int) ([]*model.ModerationLog, error) {
+func (s *spyRepo) List(filter model.ModerationLogFilter) ([]*model.ModerationLog, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if offset >= len(s.logs) {
-		return nil, nil
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 10
 	}
-	end := offset + limit
+	end := limit
 	if end > len(s.logs) {
 		end = len(s.logs)
 	}
-	out := make([]*model.ModerationLog, end-offset)
-	copy(out, s.logs[offset:end])
+	out := make([]*model.ModerationLog, end)
+	copy(out, s.logs[:end])
 	return out, nil
 }
 
@@ -261,8 +262,8 @@ type panicRepo struct{}
 func (panicRepo) Create(*model.ModerationLog) error {
 	panic("boom")
 }
-func (panicRepo) CreateMany([]*model.ModerationLog) error       { panic("boom") }
-func (panicRepo) List(int, int) ([]*model.ModerationLog, error) { return nil, nil }
+func (panicRepo) CreateMany([]*model.ModerationLog) error                        { panic("boom") }
+func (panicRepo) List(model.ModerationLogFilter) ([]*model.ModerationLog, error) { return nil, nil }
 
 func TestService_Log_recoverFromGoroutinePanic(t *testing.T) {
 	gen, err := id.NewGenerator("aidx")
@@ -280,13 +281,13 @@ func TestService_List_returnsEmptySliceWhenUnwired(t *testing.T) {
 	// Service.List は nil receiver / nil repo でも non-nil slice を返す。
 	// JSON encoder が `null` ではなく `[]` を出力するための契約。
 	var svc *Service
-	logs, err := svc.List(10, 0)
+	logs, err := svc.List(model.ModerationLogFilter{Limit: 10})
 	require.NoError(t, err)
 	assert.NotNil(t, logs)
 	assert.Empty(t, logs)
 
 	svc = New(nil, nil)
-	logs, err = svc.List(10, 0)
+	logs, err = svc.List(model.ModerationLogFilter{Limit: 10})
 	require.NoError(t, err)
 	assert.NotNil(t, logs)
 	assert.Empty(t, logs)
@@ -296,7 +297,7 @@ func TestService_List_returnsEmptySliceWhenRepoReturnsNil(t *testing.T) {
 	repo := &spyRepo{} // empty
 	svc := newSvc(t, repo)
 
-	logs, err := svc.List(10, 100) // offset 過大 → repo は nil 返却
+	logs, err := svc.List(model.ModerationLogFilter{Limit: 10}) // 空 repo → 空
 	require.NoError(t, err)
 	assert.NotNil(t, logs, "must return non-nil slice so JSON encodes as []")
 	assert.Empty(t, logs)
@@ -307,7 +308,7 @@ func TestService_List_passesThroughRepoError(t *testing.T) {
 	gen, _ := id.NewGenerator("aidx")
 	svc := New(repo, gen)
 
-	logs, err := svc.List(10, 0)
+	logs, err := svc.List(model.ModerationLogFilter{Limit: 10})
 	require.Error(t, err)
 	assert.Nil(t, logs)
 }
@@ -318,7 +319,7 @@ func TestService_List_returnsRepoEntries(t *testing.T) {
 	require.NoError(t, repo.Create(&model.ModerationLog{ID: "l1", Type: "suspend"}))
 	require.NoError(t, repo.Create(&model.ModerationLog{ID: "l2", Type: "unsuspend"}))
 
-	logs, err := svc.List(10, 0)
+	logs, err := svc.List(model.ModerationLogFilter{Limit: 10})
 	require.NoError(t, err)
 	require.Len(t, logs, 2)
 }
@@ -329,7 +330,7 @@ type errorListRepo struct {
 
 func (r *errorListRepo) Create(*model.ModerationLog) error       { return nil }
 func (r *errorListRepo) CreateMany([]*model.ModerationLog) error { return nil }
-func (r *errorListRepo) List(int, int) ([]*model.ModerationLog, error) {
+func (r *errorListRepo) List(model.ModerationLogFilter) ([]*model.ModerationLog, error) {
 	return nil, r.err
 }
 

--- a/internal/model/abuse_report.go
+++ b/internal/model/abuse_report.go
@@ -36,3 +36,16 @@ type ModerationLog struct {
 }
 
 func (ModerationLog) TableName() string { return "moderation_log" }
+
+// ModerationLogFilter parameterises ModerationLogRepository.List, mirroring
+// upstream admin/show-moderation-logs paramDef (#1539). SinceID/UntilID are the
+// id-cursor (sinceDate/untilDate are normalized to ids by the handler); Type /
+// UserID narrow by log type / actor; Search is an info::text ILIKE match.
+type ModerationLogFilter struct {
+	Limit   int
+	SinceID string
+	UntilID string
+	Type    string
+	UserID  string
+	Search  string
+}

--- a/internal/repository/abuse_report.go
+++ b/internal/repository/abuse_report.go
@@ -96,7 +96,7 @@ type ModerationLogRepository interface {
 	// admin operations want to record N entries without spawning N
 	// goroutines + N round-trips (#671).
 	CreateMany(logs []*model.ModerationLog) error
-	List(limit, offset int) ([]*model.ModerationLog, error)
+	List(filter model.ModerationLogFilter) ([]*model.ModerationLog, error)
 }
 
 type moderationLogRepository struct {
@@ -118,17 +118,33 @@ func (r *moderationLogRepository) CreateMany(logs []*model.ModerationLog) error 
 	return r.db.Create(&logs).Error
 }
 
-func (r *moderationLogRepository) List(limit, offset int) ([]*model.ModerationLog, error) {
+func (r *moderationLogRepository) List(filter model.ModerationLogFilter) ([]*model.ModerationLog, error) {
+	limit := filter.Limit
 	if limit <= 0 {
 		limit = 10
 	}
 	if limit > 100 {
 		limit = 100
 	}
-	q := r.db.Preload("User").Order("id DESC").Limit(limit)
-	if offset > 0 {
-		q = q.Offset(offset)
+	// upstream show-moderation-logs.ts: type / userId 完全一致 + info::text ILIKE
+	// search + id-cursor pagination (sinceId/untilId)。
+	q := r.db.Preload("User")
+	if filter.Type != "" {
+		q = q.Where("type = ?", filter.Type)
 	}
+	if filter.UserID != "" {
+		q = q.Where(`"userId" = ?`, filter.UserID)
+	}
+	if filter.Search != "" {
+		q = q.Where("info::text ILIKE ?", "%"+escapeLike(filter.Search)+"%")
+	}
+	if filter.UntilID != "" {
+		q = q.Where("id < ?", filter.UntilID)
+	}
+	if filter.SinceID != "" {
+		q = q.Where("id > ?", filter.SinceID)
+	}
+	q = q.Order("id DESC").Limit(limit)
 	var logs []*model.ModerationLog
 	if err := q.Find(&logs).Error; err != nil {
 		return nil, err

--- a/internal/repository/abuse_report_test.go
+++ b/internal/repository/abuse_report_test.go
@@ -196,14 +196,14 @@ func TestAbuseReportRepository_List_OriginFilter(t *testing.T) {
 
 func TestModerationLogRepository_List_DefaultLimit(t *testing.T) {
 	repo := NewModerationLogRepository(testDB)
-	logs, err := repo.List(0, 0) // limit=0 → default 10
+	logs, err := repo.List(model.ModerationLogFilter{}) // limit=0 → default 10
 	require.NoError(t, err)
 	_ = logs
 }
 
 func TestModerationLogRepository_List_LimitCap(t *testing.T) {
 	repo := NewModerationLogRepository(testDB)
-	logs, err := repo.List(999, 0) // > 100 → capped
+	logs, err := repo.List(model.ModerationLogFilter{Limit: 999}) // > 100 → capped
 	require.NoError(t, err)
 	assert.LessOrEqual(t, len(logs), 100)
 }
@@ -232,7 +232,7 @@ func TestModerationLogRepository_CRUD(t *testing.T) {
 	require.NoError(t, repo.Create(log))
 	defer cleanupModLog(t, log.ID)
 
-	logs, err := repo.List(10, 0)
+	logs, err := repo.List(model.ModerationLogFilter{Limit: 10})
 	require.NoError(t, err)
 	assert.NotEmpty(t, logs)
 }
@@ -251,7 +251,7 @@ func TestModerationLogRepository_CreateMany(t *testing.T) {
 	defer cleanupModLog(t, "ml_b2")
 	defer cleanupModLog(t, "ml_b3")
 
-	logs, err := repo.List(100, 0)
+	logs, err := repo.List(model.ModerationLogFilter{Limit: 100})
 	require.NoError(t, err)
 	// 3 件以上ある (他のテストの行も拾う可能性あるが少なくとも 3 件は入っている)
 	var found int
@@ -273,7 +273,7 @@ func TestModerationLogRepository_List_Error(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	repo := NewModerationLogRepository(testDB.WithContext(ctx))
-	_, err := repo.List(10, 0)
+	_, err := repo.List(model.ModerationLogFilter{Limit: 10})
 	assert.Error(t, err)
 }
 
@@ -287,11 +287,45 @@ func TestModerationLogRepository_List_Pagination(t *testing.T) {
 	defer cleanupModLog(t, log1.ID)
 	defer cleanupModLog(t, log2.ID)
 
-	logs, err := repo.List(1, 0)
+	logs, err := repo.List(model.ModerationLogFilter{Limit: 1})
 	require.NoError(t, err)
 	assert.Len(t, logs, 1)
 
-	logs, err = repo.List(10, 1)
+	// #1539: untilId cursor で ml_p2 より前 (= ml_p1) を返す。
+	logs, err = repo.List(model.ModerationLogFilter{Limit: 10, UntilID: "ml_p2"})
 	require.NoError(t, err)
-	assert.NotEmpty(t, logs)
+	require.NotEmpty(t, logs)
+	for _, l := range logs {
+		assert.Less(t, l.ID, "ml_p2")
+	}
+}
+
+// #1539: type / userId / search の絞り込み。
+func TestModerationLogRepository_List_Filters(t *testing.T) {
+	repo := NewModerationLogRepository(testDB)
+	createTestUser(t, "ml_flt")
+	createTestUser(t, "ml_flt2")
+	a := &model.ModerationLog{ID: "ml_f1", UserID: "ml_flt", Type: "suspend", Info: []byte(`{"targetUserId":"victimA"}`)}
+	b := &model.ModerationLog{ID: "ml_f2", UserID: "ml_flt2", Type: "deleteNote", Info: []byte(`{"noteId":"n9"}`)}
+	require.NoError(t, repo.Create(a))
+	require.NoError(t, repo.Create(b))
+	defer cleanupModLog(t, a.ID)
+	defer cleanupModLog(t, b.ID)
+
+	byType, err := repo.List(model.ModerationLogFilter{Limit: 100, Type: "suspend"})
+	require.NoError(t, err)
+	for _, l := range byType {
+		assert.Equal(t, "suspend", l.Type)
+	}
+	byUser, err := repo.List(model.ModerationLogFilter{Limit: 100, UserID: "ml_flt2"})
+	require.NoError(t, err)
+	for _, l := range byUser {
+		assert.Equal(t, "ml_flt2", l.UserID)
+	}
+	bySearch, err := repo.List(model.ModerationLogFilter{Limit: 100, Search: "victimA"})
+	require.NoError(t, err)
+	require.NotEmpty(t, bySearch)
+	for _, l := range bySearch {
+		assert.Contains(t, string(l.Info), "victimA")
+	}
 }

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -6270,18 +6270,35 @@ func (m *MockModerationLogRepository) CallCounts() (create, createMany int) {
 	return m.CreateCalls, m.CreateManyCalls
 }
 
-func (m *MockModerationLogRepository) List(limit, offset int) ([]*model.ModerationLog, error) {
+func (m *MockModerationLogRepository) List(filter model.ModerationLogFilter) ([]*model.ModerationLog, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	limit := filter.Limit
 	if limit <= 0 {
 		limit = 10
 	}
-	if offset >= len(m.Logs) {
-		return nil, nil
+	out := make([]*model.ModerationLog, 0, len(m.Logs))
+	for _, l := range m.Logs {
+		if filter.Type != "" && l.Type != filter.Type {
+			continue
+		}
+		if filter.UserID != "" && l.UserID != filter.UserID {
+			continue
+		}
+		if filter.Search != "" && !strings.Contains(strings.ToLower(string(l.Info)), strings.ToLower(filter.Search)) {
+			continue
+		}
+		if filter.UntilID != "" && l.ID >= filter.UntilID {
+			continue
+		}
+		if filter.SinceID != "" && l.ID <= filter.SinceID {
+			continue
+		}
+		out = append(out, l)
 	}
-	end := min(offset+limit, len(m.Logs))
-	out := make([]*model.ModerationLog, end-offset)
-	copy(out, m.Logs[offset:end])
+	if len(out) > limit {
+		out = out[:limit]
+	}
 	return out, nil
 }
 


### PR DESCRIPTION
## Summary

#1539 (admin/* singletons) の `show-moderation-logs` 差分を解消する。

## 主な変更点

### 絞り込み / pagination (#1539 MEDIUM)
upstream `show-moderation-logs.ts` は `limit`/`sinceId`/`untilId`/`sinceDate`/`untilDate`/`type`/`userId`/`search` を受け、cursor pagination + type/userId 完全一致 + `info::text ILIKE` search を実装する。mk-go は `limit`/`offset` のみだった。

- `ModerationLogRepository.List` を `model.ModerationLogFilter` (Limit/SinceID/UntilID/Type/UserID/Search) 受けに変更。
- handler は `id.NormalizeCursor` で `sinceDate`/`untilDate` を aidx prefix に正規化して渡す。`offset` は upstream に無いため廃止 (cursor へ移行)。

### user packing (#1539 MEDIUM)
upstream は `user` を `UserDetailedNotMe` (optional:false) で pack する。mk-go は生 `model.User` を `l.User != nil` のときだけ埋めており、`usernameLower`/`inbox` 等の内部列が漏れ `avatarUrl` 等 packed field が欠落していた。`entity.PackUserDetailed` で pack し、actor profile は distinct user で 1 度だけ fetch する。

## テスト

- 統合 (`internal/repository`): type/userId/search filter + untilId cursor。
- 単体 (`internal/api/admin`): user packing (packed object 化) + type/userId/search filter。既存の offset ベース test を cursor に更新。

実行: `go test ./internal/api/admin/... ./internal/core/moderationlog/... ./internal/repository/...` (coverage: admin 89.4% / moderationlog 98.0%)

## 関連

Refs #1539 (admin/* singletons の一部。残項目は後続 PR / follow-up issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)