### PR TITLE
Fix admin parity: update-proxy-account を MeDetailed で返す + unset-avatar/banner の log fileId + no-op guard (#1539)

### DIFF
--- a/internal/api/admin/moderation.go
+++ b/internal/api/admin/moderation.go
@@ -11,6 +11,9 @@ import (
 )
 
 // UnsetUserAvatar handles POST /api/admin/unset-user-avatar.
+//
+// upstream unset-user-avatar.ts: avatarId が既に null なら no-op (log も書かない)、
+// それ以外は解除して moderation log に fileId: 旧 avatarId を含めて記録する (#1539)。
 func (h *Handler) UnsetUserAvatar(c echo.Context) error {
 	var req struct {
 		UserID string `json:"userId"`
@@ -18,13 +21,25 @@ func (h *Handler) UnsetUserAvatar(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return c.NoContent(http.StatusNoContent)
 	}
+	user, err := h.userRepo.FindByID(req.UserID)
+	if err != nil || user == nil || user.AvatarID == nil {
+		// 既に未設定 / 不在なら no-op (upstream は avatarId==null で early-return)。
+		return c.NoContent(http.StatusNoContent)
+	}
+	// fileId は UpdateUser が user pointer を mutate する前に値で控える
+	// (log は goroutine で後から marshal するため、pointer のままだと nil 化する)。
+	fileID := *user.AvatarID
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"avatarId": nil, "avatarUrl": nil, "avatarBlurhash": nil}); err == nil {
-		h.logUserAction(c, moderationlog.LogUnsetUserAvatar, req.UserID)
+		info := moderationlog.UserInfo(user)
+		info["fileId"] = fileID
+		h.logModeration(c, moderationlog.LogUnsetUserAvatar, info)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
 
 // UnsetUserBanner handles POST /api/admin/unset-user-banner.
+//
+// upstream unset-user-banner.ts: bannerId 解除版の UnsetUserAvatar 相当 (#1539)。
 func (h *Handler) UnsetUserBanner(c echo.Context) error {
 	var req struct {
 		UserID string `json:"userId"`
@@ -32,8 +47,15 @@ func (h *Handler) UnsetUserBanner(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return c.NoContent(http.StatusNoContent)
 	}
+	user, err := h.userRepo.FindByID(req.UserID)
+	if err != nil || user == nil || user.BannerID == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	fileID := *user.BannerID
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"bannerId": nil, "bannerUrl": nil, "bannerBlurhash": nil}); err == nil {
-		h.logUserAction(c, moderationlog.LogUnsetUserBanner, req.UserID)
+		info := moderationlog.UserInfo(user)
+		info["fileId"] = fileID
+		h.logModeration(c, moderationlog.LogUnsetUserBanner, info)
 	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/admin/moderation_test.go
+++ b/internal/api/admin/moderation_test.go
@@ -159,26 +159,50 @@ func TestUpdateAbuseUserReport_LogPayload(t *testing.T) {
 
 func TestUnsetUserAvatar_WritesModerationLog(t *testing.T) {
 	h, userRepo, _, _ := newTestHandler(t)
-	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	avatarID := "av1"
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", AvatarID: &avatarID}
 	repo := attachModLog(t, h)
 
 	rec := doPost(h.UnsetUserAvatar, `{"userId":"u1"}`, adminUser)
 	require.Equal(t, http.StatusNoContent, rec.Code)
 
 	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
-	assert.Equal(t, "unsetUserAvatar", repo.Snapshot()[0].Type)
+	log := repo.Snapshot()[0]
+	assert.Equal(t, "unsetUserAvatar", log.Type)
+	// #1539: log info に解除した fileId を含める。
+	var info map[string]any
+	require.NoError(t, json.Unmarshal(log.Info, &info))
+	assert.Equal(t, "av1", info["fileId"])
+	assert.Equal(t, "u1", info["userId"])
 }
 
 func TestUnsetUserBanner_WritesModerationLog(t *testing.T) {
 	h, userRepo, _, _ := newTestHandler(t)
-	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	bannerID := "bn1"
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", BannerID: &bannerID}
 	repo := attachModLog(t, h)
 
 	rec := doPost(h.UnsetUserBanner, `{"userId":"u1"}`, adminUser)
 	require.Equal(t, http.StatusNoContent, rec.Code)
 
 	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
-	assert.Equal(t, "unsetUserBanner", repo.Snapshot()[0].Type)
+	log := repo.Snapshot()[0]
+	assert.Equal(t, "unsetUserBanner", log.Type)
+	var info map[string]any
+	require.NoError(t, json.Unmarshal(log.Info, &info))
+	assert.Equal(t, "bn1", info["fileId"])
+}
+
+// #1539: 既に未設定なら no-op で moderation log を書かない。
+func TestUnsetUserAvatar_AlreadyUnsetNoLog(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"} // avatarId nil
+	repo := attachModLog(t, h)
+
+	rec := doPost(h.UnsetUserAvatar, `{"userId":"u1"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	time.Sleep(50 * time.Millisecond)
+	assert.Empty(t, repo.Snapshot(), "already-unset avatar must not write a log")
 }
 
 func TestUpdateAbuseUserReport_WritesModerationLog(t *testing.T) {

--- a/internal/api/admin/proxy_account.go
+++ b/internal/api/admin/proxy_account.go
@@ -14,8 +14,8 @@ import (
 // 本家 update-proxy-account.ts と同じく proxy system user の profile.description
 // を更新する handler (旧 stub は誤って meta.proxyAccountId を書き換えていた、#348)。
 // frontend admin/settings 画面の proxyAccountForm が `{ description }` 形式で
-// 呼び出すのでこれに合わせる。Response は UserDetailed (mk-go では UserLite +
-// description で代替)。
+// 呼び出すのでこれに合わせる。Response は upstream update-proxy-account.ts と同じく
+// MeDetailed schema で返す (#1539)。
 func (h *Handler) UpdateProxyAccount(c echo.Context) error {
 	var req struct {
 		Description *string `json:"description"`
@@ -42,7 +42,7 @@ func (h *Handler) UpdateProxyAccount(c echo.Context) error {
 			"after":  req.Description,
 		})
 	}
-	// 更新後 profile を再取得して UserDetailed を返す。
+	// 更新後 profile を再取得して MeDetailed を返す (upstream schema 'MeDetailed')。
 	profile, _ := h.userRepo.FindProfileByUserID(proxy.ID)
-	return c.JSON(http.StatusOK, entity.PackUserDetailed(proxy, profile))
+	return c.JSON(http.StatusOK, entity.PackMeDetailed(proxy, profile))
 }


### PR DESCRIPTION
## Summary

#1539 (admin/* singletons) の response/log shape 差分を解消する。

## 主な変更点

- **admin/update-proxy-account** (#1539 LOW): upstream は `userEntityService.pack(schema:'MeDetailed')` を返すが mk-go は `PackUserDetailed` だった。`entity.PackMeDetailed` に切替え (MeDetailed 固有 field `hasUnread*`/`policies`/`roles`/`twoFactorEnabled` 等を含める)。
- **admin/unset-user-avatar, unset-user-banner** (#1539 LOW): upstream は moderation log info に `fileId: 旧 avatarId/bannerId` を含め、`avatarId`/`bannerId` が既に null なら **no-op** (log も書かない)。mk-go は fileId 無しで常に UPDATE+log していた。`FindByID` で取得し、既に未設定なら no-op、解除時は fileId (UpdateUser 前に値で控える) + `UserInfo` を log に含める。

## テスト

`internal/api/admin`: unset-avatar/banner の log fileId 検証 + 既未設定の no-op (log 無し) を追加。proxy account は既存 test が MeDetailed superset で引き続き pass。

実行: `go test ./internal/api/admin/...` (coverage 89.4%, gate 80%)

## 関連

Refs #1539 (admin/* singletons の一部)

🤖 Generated with [Claude Code](https://claude.com/claude-code)