### PR TITLE
Fix admin parity: suspend/delete/unsuspend-user で AP Delete/Undo(Delete) を配信 (#1759)

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -1068,6 +1068,50 @@ func (r *Renderer) RenderDelete(author *model.User, noteURI string) *Delete {
 	return d
 }
 
+// RenderDeleteActor renders a Delete activity whose object is a local user's own
+// actor URI, used when an account is suspended or deleted (#1759). Mirrors
+// upstream ApRendererService.renderDelete(genLocalUserUri(user.id), user): both
+// actor と object が当該ユーザーの URI 文字列で、Tombstone ではなく bare IRI を
+// object に置く (note の Delete と違い actor delete は Tombstone を使わない)。
+func (r *Renderer) RenderDeleteActor(user *model.User) *Delete {
+	uri := r.urls.UserURI(user.ID)
+	d := &Delete{
+		Activity: Activity{
+			Object: Object{
+				ID:   uri + "#Delete",
+				Type: "Delete",
+			},
+			Actor: uri,
+			To:    []string{Public},
+		},
+		Object: uri,
+	}
+	AddContext(d)
+	return d
+}
+
+// RenderUndoDeleteActor wraps RenderDeleteActor in an Undo, used when a suspended
+// account is unsuspended (#1759). Mirrors upstream renderUndo(renderDelete(...))。
+// 内側 Delete は @context を持たない (Undo 側のみ context を付ける)。
+func (r *Renderer) RenderUndoDeleteActor(user *model.User) *Undo {
+	uri := r.urls.UserURI(user.ID)
+	inner := r.RenderDeleteActor(user)
+	inner.Context = nil // inner activity は @context を持たない
+	u := &Undo{
+		Activity: Activity{
+			Object: Object{
+				ID:   uri + "#Undo-Delete",
+				Type: "Undo",
+			},
+			Actor: uri,
+			To:    []string{Public},
+		},
+		Object: inner,
+	}
+	AddContext(u)
+	return u
+}
+
 // RenderFlag returns a Flag activity that forwards an abuse report to the
 // origin instance of a remote user. Mirrors upstream ApRendererService
 // renderFlag — the actor is the local instance's system account (to

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -643,6 +643,33 @@ func TestRenderer_RenderDelete(t *testing.T) {
 	assert.Contains(t, d.To, Public)
 }
 
+// #1759: actor delete は object も actor も当該 user の URI 文字列 (Tombstone 不使用)。
+func TestRenderer_RenderDeleteActor(t *testing.T) {
+	r := newRenderer()
+	u := &model.User{ID: "alice", Username: "alice"}
+	d := r.RenderDeleteActor(u)
+	assert.Equal(t, "Delete", d.Type)
+	assert.Equal(t, "https://example.com/users/alice", d.Actor)
+	assert.Equal(t, "https://example.com/users/alice#Delete", d.ID)
+	assert.Equal(t, "https://example.com/users/alice", d.Object)
+	assert.Contains(t, d.To, Public)
+	assert.NotEmpty(t, d.Context, "top-level Delete carries @context")
+}
+
+// #1759: unsuspend の Undo(Delete)。inner Delete は @context を持たない。
+func TestRenderer_RenderUndoDeleteActor(t *testing.T) {
+	r := newRenderer()
+	u := &model.User{ID: "alice", Username: "alice"}
+	un := r.RenderUndoDeleteActor(u)
+	assert.Equal(t, "Undo", un.Type)
+	assert.Equal(t, "https://example.com/users/alice", un.Actor)
+	assert.NotEmpty(t, un.Context)
+	inner, ok := un.Object.(*Delete)
+	require.True(t, ok)
+	assert.Equal(t, "Delete", inner.Type)
+	assert.Nil(t, inner.Context, "inner Delete must not carry @context")
+}
+
 func TestRenderer_RenderPerson_Bot(t *testing.T) {
 	r := newRenderer()
 	u := &model.User{ID: "u1", Username: "bot", IsBot: true}

--- a/internal/api/admin/accounts.go
+++ b/internal/api/admin/accounts.go
@@ -73,11 +73,19 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 	if h.isProtectedAccount(req.UserID) {
 		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Cannot delete a root or system account.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 	}
+	// AP Delete(actor) 配信のため、更新前に user を控える (#1759)。
+	user, _ := h.userRepo.FindByID(req.UserID)
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": true, "isDeleted": true}); err == nil {
 		// AccountsDelete と同じ。target の全 token cache entry を即時
 		// invalidate (#965)。
 		h.invalidateUserTokenCache(req.UserID)
 		h.logUserAction(c, moderationlog.LogDeleteAccount, req.UserID)
+	}
+	// upstream DeleteAccountService: local user は物理削除 job の前に全 sharedInbox
+	// へ Delete(actor) を配信する (#1759)。mk-go の cascade は soft (user 行/鍵を
+	// 残す) ため queue 経由配信でも署名鍵は生存する。
+	if user != nil && h.userModerationFed != nil {
+		h.userModerationFed.OnUserDeleted(user)
 	}
 	h.scheduleAccountCascade(req.UserID)
 	return c.NoContent(http.StatusNoContent)

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -151,6 +151,27 @@ type Handler struct {
 	// するために使う (#1407 review)。未配線時は最大 cacheTTL (5min) 待ちで
 	// stale な配送可否判定が残るが security regression ではないため optional。
 	instanceSuspendInvalidator InstanceSuspendCacheInvalidator
+	// userModerationFed は suspend / delete-account / unsuspend 時に対象 local
+	// user の AP Delete / Undo(Delete) を remote instances へ配信する (#1759)。
+	// nil なら連合副作用は no-op (security guard / DB 更新には影響しない)。
+	userModerationFed UserModerationFederationHook
+}
+
+// UserModerationFederationHook delivers AP Delete / Undo(Delete) for a local
+// user's actor to remote instances when the account is suspended, deleted, or
+// unsuspended (#1759). Implemented by core/federation.UserModerationDeliveryHook.
+// nil disables the federation side-effect.
+type UserModerationFederationHook interface {
+	// OnUserDeleted は suspend / delete-account で Delete(actor) を配信する。
+	OnUserDeleted(user *model.User)
+	// OnUserRestored は unsuspend で Undo(Delete) を配信する。
+	OnUserRestored(user *model.User)
+}
+
+// SetUserModerationFederationHook wires the AP delivery hook used on
+// suspend / delete-account / unsuspend (#1759). nil disables federation.
+func (h *Handler) SetUserModerationFederationHook(hook UserModerationFederationHook) {
+	h.userModerationFed = hook
 }
 
 // InstanceSuspendCacheInvalidator drops the cached delivery-suspend decision
@@ -987,6 +1008,11 @@ func (h *Handler) SuspendUser(c echo.Context) error {
 	// 凍結直後の auth bypass 防止 (#965)。target の全 token cache entry を
 	// 即時削除し、middleware 通過後の P2 gate (#964) に依存せず確実に弾く。
 	h.invalidateUserTokenCache(req.UserID)
+	// upstream UserSuspendService.suspend: local user なら全 sharedInbox へ
+	// Delete(actor) を配信する (#1759)。best-effort (queue 経由)。
+	if h.userModerationFed != nil {
+		h.userModerationFed.OnUserDeleted(user)
+	}
 	h.logUserActionWithUser(c, moderationlog.LogSuspend, user)
 	return c.NoContent(http.StatusNoContent)
 }
@@ -1013,6 +1039,11 @@ func (h *Handler) UnsuspendUser(c echo.Context) error {
 	// P2 gate (#964) が cache hit 経路でも fire してしまい、解除済 user が
 	// 認証通らない逆方向の bug になる。
 	h.invalidateUserTokenCache(req.UserID)
+	// upstream UserSuspendService.unsuspend: local user なら全 sharedInbox へ
+	// Undo(Delete) を配信する (#1759)。
+	if h.userModerationFed != nil {
+		h.userModerationFed.OnUserRestored(user)
+	}
 	h.logUserActionWithUser(c, moderationlog.LogUnsuspend, user)
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -566,6 +566,48 @@ func TestSuspendUser_NoInvalidatorIsNoop(t *testing.T) {
 		"invalidator 未配線でも core suspend 動作は止まらない")
 }
 
+// #1759: suspend / delete-account は対象 user の AP Delete を、unsuspend は
+// Undo(Delete) を federation hook 経由で配信する。
+type stubUserModFed struct {
+	deleted  []string
+	restored []string
+}
+
+func (s *stubUserModFed) OnUserDeleted(u *model.User)  { s.deleted = append(s.deleted, u.ID) }
+func (s *stubUserModFed) OnUserRestored(u *model.User) { s.restored = append(s.restored, u.ID) }
+
+func TestSuspendUser_DeliversAPDelete(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "target"}
+	fed := &stubUserModFed{}
+	h.SetUserModerationFederationHook(fed)
+	rec := doPost(h.SuspendUser, `{"userId":"u1"}`, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, []string{"u1"}, fed.deleted)
+	assert.Empty(t, fed.restored)
+}
+
+func TestUnsuspendUser_DeliversUndoDelete(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", IsSuspended: true}
+	fed := &stubUserModFed{}
+	h.SetUserModerationFederationHook(fed)
+	rec := doPost(h.UnsuspendUser, `{"userId":"u1"}`, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, []string{"u1"}, fed.restored)
+	assert.Empty(t, fed.deleted)
+}
+
+func TestDeleteAccount_DeliversAPDelete(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "target"}
+	fed := &stubUserModFed{}
+	h.SetUserModerationFederationHook(fed)
+	rec := doPost(h.DeleteAccount, `{"userId":"u1"}`, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, []string{"u1"}, fed.deleted)
+}
+
 // SuspendUser が target を見つけられない (= UpdateUser 前に NotFound) と
 // invalidate は呼ばない。404 を返した時点で cache に target の entry が
 // 存在する保証もないので、空打ちを避ける。

--- a/internal/core/federation/user_moderation_delivery_hook.go
+++ b/internal/core/federation/user_moderation_delivery_hook.go
@@ -1,0 +1,84 @@
+package federation
+
+import (
+	"encoding/json"
+	"log/slog"
+
+	"github.com/shiroha-a/mk/internal/activitypub"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// UserModerationDeliveryHook emits AP Delete / Undo(Delete) activities for a
+// local user's actor when the account is suspended, deleted, or unsuspended
+// (#1759). Mirrors upstream UserSuspendService / DeleteAccountService, which
+// deliver Delete(actor) to every known sharedInbox on suspend/delete and
+// Undo(Delete) on unsuspend.
+//
+// 配信ルール (NoteDeleteDeliveryHook と同方針):
+//   - user がリモート → 配信不要 (当該インスタンスが発火元)
+//   - それ以外 → フォロワー (リモート) + 既知のリモートインスタンス全体
+//     (sharedInbox 単位) に配信する。フォロー関係に無い instance も ap/show
+//     で actor を pull 済みのことがあるためブロードキャストで補償する。
+type UserModerationDeliveryHook struct {
+	deliver  *DeliverService
+	renderer *activitypub.Renderer
+	userRepo repository.UserRepository
+}
+
+// NewUserModerationDeliveryHook constructs a UserModerationDeliveryHook.
+func NewUserModerationDeliveryHook(
+	deliver *DeliverService,
+	renderer *activitypub.Renderer,
+	userRepo repository.UserRepository,
+) *UserModerationDeliveryHook {
+	return &UserModerationDeliveryHook{deliver: deliver, renderer: renderer, userRepo: userRepo}
+}
+
+// OnUserDeleted delivers a Delete(actor) for a suspended or deleted local user.
+// delete-account 経路では keypair が cascade で消える前に呼ぶこと (署名に必要)。
+func (h *UserModerationDeliveryHook) OnUserDeleted(user *model.User) {
+	if user == nil || h.renderer == nil {
+		return
+	}
+	h.broadcast(user, h.renderer.RenderDeleteActor(user))
+}
+
+// OnUserRestored delivers an Undo(Delete) for an unsuspended local user.
+func (h *UserModerationDeliveryHook) OnUserRestored(user *model.User) {
+	if user == nil || h.renderer == nil {
+		return
+	}
+	h.broadcast(user, h.renderer.RenderUndoDeleteActor(user))
+}
+
+// broadcast signs the activity with the user's key and delivers it to the
+// user's remote followers plus every known remote sharedInbox. Errors are
+// best-effort logged (moderation actions must not fail on delivery hiccups).
+func (h *UserModerationDeliveryHook) broadcast(user *model.User, activity any) {
+	if h.deliver == nil || !user.IsLocal() {
+		return
+	}
+	body, err := json.Marshal(activity)
+	if err != nil {
+		slog.Warn("user moderation delivery: marshal failed", "userId", user.ID, "err", err)
+		return
+	}
+	if err := h.deliver.DeliverToFollowers(user.ID, body); err != nil {
+		slog.Warn("user moderation delivery: followers deliver failed", "userId", user.ID, "err", err)
+	}
+	if h.userRepo == nil {
+		return
+	}
+	inboxes, err := h.userRepo.ListRemoteInboxes()
+	if err != nil {
+		slog.Warn("user moderation delivery: list remote inboxes failed", "userId", user.ID, "err", err)
+		return
+	}
+	if len(inboxes) == 0 {
+		return
+	}
+	if err := h.deliver.DeliverActivity(user.ID, body, inboxes); err != nil {
+		slog.Warn("user moderation delivery: broadcast failed", "userId", user.ID, "err", err)
+	}
+}

--- a/internal/core/federation/user_moderation_delivery_hook_test.go
+++ b/internal/core/federation/user_moderation_delivery_hook_test.go
@@ -1,0 +1,78 @@
+package federation_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/activitypub"
+	"github.com/shiroha-a/mk/internal/core/federation"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newUserModHook(t *testing.T) (
+	*federation.UserModerationDeliveryHook,
+	*stubEnqueuer,
+	*testutil.MockUserRepository,
+	*testutil.MockFollowingRepository,
+	*testutil.MockUserKeypairRepository,
+) {
+	t.Helper()
+	enq := &stubEnqueuer{}
+	userRepo := testutil.NewMockUserRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	keypairRepo := testutil.NewMockUserKeypairRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	deliver := federation.NewDeliverService(enq, userRepo, followingRepo, keypairRepo, urls)
+	renderer := activitypub.NewRenderer(urls)
+	hook := federation.NewUserModerationDeliveryHook(deliver, renderer, userRepo)
+	return hook, enq, userRepo, followingRepo, keypairRepo
+}
+
+// #1759: suspend / delete は local user の actor へ Delete を配信する。
+func TestUserModHook_OnUserDeleted_LocalUser(t *testing.T) {
+	hook, enq, userRepo, followingRepo, keypairRepo := newUserModHook(t)
+	u := &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["alice"] = u
+	keypairRepo.Keypairs["alice"] = &model.UserKeypair{UserID: "alice", PrivateKey: "PEM"}
+	followingRepo.RemoteInboxes["alice"] = []string{"https://r.example/inbox"}
+
+	hook.OnUserDeleted(u)
+	require.NotEmpty(t, enq.calls)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(enq.calls[0].Body, &got))
+	assert.Equal(t, "Delete", got["type"])
+	// actor delete は object も actor も当該 user の URI 文字列。
+	assert.Equal(t, got["actor"], got["object"], "actor delete: object == actor URI")
+	assert.Contains(t, got["object"], "/users/alice")
+}
+
+// #1759: unsuspend は Undo(Delete) を配信する。
+func TestUserModHook_OnUserRestored_LocalUser(t *testing.T) {
+	hook, enq, userRepo, followingRepo, keypairRepo := newUserModHook(t)
+	u := &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["alice"] = u
+	keypairRepo.Keypairs["alice"] = &model.UserKeypair{UserID: "alice", PrivateKey: "PEM"}
+	followingRepo.RemoteInboxes["alice"] = []string{"https://r.example/inbox"}
+
+	hook.OnUserRestored(u)
+	require.NotEmpty(t, enq.calls)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(enq.calls[0].Body, &got))
+	assert.Equal(t, "Undo", got["type"])
+	inner, ok := got["object"].(map[string]any)
+	require.True(t, ok, "Undo wraps the Delete object")
+	assert.Equal(t, "Delete", inner["type"])
+}
+
+// #1759: remote user は配信しない (当該インスタンスが発火元ではない)。
+func TestUserModHook_RemoteUserSkipped(t *testing.T) {
+	hook, enq, _, _, _ := newUserModHook(t)
+	host := "remote.example"
+	hook.OnUserDeleted(&model.User{ID: "bob", Username: "bob", Host: &host})
+	assert.Empty(t, enq.calls, "remote user must not trigger delivery")
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2212,6 +2212,9 @@ func (s *Server) setupRoutes() {
 	adminHandler.SetSigninRepo(signinRepo)
 	adminHandler.SetAbuseRepo(abuseReportRepo)
 	adminHandler.SetAbuseForwarder(coreabuse.NewForwarder(abuseReportRepo, sysAcctSvc, apRenderer, deliverService))
+	// suspend / delete-account / unsuspend 時に対象 local user の AP Delete /
+	// Undo(Delete) を remote instances へ配信する (#1759)。
+	adminHandler.SetUserModerationFederationHook(corefederation.NewUserModerationDeliveryHook(deliverService, apRenderer, userRepo))
 	adminHandler.SetDeleteAccountEnqueuer(s.queueClient)
 	adminHandler.SetPasswordResetRepo(resetReqRepo)
 	adminHandler.SetServerURL(s.config.URL)


### PR DESCRIPTION
## Summary

#1539 から分離した連合副作用 (#1759) の第一弾。upstream `UserSuspendService` / `DeleteAccountService` は local user を suspend / delete すると全 sharedInbox に AP `Delete(actor)` を、unsuspend すると `Undo(Delete)` を配信するが、mk-go は DB 更新のみで配信していなかった。

## 主な変更点

- **renderer**: `RenderDeleteActor` (object = actor 自身の URI 文字列、note と違い Tombstone は使わない) と `RenderUndoDeleteActor` (Delete を Undo で wrap、inner Delete は @context 無し) を追加。
- **core/federation**: `UserModerationDeliveryHook` を新設 (`NoteDeleteDeliveryHook` と同方針: local user のみ、follower + 全 remote sharedInbox へ best-effort 配信)。`OnUserDeleted` / `OnUserRestored` を提供。
- **admin handler**: `UserModerationFederationHook` interface + setter を追加し、`SuspendUser` / `DeleteAccount` で `OnUserDeleted`、`UnsuspendUser` で `OnUserRestored` を呼ぶ。delete-account は cascade (soft delete) の前に配信して署名鍵が残るうちに送る。router で配線。

security guard (moderator/root/system 拒否、#1510) と DB 更新は従来どおり。

## スコープ外 (後続)

followRequest 双方向削除 + unFollowAll + internal event は #1759 の後続 PR で扱う。

## テスト

renderer の Delete/Undo shape / hook の local 配信・remote skip / handler 3 経路が hook を呼ぶこと。

実行: `go test ./internal/activitypub/... ./internal/core/federation/... ./internal/api/admin/...` (coverage: activitypub 91.0% / federation 90.1% / admin 89.6%)

## 関連

Refs #1759

🤖 Generated with [Claude Code](https://claude.com/claude-code)