### PR TITLE
Phase: server-side achievement 付与 infra + myNoteFavorited1 (#1762)

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -69,7 +69,10 @@ type Handler struct {
 	clipNoteRepo     repository.ClipNoteRepository
 	clipFavoriteRepo repository.ClipFavoriteRepository
 	moderatorChecker ModeratorChecker
-	bufReader        entity.BufferedReactionsReader
+	// achievementGranter は notes/favorites/create で local note 著者に
+	// myNoteFavorited1 を付与するのに使う (#1762)。未配線時は付与しない。
+	achievementGranter AchievementGranter
+	bufReader          entity.BufferedReactionsReader
 	// ugcVisibility controls what unauthenticated visitors can see.
 	// "all" (default), "local", "none"
 	ugcVisibility string
@@ -212,6 +215,18 @@ type ModeratorChecker interface {
 // SetModeratorChecker wires the moderator check used by notes/delete.
 func (h *Handler) SetModeratorChecker(m ModeratorChecker) {
 	h.moderatorChecker = m
+}
+
+// AchievementGranter unlocks a server-side achievement for a user. core/achievement.Service
+// implements it. Used by notes/favorites/create to grant myNoteFavorited1 (#1762).
+type AchievementGranter interface {
+	Grant(ctx context.Context, userID, name string) (bool, error)
+}
+
+// SetAchievementGranter wires the achievement grant service. When unset,
+// favorite-driven achievements are simply not granted (degrade).
+func (h *Handler) SetAchievementGranter(g AchievementGranter) {
+	h.achievementGranter = g
 }
 
 // SetPollRepo attaches a PollRepository used by notes/polls/recommendation (#1538).

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
+	coreachievement "github.com/shiroha-a/mk/internal/core/achievement"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -42,7 +43,8 @@ func (h *Handler) FavoritesCreate(c echo.Context) error {
 	if h.queryService == nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "6dd26674-e060-4816-909a-45ba3f4da458"))
 	}
-	if _, err := h.queryService.RequireVisible(user, req.NoteID); err != nil {
+	target, err := h.queryService.RequireVisible(user, req.NoteID)
+	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "6dd26674-e060-4816-909a-45ba3f4da458"))
 	}
 	if h.favoriteRepo == nil {
@@ -61,6 +63,14 @@ func (h *Handler) FavoritesCreate(c echo.Context) error {
 	}
 	if err := h.favoriteRepo.Create(fav); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	// upstream favorites/create.ts: local note を他人が favorite したとき著者に
+	// myNoteFavorited1 を付与する (#1762)。best-effort で favorite 自体 (204) は
+	// 巻き戻さない。granter 未配線時は skip。
+	if h.achievementGranter != nil && target.UserHost == nil && target.UserID != user.ID {
+		if _, err := h.achievementGranter.Grant(c.Request().Context(), target.UserID, coreachievement.MyNoteFavorited1); err != nil {
+			slog.Warn("favorites/create: achievement grant failed", "author", target.UserID, "err", err)
+		}
 	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -1,7 +1,9 @@
 package notes
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -9,6 +11,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	coreachievement "github.com/shiroha-a/mk/internal/core/achievement"
 	corenote "github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/core/translate"
 	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
@@ -232,6 +235,68 @@ func TestFavoritesCreate_SpecifiedNote_InList_OK(t *testing.T) {
 		ID: "n1", UserID: "u1", Visibility: model.NoteVisibilitySpecified,
 		VisibleUserIDs: []string{"u2"},
 	}
+	rec := postExtra(h.FavoritesCreate, `{"noteId":"n1"}`, &model.User{ID: "u2"})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Len(t, favRepo.Favorites, 1)
+}
+
+// --- Favorites achievement (#1762) ---
+
+type recordingGranter struct {
+	calls [][2]string
+	err   error
+}
+
+func (g *recordingGranter) Grant(_ context.Context, userID, name string) (bool, error) {
+	g.calls = append(g.calls, [2]string{userID, name})
+	if g.err != nil {
+		return false, g.err
+	}
+	return true, nil
+}
+
+// local note を他人が favorite すると著者に myNoteFavorited1 が付与される。
+func TestFavoritesCreate_GrantsMyNoteFavorited1(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic}
+	g := &recordingGranter{}
+	h.SetAchievementGranter(g)
+	rec := postExtra(h.FavoritesCreate, `{"noteId":"n1"}`, &model.User{ID: "u2"})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	require.Len(t, g.calls, 1)
+	assert.Equal(t, "u1", g.calls[0][0])
+	assert.Equal(t, coreachievement.MyNoteFavorited1, g.calls[0][1])
+}
+
+// 自分のノートを favorite しても付与しない (upstream note.userId !== me.id)。
+func TestFavoritesCreate_SelfFavorite_NoGrant(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic}
+	g := &recordingGranter{}
+	h.SetAchievementGranter(g)
+	rec := postExtra(h.FavoritesCreate, `{"noteId":"n1"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Empty(t, g.calls)
+}
+
+// remote note (UserHost != nil) では著者に付与しない (upstream note.userHost == null)。
+func TestFavoritesCreate_RemoteNote_NoGrant(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	host := "remote.example"
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "ru1", UserHost: &host, Visibility: model.NoteVisibilityPublic}
+	g := &recordingGranter{}
+	h.SetAchievementGranter(g)
+	rec := postExtra(h.FavoritesCreate, `{"noteId":"n1"}`, &model.User{ID: "u2"})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Empty(t, g.calls)
+}
+
+// grant が失敗しても favorite (204) は成功する (best-effort)。
+func TestFavoritesCreate_GrantError_StillFavorites(t *testing.T) {
+	h, noteRepo, favRepo := newExtraHandler(t)
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic}
+	g := &recordingGranter{err: errors.New("boom")}
+	h.SetAchievementGranter(g)
 	rec := postExtra(h.FavoritesCreate, `{"noteId":"n1"}`, &model.User{ID: "u2"})
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 	assert.Len(t, favRepo.Favorites, 1)

--- a/internal/core/achievement/achievement.go
+++ b/internal/core/achievement/achievement.go
@@ -1,0 +1,104 @@
+// Package achievement provides server-side granting of user achievements,
+// mirroring Misskey's AchievementService. Achievement type names live in
+// internal/misc/achievement; this package is the write path that unlocks them
+// and emits the achievementEarned notification.
+//
+// This is the path for server-triggered achievements (e.g. having your note
+// favorited). The client-self-claim endpoint /api/i/claim-achievement writes
+// the same profile.achievements column with equivalent semantics; the two
+// coexist on the same storage.
+package achievement
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/core/notification"
+	misc "github.com/shiroha-a/mk/internal/misc/achievement"
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// Server-side granted achievement type names. Keep in sync with
+// internal/misc/achievement ACHIEVEMENT_TYPES; using typed constants here keeps
+// call sites typo-safe.
+const (
+	// MyNoteFavorited1 is granted to a local note's author when someone else
+	// favorites the note (notes/favorites/create).
+	MyNoteFavorited1 = "myNoteFavorited1"
+)
+
+// ProfileStore reads and updates the user profile holding the achievements
+// JSON column. Satisfied by *user.Service (GetProfile / UpdateProfileFields).
+type ProfileStore interface {
+	GetProfile(userID string) *model.UserProfile
+	UpdateProfileFields(userID string, fields map[string]any) error
+}
+
+// Notifier creates the achievementEarned notification. Satisfied by
+// *notification.Service. Optional: when nil, grants are recorded without a
+// notification.
+type Notifier interface {
+	Create(ctx context.Context, in notification.CreateInput) (*notification.Notification, error)
+}
+
+// Service grants achievements to users.
+type Service struct {
+	profiles ProfileStore
+	notifier Notifier
+}
+
+// NewService creates an achievement Service. notifier may be nil to disable
+// notification emission (grants are still persisted).
+func NewService(profiles ProfileStore, notifier Notifier) *Service {
+	return &Service{profiles: profiles, notifier: notifier}
+}
+
+// Grant unlocks achievement `name` for userID and reports whether a new
+// achievement was recorded. It mirrors upstream AchievementService.create and
+// is idempotent: it is a no-op (returns false, nil) when name is not a known
+// achievement type, when the user's profile is missing, or when the user has
+// already unlocked it. The achievementEarned notification is best-effort; a
+// notification failure does not roll back the grant.
+func (s *Service) Grant(ctx context.Context, userID, name string) (bool, error) {
+	if !misc.IsValidType(name) {
+		return false, nil
+	}
+	profile := s.profiles.GetProfile(userID)
+	if profile == nil {
+		return false, nil
+	}
+
+	var achievements []map[string]any
+	if profile.Achievements != nil {
+		_ = json.Unmarshal(profile.Achievements, &achievements)
+	}
+	for _, a := range achievements {
+		if a["name"] == name {
+			return false, nil
+		}
+	}
+
+	achievements = append(achievements, map[string]any{
+		"name":       name,
+		"unlockedAt": time.Now().UnixMilli(),
+	})
+	data, _ := json.Marshal(achievements)
+	if err := s.profiles.UpdateProfileFields(userID, map[string]any{"achievements": string(data)}); err != nil {
+		return false, err
+	}
+
+	if s.notifier != nil {
+		if _, err := s.notifier.Create(ctx, notification.CreateInput{
+			NotifieeID: userID,
+			Type:       notification.TypeAchievementEarned,
+			Extra:      map[string]any{"achievement": name},
+		}); err != nil {
+			// 通知失敗は実績付与 (永続化済み) を巻き戻さない。upstream も
+			// createNotification を await せず fire-and-forget している。
+			slog.Warn("achievement grant: notification create failed", "user", userID, "achievement", name, "err", err)
+		}
+	}
+	return true, nil
+}

--- a/internal/core/achievement/achievement_test.go
+++ b/internal/core/achievement/achievement_test.go
@@ -1,0 +1,150 @@
+package achievement
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/core/notification"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+)
+
+type stubProfiles struct {
+	profiles  map[string]*model.UserProfile
+	updates   []map[string]any
+	updateErr error
+}
+
+func (s *stubProfiles) GetProfile(userID string) *model.UserProfile {
+	return s.profiles[userID]
+}
+
+func (s *stubProfiles) UpdateProfileFields(userID string, fields map[string]any) error {
+	if s.updateErr != nil {
+		return s.updateErr
+	}
+	s.updates = append(s.updates, fields)
+	// 永続化を模倣して in-memory profile にも反映する (後続 Grant の冪等性確認用)。
+	if p := s.profiles[userID]; p != nil {
+		if v, ok := fields["achievements"].(string); ok {
+			p.Achievements = datatypes.JSON(v)
+		}
+	}
+	return nil
+}
+
+type stubNotifier struct {
+	calls []notification.CreateInput
+	err   error
+}
+
+func (s *stubNotifier) Create(_ context.Context, in notification.CreateInput) (*notification.Notification, error) {
+	s.calls = append(s.calls, in)
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &notification.Notification{}, nil
+}
+
+func TestGrant_New(t *testing.T) {
+	profiles := &stubProfiles{profiles: map[string]*model.UserProfile{"u1": {UserID: "u1"}}}
+	notifier := &stubNotifier{}
+	svc := NewService(profiles, notifier)
+
+	granted, err := svc.Grant(context.Background(), "u1", MyNoteFavorited1)
+	require.NoError(t, err)
+	assert.True(t, granted)
+	require.Len(t, profiles.updates, 1)
+	assert.Contains(t, profiles.updates[0]["achievements"], MyNoteFavorited1)
+	// notification は achievementEarned + Extra.achievement = type で 1 回。
+	require.Len(t, notifier.calls, 1)
+	assert.Equal(t, "u1", notifier.calls[0].NotifieeID)
+	assert.Equal(t, notification.TypeAchievementEarned, notifier.calls[0].Type)
+	assert.Equal(t, MyNoteFavorited1, notifier.calls[0].Extra["achievement"])
+}
+
+func TestGrant_Duplicate(t *testing.T) {
+	profiles := &stubProfiles{profiles: map[string]*model.UserProfile{
+		"u1": {UserID: "u1", Achievements: datatypes.JSON(`[{"name":"myNoteFavorited1","unlockedAt":1000}]`)},
+	}}
+	notifier := &stubNotifier{}
+	svc := NewService(profiles, notifier)
+
+	granted, err := svc.Grant(context.Background(), "u1", MyNoteFavorited1)
+	require.NoError(t, err)
+	assert.False(t, granted, "既獲得なら no-op")
+	assert.Empty(t, profiles.updates)
+	assert.Empty(t, notifier.calls)
+}
+
+func TestGrant_Idempotent_SecondCallNoOp(t *testing.T) {
+	profiles := &stubProfiles{profiles: map[string]*model.UserProfile{"u1": {UserID: "u1"}}}
+	svc := NewService(profiles, &stubNotifier{})
+
+	g1, _ := svc.Grant(context.Background(), "u1", MyNoteFavorited1)
+	g2, _ := svc.Grant(context.Background(), "u1", MyNoteFavorited1)
+	assert.True(t, g1)
+	assert.False(t, g2, "2 回目は永続化済みなので no-op")
+	assert.Len(t, profiles.updates, 1)
+}
+
+func TestGrant_UnknownType(t *testing.T) {
+	profiles := &stubProfiles{profiles: map[string]*model.UserProfile{"u1": {UserID: "u1"}}}
+	notifier := &stubNotifier{}
+	svc := NewService(profiles, notifier)
+
+	granted, err := svc.Grant(context.Background(), "u1", "bogusAchievement")
+	require.NoError(t, err)
+	assert.False(t, granted)
+	assert.Empty(t, profiles.updates)
+	assert.Empty(t, notifier.calls)
+}
+
+func TestGrant_NoProfile(t *testing.T) {
+	profiles := &stubProfiles{profiles: map[string]*model.UserProfile{}}
+	svc := NewService(profiles, &stubNotifier{})
+
+	granted, err := svc.Grant(context.Background(), "ghost", MyNoteFavorited1)
+	require.NoError(t, err)
+	assert.False(t, granted)
+	assert.Empty(t, profiles.updates)
+}
+
+func TestGrant_UpdateError(t *testing.T) {
+	profiles := &stubProfiles{
+		profiles:  map[string]*model.UserProfile{"u1": {UserID: "u1"}},
+		updateErr: errors.New("db down"),
+	}
+	notifier := &stubNotifier{}
+	svc := NewService(profiles, notifier)
+
+	granted, err := svc.Grant(context.Background(), "u1", MyNoteFavorited1)
+	assert.Error(t, err)
+	assert.False(t, granted)
+	assert.Empty(t, notifier.calls, "永続化失敗時は通知しない")
+}
+
+func TestGrant_NilNotifier(t *testing.T) {
+	profiles := &stubProfiles{profiles: map[string]*model.UserProfile{"u1": {UserID: "u1"}}}
+	svc := NewService(profiles, nil)
+
+	granted, err := svc.Grant(context.Background(), "u1", MyNoteFavorited1)
+	require.NoError(t, err)
+	assert.True(t, granted, "notifier nil でも付与は永続化される")
+	assert.Len(t, profiles.updates, 1)
+}
+
+func TestGrant_NotificationError_StillGrants(t *testing.T) {
+	profiles := &stubProfiles{profiles: map[string]*model.UserProfile{"u1": {UserID: "u1"}}}
+	notifier := &stubNotifier{err: errors.New("notify fail")}
+	svc := NewService(profiles, notifier)
+
+	granted, err := svc.Grant(context.Background(), "u1", MyNoteFavorited1)
+	require.NoError(t, err, "通知失敗は grant を巻き戻さない")
+	assert.True(t, granted)
+	assert.Len(t, profiles.updates, 1)
+	assert.Len(t, notifier.calls, 1)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -62,6 +62,7 @@ import (
 	apiwebhooks "github.com/shiroha-a/mk/internal/api/webhooks"
 	"github.com/shiroha-a/mk/internal/api/wellknown"
 	coreabuse "github.com/shiroha-a/mk/internal/core/abuse"
+	coreachievement "github.com/shiroha-a/mk/internal/core/achievement"
 	coreannouncement "github.com/shiroha-a/mk/internal/core/announcement"
 	coreantenna "github.com/shiroha-a/mk/internal/core/antenna"
 	"github.com/shiroha-a/mk/internal/core/avatardecoration"
@@ -1284,6 +1285,11 @@ func (s *Server) setupRoutes() {
 	api.POST("/notes/polls/vote", notesHandler.PollsVote, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:votes"))
 	// Notes extra endpoints (Phase 6)
 	notesHandler.SetFavoriteRepo(noteFavoriteRepo)
+	// #1762: local note を favorite されたとき著者に myNoteFavorited1 を付与する
+	// server-side achievement infra。claim-achievement と同じ profile.achievements
+	// を更新する。
+	achievementService := coreachievement.NewService(userService, notificationService)
+	notesHandler.SetAchievementGranter(achievementService)
 	api.POST("/notes/favorites/create", notesHandler.FavoritesCreate, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:favorites"))
 	api.POST("/notes/favorites/delete", notesHandler.FavoritesDelete, middleware.RequireAuth(), middleware.RequireScope("write:favorites"))
 	api.POST("/notes/featured", notesHandler.Featured)


### PR DESCRIPTION
## Summary

mk-go には server-side で achievement を付与する infra が無く、achievement 獲得は client-driven な `/api/i/claim-achievement` 経由のみだった。サーバ側イベントを契機にした自動付与ができず、#1538 (notes/* core parity) の LOW 項目「notes/favorites/create で `myNoteFavorited1` が付与されない」が未実装だった。本 PR で付与 infra を新設し、`myNoteFavorited1` を実装する。

## 主な変更点

- `internal/core/achievement` に `Service.Grant(ctx, userID, name) (bool, error)` を新設。upstream `AchievementService.create` と同一セマンティクス: 未知 type / profile 不在 / 既獲得は no-op、`{name, unlockedAt}` を append して persist、`achievementEarned` 通知を best-effort 発火。依存は小さい interface (`ProfileStore` / `Notifier`) で受け `*user.Service` / `*notification.Service` がそのまま満たす (import cycle 回避)。冪等。
- `notes/favorites/create`: `RequireVisible` の戻り note を捕捉し、local note (`userHost == nil`) を他人 (`userId != me`) が favorite したとき著者に `myNoteFavorited1` を付与 (upstream `favorites/create.ts:88-90`)。granter 未配線時は skip、grant 失敗でも favorite (204) は巻き戻さない (best-effort)。
- router で `achievementService` を構築し notes に注入。

## スコープ

- client-self-claim の `/api/i/claim-achievement` は同じ `profile.achievements` を更新する別経路として共存 (本 PR では未変更)。
- その他のサーバ側トリガー (notes count マイルストーン / followers / login streak 等) は段階的に別途対応する (本 PR は infra + `myNoteFavorited1` に限定)。

## テスト

- `internal/core/achievement`: `Grant` の全分岐 (新規 / 重複 / 冪等 / 未知 type / profile nil / notifier nil / update error / 通知失敗でも grant) を網羅、coverage 100%。
- `internal/api/notes`: favorites で付与される / self-favorite は付与しない / remote note は付与しない / grant 失敗でも 204。coverage 91.7%。
- 実行: `go test ./internal/core/achievement/... ./internal/api/notes/...`

Refs #1762

🤖 Generated with [Claude Code](https://claude.com/claude-code)