### PR TITLE
Fix notes parity (再監査): deleteNote modlog + polls/recommendation excludeChannels + NO_POLL 400 + TOO_MANY_DRAFTS (#1765)

### DIFF
--- a/internal/api/apierr/echo.go
+++ b/internal/api/apierr/echo.go
@@ -106,7 +106,7 @@ func JSONTooManyUsers(c echo.Context) error {
 	return c.JSON(http.StatusBadRequest, TooManyUsers())
 }
 
-// JSONTooManyNoteDrafts writes a 400 TOO_MANY_NOTE_DRAFTS response.
+// JSONTooManyNoteDrafts writes a 400 TOO_MANY_DRAFTS response.
 func JSONTooManyNoteDrafts(c echo.Context) error {
 	return c.JSON(http.StatusBadRequest, TooManyNoteDrafts())
 }

--- a/internal/api/apierr/echo_test.go
+++ b/internal/api/apierr/echo_test.go
@@ -147,7 +147,7 @@ func TestJSONCountLimitHelpers(t *testing.T) {
 		{"TooManyClipNotes", JSONTooManyClipNotes, "TOO_MANY_CLIP_NOTES", UUIDTooManyClipNotes},
 		{"TooManyUserLists", JSONTooManyUserLists, "TOO_MANY_USERLISTS", UUIDTooManyUserLists},
 		{"TooManyUsers", JSONTooManyUsers, "TOO_MANY_USERS", UUIDTooManyUsers},
-		{"TooManyNoteDrafts", JSONTooManyNoteDrafts, "TOO_MANY_NOTE_DRAFTS", UUIDTooManyNoteDrafts},
+		{"TooManyNoteDrafts", JSONTooManyNoteDrafts, "TOO_MANY_DRAFTS", UUIDTooManyNoteDrafts},
 		{"TooManyMutedWords", JSONTooManyMutedWords, "TOO_MANY_MUTED_WORDS", UUIDTooManyMutedWords},
 		{"ExceededLimitOfCreateInviteCode", JSONExceededLimitOfCreateInviteCode, "EXCEEDED_LIMIT_OF_CREATE_INVITE_CODE", UUIDExceededLimitOfCreateInviteCode},
 		{"MaxFileSizeExceeded", JSONMaxFileSizeExceeded, "MAX_FILE_SIZE_EXCEEDED", UUIDMaxFileSizeExceeded},

--- a/internal/api/apierr/errors.go
+++ b/internal/api/apierr/errors.go
@@ -414,11 +414,13 @@ func TooManyUsers() map[string]any {
 	return Error("TOO_MANY_USERS", "You can not push users any more.", UUIDTooManyUsers)
 }
 
-// TooManyNoteDrafts returns the upstream `NoteDraftService` の IdentifiableError
-// shape (notes/drafts/create)。upstream は code が無く message のみだが、mk-go は
-// `TOO_MANY_NOTE_DRAFTS` という code を発番して frontend が分岐できるようにする。
+// TooManyNoteDrafts returns the notes/drafts/create draft-limit error. upstream
+// drafts/create.ts:121-125 の tooManyDrafts は code='TOO_MANY_DRAFTS' / id=9ee33bbe
+// で、code・id とも upstream に揃える (#1765。以前は「upstream に code が無い」という
+// 誤った前提で TOO_MANY_NOTE_DRAFTS を独自発番しており、drop-in frontend が
+// 認識できなかった)。
 func TooManyNoteDrafts() map[string]any {
-	return Error("TOO_MANY_NOTE_DRAFTS", "Too many drafts.", UUIDTooManyNoteDrafts)
+	return Error("TOO_MANY_DRAFTS", "Too many drafts.", UUIDTooManyNoteDrafts)
 }
 
 // TooManyMutedWords returns the upstream `tooManyMutedWords` shape (i/update mutedWords)。

--- a/internal/api/apierr/errors_test.go
+++ b/internal/api/apierr/errors_test.go
@@ -225,7 +225,7 @@ func TestCountLimitHelpers(t *testing.T) {
 		{"TooManyClipNotes", TooManyClipNotes, "TOO_MANY_CLIP_NOTES", UUIDTooManyClipNotes},
 		{"TooManyUserLists", TooManyUserLists, "TOO_MANY_USERLISTS", UUIDTooManyUserLists},
 		{"TooManyUsers", TooManyUsers, "TOO_MANY_USERS", UUIDTooManyUsers},
-		{"TooManyNoteDrafts", TooManyNoteDrafts, "TOO_MANY_NOTE_DRAFTS", UUIDTooManyNoteDrafts},
+		{"TooManyNoteDrafts", TooManyNoteDrafts, "TOO_MANY_DRAFTS", UUIDTooManyNoteDrafts},
 		{"TooManyMutedWords", TooManyMutedWords, "TOO_MANY_MUTED_WORDS", UUIDTooManyMutedWords},
 		{"ExceededLimitOfCreateInviteCode", ExceededLimitOfCreateInviteCode, "EXCEEDED_LIMIT_OF_CREATE_INVITE_CODE", UUIDExceededLimitOfCreateInviteCode},
 		{"MaxFileSizeExceeded", MaxFileSizeExceeded, "MAX_FILE_SIZE_EXCEEDED", UUIDMaxFileSizeExceeded},

--- a/internal/api/notes/handler_drafts.go
+++ b/internal/api/notes/handler_drafts.go
@@ -506,9 +506,11 @@ func (h *Handler) ThreadMutingDelete(c echo.Context) error {
 func (h *Handler) PollsRecommendation(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req struct {
-		Limit           int      `json:"limit"`
-		Offset          int      `json:"offset"`
-		ExcludeChannels []string `json:"excludeChannels"`
+		Limit  int `json:"limit"`
+		Offset int `json:"offset"`
+		// upstream recommendation.ts:35 は excludeChannels を boolean で受け、
+		// true のとき全 channel poll を除外する (#1765。以前は []string だった)。
+		ExcludeChannels bool `json:"excludeChannels"`
 	}
 	_ = c.Bind(&req)
 	if h.pollRepo == nil || h.noteRepo == nil {

--- a/internal/api/notes/handler_drafts_test.go
+++ b/internal/api/notes/handler_drafts_test.go
@@ -257,7 +257,7 @@ func TestDraftsCreate_NoteDraftLimitExceeded(t *testing.T) {
 	}})
 	rec := postDraft(h.DraftsCreate, `{"text":"third"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
-	assert.Contains(t, rec.Body.String(), "TOO_MANY_NOTE_DRAFTS")
+	assert.Contains(t, rec.Body.String(), "TOO_MANY_DRAFTS")
 }
 
 func TestDraftsCreate_NoteDraftLimit_PassesUnderLimit(t *testing.T) {

--- a/internal/api/notes/polls_handler.go
+++ b/internal/api/notes/polls_handler.go
@@ -30,8 +30,10 @@ func (h *Handler) PollsVote(c echo.Context) error {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "ecafbd2e-c283-4d6d-aecb-1a0a33b75396"))
 		case errors.Is(err, poll.ErrNoPoll):
 			// upstream vote.ts は poll を持たない note への投票に対し NO_SUCH_NOTE
-			// でなく専用の NO_POLL を返す (#1538)。
-			return c.JSON(http.StatusNotFound, apierr.Error("NO_POLL", "The note has no poll.", "5f979967-52d9-4314-a911-1c673727f92f"))
+			// でなく専用の NO_POLL を返す (#1538)。HTTP status は upstream noPoll が
+			// httpStatusCode 未指定 = kind 'client' default = 400 のため 400 に
+			// 揃える (#1765。以前は NO_SUCH_* 慣習で 404 を返していた)。
+			return c.JSON(http.StatusBadRequest, apierr.Error("NO_POLL", "The note has no poll.", "5f979967-52d9-4314-a911-1c673727f92f"))
 		case errors.Is(err, poll.ErrNoteNotVisible):
 			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "You can not see this note.", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
 		case errors.Is(err, poll.ErrYouHaveBeenBlocked):

--- a/internal/api/notes/polls_handler_test.go
+++ b/internal/api/notes/polls_handler_test.go
@@ -126,7 +126,8 @@ func TestPollsVote_NoPoll(t *testing.T) {
 	c, rec := newJSONRequest(t, "/api/notes/polls/vote", `{"noteId":"n1","choice":0}`)
 	setAuthUser(c, &model.User{ID: "viewer"})
 	require.NoError(t, h.PollsVote(c))
-	assert.Equal(t, http.StatusNotFound, rec.Code)
+	// upstream noPoll は httpStatusCode 未指定 = 400 (#1765)。
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 	// upstream vote.ts は poll を持たない note に専用の NO_POLL を返す (#1538)。
 	assert.Contains(t, rec.Body.String(), "NO_POLL")
 	assert.Contains(t, rec.Body.String(), "5f979967-52d9-4314-a911-1c673727f92f")

--- a/internal/core/moderationlog/note_delete_hook.go
+++ b/internal/core/moderationlog/note_delete_hook.go
@@ -1,0 +1,39 @@
+package moderationlog
+
+import (
+	"context"
+
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// NoteDeleteHook adapts the moderation-log Service to core/note's
+// ModeratorDeleteHook, writing a `deleteNote` entry when a moderator deletes
+// another user's note. Mirrors upstream NoteDeleteService which logs
+// `deleteNote` when `deleter && note.userId !== deleter.id` (#1765).
+type NoteDeleteHook struct {
+	svc *Service
+}
+
+// NewNoteDeleteHook creates a NoteDeleteHook backed by svc.
+func NewNoteDeleteHook(svc *Service) *NoteDeleteHook {
+	return &NoteDeleteHook{svc: svc}
+}
+
+// OnModeratorNoteDeleted writes the deleteNote moderation log entry.
+// Best-effort: the moderation-log Service swallows its own errors.
+func (h *NoteDeleteHook) OnModeratorNoteDeleted(moderatorID string, note *model.Note, author *model.User) {
+	if h.svc == nil || note == nil {
+		return
+	}
+	// upstream は {noteId, noteUserId, noteUserUsername, noteUserHost, note} を
+	// 記録する。mk-go は note 本体の埋め込みは省き、追跡に必要な scalar のみ残す。
+	info := map[string]any{
+		"noteId":       note.ID,
+		"noteUserId":   note.UserID,
+		"noteUserHost": note.UserHost,
+	}
+	if author != nil {
+		info["noteUserUsername"] = author.Username
+	}
+	h.svc.Log(context.Background(), moderatorID, LogDeleteNote, info)
+}

--- a/internal/core/moderationlog/note_delete_hook_test.go
+++ b/internal/core/moderationlog/note_delete_hook_test.go
@@ -1,0 +1,53 @@
+package moderationlog
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoteDeleteHook_WritesDeleteNoteLog(t *testing.T) {
+	repo := &spyRepo{}
+	svc := newSvc(t, repo)
+	hook := NewNoteDeleteHook(svc)
+
+	host := "remote.example"
+	hook.OnModeratorNoteDeleted("mod1",
+		&model.Note{ID: "n1", UserID: "author1", UserHost: &host},
+		&model.User{ID: "author1", Username: "alice"})
+
+	require.Eventually(t, func() bool { return len(repo.snapshot()) == 1 }, 2*time.Second, 5*time.Millisecond)
+	logs := repo.snapshot()
+	assert.Equal(t, "mod1", logs[0].UserID)
+	assert.Equal(t, "deleteNote", logs[0].Type)
+
+	var info map[string]any
+	require.NoError(t, json.Unmarshal(logs[0].Info, &info))
+	assert.Equal(t, "n1", info["noteId"])
+	assert.Equal(t, "author1", info["noteUserId"])
+	assert.Equal(t, "remote.example", info["noteUserHost"])
+	assert.Equal(t, "alice", info["noteUserUsername"])
+}
+
+func TestNoteDeleteHook_NilGuards(t *testing.T) {
+	// nil svc receiver -> noop, no panic.
+	(&NoteDeleteHook{}).OnModeratorNoteDeleted("mod1", &model.Note{ID: "n1"}, nil)
+
+	repo := &spyRepo{}
+	svc := newSvc(t, repo)
+	// nil note -> noop.
+	NewNoteDeleteHook(svc).OnModeratorNoteDeleted("mod1", nil, nil)
+	// local note (UserHost nil) + nil author -> logs with noteUserHost null and no username.
+	NewNoteDeleteHook(svc).OnModeratorNoteDeleted("mod1", &model.Note{ID: "n2", UserID: "a2"}, nil)
+
+	require.Eventually(t, func() bool { return len(repo.snapshot()) == 1 }, 2*time.Second, 5*time.Millisecond)
+	var info map[string]any
+	require.NoError(t, json.Unmarshal(repo.snapshot()[0].Info, &info))
+	assert.Equal(t, "n2", info["noteId"])
+	_, hasUsername := info["noteUserUsername"]
+	assert.False(t, hasUsername, "nil author omits noteUserUsername")
+}

--- a/internal/core/moderationlog/types.go
+++ b/internal/core/moderationlog/types.go
@@ -36,6 +36,9 @@ const (
 	LogUnsetUserAvatar LogType = "unsetUserAvatar"
 	LogUnsetUserBanner LogType = "unsetUserBanner"
 
+	// Notes
+	LogDeleteNote LogType = "deleteNote"
+
 	// Roles
 	LogCreateRole   LogType = "createRole"
 	LogUpdateRole   LogType = "updateRole"

--- a/internal/core/moderationlog/types_test.go
+++ b/internal/core/moderationlog/types_test.go
@@ -19,6 +19,7 @@ func TestLogTypeValues(t *testing.T) {
 		{LogDeleteAccount, "deleteAccount"},
 		{LogUnsetUserAvatar, "unsetUserAvatar"},
 		{LogUnsetUserBanner, "unsetUserBanner"},
+		{LogDeleteNote, "deleteNote"},
 		{LogCreateRole, "createRole"},
 		{LogUpdateRole, "updateRole"},
 		{LogDeleteRole, "deleteRole"},

--- a/internal/core/note/note_create_service_test.go
+++ b/internal/core/note/note_create_service_test.go
@@ -39,7 +39,7 @@ func (f *failingPollRepo) ListExpiredUnnotified(_ time.Time, _ int) ([]*model.Po
 	return nil, nil
 }
 func (f *failingPollRepo) MarkNotified(_ string, _ time.Time) error { return nil }
-func (f *failingPollRepo) ListRecommendation(_ string, _, _ []string, _, _ int) ([]string, error) {
+func (f *failingPollRepo) ListRecommendation(_ string, _ []string, _ bool, _, _ int) ([]string, error) {
 	return nil, nil
 }
 

--- a/internal/core/note/note_delete_service.go
+++ b/internal/core/note/note_delete_service.go
@@ -47,15 +47,24 @@ type DeleteNoteStreamHook interface {
 	OnNoteDeleted(noteID string, deletedAt time.Time)
 }
 
+// ModeratorDeleteHook is invoked when a moderator deletes another user's note
+// so the action can be written to the moderation log (upstream
+// NoteDeleteService writes a `deleteNote` moderation log when
+// `deleter && note.userId !== deleter.id`, #1765)。失敗はベストエフォート。
+type ModeratorDeleteHook interface {
+	OnModeratorNoteDeleted(moderatorID string, note *model.Note, author *model.User)
+}
+
 // DeleteService provides note deletion logic.
 type DeleteService struct {
-	noteRepo       repository.NoteRepository
-	userRepo       repository.UserRepository
-	federationHook DeleteFederationHook
-	indexHook      IndexHook
-	chartHook      DeleteChartHook
-	timelineHook   DeleteTimelineHook
-	noteStreamHook DeleteNoteStreamHook
+	noteRepo            repository.NoteRepository
+	userRepo            repository.UserRepository
+	federationHook      DeleteFederationHook
+	indexHook           IndexHook
+	chartHook           DeleteChartHook
+	timelineHook        DeleteTimelineHook
+	noteStreamHook      DeleteNoteStreamHook
+	moderatorDeleteHook ModeratorDeleteHook
 }
 
 // NewDeleteService creates a new DeleteService.
@@ -92,6 +101,13 @@ func (s *DeleteService) SetChartHook(h DeleteChartHook) {
 // Redis fanout timelines can be purged of the note ID (#379)。
 func (s *DeleteService) SetTimelineHook(h DeleteTimelineHook) {
 	s.timelineHook = h
+}
+
+// SetModeratorDeleteHook attaches a ModeratorDeleteHook invoked when a
+// moderator deletes another user's note so the action is written to the
+// moderation log (#1765)。
+func (s *DeleteService) SetModeratorDeleteHook(h ModeratorDeleteHook) {
+	s.moderatorDeleteHook = h
 }
 
 // SetNoteStreamHook attaches a DeleteNoteStreamHook invoked after Delete so
@@ -168,6 +184,12 @@ func (s *DeleteService) DeleteAs(actor *model.User, isModerator bool, noteID str
 	// クライアントへ即時反映する (#700)。失敗はベストエフォート。
 	if s.noteStreamHook != nil {
 		s.noteStreamHook.OnNoteDeleted(note.ID, deletedAt)
+	}
+	// moderator が他人の note を削除したときは moderation log に deleteNote を
+	// 残す (upstream NoteDeleteService の deleter && note.userId !== deleter.id、
+	// #1765)。自分の note 削除・federation 経路 (isModerator=false) では発火しない。
+	if isModerator && note.UserID != actor.ID && s.moderatorDeleteHook != nil {
+		s.moderatorDeleteHook.OnModeratorNoteDeleted(actor.ID, note, author)
 	}
 	return nil
 }

--- a/internal/core/note/note_delete_service_test.go
+++ b/internal/core/note/note_delete_service_test.go
@@ -121,6 +121,54 @@ func TestDeleteService_FederationHookInvoked(t *testing.T) {
 	assert.Equal(t, "n1", hook.note.ID)
 }
 
+// recordingModeratorDeleteHook captures deleteNote moderation-log hook firings.
+type recordingModeratorDeleteHook struct {
+	calls       int
+	moderatorID string
+	note        *model.Note
+	author      *model.User
+}
+
+func (h *recordingModeratorDeleteHook) OnModeratorNoteDeleted(moderatorID string, n *model.Note, a *model.User) {
+	h.calls++
+	h.moderatorID = moderatorID
+	h.note = n
+	h.author = a
+}
+
+// #1765: moderator が他人の note を削除したとき deleteNote modlog hook が発火する。
+func TestDeleteService_ModeratorDeleteHook_OtherUsersNote(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "author1"}
+	svc := note.NewDeleteService(noteRepo)
+	hook := &recordingModeratorDeleteHook{}
+	svc.SetModeratorDeleteHook(hook)
+
+	require.NoError(t, svc.DeleteAs(&model.User{ID: "mod1"}, true, "n1"))
+	assert.Equal(t, 1, hook.calls)
+	assert.Equal(t, "mod1", hook.moderatorID)
+	require.NotNil(t, hook.note)
+	assert.Equal(t, "n1", hook.note.ID)
+	require.NotNil(t, hook.author)
+	assert.Equal(t, "author1", hook.author.ID)
+}
+
+// 自分の note 削除 / 著者本人の削除 (isModerator=false) では発火しない。
+func TestDeleteService_ModeratorDeleteHook_NotFiredForSelfOrAuthor(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	noteRepo.Notes["own"] = &model.Note{ID: "own", UserID: "mod1"}
+	noteRepo.Notes["n2"] = &model.Note{ID: "n2", UserID: "user2"}
+	svc := note.NewDeleteService(noteRepo)
+	hook := &recordingModeratorDeleteHook{}
+	svc.SetModeratorDeleteHook(hook)
+
+	// moderator が自分の note を削除 (note.userId == actor) → 発火しない。
+	require.NoError(t, svc.DeleteAs(&model.User{ID: "mod1"}, true, "own"))
+	// 著者本人の削除 (Delete = isModerator false) → 発火しない。
+	require.NoError(t, svc.Delete(&model.User{ID: "user2"}, "n2"))
+	assert.Equal(t, 0, hook.calls)
+}
+
 // recordingDeleteIndexHook captures index hook calls so we can check the
 // search-index hookup wired into DeleteService.
 type recordingDeleteIndexHook struct {

--- a/internal/repository/poll.go
+++ b/internal/repository/poll.go
@@ -24,10 +24,10 @@ type PollRepository interface {
 	MarkNotified(noteID string, t time.Time) error
 	// ListRecommendation returns note ids of local public unexpired polls the
 	// viewer has not authored, not voted on, and whose author is not in
-	// mutedUserIDs, optionally excluding polls posted to excludeChannelIDs.
-	// Ordered by noteId DESC, paginated by limit/offset. Mirrors upstream
-	// notes/polls/recommendation (#1538).
-	ListRecommendation(viewerID string, mutedUserIDs, excludeChannelIDs []string, limit, offset int) ([]string, error)
+	// mutedUserIDs. When excludeChannels is true, channel polls are excluded
+	// entirely (channelId IS NULL). Ordered by noteId DESC, paginated by
+	// limit/offset. Mirrors upstream notes/polls/recommendation (#1538, #1765).
+	ListRecommendation(viewerID string, mutedUserIDs []string, excludeChannels bool, limit, offset int) ([]string, error)
 }
 
 type pollRepository struct {
@@ -92,7 +92,7 @@ func (r *pollRepository) MarkNotified(noteID string, t time.Time) error {
 // not already voted on (NOT EXISTS poll_vote), authored by a non-muted user,
 // optionally excluding given channels; ordered by noteId DESC. OR-conditions are
 // parenthesized so they bind correctly against the other ANDed clauses.
-func (r *pollRepository) ListRecommendation(viewerID string, mutedUserIDs, excludeChannelIDs []string, limit, offset int) ([]string, error) {
+func (r *pollRepository) ListRecommendation(viewerID string, mutedUserIDs []string, excludeChannels bool, limit, offset int) ([]string, error) {
 	if limit <= 0 {
 		limit = 10
 	}
@@ -105,8 +105,10 @@ func (r *pollRepository) ListRecommendation(viewerID string, mutedUserIDs, exclu
 	if len(mutedUserIDs) > 0 {
 		q = q.Where(`"userId" NOT IN ?`, mutedUserIDs)
 	}
-	if len(excludeChannelIDs) > 0 {
-		q = q.Where(`("channelId" IS NULL OR "channelId" NOT IN ?)`, excludeChannelIDs)
+	if excludeChannels {
+		// upstream recommendation.ts:91-93 は excludeChannels=true で
+		// channelId IS NULL (= 全 channel poll 除外) を適用する。
+		q = q.Where(`"channelId" IS NULL`)
 	}
 	q = q.Order(`"noteId" DESC`).Limit(limit)
 	if offset > 0 {

--- a/internal/repository/poll_test.go
+++ b/internal/repository/poll_test.go
@@ -249,18 +249,18 @@ func TestPollRepository_ListRecommendation(t *testing.T) {
 	require.NoError(t, testDB.Create(&model.PollVote{ID: "pv_lr_1", UserID: viewer.ID, NoteID: "p_lr_voted", Choice: 0}).Error)
 	t.Cleanup(func() { testDB.Exec(`DELETE FROM "poll_vote" WHERE id = ?`, "pv_lr_1") })
 
-	ids, err := repo.ListRecommendation(viewer.ID, []string{muted.ID}, []string{ch}, 10, 0)
+	ids, err := repo.ListRecommendation(viewer.ID, []string{muted.ID}, true, 10, 0)
 	require.NoError(t, err)
 	// good1/good2 のみ (self/followers/expired/remote/muted/channel/voted は除外)、noteId DESC。
 	assert.Equal(t, []string{"p_lr_good2", "p_lr_good1"}, ids)
 
-	// excludeChannels 無しなら channel poll も含まれる。
-	ids2, err := repo.ListRecommendation(viewer.ID, []string{muted.ID}, nil, 10, 0)
+	// excludeChannels=false なら channel poll も含まれる。
+	ids2, err := repo.ListRecommendation(viewer.ID, []string{muted.ID}, false, 10, 0)
 	require.NoError(t, err)
 	assert.Contains(t, ids2, "p_lr_chan")
 
 	// limit/offset。
-	page, err := repo.ListRecommendation(viewer.ID, []string{muted.ID}, []string{ch}, 1, 1)
+	page, err := repo.ListRecommendation(viewer.ID, []string{muted.ID}, true, 1, 1)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"p_lr_good1"}, page)
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2232,6 +2232,8 @@ func (s *Server) setupRoutes() {
 	adminHandler.SetEmailSender(miscsmtp.SubjectBodySenderFromMeta(metaRepo, s.config.ProxySmtp))
 	modLogService := coremodlog.New(modLogRepo, idGen)
 	adminHandler.SetModLogService(modLogService)
+	// #1765: moderator が他人の note を削除したとき deleteNote moderation log を残す。
+	noteDeleteService.SetModeratorDeleteHook(coremodlog.NewNoteDeleteHook(modLogService))
 	// announcements (別パッケージの Handler) も AdminCreate/Update/Delete で
 	// modlog を書くため同じ service instance を共有する。
 	announcementHandler.SetModLogService(modLogService)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -2923,19 +2923,16 @@ var pollMockVoted = map[string]struct{}{}
 func MockPollVoted(userID, noteID string) { pollMockVoted[userID+":"+noteID] = struct{}{} }
 
 // ListRecommendation mirrors the live query in-memory: local public unexpired
-// polls not authored by / voted by the viewer, author not muted, channel not
-// excluded; ordered by noteId DESC; limit/offset applied.
-func (m *MockPollRepository) ListRecommendation(viewerID string, mutedUserIDs, excludeChannelIDs []string, limit, offset int) ([]string, error) {
+// polls not authored by / voted by the viewer, author not muted; when
+// excludeChannels is true all channel polls are dropped; ordered by noteId
+// DESC; limit/offset applied.
+func (m *MockPollRepository) ListRecommendation(viewerID string, mutedUserIDs []string, excludeChannels bool, limit, offset int) ([]string, error) {
 	if limit <= 0 {
 		limit = 10
 	}
 	muted := make(map[string]struct{}, len(mutedUserIDs))
 	for _, id := range mutedUserIDs {
 		muted[id] = struct{}{}
-	}
-	excl := make(map[string]struct{}, len(excludeChannelIDs))
-	for _, id := range excludeChannelIDs {
-		excl[id] = struct{}{}
 	}
 	now := time.Now()
 	var ids []string
@@ -2958,10 +2955,8 @@ func (m *MockPollRepository) ListRecommendation(viewerID string, mutedUserIDs, e
 		if _, ok := muted[p.UserID]; ok {
 			continue
 		}
-		if p.ChannelID != nil {
-			if _, ok := excl[*p.ChannelID]; ok {
-				continue
-			}
+		if excludeChannels && p.ChannelID != nil {
+			continue
 		}
 		ids = append(ids, p.NoteID)
 	}


### PR DESCRIPTION
## Summary

再監査 (#1765) の **notes/*** 領域から MEDIUM 2 件 + LOW 2 件を解消する。

## 主な変更点

- **[MEDIUM] notes/delete — deleteNote moderation log**: moderator が他人の note を削除したとき `deleteNote` moderation log を残す (upstream `NoteDeleteService` の `deleter && note.userId !== deleter.id`)。`DeleteService` に `ModeratorDeleteHook` を追加し `isModerator && note.UserID != actor.ID` のときのみ発火。`moderationlog` に `LogDeleteNote` 型 + `NoteDeleteHook` adapter を追加、router で配線。federation 経路 (isModerator=false) と自分の note 削除では発火しない。
- **[MEDIUM] notes/polls/recommendation — excludeChannels boolean**: upstream `recommendation.ts:35` に合わせ `excludeChannels` を boolean 化 (true で `channelId IS NULL` = 全 channel poll 除外)。以前は `[]string` で、upstream 通り `true` を送ると bind 失敗して無視されていた。
- **[LOW] notes/polls/vote — NO_POLL 400**: HTTP status を 404 -> 400 (upstream noPoll は httpStatusCode 未指定 = kind client default = 400)。code/id は不変。
- **[LOW] notes/drafts/create — TOO_MANY_DRAFTS**: ドラフト上限エラーの code を独自の `TOO_MANY_NOTE_DRAFTS` から upstream の `TOO_MANY_DRAFTS` に揃える (id は元から一致)。「upstream に code が無い」という以前のコメントの前提が誤りだった。

## スコープ (follow-up / 据え置き)

- **follow-up issue に分離** (search/filter/auth 層を跨ぐ LOW): list endpoint (children/replies/renotes/mentions/search-by-tag/featured) の suspended-user/blocked-host filter, notes/search の offset param, notes/search の canSearchNotes denial code (UNAVAILABLE) + 匿名許可。
- **据え置き** (意図的): reactions/create の不可視ノート `ACCESS_DENIED` (#1538 の IDOR 強化、upstream はエラー漏洩), entity:Note の `deletedAt` (mk-go は soft-delete 非対応・optional field, entity #1781 で追跡)。

## テスト

- deleteNote hook (moderator-delete-of-others のみ発火 / 自分・著者は非発火), `NoteDeleteHook` adapter (info payload + nil guards), `excludeChannels` boolean の include/exclude, NO_POLL 400, TOO_MANY_DRAFTS code を追加・更新。
- coverage: core/note 94.7% / core/moderationlog 98.2% / api/notes 91.7% / apierr 100%。

Refs #1765

🤖 Generated with [Claude Code](https://claude.com/claude-code)