### PR TITLE
Fix users parity (再監査): excludeUserFromMute + lists/show 匿名 + flashs/gallery/relation shape (#1766)

### DIFF
--- a/internal/api/users/content_lists.go
+++ b/internal/api/users/content_lists.go
@@ -131,16 +131,15 @@ func (h *Handler) Flashs(c echo.Context) error {
 			createdAt = t.UTC().Format(tsFormat)
 		}
 		entry := map[string]any{
-			"id":          f.ID,
-			"createdAt":   createdAt,
-			"updatedAt":   f.UpdatedAt.UTC().Format(tsFormat),
-			"title":       f.Title,
-			"summary":     f.Summary,
-			"userId":      f.UserID,
-			"script":      f.Script,
-			"permissions": []string(f.Permissions),
-			"likedCount":  f.LikedCount,
-			"visibility":  f.Visibility,
+			"id":         f.ID,
+			"createdAt":  createdAt,
+			"updatedAt":  f.UpdatedAt.UTC().Format(tsFormat),
+			"title":      f.Title,
+			"summary":    f.Summary,
+			"userId":     f.UserID,
+			"script":     f.Script,
+			"likedCount": f.LikedCount,
+			"visibility": f.Visibility,
 		}
 		if packedUser != nil {
 			entry["user"] = packedUser
@@ -197,11 +196,16 @@ func (h *Handler) GalleryPosts(c echo.Context) error {
 			"title":       g.Title,
 			"description": g.Description,
 			"fileIds":     []string(g.FileIDs),
-			"tags":        []string(g.Tags),
 			"isSensitive": g.IsSensitive,
 			"likedCount":  g.LikedCount,
 			// fileIds から DriveFile を解決する (#1555、i/gallery/posts と同じ)。
 			"files": h.resolveGalleryFiles(g.FileIDs),
+		}
+		// upstream GalleryPostEntityService.ts:56 は tags を length>0 のときのみ
+		// 出力する (空なら undefined で省略)。空配列を "tags":[] として出さない
+		// よう揃える (#1766)。
+		if len(g.Tags) > 0 {
+			entry["tags"] = []string(g.Tags)
 		}
 		if viewer != nil {
 			liked := false

--- a/internal/api/users/content_lists_test.go
+++ b/internal/api/users/content_lists_test.go
@@ -146,6 +146,9 @@ func TestFlashs_HidesNonPublic(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
 	require.Len(t, rows, 1)
 	assert.Equal(t, "f1", rows[0]["id"])
+	// #1766: upstream Flash schema に permissions は無い (create paramDef のみ)。
+	_, hasPerm := rows[0]["permissions"]
+	assert.False(t, hasPerm, "permissions は packed Flash に含めない")
 }
 
 // --- GalleryPosts ---
@@ -167,6 +170,9 @@ func TestGalleryPosts_ReturnsAll(t *testing.T) {
 	var rows []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
 	assert.Len(t, rows, 2)
+	// #1766: 空 tags は出力しない (upstream は length>0 のみ)。
+	_, hasTags := rows[0]["tags"]
+	assert.False(t, hasTags, "空 tags は省略される")
 }
 
 // #1555 users/gallery/posts も fileIds から DriveFile を解決する

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -836,6 +836,13 @@ func (h *Handler) Notes(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
+	// upstream notes.ts:214-217 は generateBaseNoteFilteringQuery に
+	// excludeUserFromMute: ps.userId を渡し QueryService が
+	// `muting.muteeId != :excludeId` を加える。viewer が target 本人を mute して
+	// いても target のプロフィール note は mute filter から除外して表示するのが
+	// 標準挙動 (mute した相手のページを直接開けば見える)。mute set から target を
+	// 除いて同挙動にする (#1766)。block 判定は除外しない。
+	delete(sets.MutedUserIDs, req.UserID)
 	notes, err = notesfilter.ApplyMuteBlockChannel(notes, sets, h.noteRepo)
 	if err != nil {
 		return apierr.JSONInternalError(c)

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -59,7 +59,10 @@ func (h *Handler) Relation(c echo.Context) error {
 		if single == "" {
 			return invalidParam()
 		}
-		return c.JSON(http.StatusOK, h.computeRelation(viewer, single))
+		// upstream relation.ts:135-137 は単一 userId (string) でも
+		// `.then(it => [it])` で単一要素配列を返す (res schema は object|array の
+		// oneOf だが実コードは常に配列)。drop-in 互換のため配列に揃える (#1766)。
+		return c.JSON(http.StatusOK, []map[string]any{h.computeRelation(viewer, single)})
 	}
 	var arr []string
 	if err := json.Unmarshal(req.UserID, &arr); err == nil {

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -59,8 +59,10 @@ func TestRelation_Success(t *testing.T) {
 	rec := postExtra(h.Relation, `{"userId":"u2"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusOK, rec.Code)
 
-	var resp map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	var relArr []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &relArr))
+	require.Len(t, relArr, 1)
+	resp := relArr[0]
 	assert.Equal(t, "u2", resp["id"])
 	assert.Equal(t, false, resp["isFollowing"])
 }
@@ -77,8 +79,10 @@ func TestRelation_NilViewer(t *testing.T) {
 	h, _, _ := newExtraHandler(t)
 	rec := postExtra(h.Relation, `{"userId":"u2"}`, nil)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	var resp map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	var relArr []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &relArr))
+	require.Len(t, relArr, 1)
+	resp := relArr[0]
 	assert.Equal(t, false, resp["isFollowing"])
 	assert.Equal(t, false, resp["isBlocking"])
 }
@@ -104,8 +108,10 @@ func TestRelation_TransientDBErrorFallsBackToFalse(t *testing.T) {
 
 	rec := postExtra(h.Relation, `{"userId":"u2"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusOK, rec.Code)
-	var resp map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	var relArr []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &relArr))
+	require.Len(t, relArr, 1)
+	resp := relArr[0]
 	assert.Equal(t, false, resp["isFollowing"])
 	assert.Equal(t, false, resp["isFollowed"])
 }
@@ -121,8 +127,10 @@ func TestRelation_PartialDirection(t *testing.T) {
 
 	rec := postExtra(h.Relation, `{"userId":"u2"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusOK, rec.Code)
-	var resp map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	var relArr []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &relArr))
+	require.Len(t, relArr, 1)
+	resp := relArr[0]
 	// u1 → u2 follow のみ。逆方向 (= u2 → u1) は存在しない。
 	assert.Equal(t, true, resp["isFollowing"])
 	assert.Equal(t, false, resp["isFollowed"])
@@ -163,8 +171,10 @@ func TestRelation_PopulatedRelations(t *testing.T) {
 
 	rec := postExtra(h.Relation, `{"userId":"u2"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusOK, rec.Code)
-	var resp map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	var relArr []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &relArr))
+	require.Len(t, relArr, 1)
+	resp := relArr[0]
 	assert.Equal(t, "u2", resp["id"])
 	assert.Equal(t, true, resp["isFollowing"])
 	assert.Equal(t, true, resp["isFollowed"])

--- a/internal/api/users/handler_parity1547_test.go
+++ b/internal/api/users/handler_parity1547_test.go
@@ -42,13 +42,16 @@ func TestRelation_ArrayForm(t *testing.T) {
 	assert.Equal(t, "u3", out[1]["id"])
 }
 
-func TestRelation_SingleFormStillObject(t *testing.T) {
+// #1766: upstream relation.ts は単一 userId (string) でも単一要素配列を返す
+// (`.then(it => [it])`)。mk-go も配列に揃える。
+func TestRelation_SingleFormReturnsArray(t *testing.T) {
 	h, _ := newTestHandler(t)
 	rec := postStub(h.Relation, `{"userId":"u2"}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusOK, rec.Code)
-	var out map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out), "単体入力は従来どおりオブジェクト")
-	assert.Equal(t, "u2", out["id"])
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out), "単体入力でも単一要素配列で応答する")
+	require.Len(t, out, 1)
+	assert.Equal(t, "u2", out[0]["id"])
 }
 
 // --- N3 / X1 / X4: viewer が target にブロックされている場合の早期 [] ---

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -829,6 +829,36 @@ func TestNotes_Success(t *testing.T) {
 	assert.Len(t, out, 1)
 }
 
+// #1766: viewer が target 本人を mute していても、target のプロフィール note は
+// mute filter から除外して返す (upstream notes.ts の excludeUserFromMute)。
+func TestNotes_ExcludesTargetFromMute(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addTestUser(repo) // "user1" を target として追加
+	noteRepo := h.noteRepo.(*testutil.MockNoteRepository)
+	text := "from target"
+	noteRepo.Notes["n1"] = &model.Note{
+		ID: "n1", UserID: "user1", Text: &text,
+		Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}")),
+	}
+	// viewer1 が target (user1) を mute している。
+	mutingRepo := testutil.NewMockMutingRepository()
+	require.NoError(t, mutingRepo.Create(&model.Muting{ID: "m1", MuterID: "viewer1", MuteeID: "user1"}))
+	h.SetMutingRepo(mutingRepo)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"userId":"user1"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), &model.User{ID: "viewer1"})
+
+	require.NoError(t, h.Notes(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Len(t, out, 1, "mute した相手本人のプロフィール note は除外されない")
+}
+
 // --- #1021: withFiles / withReplies / withRenotes / withChannelNotes filter ---
 
 // 4 種類のノート (text のみ / file 添付あり / reply / pure renote / channel) を

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1368,9 +1368,10 @@ func (s *Server) setupRoutes() {
 	api.POST("/users/report-abuse", usersHandler.ReportAbuse, middleware.RequireAuth(), middleware.RequireScope("write:report-abuse"))
 	api.POST("/users/reactions", usersHandler.Reactions)
 	api.POST("/users/featured-notes", usersHandler.FeaturedNotes)
-	api.POST("/users/search-by-username-and-host", usersHandler.SearchByUsernameAndHost,
-		middleware.RequireAuth(),
-		middleware.RequireRolePolicy(roleService, corerole.PolicyCanSearchUsers))
+	// upstream search-by-username-and-host.ts:13 は requireCredential:false かつ
+	// requiredRolePolicy 無し (匿名・全 role に開放)。mk-go が独自に付けていた
+	// RequireAuth + canSearchUsers gate を外して揃える (#1766)。
+	api.POST("/users/search-by-username-and-host", usersHandler.SearchByUsernameAndHost)
 	api.POST("/users/update-memo", usersHandler.UpdateMemo, middleware.RequireAuth(), middleware.RequireScope("write:account"))
 	usersHandler.SetAbuseRepo(repository.NewAbuseReportRepository(s.db))
 	usersHandler.SetMemoRepo(repository.NewUserMemoRepository(s.db))
@@ -2160,7 +2161,11 @@ func (s *Server) setupRoutes() {
 	// public list を閲覧可、#1550)。未認証 && userId 未指定は handler が INVALID_PARAM。
 	api.POST("/users/lists/list", userListHandler.List, middleware.RequireScope("read:account"))
 	api.POST("/users/lists/create", userListHandler.Create, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:account"))
-	api.POST("/users/lists/show", userListHandler.Show, middleware.RequireAuth(), middleware.RequireScope("read:account"))
+	// upstream users/lists/show.ts:16 は requireCredential:false (kind は token
+	// 認証時のみ適用)。public list は匿名でも閲覧可能で、Show handler も
+	// viewer==nil を許容する。RequireAuth を外し RequireScope のみ残す (匿名は
+	// RequireScope を素通り、app token のみ scope を強制、#1766)。
+	api.POST("/users/lists/show", userListHandler.Show, middleware.RequireScope("read:account"))
 	api.POST("/users/lists/push", userListHandler.Push, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:account"))
 	api.POST("/users/lists/pull", userListHandler.Pull, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:account"))
 	api.POST("/users/lists/delete", userListHandler.Delete, middleware.RequireAuth(), middleware.RequireScope("write:account"))


### PR DESCRIPTION
## Summary

再監査 (#1766) の **users/*** 領域から MEDIUM 2 件 + LOW 4 件を解消する。

## 主な変更点

- **[MEDIUM] users/lists/show — 匿名で public list 閲覧可**: upstream `show.ts:16` は `requireCredential:false` (kind は token 認証時のみ)。Show handler も `viewer==nil` を許容するのに router の `RequireAuth()` だけが匿名を 401 で弾いていた。`RequireAuth` を外し `RequireScope` のみ残す (匿名は素通り、app token のみ scope 強制)。
- **[MEDIUM] users/notes — excludeUserFromMute**: viewer が target 本人を mute していると target のプロフィール note が全て落ちていた。upstream `notes.ts:214-217` の `excludeUserFromMute: ps.userId` 相当として mute set から target を除く (block は除外しない)。
- **[LOW] users/flashs — permissions 除去**: packed Flash schema に無い `permissions` field を出力していたので除去 (upstream `FlashEntityService.pack` は含めない、create paramDef のみ)。
- **[LOW] users/gallery/posts — 空 tags 省略**: 空でも `"tags":[]` を出していたが upstream `GalleryPostEntityService.ts:56` は `length>0` のときのみ出力。
- **[LOW] users/relation — 単一でも配列**: 単一 userId (string) で bare object を返していたが upstream `relation.ts:135-137` は単一でも `[it]` (単一要素配列) を返すので揃える。
- **[LOW] users/search-by-username-and-host — 匿名開放**: upstream `search-by-username-and-host.ts:13` は `requireCredential:false` かつ `requiredRolePolicy` 無し。独自に付けていた `RequireAuth` + `canSearchUsers` gate を外す。

## スコープ (follow-up / 据え置き)

- **follow-up #1784 に分離**: users/{clips,pages,flashs} の owner-public-only (viewer 利用箇所と兼ね合い), users/search の匿名許可 (匿名 base-policy middleware が必要、notes/search #1783 と共有)。
- **据え置き** (意図的): users/lists/update-membership の NO_SUCH_USER — upstream は「実在 user だが非 member」で unhandled 500、mk-go の NO_SUCH_USER の方が graceful なので upstream のバグは再現しない。

## テスト

- excludeUserFromMute (mute した相手本人の note は残る), relation 配列化 (単一/配列), flashs に permissions 無し, gallery 空 tags 省略 を追加・更新。
- coverage: users 90.5% / userlists 96.8%。

Refs #1766

🤖 Generated with [Claude Code](https://claude.com/claude-code)