### PR TITLE
Fix i parity (再監査): loggedInDays 記録 + read-announcement + 2fa 入力正規化/status (#1767)

### DIFF
--- a/internal/api/announcements/handler.go
+++ b/internal/api/announcements/handler.go
@@ -156,13 +156,17 @@ func (h *Handler) ReadAnnouncement(c echo.Context) error {
 	}
 	a, err := h.repo.FindByID(req.AnnouncementID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "b57b5e1d-0158-4f8d-bd54-1ab374089a15"))
+		// upstream read-announcement.ts は errors:{} (NO_SUCH_ANNOUNCEMENT 無し)。
+		// AnnouncementService.read は insert を try/catch で囲み、不明な id は FK
+		// 違反が握り潰されて void (204) になる。mk-go も silent 204 で揃える
+		// (#1767。以前は 404 NO_SUCH_ANNOUNCEMENT)。
+		return c.NoContent(http.StatusNoContent)
 	}
-	// per-user announcementのうち他ユーザー宛ては、そのユーザー以外は
-	// 閲覧できないので「存在しない」扱いで弾く(IDから本人宛てか推測
-	// されるのを防ぐため)。
+	// per-user announcement のうち他ユーザー宛ては、upstream も ownership check が
+	// 無く read を記録して 204 を返すだけ (isActive は変えない)。mk-go は記録せず
+	// silent 204 で揃える (foreign read は surface しないため無害、#1767)。
 	if a.UserID != nil && *a.UserID != user.ID {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "b57b5e1d-0158-4f8d-bd54-1ab374089a15"))
+		return c.NoContent(http.StatusNoContent)
 	}
 	already, _ := h.repo.IsRead(user.ID, req.AnnouncementID)
 	if already {
@@ -175,6 +179,11 @@ func (h *Handler) ReadAnnouncement(c echo.Context) error {
 	}
 	if err := h.repo.MarkRead(read); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	// upstream AnnouncementService.read:214-217: 自分宛て per-user announcement は
+	// 初回既読時に isActive=false にして自動 deactivate する (#1767)。best-effort。
+	if a.UserID != nil && *a.UserID == user.ID {
+		_ = h.repo.UpdateFields(req.AnnouncementID, map[string]any{"isActive": false})
 	}
 	// TS本家AnnouncementService.read(line 220): 残unread数が0になった時点で
 	// mainにreadAllAnnouncementsをpublishする(body: null)。

--- a/internal/api/announcements/handler_test.go
+++ b/internal/api/announcements/handler_test.go
@@ -140,10 +140,33 @@ func TestReadAnnouncement_AlreadyRead(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
-func TestReadAnnouncement_NotFound(t *testing.T) {
+// #1767: upstream read-announcement は不明な id を silent 204 で返す
+// (errors:{}、insert の FK 違反を握り潰す)。404 NO_SUCH_ANNOUNCEMENT は返さない。
+func TestReadAnnouncement_UnknownIsNoOp(t *testing.T) {
 	h, _ := newTestHandler(t)
 	rec := doPost(h.ReadAnnouncement, `{"announcementId":"ghost"}`, &model.User{ID: "u1"})
-	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+// #1767: 自分宛て per-user announcement は初回 read で isActive=false に
+// deactivate する (upstream AnnouncementService.read:214-217)。
+func TestReadAnnouncement_DeactivatesOwnPerUser(t *testing.T) {
+	h, repo := newTestHandler(t)
+	uid := "u1"
+	repo.Items["a1"] = &model.Announcement{ID: "a1", UserID: &uid, IsActive: true}
+	rec := doPost(h.ReadAnnouncement, `{"announcementId":"a1"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.False(t, repo.Items["a1"].IsActive, "自分宛て per-user は read で deactivate")
+}
+
+// #1767: 他ユーザー宛て per-user は silent 204 で、isActive も変えない。
+func TestReadAnnouncement_ForeignPerUserIsNoOp(t *testing.T) {
+	h, repo := newTestHandler(t)
+	other := "u2"
+	repo.Items["a1"] = &model.Announcement{ID: "a1", UserID: &other, IsActive: true}
+	rec := doPost(h.ReadAnnouncement, `{"announcementId":"a1"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.True(t, repo.Items["a1"].IsActive, "他ユーザー宛ては deactivate しない")
 }
 
 func TestReadAnnouncement_InvalidParam(t *testing.T) {

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -5,12 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/notehide"
 	"github.com/shiroha-a/mk/internal/core/notification"
@@ -771,10 +773,38 @@ func (h *Handler) RegistryRemove(c echo.Context) error {
 // (email / mutedWords / twoFactor* / clientData / role / unread 等) を
 // resp map に merge する design (#971)。MeDetailed packer に新 field が
 // 追加されたとき自動追従する。
+// recordLoginDay appends today's date to the profile's loggedInDates when not
+// already present and persists it, mirroring upstream i.ts. The date format is
+// server-local `YYYY/M/D` (no zero-padding, 1-indexed month) to match
+// `${getFullYear()}/${getMonth()+1}/${getDate()}`. Updates profile in place so
+// the response's loggedInDays reflects the new count. Best-effort.
+func (h *Handler) recordLoginDay(userID string, profile *model.UserProfile) {
+	now := time.Now()
+	today := fmt.Sprintf("%d/%d/%d", now.Year(), int(now.Month()), now.Day())
+	for _, d := range profile.LoggedInDates {
+		if d == today {
+			return
+		}
+	}
+	newDates := append(append(pq.StringArray{}, profile.LoggedInDates...), today)
+	if err := h.userService.UpdateProfileFields(userID, map[string]any{"loggedInDates": newDates}); err != nil {
+		slog.Warn("i: record login day failed", "user", userID, "err", err)
+		return
+	}
+	profile.LoggedInDates = newDates
+}
+
 func (h *Handler) Me(c echo.Context) error {
 	u := middleware.GetUser(c)
 
 	profile := h.userService.GetProfile(u.ID)
+
+	// upstream i.ts:67-72: /api/i アクセスごとに当日を loggedInDates に追記する
+	// (loggedInDays と login-streak achievement の唯一の source、#1767)。
+	// best-effort: 永続化失敗でも応答は返す (upstream も update を await しない)。
+	if profile != nil {
+		h.recordLoginDay(u.ID, profile)
+	}
 
 	// MeDetailed を JSON round-trip で map に展開して base にする。
 	// 1 request あたり Marshal + Unmarshal が 1 回ずつ走るが、/api/i は

--- a/internal/api/i/handler_2fa.go
+++ b/internal/api/i/handler_2fa.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
@@ -16,6 +18,7 @@ import (
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
 )
 
 // wrapWebAuthnRequest builds a fresh *http.Request whose body is the
@@ -125,7 +128,11 @@ func (h *Handler) TwoFADone(c echo.Context) error {
 	// window 内) に同じ code で signin を試みると replay として 403 になる
 	// (permanent secret に同 value で昇格するため Redis slot に hit する)。
 	// 次の TOTP step に進めば解消する。
-	if !twofactor.ValidateWithReplay(c.Request().Context(), h.totpReplayGuard, user.ID, req.Token, *profile.TwoFactorTempSecret) {
+	// upstream done.ts:54 は `ps.token.replace(/\s/g, '')` で TOTP code から
+	// 全空白を除去してから検証する (authenticator が "123 456" のように表示する
+	// code を受け付ける、#1767)。strings.Fields は連続空白も畳む。
+	token := strings.Join(strings.Fields(req.Token), "")
+	if !twofactor.ValidateWithReplay(c.Request().Context(), h.totpReplayGuard, user.ID, token, *profile.TwoFactorTempSecret) {
 		return c.JSON(http.StatusForbidden, apierr.InvalidToken())
 	}
 
@@ -458,8 +465,11 @@ func (h *Handler) TwoFARemoveKey(c echo.Context) error {
 		return c.JSON(http.StatusForbidden, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "141c598d-a825-44c8-9173-cfb9d92be493"))
 	}
 
-	if err := h.securityKeyRepo.Delete(req.CredentialID, user.ID); err != nil {
-		return c.JSON(http.StatusNotFound, apierr.NoSuchKey())
+	// upstream remove-key.ts:74-78 は delete を無条件に実行し no-match でも
+	// 成功 ({}) を返す (NO_SUCH_KEY error は定義されていない、#1767)。no-match
+	// (ErrRecordNotFound) は成功扱いで素通りし、実 DB error のみ 500 にする。
+	if err := h.securityKeyRepo.Delete(req.CredentialID, user.ID); err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return apierr.JSONInternalError(c)
 	}
 
 	if remaining, err := h.securityKeyRepo.CountByUser(user.ID); err == nil && remaining == 0 {
@@ -491,15 +501,18 @@ func (h *Handler) TwoFAUpdateKey(c echo.Context) error {
 	// upstream (update-key.ts) は key not-found (NO_SUCH_KEY) と not-owned
 	// (ACCESS_DENIED) を区別する。UpdateName は両者を ErrRecordNotFound に
 	// 畳むため、先に FindByID して所有権を判定する (#1555)。
+	// upstream update-key.ts の noSuchKey / accessDenied は httpStatusCode 未指定
+	// = kind 'client' default = 400 (#1767)。code/id は一致させつつ status を
+	// 400 に揃える (以前は 404 / 403 を返していた)。
 	key, err := h.securityKeyRepo.FindByID(req.CredentialID)
 	if err != nil || key == nil {
-		return c.JSON(http.StatusNotFound, apierr.NoSuchKey())
+		return c.JSON(http.StatusBadRequest, apierr.NoSuchKey())
 	}
 	if key.UserID != user.ID {
-		return c.JSON(http.StatusForbidden, apierr.AccessDenied())
+		return c.JSON(http.StatusBadRequest, apierr.AccessDenied())
 	}
 	if err := h.securityKeyRepo.UpdateName(req.CredentialID, user.ID, req.Name); err != nil {
-		return c.JSON(http.StatusNotFound, apierr.NoSuchKey())
+		return c.JSON(http.StatusBadRequest, apierr.NoSuchKey())
 	}
 	// 表示名変更も meUpdated で UI 反映 (#707)。
 	h.publishMeUpdated(user.ID)

--- a/internal/api/i/handler_2fa_flow_test.go
+++ b/internal/api/i/handler_2fa_flow_test.go
@@ -137,6 +137,26 @@ func TestTwoFADone_Success(t *testing.T) {
 	assert.Len(t, profile.TwoFactorBackupSecret, 5)
 }
 
+// #1767: upstream done.ts は token から空白を除去してから検証する
+// (authenticator が "123 456" と表示する code を受け付ける)。
+func TestTwoFADone_StripsWhitespaceFromToken(t *testing.T) {
+	h, repo := newExtraHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	rec := postExtra(h.TwoFARegister, `{"password":"pass"}`, user)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	secret := resp["secret"].(string)
+
+	token, err := totp.GenerateCode(secret, time.Now())
+	require.NoError(t, err)
+	// 6 桁 code の中央に空白を挿入 ("123 456" 形式)。
+	spaced := token[:3] + " " + token[3:]
+	rec2 := postExtra(h.TwoFADone, `{"token":"`+spaced+`"}`, user)
+	require.Equal(t, http.StatusOK, rec2.Code, "空白入り TOTP code も受理される")
+	assert.True(t, repo.Profiles["u1"].TwoFactorEnabled)
+}
+
 // #1555 TwoFADone は 2FA 有効化後に meUpdated を publish する (upstream done.ts)。
 func TestTwoFADone_PublishesMeUpdated(t *testing.T) {
 	h, repo := newExtraHandler(t)

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -334,7 +334,18 @@ func TestMe_LoggedInDays(t *testing.T) {
 
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	assert.Equal(t, float64(3), resp["loggedInDays"])
+	// #1767: Me が当日 (YYYY/M/D) を loggedInDates に追記するので 3 -> 4。
+	assert.Equal(t, float64(4), resp["loggedInDays"])
+	require.Len(t, userRepo.Profiles["user1"].LoggedInDates, 4)
+
+	// 2 回目の呼び出しでは当日が既に存在するので増えない (冪等)。
+	rec2 := httptest.NewRecorder()
+	c2 := e.NewContext(httptest.NewRequest(http.MethodPost, "/api/i", nil), rec2)
+	c2.Set(string(middleware.UserContextKey), user)
+	require.NoError(t, h.Me(c2))
+	var resp2 map[string]any
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp2))
+	assert.Equal(t, float64(4), resp2["loggedInDays"], "当日は二重追記しない")
 }
 
 func TestMe_BackupCodesStock(t *testing.T) {

--- a/internal/api/i/handler_webauthn_test.go
+++ b/internal/api/i/handler_webauthn_test.go
@@ -329,11 +329,12 @@ func TestTwoFARemoveKey_MissingFields(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
-func TestTwoFARemoveKey_NotFound(t *testing.T) {
+// #1767: upstream remove-key は no-match でも no-op 成功 (204)。NO_SUCH_KEY は無い。
+func TestTwoFARemoveKey_MissingIsNoOp(t *testing.T) {
 	h, repo, _ := newWebAuthnHandler(t)
 	user := setupUserWithPassword(repo, "u1", "pass")
 	rec := postExtra(h.TwoFARemoveKey, `{"password":"pass","credentialId":"ghost"}`, user)
-	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
 func TestTwoFARemoveKey_Success(t *testing.T) {
@@ -406,7 +407,8 @@ func TestTwoFAUpdateKey_NotFound(t *testing.T) {
 	h, repo, _ := newWebAuthnHandler(t)
 	user := setupUserWithPassword(repo, "u1", "pass")
 	rec := postExtra(h.TwoFAUpdateKey, `{"password":"pass","credentialId":"ghost","name":"x"}`, user)
-	assert.Equal(t, http.StatusNotFound, rec.Code)
+	// #1767: upstream noSuchKey は httpStatusCode 未指定 = 400 (code は一致)。
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestTwoFAUpdateKey_Success(t *testing.T) {
@@ -431,7 +433,8 @@ func TestTwoFAUpdateKey_AccessDenied(t *testing.T) {
 		ID: "key1", UserID: "u2", Name: "old", PublicKey: "pk",
 	}))
 	rec := postExtra(h.TwoFAUpdateKey, `{"password":"pass","credentialId":"key1","name":"x"}`, user)
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	// #1767: upstream accessDenied は httpStatusCode 未指定 = 400 (code は一致)。
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 	assert.Contains(t, rec.Body.String(), "ACCESS_DENIED")
 	// 名前は変更されない。
 	assert.Equal(t, "old", skRepo.keys["key1"].Name)


### PR DESCRIPTION
## Summary

再監査 (#1767) の **i/*** 領域から MEDIUM 1 件 + LOW 5 件を解消する。

## 主な変更点

- **[MEDIUM] /api/i — loggedInDays 記録**: アクセスごとに当日 (server-local `YYYY/M/D`) を `loggedInDates` に追記 (upstream `i.ts:67-72`)。これまで一切書き込みが無く `loggedInDays` が常に 0 で login-streak achievement が進まなかった。best-effort + 冪等 (`recordLoginDay`)。
- **[LOW] i/read-announcement — per-user deactivate**: 自分宛て per-user announcement を初回 read で `isActive=false` に (upstream `AnnouncementService.read`)。
- **[LOW] i/read-announcement — silent 204**: 不明な id / 他ユーザー宛て per-user を 404 でなく silent 204 で返す (upstream `errors:{}`、insert を try/catch で握り潰す)。
- **[LOW] i/2fa/done — TOTP 空白除去**: token から全空白を除去してから検証 (upstream `token.replace(/\s/g,'')`)。"123 456" 形式を受理。
- **[LOW] i/2fa/remove-key — no-op 成功**: no-match を 404 NO_SUCH_KEY でなく成功で返す (upstream は無条件 delete + `{}`)。実 DB error のみ 500。
- **[LOW] i/2fa/update-key — status 400**: NO_SUCH_KEY / ACCESS_DENIED の HTTP status を 404/403 から 400 に (upstream は kind client default = 400、code/id は一致)。

## スコープ

- **follow-up #1786 に分離**: i/update の rel=me `verifiedLinks` 検証 (outbound fetch + HTML parse + SSRF ガードを伴う subsystem)。

## テスト

- loggedInDays 追記 + 冪等, read-announcement (deactivate / foreign no-op / unknown no-op), 2fa/done 空白除去, remove-key no-op 成功, update-key 400 を追加・更新。
- coverage: i 90.6% / announcements 96.7%。

Refs #1767

🤖 Generated with [Claude Code](https://claude.com/claude-code)