### PR TITLE
Fix clips parity (再監査): remove-note 冪等化 + Note.clippedCount 維持 (#1768)

### DIFF
--- a/internal/api/clips/handler.go
+++ b/internal/api/clips/handler.go
@@ -385,8 +385,10 @@ func (h *Handler) RemoveNote(c echo.Context) error {
 		switch {
 		case errors.Is(err, coreclip.ErrClipNotFound):
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CLIP", "No such clip.", "b80525c6-97f7-49d7-a42d-ebccd49cfd52"))
-		case errors.Is(err, coreclip.ErrNotClipped):
-			return notClipped(c)
+		case errors.Is(err, coreclip.ErrNoteNotFound):
+			// upstream remove-note.ts は note 不在のみ NO_SUCH_NOTE を返す (#1768)。
+			// clip に含まれない note の削除は service 側で silent success になる。
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "aff017de-190e-434b-893e-33a9ff5049d8"))
 		}
 		return apierr.JSONInternalError(c)
 	}
@@ -508,8 +510,4 @@ func (h *Handler) clipExtras(cl *model.Clip, viewer *model.User) entity.ClipExtr
 		}
 	}
 	return extras
-}
-
-func notClipped(c echo.Context) error {
-	return c.JSON(http.StatusBadRequest, apierr.Error("NOT_CLIPPED", "The note is not clipped.", "aff017de-190e-434b-893e-33a9ff5049d8"))
 }

--- a/internal/api/clips/handler_test.go
+++ b/internal/api/clips/handler_test.go
@@ -646,13 +646,26 @@ func TestRemoveNote_NonOwnerHidden(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "NO_SUCH_CLIP")
 }
 
-func TestRemoveNote_NotClipped(t *testing.T) {
+// #1768: note 不在は NO_SUCH_NOTE 404 (NOT_CLIPPED は廃止)。
+func TestRemoveNote_NoSuchNote(t *testing.T) {
 	h, repo, _, _ := newHandler(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice"}
 	c, rec := newReq(t, `{"clipId":"c1","noteId":"n1"}`)
 	setUser(c, "alice")
 	require.NoError(t, h.RemoveNote(c))
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_NOTE")
+}
+
+// #1768: note は実在するが clip に無い場合は silent success (204)。
+func TestRemoveNote_NotInClipIsNoOp(t *testing.T) {
+	h, repo, _, notes := newHandler(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "alice"}
+	notes.Notes["n1"] = &model.Note{ID: "n1"}
+	c, rec := newReq(t, `{"clipId":"c1","noteId":"n1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.RemoveNote(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
 // failingClipNoteDeleteRepo causes Delete to fail (other than not clipped).
@@ -669,7 +682,10 @@ func TestRemoveNote_RepoError(t *testing.T) {
 	mock.Entries["cn1"] = &model.ClipNote{ID: "cn1", ClipID: "c1", NoteID: "n1"}
 	noteRepo := &failingClipNoteDeleteRepo{MockClipNoteRepository: mock}
 	idGen, _ := id.NewGenerator("aidx")
-	svc := coreclip.NewService(repo, noteRepo, testutil.NewMockNoteRepository(), idGen)
+	// note は実在させて存在チェックを通し、clip_note Delete 失敗の 500 path に到達させる。
+	notes := testutil.NewMockNoteRepository()
+	notes.Notes["n1"] = &model.Note{ID: "n1"}
+	svc := coreclip.NewService(repo, noteRepo, notes, idGen)
 	h := NewHandler(svc, idGen)
 	c, rec := newReq(t, `{"clipId":"c1","noteId":"n1"}`)
 	setUser(c, "alice")

--- a/internal/core/clip/clip_service.go
+++ b/internal/core/clip/clip_service.go
@@ -26,8 +26,6 @@ var (
 	// ErrAlreadyClipped is returned when a note is already attached to the
 	// clip.
 	ErrAlreadyClipped = errors.New("note is already clipped")
-	// ErrNotClipped is returned when there is no clip_note row to remove.
-	ErrNotClipped = errors.New("note is not clipped")
 	// ErrTooManyClips は Create で clipLimit 超過 (#1029、upstream
 	// tooManyClips)。
 	ErrTooManyClips = errors.New("clip limit exceeded")
@@ -250,6 +248,9 @@ func (s *Service) AddNote(ownerID, clipID, noteID string) error {
 		return err
 	}
 	_ = s.repo.IncrementCount(clipID, "notesCount", 1)
+	// upstream ClipService.addNote:131 は note の clippedCount を increment する
+	// (#1768。これまで未維持で常に 0 だった)。
+	_ = s.notes.IncrementCount(noteID, "clippedCount", 1)
 	_ = s.repo.UpdateFields(clipID, map[string]any{"lastClippedAt": &now})
 	return nil
 }
@@ -263,14 +264,23 @@ func (s *Service) RemoveNote(ownerID, clipID, noteID string) error {
 	if c.UserID != ownerID {
 		return ErrClipNotFound
 	}
+	// upstream removeNote は note の存在を notesRepository で確認し、無ければ
+	// NoSuchNote を投げる (#1768)。
+	if _, err := s.notes.FindByID(noteID); err != nil {
+		return ErrNoteNotFound
+	}
 	cn, err := s.noteRepo.FindByPair(clipID, noteID)
 	if err != nil {
-		return ErrNotClipped
+		// upstream clipNotesRepository.delete は idempotent で、clip に含まれない
+		// note の削除は silent success (NOT_CLIPPED error は upstream に無い、#1768)。
+		return nil
 	}
 	if err := s.noteRepo.Delete(cn); err != nil {
 		return err
 	}
 	_ = s.repo.IncrementCount(clipID, "notesCount", -1)
+	// upstream ClipService.removeNote:156 は note の clippedCount を decrement する。
+	_ = s.notes.IncrementCount(noteID, "clippedCount", -1)
 	return nil
 }
 

--- a/internal/core/clip/clip_service_test.go
+++ b/internal/core/clip/clip_service_test.go
@@ -219,6 +219,19 @@ func TestAddNote_HappyPath(t *testing.T) {
 	assert.Len(t, noteRepo.Entries, 1)
 	assert.Equal(t, 1, repo.Clips["c1"].NotesCount)
 	require.NotNil(t, repo.Clips["c1"].LastClippedAt)
+	// #1768: note の clippedCount も increment される。
+	assert.Equal(t, int16(1), notes.Notes["n1"].ClippedCount)
+}
+
+// #1768: add -> remove で note の clippedCount が 1 -> 0 に維持される。
+func TestClippedCount_MaintainedOnAddRemove(t *testing.T) {
+	svc, repo, _, notes := newSvc(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "u1"}
+	notes.Notes["n1"] = &model.Note{ID: "n1"}
+	require.NoError(t, svc.AddNote("u1", "c1", "n1"))
+	assert.Equal(t, int16(1), notes.Notes["n1"].ClippedCount)
+	require.NoError(t, svc.RemoveNote("u1", "c1", "n1"))
+	assert.Equal(t, int16(0), notes.Notes["n1"].ClippedCount)
 }
 
 func TestAddNote_ClipNotFound(t *testing.T) {
@@ -293,11 +306,21 @@ func TestRemoveNote_NonOwnerHidden(t *testing.T) {
 	assert.ErrorIs(t, err, clip.ErrClipNotFound)
 }
 
-func TestRemoveNote_NotClipped(t *testing.T) {
+// #1768: note は実在するが clip に含まれない場合、upstream は idempotent delete で
+// silent success。NOT_CLIPPED error は返さない。
+func TestRemoveNote_NotInClipIsNoOp(t *testing.T) {
+	svc, repo, _, notes := newSvc(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "u1"}
+	notes.Notes["n1"] = &model.Note{ID: "n1"}
+	assert.NoError(t, svc.RemoveNote("u1", "c1", "n1"))
+}
+
+// #1768: note 自体が存在しなければ NO_SUCH_NOTE (ErrNoteNotFound)。
+func TestRemoveNote_NoSuchNote(t *testing.T) {
 	svc, repo, _, _ := newSvc(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "u1"}
 	err := svc.RemoveNote("u1", "c1", "n1")
-	assert.ErrorIs(t, err, clip.ErrNotClipped)
+	assert.ErrorIs(t, err, clip.ErrNoteNotFound)
 }
 
 // failingDeleteRepo causes Delete to fail.

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -955,6 +955,8 @@ func (m *MockNoteRepository) IncrementCount(noteID, column string, delta int) er
 		n.RenoteCount += int16(delta)
 	case "repliesCount":
 		n.RepliesCount += int16(delta)
+	case "clippedCount":
+		n.ClippedCount += int16(delta)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

再監査 (#1768) の **clips/*** 領域 MEDIUM 2 件を解消する (どちらも clip 関連、following は差分なし)。

## 主な変更点

- **[MEDIUM] clips/remove-note — 冪等化 + NO_SUCH_NOTE**: upstream `ClipService.removeNote` に揃える。note 不在は `NO_SUCH_NOTE` (id `aff017de`)、clip に含まれない note の削除は idempotent な silent success にする。これまでは note 非存在を問わず「clip に無い」を一律 400 `NOT_CLIPPED` で返していた (upstream に `NOT_CLIPPED` error は存在せず、`NO_SUCH_NOTE` の id を流用していた)。`ErrNotClipped` / `notClipped` helper を削除。
- **[MEDIUM] entity:Note — clippedCount 維持**: clips/add-note で `note.clippedCount` を increment、remove-note で decrement (upstream `ClipService.addNote:131` / `removeNote:156`)。これまで未維持で全 Note レスポンスで常に 0 だった。

## テスト

- remove-note: no-such-note (404) / not-in-clip (204 silent) / repo-error (500)。
- clippedCount: add で +1、remove で 0 復帰。
- mock `NoteRepository.IncrementCount` に `clippedCount` case を追加。
- coverage: core/clip 96.3% / api/clips 91.1%。

Refs #1768

🤖 Generated with [Claude Code](https://claude.com/claude-code)