### PR TITLE
Fix drive parity (再監査): Usage capacity を driveCapacityMb policy 連動 + files/update comment null クリア (#1769)

### DIFF
--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -321,11 +321,13 @@ func (h *Handler) packDriveFileShow(f *model.DriveFile) entity.DriveFileEntity {
 
 // FilesUpdateRequest is the body for drive/files/update.
 type FilesUpdateRequest struct {
-	FileID      string  `json:"fileId"`
-	Name        *string `json:"name"`
-	FolderID    *string `json:"folderId"`
-	Comment     *string `json:"comment"`
-	IsSensitive *bool   `json:"isSensitive"`
+	FileID string  `json:"fileId"`
+	Name   *string `json:"name"`
+	// upstream update.ts paramDef は comment が nullable。JSON の `comment:null`
+	// (= 明示クリア) と省略を区別するため json.RawMessage で受ける (#1769)。
+	Comment     json.RawMessage `json:"comment"`
+	FolderID    *string         `json:"folderId"`
+	IsSensitive *bool           `json:"isSensitive"`
 	// folderIdをnullに設定したい場合用 (JSON nullの判定不可なので明示フラグ)
 	UnsetFolder bool `json:"unsetFolder"`
 }
@@ -342,12 +344,22 @@ func (h *Handler) FilesUpdate(c echo.Context) error {
 		IsSensitive: req.IsSensitive,
 	}
 	if req.Comment != nil {
-		// upstream update.ts paramDef は comment maxLength=512 (#1564)。
-		if utf8.RuneCountInString(*req.Comment) > maxDriveCommentLength {
-			return apierr.JSONInvalidParam(c)
+		if string(req.Comment) == "null" {
+			// 明示 null → comment をクリア (upstream は comment:null で消せる、#1769)。
+			var nilStr *string
+			in.Comment = &nilStr
+		} else {
+			var comment string
+			if err := json.Unmarshal(req.Comment, &comment); err != nil {
+				return apierr.JSONInvalidParam(c)
+			}
+			// upstream update.ts paramDef は comment maxLength=512 (#1564)。
+			if utf8.RuneCountInString(comment) > maxDriveCommentLength {
+				return apierr.JSONInvalidParam(c)
+			}
+			cp := &comment
+			in.Comment = &cp
 		}
-		c2 := req.Comment
-		in.Comment = &c2
 	}
 	if req.UnsetFolder {
 		var nilPtr *string
@@ -683,8 +695,11 @@ func (h *Handler) Usage(c echo.Context) error {
 	if h.fileRepo != nil {
 		usage, _ = h.fileRepo.UsageByUser(user.ID)
 	}
+	// upstream drive.ts:49-53 は driveCapacityMb role policy から capacity を
+	// 算出する (1024*1024*driveCapacityMb)。以前は 1GiB ハードコードで policy /
+	// role 上書きを無視していた (#1769)。
 	return c.JSON(http.StatusOK, map[string]any{
-		"capacity": int64(1024 * 1024 * 1024), // 1GB default
+		"capacity": h.svc.Capacity(user.ID),
 		"usage":    usage,
 	})
 }

--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -354,6 +354,33 @@ func TestFilesUpdate_Success(t *testing.T) {
 	shapetest.Assert(t, "DriveFile", resp) // L3 (#1312)
 }
 
+// #1769: comment:null で既存 comment をクリアできる。
+func TestFilesUpdate_ClearsCommentWithNull(t *testing.T) {
+	h, fileRepo, _ := newHandler(t)
+	uid := "u1"
+	existing := "old comment"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &uid, Name: "n", Comment: &existing}
+	c, rec := newJSONReq(t, `{"fileId":"f1","comment":null}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesUpdate(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Nil(t, fileRepo.Files["f1"].Comment, "comment:null で comment がクリアされる")
+}
+
+// #1769: comment 省略時は既存 comment を維持する (null クリアと区別)。
+func TestFilesUpdate_OmittedCommentKept(t *testing.T) {
+	h, fileRepo, _ := newHandler(t)
+	uid := "u1"
+	existing := "keep"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &uid, Name: "n", Comment: &existing}
+	c, rec := newJSONReq(t, `{"fileId":"f1","name":"n2"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesUpdate(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, fileRepo.Files["f1"].Comment)
+	assert.Equal(t, "keep", *fileRepo.Files["f1"].Comment)
+}
+
 func TestFilesUpdate_InvalidParam(t *testing.T) {
 	h, _, _ := newHandler(t)
 	c, rec := newJSONReq(t, `{}`)

--- a/internal/core/drive/drive_service.go
+++ b/internal/core/drive/drive_service.go
@@ -628,6 +628,20 @@ func (s *Service) FindByHash(user *model.User, md5 string) ([]*model.DriveFile, 
 	return s.fileRepo.FindAllByMD5(user.ID, md5)
 }
 
+// Capacity returns the user's drive capacity in bytes derived from the
+// driveCapacityMb role policy (1024*1024*driveCapacityMb), mirroring upstream
+// drive.ts (`capacity: 1024 * 1024 * policies.driveCapacityMb`). Falls back to
+// the default 100 MiB when no role checker is wired (#1769)。
+func (s *Service) Capacity(userID string) int64 {
+	mb := 100 // DefaultPolicies driveCapacityMb
+	if s.roleChecker != nil {
+		if v, ok := s.roleChecker.GetUserPolicies(userID)["driveCapacityMb"].(int); ok {
+			mb = v
+		}
+	}
+	return int64(1024 * 1024 * mb)
+}
+
 // UpdateInput holds the editable fields of a drive file.
 type UpdateInput struct {
 	Name        *string

--- a/internal/core/drive/drive_service_test.go
+++ b/internal/core/drive/drive_service_test.go
@@ -224,6 +224,19 @@ func (f *fakeMod) GetUserPolicies(userID string) map[string]any {
 	return f.policies[userID]
 }
 
+// #1769: Capacity は driveCapacityMb role policy から算出する
+// (1024*1024*driveCapacityMb)。roleChecker 未配線時は default 100 MiB。
+func TestCapacity_FromPolicy(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	// roleChecker 未配線 → default 100 MiB。
+	assert.Equal(t, int64(100*1024*1024), svc.Capacity("u1"))
+	// policy override は反映される。
+	svc.SetRoleChecker(&fakeMod{policies: map[string]map[string]any{"u1": {"driveCapacityMb": 500}}})
+	assert.Equal(t, int64(500*1024*1024), svc.Capacity("u1"))
+	// override の無い user は default 100 MiB に fallback。
+	assert.Equal(t, int64(100*1024*1024), svc.Capacity("u2"))
+}
+
 func TestShow_ModeratorBypass(t *testing.T) {
 	svc, fileRepo, _ := newSvc(t)
 	other := "other"


### PR DESCRIPTION
## Summary

再監査 (#1769) の **drive/*** 領域 MEDIUM 1 件 + LOW 1 件を解消する。

## 主な変更点

- **[MEDIUM] /api/drive — capacity を policy 連動**: Usage の `capacity` を `driveCapacityMb` role policy から算出 (`1024*1024*driveCapacityMb`、upstream `drive.ts:49-53`)。これまで 1GiB ハードコードで policy / role 上書きを無視し、frontend のドライブ使用量バーが誤った総容量を表示していた。core に `Service.Capacity` を追加 (roleChecker 未配線時 default 100MiB)。
- **[LOW] /api/drive/files/update — comment null クリア**: `comment:null` で既存 comment を明示クリアできるように。HTTP req の `Comment` を `*string` → `json.RawMessage` に変え、省略 / 明示 null / 値 を区別 (core `UpdateInput.Comment` は元から `**string` で null クリア対応済)。

## 据え置き (意図的)

- files/update・files/delete に moderator bypass が無い件は #499 の意図的な privilege-escalation hardening (moderator の正規経路は admin/drive/*) で、セキュリティ後退ではない。

## テスト

- `Capacity` の policy 連動 + default fallback、files/update の `comment:null` クリア / 省略時維持 を追加。
- coverage: core/drive 98.5% / api/drive 91.3%。

Refs #1769

🤖 Generated with [Claude Code](https://claude.com/claude-code)