### PR TITLE
Fix channels parity (再監査): unfavorite の NO_SUCH_CHANNEL + lastNotedAt の ISO ms 正規化 (#1770)

### DIFF
--- a/internal/api/channels/favorites.go
+++ b/internal/api/channels/favorites.go
@@ -57,6 +57,12 @@ func (h *Handler) Unfavorite(c echo.Context) error {
 	if h.favoriteRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
+	// upstream unfavorite.ts:53-58 は delete 前に findOneBy で channel 存在を確認し、
+	// 無ければ NO_SUCH_CHANNEL を返す (Favorite と対称、#1770)。unfavorite 固有の
+	// error id は favorite (4938f5f3) と異なり 353c68dd である点に注意。
+	if _, err := h.svc.Show(req.ChannelID); err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_CHANNEL", "No such channel.", "353c68dd-131a-476c-aa99-88a345e83668"))
+	}
 	if err := h.favoriteRepo.Delete(user.ID, req.ChannelID); err != nil {
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/channels/favorites_test.go
+++ b/internal/api/channels/favorites_test.go
@@ -102,12 +102,22 @@ func TestFavorite_NilRepo(t *testing.T) {
 // --- Unfavorite ---
 
 func TestUnfavorite_Success(t *testing.T) {
-	h, _, favRepo, _ := newStubHandler(t)
+	h, chRepo, favRepo, _ := newStubHandler(t)
+	chRepo.Channels["ch1"] = &model.Channel{ID: "ch1", Name: "test"}
 	favRepo.Favorites["u1:ch1"] = &model.ChannelFavorite{ID: "f1", UserID: "u1", ChannelID: "ch1"}
 	rec := postStubWithBody(t, h.Unfavorite, `{"channelId":"ch1"}`, "u1")
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 	exists, _ := favRepo.Exists("u1", "ch1")
 	assert.False(t, exists)
+}
+
+// #1770: 存在しない channel の unfavorite は NO_SUCH_CHANNEL (id 353c68dd)。
+func TestUnfavorite_NoSuchChannel(t *testing.T) {
+	h, _, _, _ := newStubHandler(t)
+	rec := postStubWithBody(t, h.Unfavorite, `{"channelId":"ghost"}`, "u1")
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_CHANNEL")
+	assert.Contains(t, rec.Body.String(), "353c68dd-131a-476c-aa99-88a345e83668")
 }
 
 func TestUnfavorite_MissingChannelID(t *testing.T) {

--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -543,7 +543,13 @@ func (h *Handler) channelToMap(ch *model.Channel, bannerURL any) map[string]any 
 		"usersCount":            ch.UsersCount,
 		"isSensitive":           ch.IsSensitive,
 		"allowRenoteToExternal": ch.AllowRenoteToExternal,
-		"lastNotedAt":           ch.LastNotedAt,
+		"lastNotedAt":           nil,
+	}
+	// upstream ChannelEntityService は lastNotedAt を toISOString() で常に 3桁 ms
+	// にする。createdAt と同様 .000Z に正規化する (#1770。以前は *time.Time を生で
+	// 入れて Go 既定の RFC3339Nano になっていた)。nil は null のまま。
+	if ch.LastNotedAt != nil {
+		out["lastNotedAt"] = ch.LastNotedAt.UTC().Format("2006-01-02T15:04:05.000Z")
 	}
 	// Misskey TS は createdAt を channel.id (aidx) から導出する。golden Channel
 	// でも createdAt は必須なので他 entity と同じ ISO ms 形式で埋める (#1280)。

--- a/internal/api/channels/handler_test.go
+++ b/internal/api/channels/handler_test.go
@@ -1028,6 +1028,9 @@ func TestFeatured_BatchEmbedsFollowState(t *testing.T) {
 	assert.Equal(t, 1, fav.existsManyCalls)
 
 	body := rec.Body.String()
+	// #1770: lastNotedAt は upstream の toISOString() に合わせ 3桁 ms (.000Z) 形式。
+	assert.Regexp(t, `"lastNotedAt":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z"`, body,
+		"lastNotedAt must be normalized to 3-digit ms ISO format")
 	assert.Contains(t, body, `"isFollowing":true`,
 		"alice's followed channel must report isFollowing=true")
 	assert.Contains(t, body, `"isFollowing":false`,


### PR DESCRIPTION
## Summary

再監査 (#1770) の **channels/*** 領域 MEDIUM 1 件 + LOW 1 件を解消する。

## 主な変更点

- **[MEDIUM] channels/unfavorite — NO_SUCH_CHANNEL**: delete 前に channel 存在を確認し、無ければ `NO_SUCH_CHANNEL` を返す (upstream `unfavorite.ts` と対称、Favorite と同様)。unfavorite 固有の error id は favorite (`4938f5f3`) と異なり **`353c68dd`**。これまで存在しない channelId でも 204 を返していた。
- **[LOW] entity:Channel — lastNotedAt 正規化**: createdAt と同様 `.000Z` (3桁 ms) 形式に正規化 (upstream `ChannelEntityService` の `toISOString()`)。これまで `*time.Time` を生で入れて Go 既定の RFC3339Nano になっていた。nil は null のまま。

## スコープ (follow-up / 対応不要)

- **follow-up #1790 に分離**: channel timeline の muted-channel renote filter (`renoteChannelId` 除外) — `ListByChannelID` のクエリ変更を伴う。
- **対応不要**: timeline `allowPartial` param — mk-go は常に DB-backed で redis fanout partial の概念が無く、param は無害に無視される (response-shape 影響なし)。

## テスト

- unfavorite の NO_SUCH_CHANNEL(353c68dd) / channel 存在時の成功、lastNotedAt の 3桁 ms 形式。
- coverage: api/channels 93.1%。

Refs #1770

🤖 Generated with [Claude Code](https://claude.com/claude-code)