### PR TITLE
Fix users parity (再監査 follow-up): clips/pages/flashs owner-public-only + users/search 匿名許可 (#1784)

### DIFF
--- a/internal/api/users/content_lists.go
+++ b/internal/api/users/content_lists.go
@@ -41,13 +41,10 @@ func (h *Handler) Clips(c echo.Context) error {
 	req.SinceID, req.UntilID = id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
 	viewer := middleware.GetUser(c)
 	isSelf := viewer != nil && viewer.ID == req.UserID
-	var rows []*model.Clip
-	var err error
-	if isSelf {
-		rows, err = h.clipRepo.ListByUser(req.UserID, req.SinceID, req.UntilID, req.Limit, req.Offset)
-	} else {
-		rows, err = h.clipRepo.ListPublicByUser(req.UserID, req.SinceID, req.UntilID, req.Limit, req.Offset)
-	}
+	// upstream clips.ts:54 は viewer に関係なく公開 clip のみ返す (clip.isPublic=true)。
+	// owner の非公開 clip は i/clips 等で取得する設計 (#1784)。notesCount は owner
+	// 閲覧時のみ出すため isSelf は下の ClipExtras で引き続き使う。
+	rows, err := h.clipRepo.ListPublicByUser(req.UserID, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
@@ -104,15 +101,9 @@ func (h *Handler) Flashs(c echo.Context) error {
 	clampListLimit(&req.Limit)
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	req.SinceID, req.UntilID = id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
-	viewer := middleware.GetUser(c)
-	isSelf := viewer != nil && viewer.ID == req.UserID
-	var rows []*model.Flash
-	var err error
-	if isSelf {
-		rows, err = h.flashRepo.ListByUser(req.UserID, req.SinceID, req.UntilID, req.Limit, req.Offset)
-	} else {
-		rows, err = h.flashRepo.ListPublicByUser(req.UserID, req.SinceID, req.UntilID, req.Limit, req.Offset)
-	}
+	// upstream flashs.ts:54 は viewer に関係なく公開 flash のみ返す
+	// (visibility='public')。owner の非公開 flash は i/* 系で取得する設計 (#1784)。
+	rows, err := h.flashRepo.ListPublicByUser(req.UserID, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
@@ -272,15 +263,9 @@ func (h *Handler) Pages(c echo.Context) error {
 	clampListLimit(&req.Limit)
 	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
 	req.SinceID, req.UntilID = id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
-	viewer := middleware.GetUser(c)
-	isSelf := viewer != nil && viewer.ID == req.UserID
-	var rows []*model.Page
-	var err error
-	if isSelf {
-		rows, err = h.pageRepo.ListByUser(req.UserID, req.SinceID, req.UntilID, req.Limit, req.Offset)
-	} else {
-		rows, err = h.pageRepo.ListPublicByUser(req.UserID, req.SinceID, req.UntilID, req.Limit, req.Offset)
-	}
+	// upstream pages.ts:54 は viewer に関係なく公開 page のみ返す
+	// (visibility='public')。owner の非公開 page は i/pages 等で取得する設計 (#1784)。
+	rows, err := h.pageRepo.ListPublicByUser(req.UserID, req.SinceID, req.UntilID, req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/users/content_lists_test.go
+++ b/internal/api/users/content_lists_test.go
@@ -83,7 +83,9 @@ func TestClips_PublicFilterPushedDown(t *testing.T) {
 	assert.Len(t, rows, 2, "LIMIT must apply to already-public-filtered set")
 }
 
-func TestClips_OwnerSeesPrivate(t *testing.T) {
+// #1784: upstream clips.ts は owner でも公開 clip のみ返す (clip.isPublic=true)。
+// 非公開 clip は owner であっても users/clips には現れない。
+func TestClips_OwnerSeesOnlyPublic(t *testing.T) {
 	h, _ := newTestHandler(t)
 	repo := testutil.NewMockClipRepository()
 	require.NoError(t, repo.Create(&model.Clip{ID: "c1", UserID: "owner", IsPublic: true}))
@@ -93,7 +95,8 @@ func TestClips_OwnerSeesPrivate(t *testing.T) {
 	rec := postStub(h.Clips, `{"userId":"owner"}`, &model.User{ID: "owner"})
 	var rows []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
-	assert.Len(t, rows, 2)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "c1", rows[0]["id"])
 }
 
 // misskey_dart の Clip.fromJson が非null必須とする createdAt / user /

--- a/internal/server/middleware/role_policy.go
+++ b/internal/server/middleware/role_policy.go
@@ -59,3 +59,26 @@ func RequireRolePolicy(checker RolePolicyChecker, policyKey string) echo.Middlew
 		}
 	}
 }
+
+// RequireRolePolicyPublic gates an endpoint on a role policy while allowing
+// anonymous access (upstream requireCredential:false + requiredRolePolicy、例:
+// users/search)。匿名は base/default policy で評価する (HasRolePolicy に空 userID を
+// 渡すと DefaultPolicies + meta.policies が引かれる)。policy 不許可は 403
+// ROLE_PERMISSION_DENIED、401 は返さない (#1784)。checker 未配線時は gate skip。
+func RequireRolePolicyPublic(checker RolePolicyChecker, policyKey string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if checker == nil {
+				return next(c)
+			}
+			uid := ""
+			if u := GetUser(c); u != nil {
+				uid = u.ID
+			}
+			if !checker.HasRolePolicy(uid, policyKey) {
+				return c.JSON(http.StatusForbidden, apierr.RolePermissionDenied())
+			}
+			return next(c)
+		}
+	}
+}

--- a/internal/server/middleware/role_policy_test.go
+++ b/internal/server/middleware/role_policy_test.go
@@ -127,3 +127,64 @@ func TestRequireRolePolicy_DifferentPolicyKey(t *testing.T) {
 	require.NoError(t, handler(c))
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 }
+
+// #1784: RequireRolePolicyPublic は匿名 (uid="") も base policy で評価し、
+// policy=true なら通す (401 は返さない)。
+func TestRequireRolePolicyPublic_AnonymousAllowedByBasePolicy(t *testing.T) {
+	checker := newStubPolicyChecker()
+	checker.set("", "canSearchUsers", true) // base policy
+
+	c, rec := newRolePolicyReq(t, nil)
+	called := false
+	handler := RequireRolePolicyPublic(checker, "canSearchUsers")(func(c echo.Context) error {
+		called = true
+		return c.String(http.StatusOK, "ok")
+	})
+
+	require.NoError(t, handler(c))
+	assert.Equal(t, http.StatusOK, rec.Code, "匿名でも base policy=true なら通る")
+	assert.True(t, called)
+}
+
+// base policy=false なら匿名は 403 ROLE_PERMISSION_DENIED (401 ではない)。
+func TestRequireRolePolicyPublic_AnonymousDenied(t *testing.T) {
+	checker := newStubPolicyChecker() // base canSearchUsers=false
+
+	c, rec := newRolePolicyReq(t, nil)
+	called := false
+	handler := RequireRolePolicyPublic(checker, "canSearchUsers")(func(c echo.Context) error {
+		called = true
+		return c.String(http.StatusOK, "ok")
+	})
+
+	require.NoError(t, handler(c))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "ROLE_PERMISSION_DENIED")
+	assert.False(t, called)
+}
+
+// 認証済 user は自身の policy で評価される。
+func TestRequireRolePolicyPublic_AuthedUser(t *testing.T) {
+	checker := newStubPolicyChecker()
+	checker.set("alice", "canSearchUsers", true)
+
+	c, rec := newRolePolicyReq(t, &model.User{ID: "alice"})
+	handler := RequireRolePolicyPublic(checker, "canSearchUsers")(func(c echo.Context) error {
+		return c.String(http.StatusOK, "ok")
+	})
+	require.NoError(t, handler(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// checker 未配線時は gate skip。
+func TestRequireRolePolicyPublic_NilCheckerSkips(t *testing.T) {
+	c, rec := newRolePolicyReq(t, nil)
+	called := false
+	handler := RequireRolePolicyPublic(nil, "canSearchUsers")(func(c echo.Context) error {
+		called = true
+		return c.String(http.StatusOK, "ok")
+	})
+	require.NoError(t, handler(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, called)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1360,9 +1360,11 @@ func (s *Server) setupRoutes() {
 		fetcher: corefederation.NewRemoteStatsFetcher(s.config.AllowedPrivateNetworks, s.config.UserAgent, s.outboundOpts()...),
 	})
 	api.POST("/users/show", usersHandler.Show)
+	// upstream search.ts:15-16 は requireCredential:false + requiredRolePolicy:
+	// canSearchUsers。canSearchUsers の base default は true なので匿名も検索でき、
+	// false の role のみ 403 になる。RequireAuth(401) は付けない (#1784)。
 	api.POST("/users/search", usersHandler.Search,
-		middleware.RequireAuth(),
-		middleware.RequireRolePolicy(roleService, corerole.PolicyCanSearchUsers))
+		middleware.RequireRolePolicyPublic(roleService, corerole.PolicyCanSearchUsers))
 	api.POST("/users/notes", usersHandler.Notes)
 	api.POST("/users/followers", usersHandler.Followers)
 	api.POST("/users/following", usersHandler.Following)


### PR DESCRIPTION
## Summary

#1766 から分離した **users/*** の LOW 2 件 (#1784) を解消する。

## 主な変更点

- **[LOW] users/{clips,pages,flashs} owner-public-only**: owner 視点でも公開分のみ返すよう揃える (upstream `clips.ts:54` isPublic / `flashs.ts:54`・`pages.ts:54` visibility='public'、viewer 不問)。これまで `isSelf` のとき `ListByUser` で非公開も返していた。owner の非公開は i/clips・i/pages 等で取得する設計。Clips の notesCount は owner 閲覧時のみ出すため `isSelf` は `ClipExtras.ShowNotesCount` で引き続き使用。
- **[LOW] users/search 匿名許可**: upstream は `requireCredential:false` + `requiredRolePolicy:canSearchUsers`。`canSearchUsers` の base default は true なので匿名も検索でき、false の role のみ 403。新 middleware `RequireRolePolicyPublic` (匿名は base policy で評価、401 は返さない) を追加し route の `RequireAuth` を外す。

## テスト

- clips owner が公開のみ取得、`RequireRolePolicyPublic` の匿名許可 / 拒否(403) / 認証済 / nil-checker を追加。
- coverage: api/users 90.6% / server/middleware 96.7%。

Closes #1784

🤖 Generated with [Claude Code](https://claude.com/claude-code)