### PR TITLE
Fix i parity (再監査 follow-up): i/update の rel=me verifiedLinks 検証 (#1786)

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -89,6 +89,9 @@ type Handler struct {
 	// emailValidationClient は verifymail / truemail SaaS への outbound に
 	// 使う SSRF-safe HTTP client (#638)。nil ならデフォルトクライアント。
 	emailValidationClient *http.Client
+	// verifyLinkClient は i/update の rel=me link 検証で profile field の URL を
+	// fetch するための SSRF-safe HTTP client (#1786)。nil なら検証を skip。
+	verifyLinkClient *http.Client
 	// hardMutePublisher は i/update で hardMutedWords を変更したときに
 	// streaming connection に reload signal を流す (#791)。未配線時は
 	// publish skip = 旧挙動 (= reconnect で反映)。
@@ -170,6 +173,12 @@ func (h *Handler) SetProfileUpdateHook(hook ProfileUpdateHook) {
 // + forward proxy 経由の client を渡すこと。
 func (h *Handler) SetEmailValidationClient(c *http.Client) {
 	h.emailValidationClient = c
+}
+
+// SetVerifyLinkClient wires the SSRF-safe outbound HTTP client used by i/update
+// to verify rel=me profile-field backlinks (#1786). nil disables verification.
+func (h *Handler) SetVerifyLinkClient(c *http.Client) {
+	h.verifyLinkClient = c
 }
 
 // SetNoteFieldResolver wires the shared resolver that fills Files /
@@ -1486,6 +1495,25 @@ func (h *Handler) Update(c echo.Context) error {
 			return c.JSON(http.StatusBadRequest, apierr.Error("BANNER_NOT_AN_IMAGE", "The file specified as a banner is not an image.", "75aedb19-2afd-4e6d-87fc-67941256fa60"))
 		}
 		return apierr.JSONInternalError(c)
+	}
+
+	// upstream i/update.ts:532-593: verifiedLinks を一旦 [] にリセットし、profile
+	// fields の https URL それぞれについて rel=me backlink を非同期に検証して
+	// verifiedLinks に積み直す (#1786)。同期で [] に reset (応答も空で返す)、
+	// goroutine で再検証して書き込む。fire-and-forget は upstream と同様。
+	if h.verifyLinkClient != nil && me.Username != "" && h.serverURL != "" {
+		if err := h.userService.UpdateProfileFields(me.ID, map[string]any{"verifiedLinks": pq.StringArray{}}); err == nil && bundle.Profile != nil {
+			bundle.Profile.VerifiedLinks = nil
+		}
+		myLink := strings.TrimRight(h.serverURL, "/") + "/@" + me.Username
+		if urls := httpsFieldValues(bundle.Profile); len(urls) > 0 {
+			uid := me.ID
+			go func() {
+				if verified := verifyLinks(h.verifyLinkClient, myLink, urls); len(verified) > 0 {
+					_ = h.userService.UpdateProfileFields(uid, map[string]any{"verifiedLinks": pq.StringArray(verified)})
+				}
+			}()
+		}
 	}
 
 	// hardMutedWords が変更された場合は streaming connection に reload signal

--- a/internal/api/i/verifylink.go
+++ b/internal/api/i/verifylink.go
@@ -1,0 +1,121 @@
+package i
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"golang.org/x/net/html"
+)
+
+// httpsFieldValues extracts the https:// field values from a user profile's
+// `fields` JSON ([{name,value}]). Used to pick the candidate links to verify
+// (upstream filters `fields.filter(x => x.value.startsWith('https://'))`、#1786)。
+func httpsFieldValues(profile *model.UserProfile) []string {
+	if profile == nil || len(profile.Fields) == 0 {
+		return nil
+	}
+	var fields []struct {
+		Value string `json:"value"`
+	}
+	if err := json.Unmarshal(profile.Fields, &fields); err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if strings.HasPrefix(f.Value, "https://") {
+			out = append(out, f.Value)
+		}
+	}
+	return out
+}
+
+// maxVerifyLinkBytes caps how much of a remote page we parse for rel=me
+// verification, guarding against unbounded responses.
+const maxVerifyLinkBytes = 1 << 20 // 1 MiB
+
+// verifyRelMe fetches pageURL and reports whether it links back to myLink,
+// mirroring upstream i/update.ts verifyLink: a match is any `<a href=myLink>`
+// (rel ignored) or any `<a>`/`<link>` whose rel attribute contains the token
+// "me" and whose href equals myLink. The supplied client must be SSRF-safe
+// (the caller passes the server's guarded outbound client); redirects to
+// private addresses are rejected at dial time by that transport. Any
+// error / non-200 yields false (#1786).
+func verifyRelMe(client *http.Client, pageURL, myLink string) bool {
+	if client == nil || pageURL == "" || myLink == "" {
+		return false
+	}
+	req, err := http.NewRequest(http.MethodGet, pageURL, nil)
+	if err != nil {
+		return false
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+	doc, err := html.Parse(io.LimitReader(resp.Body, maxVerifyLinkBytes))
+	if err != nil {
+		return false
+	}
+	return htmlLinksBackTo(doc, myLink)
+}
+
+// htmlLinksBackTo walks the parsed document for a back-link to myLink.
+func htmlLinksBackTo(doc *html.Node, myLink string) bool {
+	found := false
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if found {
+			return
+		}
+		if n.Type == html.ElementNode && (n.Data == "a" || n.Data == "link") {
+			var href, rel string
+			for _, attr := range n.Attr {
+				switch attr.Key {
+				case "href":
+					href = attr.Val
+				case "rel":
+					rel = attr.Val
+				}
+			}
+			if href == myLink {
+				// upstream includesMyLink: 任意の <a href=myLink> (rel 不問)。
+				if n.Data == "a" {
+					found = true
+					return
+				}
+				// upstream includesRelMeLinks: <link> は rel に "me" を含むとき。
+				for _, token := range strings.Fields(rel) {
+					if token == "me" {
+						found = true
+						return
+					}
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+	return found
+}
+
+// verifyLinks returns the subset of urls that link back to myLink, checked
+// sequentially. Used to recompute user_profile.verifiedLinks after a profile
+// update (#1786).
+func verifyLinks(client *http.Client, myLink string, urls []string) []string {
+	verified := make([]string, 0, len(urls))
+	for _, u := range urls {
+		if verifyRelMe(client, u, myLink) {
+			verified = append(verified, u)
+		}
+	}
+	return verified
+}

--- a/internal/api/i/verifylink_test.go
+++ b/internal/api/i/verifylink_test.go
@@ -1,0 +1,85 @@
+package i
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/datatypes"
+)
+
+const testMyLink = "https://example.com/@alice"
+
+// serveHTML returns a test server responding with the given HTML body.
+func serveHTML(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestVerifyRelMe_AnchorHref(t *testing.T) {
+	// `<a href=myLink>` は rel 不問で backlink とみなす (upstream includesMyLink)。
+	srv := serveHTML(t, `<html><body><a href="`+testMyLink+`">me</a></body></html>`)
+	assert.True(t, verifyRelMe(http.DefaultClient, srv.URL, testMyLink))
+}
+
+func TestVerifyRelMe_LinkRelMe(t *testing.T) {
+	srv := serveHTML(t, `<html><head><link rel="me" href="`+testMyLink+`"></head></html>`)
+	assert.True(t, verifyRelMe(http.DefaultClient, srv.URL, testMyLink))
+}
+
+func TestVerifyRelMe_AnchorRelMeMultiToken(t *testing.T) {
+	srv := serveHTML(t, `<html><body><a rel="noopener me" href="`+testMyLink+`">x</a></body></html>`)
+	assert.True(t, verifyRelMe(http.DefaultClient, srv.URL, testMyLink))
+}
+
+func TestVerifyRelMe_NoBacklink(t *testing.T) {
+	srv := serveHTML(t, `<html><body><a href="https://example.com/@bob">other</a></body></html>`)
+	assert.False(t, verifyRelMe(http.DefaultClient, srv.URL, testMyLink))
+}
+
+func TestVerifyRelMe_LinkWithoutRelMe(t *testing.T) {
+	// <link> は rel=me が無ければ href 一致でも backlink とみなさない。
+	srv := serveHTML(t, `<html><head><link rel="stylesheet" href="`+testMyLink+`"></head></html>`)
+	assert.False(t, verifyRelMe(http.DefaultClient, srv.URL, testMyLink))
+}
+
+func TestVerifyRelMe_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	assert.False(t, verifyRelMe(http.DefaultClient, srv.URL, testMyLink))
+}
+
+func TestVerifyRelMe_Guards(t *testing.T) {
+	assert.False(t, verifyRelMe(nil, "https://x", testMyLink))
+	assert.False(t, verifyRelMe(http.DefaultClient, "", testMyLink))
+	assert.False(t, verifyRelMe(http.DefaultClient, "https://x", ""))
+}
+
+func TestVerifyLinks_FiltersVerified(t *testing.T) {
+	good := serveHTML(t, `<a rel="me" href="`+testMyLink+`">me</a>`)
+	bad := serveHTML(t, `<a href="https://example.com/@bob">x</a>`)
+	out := verifyLinks(http.DefaultClient, testMyLink, []string{good.URL, bad.URL})
+	assert.Equal(t, []string{good.URL}, out)
+}
+
+func TestHTTPSFieldValues(t *testing.T) {
+	p := &model.UserProfile{Fields: datatypes.JSON(`[
+		{"name":"site","value":"https://a.example"},
+		{"name":"plain","value":"not a url"},
+		{"name":"http","value":"http://insecure.example"},
+		{"name":"site2","value":"https://b.example"}
+	]`)}
+	assert.Equal(t, []string{"https://a.example", "https://b.example"}, httpsFieldValues(p))
+
+	assert.Nil(t, httpsFieldValues(nil))
+	assert.Nil(t, httpsFieldValues(&model.UserProfile{}))
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1418,6 +1418,7 @@ func (s *Server) setupRoutes() {
 	// i/update-email の verifymail / truemail SaaS 呼び出しも SSRF-safe
 	// transport + forward proxy 経由にする (#638)。
 	iHandler.SetEmailValidationClient(s.outboundClient(10 * time.Second))
+	iHandler.SetVerifyLinkClient(s.outboundClient(10 * time.Second)) // #1786: rel=me link 検証
 	// SMTP メール送信を i/update-email 用に注入する。meta の SMTP 設定に従い、
 	// SenderFromMeta が closure 内で per-call 再 Fetch するため admin UI の
 	// 設定変更は即座に反映される (#1112)。smtpSecure 反映は #1111。


### PR DESCRIPTION
## Summary

#1767 から分離した MEDIUM (#1786)。i/update で profile field の rel=me backlink を検証して `verifiedLinks` を維持する (これまで未実装で常に空のままだった)。

## 主な変更点

- **`verifylink.go`**: `verifyRelMe` — URL を fetch し HTML を parse、`<a href=myLink>` または rel に `me` を含む `<a>`/`<link>` で href=myLink を backlink とみなす (upstream `i/update.ts` verifyLink 相当)。fetch は呼び出し側が渡す **SSRF-safe client** 経由で、private IP への redirect は transport が dial 時に拒否。応答は **1 MiB** で打ち切る。
- **i/update**: 更新成功後に `verifiedLinks` を同期で `[]` に reset (応答も空で返す)、goroutine で profile fields の `https://` URL を順次検証して `verifiedLinks` に積み直す (fire-and-forget、upstream と同様)。myLink は `serverURL + "/@" + username`。
- **router**: SSRF-safe outbound client (`s.outboundClient(10s)`) を `SetVerifyLinkClient` で配線。

repository interface は変えず既存 `UpdateProfileFields` で書き込むため mock への波及なし。

## テスト

- `verifyRelMe` (a href / link rel=me / 複数 rel token / 非backlink / rel=me 無し link / 非200 / guard)、`verifyLinks` の filter、`httpsFieldValues` を httptest で追加。
- coverage: api/i 90.1%。

## セキュリティ

- 外部 URL fetch は既存の SSRF-safe transport (`allowedPrivateNetworks` 尊重) を再利用。新規 SSRF ロジックは書いていない。応答サイズ上限 + client timeout (10s) あり。

Closes #1786

🤖 Generated with [Claude Code](https://claude.com/claude-code)