### PR TITLE
Fix channels parity (再監査 follow-up): channels/timeline で muted-channel renote を除外 (#1790)

### DIFF
--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -507,6 +507,20 @@ func (h *Handler) Timeline(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
+	// upstream channels/timeline.ts: viewer の muted channel を renote/quote した
+	// note を除外する (renoteChannelId NOT IN mutedChannels)。当該 channel 自身は
+	// muted set から除く (ignoreAuthorChannelFromMute、#1790)。
+	if viewer != nil && h.mutingRepo != nil {
+		if muts, err := h.mutingRepo.ListByUser(viewer.ID); err == nil {
+			mutedChannelIDs := make([]string, 0, len(muts))
+			for _, m := range muts {
+				if m.ChannelID != req.ChannelID {
+					mutedChannelIDs = append(mutedChannelIDs, m.ChannelID)
+				}
+			}
+			notes = notesfilter.ApplyRenoteChannelMute(notes, mutedChannelIDs)
+		}
+	}
 	notes = notesfilter.ApplyHardMute(h.userRepo, viewer, notes)
 	entities := entity.PackNotes(c.Request().Context(), notes, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldRes.Apply(entities, viewer)

--- a/internal/api/channels/handler_test.go
+++ b/internal/api/channels/handler_test.go
@@ -820,6 +820,32 @@ func TestTimeline_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// #1790: viewer が muted にしている channel を renote/quote した note は channel TL
+// から除外する (当該 channel 自身は muted set から除く)。
+func TestTimeline_ExcludesMutedChannelRenote(t *testing.T) {
+	h, repo, _, noteRepo := newHandler(t)
+	mutRepo := testutil.NewMockChannelMutingRepository()
+	h.SetMutingRepo(mutRepo)
+	repo.Channels["c1"] = &model.Channel{ID: "c1"}
+	cid := "c1"
+	mutedCh := "c_muted"
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", ChannelID: &cid, UserID: "u1", Visibility: model.NoteVisibilityPublic}
+	noteRepo.Notes["n2"] = &model.Note{ID: "n2", ChannelID: &cid, UserID: "u1", Visibility: model.NoteVisibilityPublic, RenoteChannelID: &mutedCh}
+	require.NoError(t, mutRepo.Create(&model.ChannelMuting{ID: "m1", UserID: "alice", ChannelID: mutedCh}))
+
+	c, rec := newReq(t, `{"channelId":"c1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Timeline(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	ids := make([]string, 0, len(out))
+	for _, n := range out {
+		ids = append(ids, n["id"].(string))
+	}
+	assert.ElementsMatch(t, []string{"n1"}, ids, "muted channel を renote した n2 は除外")
+}
+
 func TestTimeline_BadJSON(t *testing.T) {
 	h, _, _, _ := newHandler(t)
 	c, rec := newReq(t, `{not`)

--- a/internal/core/notesfilter/renotechannelmute.go
+++ b/internal/core/notesfilter/renotechannelmute.go
@@ -1,0 +1,25 @@
+package notesfilter
+
+import "github.com/shiroha-a/mk/internal/model"
+
+// ApplyRenoteChannelMute drops notes that renote/quote a note posted to one of
+// the viewer's muted channels, mirroring upstream channels/timeline.ts which
+// ANDs `renoteChannelId IS NULL OR renoteChannelId NOT IN (mutedChannelIds)`
+// (ignoreAuthorChannelFromMute keeps the current channel out of the muted set).
+// The caller must exclude the current channel from mutedChannelIDs (#1790)。
+func ApplyRenoteChannelMute(notes []*model.Note, mutedChannelIDs []string) []*model.Note {
+	if len(mutedChannelIDs) == 0 {
+		return notes
+	}
+	muted := toSet(mutedChannelIDs)
+	out := make([]*model.Note, 0, len(notes))
+	for _, n := range notes {
+		if n.RenoteChannelID != nil {
+			if _, ok := muted[*n.RenoteChannelID]; ok {
+				continue
+			}
+		}
+		out = append(out, n)
+	}
+	return out
+}

--- a/internal/core/notesfilter/renotechannelmute_test.go
+++ b/internal/core/notesfilter/renotechannelmute_test.go
@@ -1,0 +1,30 @@
+package notesfilter
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyRenoteChannelMute(t *testing.T) {
+	mutedCh := "ch_muted"
+	otherCh := "ch_other"
+	notes := []*model.Note{
+		{ID: "n1"},                            // 非renote
+		{ID: "n2", RenoteChannelID: &otherCh}, // 別 channel の renote (保持)
+		{ID: "n3", RenoteChannelID: &mutedCh}, // muted channel の renote (除外)
+	}
+	out := ApplyRenoteChannelMute(notes, []string{mutedCh})
+	ids := make([]string, 0, len(out))
+	for _, n := range out {
+		ids = append(ids, n.ID)
+	}
+	assert.Equal(t, []string{"n1", "n2"}, ids)
+}
+
+func TestApplyRenoteChannelMute_EmptyMutedIsNoop(t *testing.T) {
+	ch := "ch1"
+	notes := []*model.Note{{ID: "n1", RenoteChannelID: &ch}}
+	assert.Len(t, ApplyRenoteChannelMute(notes, nil), 1)
+}


### PR DESCRIPTION
## Summary

#1770 から分離した LOW (#1790)。channel timeline が viewer の muted channel を renote/quote した note を除外していなかった (upstream `channels/timeline.ts` は `renoteChannelId NOT IN mutedChannels` を AND)。

## 主な変更点

- `notesfilter.ApplyRenoteChannelMute` を新設 (`RenoteChannelID` が muted set に含まれる note を drop)。
- channels handler Timeline で viewer の muted channel (`mutingRepo.ListByUser`) から当該 channel を除いた set を作り、`svc.Timeline` の結果に post-fetch で適用 (他 note list endpoint と同じ post-fetch filter 方式)。`ignoreAuthorChannelFromMute` 相当として当該 channel 自身は muted set から除外。

## テスト

- `ApplyRenoteChannelMute` (muted renote 除外 / 別channel保持 / 空no-op)、Timeline handler で muted channel renote が除外されることを追加。
- coverage: api/channels 93.3% / core/notesfilter 98.5%。

Closes #1790

🤖 Generated with [Claude Code](https://claude.com/claude-code)