### PR TITLE
Fix chat parity (再監査): create 系 NO_SUCH_ROOM/USER + rooms/mute param + members createdAt + NO_SUCH_ROOM id (#1771)

### DIFF
--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -592,12 +592,13 @@ func (h *Handler) RoomsShow(c echo.Context) error {
 	}
 	room, err := h.repo.FindRoomByID(req.RoomID)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "6ab4d7df-5043-57b9-bd5d-ff9908288473"))
+		// upstream chat/rooms/show.ts:30 の noSuchRoom id に揃える (#1771)。
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "857ae02f-8759-4d20-9adb-6e95fffe4fd7"))
 	}
 	if h.svc != nil {
 		ok, err := h.svc.HasPermissionToViewRoomInfo(user.ID, room)
 		if err != nil || !ok {
-			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "6ab4d7df-5043-57b9-bd5d-ff9908288473"))
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "857ae02f-8759-4d20-9adb-6e95fffe4fd7"))
 		}
 	}
 	return c.JSON(http.StatusOK, h.packRoomDetailed(room, user.ID))
@@ -621,7 +622,8 @@ func (h *Handler) RoomsUpdate(c echo.Context) error {
 	}
 	room, err := h.repo.FindRoomByID(req.RoomID)
 	if err != nil || room.OwnerID != user.ID {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "6ab4d7df-5043-57b9-bd5d-ff9908288473"))
+		// upstream chat/rooms/update.ts:30 の noSuchRoom id に揃える (#1771)。
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "fcdb0f92-bda6-47f9-bd05-343e0e020932"))
 	}
 	if req.Name != "" {
 		room.Name = req.Name
@@ -729,15 +731,19 @@ func (h *Handler) RoomsMute(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req struct {
 		RoomID string `json:"roomId"`
+		// upstream mute.ts:28-34 は mute:boolean を required で受け、isMuted=mute に
+		// する (mute:false で unmute)。以前は param を無視して常に mute していた (#1771)。
+		Mute bool `json:"mute"`
 	}
 	if err := c.Bind(&req); err != nil || req.RoomID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "roomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	m, err := h.repo.FindMembership(user.ID, req.RoomID)
 	if err != nil {
-		return c.NoContent(http.StatusNoContent)
+		// upstream mute.ts は membership 不在で noSuchRoom を返す (以前は 204)。
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "c2cde4eb-8d0f-42f1-8f2f-c4d6bfc8e5df"))
 	}
-	m.IsMuted = true
+	m.IsMuted = req.Mute
 	_ = h.repo.UpdateMembership(m)
 	return c.NoContent(http.StatusNoContent)
 }
@@ -806,6 +812,15 @@ func (h *Handler) MessagesCreate(c echo.Context) error {
 	if !toRoom && !toUser {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "toUserId or toRoomId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
+	// upstream create-to-room.ts:77-91 は file/content 検証より先に room 存在を
+	// 確認し、無ければ noSuchRoom を返す。mk-go は単一 handler なので room path で
+	// 先に room を解決する (以前は service の ErrNotFound が NO_SUCH_MESSAGE に
+	// マップされ、検証順も逆だった、#1771)。
+	if toRoom && h.repo != nil {
+		if _, err := h.repo.FindRoomByID(*req.ToRoomID); err != nil {
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ROOM", "No such room.", "8098520d-2da5-4e8f-8ee1-df78b55a4ec6"))
+		}
+	}
 	// create-to-user / create-to-room で CONTENT_REQUIRED / NO_SUCH_FILE の id が
 	// 異なる (golden_error_ids.json)。
 	contentRequiredID := "25587321-b0e6-449c-9239-f8925092942c"
@@ -853,6 +868,14 @@ func (h *Handler) MessagesCreate(c echo.Context) error {
 		// RECIPIENT_IS_YOURSELF: 自分宛 DM は upstream で recipientIsYourself。
 		if *req.ToUserID == user.ID {
 			return c.JSON(http.StatusBadRequest, apierr.Error("RECIPIENT_IS_YOURSELF", "Cannot send a message to yourself.", "17e2ba79-e22a-4cbc-bf91-d327643f4a7e"))
+		}
+		// upstream create-to-user.ts:112-115 は getUser(toUserId) で recipient を
+		// 解決し、不在なら NO_SUCH_USER を返す (以前は不在 user にも message を作って
+		// いた、#1771)。user-timeline と同じ status/code/id に揃える。
+		if h.userRepo != nil {
+			if _, ferr := h.userRepo.FindByID(*req.ToUserID); ferr != nil {
+				return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "11795c64-40ea-4198-b06e-3c873ed9039d"))
+			}
 		}
 		msg, err = h.svc.CreateMessageToUser(c.Request().Context(), user.ID, *req.ToUserID, text, fileID)
 	}
@@ -1534,7 +1557,14 @@ func (h *Handler) RoomsMembers(c echo.Context) error {
 	}
 	out := make([]map[string]any, 0, len(members))
 	for _, m := range members {
-		entry := map[string]any{"id": m.ID, "userId": m.UserID, "roomId": m.RoomID, "isMuted": m.IsMuted}
+		// upstream packRoomMembership は {id, createdAt, userId, roomId, user}。
+		// createdAt は required (id=aidx 由来)、isMuted は schema に無いので出さない (#1771)。
+		entry := map[string]any{"id": m.ID, "userId": m.UserID, "roomId": m.RoomID}
+		if h.idGen != nil {
+			if t, err := h.idGen.ParseTime(m.ID); err == nil {
+				entry["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
+			}
+		}
 		if m.User != nil {
 			entry["user"] = packUser(m.User)
 		}

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -119,6 +119,8 @@ func TestRoomsShow_NotFound(t *testing.T) {
 	h, _ := newTestHandler()
 	rec := post(h.RoomsShow, `{"roomId":"ghost"}`, u1)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+	// #1771: upstream show.ts の noSuchRoom id に揃える。
+	assertErrorCode(t, rec, "NO_SUCH_ROOM", "857ae02f-8759-4d20-9adb-6e95fffe4fd7")
 }
 
 // upstream 2026.5.4 hasPermissionToViewRoomInfo gate: 他人の room に対する
@@ -172,6 +174,8 @@ func TestRoomsUpdate_NotOwner(t *testing.T) {
 	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: "other"}
 	rec := post(h.RoomsUpdate, `{"roomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+	// #1771: upstream update.ts の noSuchRoom id に揃える。
+	assertErrorCode(t, rec, "NO_SUCH_ROOM", "fcdb0f92-bda6-47f9-bd05-343e0e020932")
 }
 
 func TestRoomsUpdate_InvalidParam(t *testing.T) {
@@ -278,17 +282,25 @@ func TestRoomsLeave_InvalidParam(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// #1771: mute は mute:boolean param に従う (mute:true で mute、mute:false で unmute)。
 func TestRoomsMute(t *testing.T) {
 	h, repo := newTestHandler()
 	repo.Memberships["u1:r1"] = &model.ChatRoomMembership{UserID: "u1", RoomID: "r1"}
-	rec := post(h.RoomsMute, `{"roomId":"r1"}`, u1)
+	rec := post(h.RoomsMute, `{"roomId":"r1","mute":true}`, u1)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.True(t, repo.Memberships["u1:r1"].IsMuted)
+
+	rec = post(h.RoomsMute, `{"roomId":"r1","mute":false}`, u1)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.False(t, repo.Memberships["u1:r1"].IsMuted, "mute:false で unmute される")
 }
 
+// #1771: membership 不在は 204 でなく NO_SUCH_ROOM。
 func TestRoomsMute_NoMembership(t *testing.T) {
 	h, _ := newTestHandler()
-	rec := post(h.RoomsMute, `{"roomId":"r1"}`, u1)
-	assert.Equal(t, http.StatusNoContent, rec.Code)
+	rec := post(h.RoomsMute, `{"roomId":"r1","mute":true}`, u1)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assertErrorCode(t, rec, "NO_SUCH_ROOM", "c2cde4eb-8d0f-42f1-8f2f-c4d6bfc8e5df")
 }
 
 func TestRoomsMute_InvalidParam(t *testing.T) {
@@ -583,10 +595,21 @@ func TestMessagesCreate_Service_NoTarget(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// #1771: create-to-room は room 不在で NO_SUCH_ROOM (NO_SUCH_MESSAGE ではない)。
 func TestMessagesCreate_Service_RoomNotFound(t *testing.T) {
 	h, _ := newHandlerWithService(t)
 	rec := post(h.MessagesCreate, `{"text":"hi","toRoomId":"ghost"}`, u1)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assertErrorCode(t, rec, "NO_SUCH_ROOM", "8098520d-2da5-4e8f-8ee1-df78b55a4ec6")
+}
+
+// #1771: create-to-user は recipient 不在で NO_SUCH_USER を返す (userRepo 配線時)。
+func TestMessagesCreate_ToUser_NoSuchUser(t *testing.T) {
+	h, _ := newHandlerWithService(t)
+	h.SetUserRepo(testutil.NewMockUserRepository()) // recipient を seed しない
+	rec := post(h.MessagesCreate, `{"text":"hi","toUserId":"ghost"}`, u1)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assertErrorCode(t, rec, "NO_SUCH_USER", "11795c64-40ea-4198-b06e-3c873ed9039d")
 }
 
 func TestMessagesCreate_Service_RoomForbidden(t *testing.T) {
@@ -1639,6 +1662,24 @@ func TestRoomsMembers_OwnerAllowed(t *testing.T) {
 	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u1.ID}
 	rec := post(h.RoomsMembers, `{"roomId":"r1"}`, u1)
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// #1771: rooms/members の entry は createdAt を含み (required)、schema に無い
+// isMuted は出さない。
+func TestRoomsMembers_EntryShape(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", OwnerID: u1.ID}
+	idGen, _ := id.NewGenerator("aidx")
+	mid := idGen.Generate(time.Now())
+	repo.Memberships["u2:r1"] = &model.ChatRoomMembership{ID: mid, UserID: u2.ID, RoomID: "r1", IsMuted: true, User: u2}
+	rec := post(h.RoomsMembers, `{"roomId":"r1"}`, u1)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	assert.NotEmpty(t, out[0]["createdAt"], "createdAt は required")
+	_, hasMuted := out[0]["isMuted"]
+	assert.False(t, hasMuted, "isMuted は ChatRoomMembership schema に無いので出さない")
 }
 
 func TestMembersUpdateMembership_Auth(t *testing.T) {


### PR DESCRIPTION
## Summary

再監査 (#1771) の **chat/*** 領域 MEDIUM 6 件を解消する。

## 主な変更点

- **[MEDIUM] create-to-room**: file/content 検証より先に room 存在を確認し、無ければ `NO_SUCH_ROOM` (`8098520d`)。以前は service の ErrNotFound が `NO_SUCH_MESSAGE` にマップされ検証順も逆だった。
- **[MEDIUM] create-to-user**: recipient 不在で `NO_SUCH_USER` (`11795c64`) を返す (userRepo 配線時)。以前は存在しない user 宛ての message を作っていた。
- **[MEDIUM] rooms/members**: entry に required な `createdAt` (id 由来) を追加し、schema に無い `isMuted` を除去 (upstream `packRoomMembership` に整合)。
- **[MEDIUM] rooms/mute**: required な `mute:boolean` param に従う (`mute:false` で unmute)。membership 不在は 204 でなく `NO_SUCH_ROOM` (`c2cde4eb`)。以前は param 無視で常に mute。
- **[MEDIUM] rooms/show**: `NO_SUCH_ROOM` id を upstream の `857ae02f` に修正 (旧: 共有の誤り id `6ab4d7df`)。
- **[MEDIUM] rooms/update**: `NO_SUCH_ROOM` id を upstream の `fcdb0f92` に修正。

## スコープ (follow-up / 据え置き)

- **follow-up #1796 に分離**: `chatAvailability` role-policy gate (全 chat endpoint 横断の read/write gate + recipient policy 検査)。cross-cutting な policy subsystem のため別 PR。
- **据え置き** (意図的): ChatMessage `reactions[].user` が 1on1 message で欠落 — in-code で意図的 (room reactor 表示優先、1on1 reactor は自明) と記録済みの LOW。

## テスト

- create-to-room NO_SUCH_ROOM / create-to-user NO_SUCH_USER、rooms/mute の mute param 反映 + 不在時 NO_SUCH_ROOM、rooms/members の createdAt 有り isMuted 無し、rooms/show・update の id を追加・更新。
- coverage: api/chat 95.1%。

Refs #1771

🤖 Generated with [Claude Code](https://claude.com/claude-code)