### PR TITLE
Fix reversi/bubble-game parity (再監査): ranking GET + ReversiGame startedAt/endedAt ISO + match multiple dedup (#1774)

### DIFF
--- a/internal/api/bubblegame/handler.go
+++ b/internal/api/bubblegame/handler.go
@@ -75,16 +75,26 @@ func (h *Handler) Register(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
-// Ranking handles POST /api/bubble-game/ranking.
+// Ranking handles GET/POST /api/bubble-game/ranking. upstream ranking.ts は
+// allowGet:true で、frontend drop-and-fusion.vue は misskeyApiGet (GET +
+// query string) で gameMode を投げる。Echo の Bind は GET だと query を
+// `query` タグでしか拾わないため、fetch-rss と同様に QueryParam を先に読み、
+// 無ければ JSON body に fallback する (#1774)。
 func (h *Handler) Ranking(c echo.Context) error {
-	var req struct {
-		GameMode string `json:"gameMode"`
+	gameMode := c.QueryParam("gameMode")
+	if gameMode == "" {
+		var req struct {
+			GameMode string `json:"gameMode"`
+		}
+		// Bind 失敗は無視 (空 gameMode のまま下の guard で 400 を返す)。
+		_ = c.Bind(&req)
+		gameMode = req.GameMode
 	}
-	if err := c.Bind(&req); err != nil || req.GameMode == "" {
+	if gameMode == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "gameMode is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 
-	records, err := h.repo.Ranking(req.GameMode, 10)
+	records, err := h.repo.Ranking(gameMode, 10)
 	if err != nil {
 		return c.JSON(http.StatusOK, []any{})
 	}

--- a/internal/api/bubblegame/handler_test.go
+++ b/internal/api/bubblegame/handler_test.go
@@ -153,6 +153,38 @@ func TestRanking_Empty(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// getRanking issues a GET request with gameMode in the query string, mirroring
+// the frontend's misskeyApiGet call (#1774)。
+func getRanking(handler func(echo.Context) error, query string) *httptest.ResponseRecorder {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/?"+query, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	_ = handler(c)
+	return rec
+}
+
+// #1774: ranking は allowGet。frontend は GET + ?gameMode= で叩くため、query から
+// gameMode を読めること (JSON body 無しでも 400 にならないこと) を保証する。
+func TestRanking_GetWithQueryParam(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.records = []*model.BubbleGameRecord{
+		{ID: "r1", Score: 200, User: &model.User{ID: "u1", Username: "alice"}},
+	}
+	rec := getRanking(h.Ranking, "gameMode=normal")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp []any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp, 1)
+}
+
+// GET で gameMode が無ければ POST 同様 400。
+func TestRanking_GetMissingGameMode(t *testing.T) {
+	h, _ := newTestHandler()
+	rec := getRanking(h.Ranking, "")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
 func TestRanking_InvalidParam(t *testing.T) {
 	h, _ := newTestHandler()
 	rec := post(h.Ranking, `{}`, nil)

--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -134,10 +134,15 @@ func packGame(g *model.ReversiGame, idGen id.Generator) map[string]any {
 		"loopedBoard":          g.LoopedBoard,
 		"map":                  g.Map,
 		"bw":                   g.BW,
-		"startedAt":            g.StartedAt,
-		"endedAt":              g.EndedAt,
-		"logs":                 g.Logs,
-		"crc32":                g.CRC32,
+		// startedAt / endedAt は upstream ReversiGameEntityService が toISOString()
+		// で常にミリ秒 3 桁固定の ISO8601 を返す。*time.Time を生で map に入れると
+		// encoding/json が RFC3339Nano (小数 0 秒は .000 無し、pg microsecond は 6 桁)
+		// で出力し createdAt 等の .000Z 正規化と不一致になるため明示フォーマットする
+		// (nil は null、#1774)。
+		"startedAt": isoOrNull(g.StartedAt),
+		"endedAt":   isoOrNull(g.EndedAt),
+		"logs":      g.Logs,
+		"crc32":     g.CRC32,
 	}
 	if t, err := idGen.ParseTime(g.ID); err == nil {
 		result["createdAt"] = t.UTC().Format("2006-01-02T15:04:05.000Z")
@@ -175,6 +180,16 @@ func jsonOrNull(j datatypes.JSON) any {
 		return nil
 	}
 	return json.RawMessage(j)
+}
+
+// isoOrNull renders an optional timestamp as the millisecond-fixed ISO8601
+// string used across mk-go packers (toISOString-compatible), or null when the
+// pointer is nil. Used for ReversiGame startedAt / endedAt (#1774)。
+func isoOrNull(t *time.Time) any {
+	if t == nil {
+		return nil
+	}
+	return t.UTC().Format("2006-01-02T15:04:05.000Z")
 }
 
 // 標準8x8盤面
@@ -327,8 +342,16 @@ func (h *Handler) Match(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req struct {
 		UserID string `json:"userId"`
+		// upstream match.ts paramDef の noIrregularRules / multiple (既定 false)。
+		// noIrregularRules は specific-match では upstream も matched() で false 固定
+		// (ReversiService.ts:125) で、any-match (mk-go は 204 stub) でしか効かないため
+		// ここでは accept するが live path では inert。multiple は下の outbound dedup を
+		// スキップするのに使う (#1774)。
+		NoIrregularRules bool `json:"noIrregularRules"`
+		Multiple         bool `json:"multiple"`
 	}
 	_ = c.Bind(&req)
+	_ = req.NoIrregularRules // accepted for paramDef parity; inert on specific-match
 
 	// acct 形式 (@user / @user@host) を local user id に解決する
 	if strings.HasPrefix(req.UserID, "@") && h.userRepo != nil {
@@ -367,6 +390,18 @@ func (h *Handler) Match(c echo.Context) error {
 	if existing := h.findPendingInvitationFrom(user.ID, req.UserID); existing != nil {
 		h.sendJoinForAcceptedInvite(c, user, existing)
 		return c.JSON(http.StatusOK, packGame(existing, h.idGen))
+	}
+
+	// upstream matchSpecificUser: multiple=false なら直近 3 分以内の未開始 pending
+	// game を再利用して二重招待を防ぐ (ReversiService.ts:99-112)。mk-go では招待が
+	// 実 game 行なので、自分発 (User1=me, User2=target) の未開始 game が 3 分以内に
+	// あればそれを返す (再 Invite はしない = upstream も返すだけ)。相手発の再利用は
+	// 上の inbound-accept (mk-go 独自の Join 送信) が既に担うのでここでは扱わない。
+	// multiple=true は upstream 同様このスキップで毎回新規作成する (#1774)。
+	if !req.Multiple {
+		if existing := h.findPendingInvitationFrom(req.UserID, user.ID); existing != nil && h.withinMatchDedupWindow(existing) {
+			return c.JSON(http.StatusOK, packGame(existing, h.idGen))
+		}
 	}
 
 	// target user を一度だけ引いて pre-check と deliver 両方で使い回す
@@ -443,6 +478,18 @@ func (h *Handler) Match(c echo.Context) error {
 // ために使う。corereversi.FindPendingInvitation に共有実装。
 func (h *Handler) findPendingInvitationFrom(viewerID, inviterID string) *model.ReversiGame {
 	return corereversi.FindPendingInvitation(h.repo, viewerID, inviterID)
+}
+
+// withinMatchDedupWindow reports whether a pending game was created recently
+// enough to be reused by the multiple=false dedup. Upstream gates the dedup on
+// a 3-minute window (ReversiService.ts:103) so stale invites fall through to a
+// fresh game/invite (#1774)。idGen.ParseTime 不能なら安全側で false。
+func (h *Handler) withinMatchDedupWindow(g *model.ReversiGame) bool {
+	t, err := h.idGen.ParseTime(g.ID)
+	if err != nil {
+		return false
+	}
+	return time.Since(t) < 3*time.Minute
 }
 
 // sendJoinForAcceptedInvite delivers a Join activity to the remote inviter so

--- a/internal/api/reversi/handler_test.go
+++ b/internal/api/reversi/handler_test.go
@@ -351,6 +351,46 @@ func TestMatch_CreateError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
+// TestMatch_MultipleDedup guards #1774: multiple=false reuses a recent (<3 min)
+// outbound pending game instead of creating a duplicate, while multiple=true and
+// stale games fall through to a fresh game (upstream matchSpecificUser の
+// 3 分 dedup を multiple で skip する挙動)。
+func TestMatch_MultipleDedup(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	seedPending := func(repo *mockReversiRepo, createdAt time.Time) string {
+		gid := idGen.Generate(createdAt)
+		repo.games[gid] = &model.ReversiGame{ID: gid, User1ID: "u1", User2ID: "u2"}
+		return gid
+	}
+
+	t.Run("multiple=false reuses recent pending outbound game", func(t *testing.T) {
+		h, repo := newTestHandler()
+		gid := seedPending(repo, time.Now())
+		rec := post(h.Match, `{"userId":"u2"}`, u1)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Len(t, repo.games, 1, "既存 pending game を再利用し新規作成しない")
+		var out map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+		assert.Equal(t, gid, out["id"])
+	})
+
+	t.Run("multiple=true skips dedup and creates a new game", func(t *testing.T) {
+		h, repo := newTestHandler()
+		seedPending(repo, time.Now())
+		rec := post(h.Match, `{"userId":"u2","multiple":true}`, u1)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Len(t, repo.games, 2, "multiple=true は dedup を skip して新規作成する")
+	})
+
+	t.Run("stale pending game (>3min) is not reused", func(t *testing.T) {
+		h, repo := newTestHandler()
+		seedPending(repo, time.Now().Add(-5*time.Minute))
+		rec := post(h.Match, `{"userId":"u2"}`, u1)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Len(t, repo.games, 2, "3 分超の古い pending game は再利用せず新規作成する")
+	})
+}
+
 // --- Match with acct (CherryPick extension) ---
 
 func TestMatch_AcctLocal(t *testing.T) {
@@ -939,6 +979,36 @@ func TestPackGame_FormFields(t *testing.T) {
 		form2, ok := decoded["form2"].([]any)
 		require.True(t, ok, "form2 must round-trip as the stored array")
 		require.Len(t, form2, 1)
+	})
+}
+
+// TestPackGame_TimestampFormat guards #1774: startedAt/endedAt are emitted as
+// millisecond-fixed ISO8601 (upstream ReversiGameEntityService の toISOString)
+// like createdAt, not Go's RFC3339Nano (where trailing-zero ms drop and pg
+// microseconds yield 6 digits). nil pointers serialize to null with the key
+// present.
+func TestPackGame_TimestampFormat(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	gid := idGen.Generate(timeRef())
+
+	t.Run("non-nil times render as .000Z millisecond ISO", func(t *testing.T) {
+		started := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)        // 0 fractional
+		ended := time.Date(2026, 6, 15, 12, 5, 30, 123456000, time.UTC) // 123456us
+		g := &model.ReversiGame{ID: gid, User1ID: "alice", User2ID: "bob", StartedAt: &started, EndedAt: &ended}
+		out := packGame(g, idGen)
+		assert.Equal(t, "2026-06-15T12:00:00.000Z", out["startedAt"])
+		assert.Equal(t, "2026-06-15T12:05:30.123Z", out["endedAt"])
+	})
+
+	t.Run("nil times serialize to null with key present", func(t *testing.T) {
+		g := &model.ReversiGame{ID: gid, User1ID: "alice", User2ID: "bob"}
+		out := packGame(g, idGen)
+		s, hasS := out["startedAt"]
+		e, hasE := out["endedAt"]
+		require.True(t, hasS, "startedAt key must always be present")
+		require.True(t, hasE, "endedAt key must always be present")
+		assert.Nil(t, s)
+		assert.Nil(t, e)
 	})
 }
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2484,7 +2484,11 @@ func (s *Server) setupRoutes() {
 	bubbleGameRepo := repository.NewBubbleGameRepository(s.db)
 	bubbleGameHandler := apibubblegame.NewHandler(bubbleGameRepo, idGen)
 	api.POST("/bubble-game/register", bubbleGameHandler.Register, middleware.RequireAuth(), middleware.RequireScope("write:account"))
+	// ranking は upstream ranking.ts が allowGet:true。frontend drop-and-fusion.vue は
+	// misskeyApiGet で GET を投げるため GET+POST を二重 wire する (hashtags/trend や
+	// fetch-rss と同様、#1774)。
 	api.POST("/bubble-game/ranking", bubbleGameHandler.Ranking)
+	api.GET("/bubble-game/ranking", bubbleGameHandler.Ranking)
 
 	// chat/* — Misskey v2026 チャット機能 (実データ)
 	chatHandler := apichat.NewHandler(chatRepo, idGen)


### PR DESCRIPTION
## Summary

再監査 (#1774) の **reversi/* + bubble-game/*** 領域 MEDIUM 2 + LOW 1 を解消する。

## 主な変更点

- **[MEDIUM] bubble-game/ranking GET 対応**: upstream `ranking.ts` は `allowGet:true`。frontend `drop-and-fusion.vue` は `misskeyApiGet` (GET + `?gameMode=`) で叩くため GET ルートを追加。併せて `Ranking` handler を GET 対応にする — Echo の `Bind` は GET だと query を `query` タグでしか拾わず `gameMode` が空のまま 400 になっていたため、`fetch-rss` と同様に `QueryParam` を先に読み JSON body へ fallback。
- **[MEDIUM] reversi packGame startedAt/endedAt ISO 正規化**: `*time.Time` 生から millisecond 固定 ISO8601 (`toISOString` 互換、nil は null) に正規化。Go 既定の RFC3339Nano (0 小数秒は `.000` 無し、pg microsecond は 6 桁) で createdAt 等の `.000Z` 正規化と不一致だった。show-game/match/verify/games に効く。
- **[LOW] reversi/match noIrregularRules/multiple**: 両パラメータを Bind。`multiple=false` のとき直近 3 分以内の自分発 pending game を再利用して二重招待を防ぐ (upstream `matchSpecificUser` の 3 分 dedup を `multiple` で skip する挙動)。`noIrregularRules` は specific-match では upstream も `false` 固定 (`matched()`) で any-match (mk-go は 204 stub) でしか効かないため accept するが live path では inert。

## レビュー (implement → review → fix → PR)

adversarial finder で **bubble-game GET の query 未読バグを検出** (GET ルートを張っただけでは handler が `gameMode` を query から読めず常に 400) → 修正済み。M2/M3 は correctness 問題なしを確認。mk-go reversi は cherrypick 連合系統 (実 game 行 invitation + AP Invite) で、inbound-accept を dedup より優先する mk-go 独自挙動は意図的維持。

## テスト

- ranking の GET (query `gameMode` 読取 / 欠落時 400)、packGame の startedAt/endedAt `.000Z` + nil null、match の `multiple` dedup (再利用 / `multiple=true` skip / 3 分超 stale は新規作成) を追加。
- coverage: api/bubblegame 100% / api/reversi 93.3%。build・`go vet`・gofmt クリーン。

Closes #1774

🤖 Generated with [Claude Code](https://claude.com/claude-code)