### PR TITLE
Fix blocking parity (#1802): blocking/create+delete に UserDetailedNotMe relation block を返す

### DIFF
--- a/internal/api/blocking/handler.go
+++ b/internal/api/blocking/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
+	"github.com/shiroha-a/mk/internal/api/userrelation"
 	coreblocking "github.com/shiroha-a/mk/internal/core/blocking"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -22,6 +23,7 @@ type Handler struct {
 	svc      *coreblocking.Service
 	userRepo repository.UserRepository
 	idGen    id.Generator
+	relation userrelation.Repos
 }
 
 // NewHandler creates a new blocking Handler.
@@ -29,6 +31,14 @@ type Handler struct {
 // `blockee` user object that the upstream Misskey frontend renders.
 func NewHandler(svc *coreblocking.Service, userRepo repository.UserRepository, idGen id.Generator) *Handler {
 	return &Handler{svc: svc, userRepo: userRepo, idGen: idGen}
+}
+
+// SetRelationRepos wires the repositories used to compute the viewer->blockee
+// relation block (isBlocking etc.) returned by create / delete (#1802). When
+// unset the relation flags are simply omitted (= legacy 204-ish behavior for
+// test fixtures).
+func (h *Handler) SetRelationRepos(r userrelation.Repos) {
+	h.relation = r
 }
 
 // PairRequest is the request body for blocking/create and blocking/delete.
@@ -60,7 +70,7 @@ func (h *Handler) Create(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
-	return h.respondPackedUser(c, req.UserID)
+	return h.respondPackedUser(c, user, req.UserID)
 }
 
 // Delete handles POST /api/blocking/delete.
@@ -82,15 +92,18 @@ func (h *Handler) Delete(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
-	return h.respondPackedUser(c, req.UserID)
+	return h.respondPackedUser(c, user, req.UserID)
 }
 
 // respondPackedUser fetches the target user + profile via userRepo and writes
-// a 200 + UserDetailed response. userRepo 未 wire (= 既存 test stub) なら
-// legacy 204 を返す互換 path に落ちる (production では router で必ず wire
-// されるので影響なし、#870)。lookup 失敗時も best-effort 204 にフォール
-// バックして block / unblock の副作用 (= state 反映) を尊重する。
-func (h *Handler) respondPackedUser(c echo.Context, userID string) error {
+// a 200 + UserDetailed response carrying the viewer->target relation block
+// (isBlocking etc.), matching upstream pack(blockee, blocker, UserDetailedNotMe)
+// (#1802). userRepo 未 wire (= 既存 test stub) なら legacy 204 を返す互換 path に
+// 落ちる (production では router で必ず wire されるので影響なし、#870)。lookup
+// 失敗時も best-effort 204 にフォールバックして block / unblock の副作用 (= state
+// 反映) を尊重する。relation block は h.relation 経由で viewer (= blocker) との関係を
+// 解決するため、block 後は isBlocking=true / unblock 後は isBlocking=false が乗る。
+func (h *Handler) respondPackedUser(c echo.Context, viewer *model.User, userID string) error {
 	if h.userRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
@@ -99,7 +112,11 @@ func (h *Handler) respondPackedUser(c echo.Context, userID string) error {
 		return c.NoContent(http.StatusNoContent)
 	}
 	profile, _ := h.userRepo.FindProfileByUserID(userID)
-	return c.JSON(http.StatusOK, entity.PackUserDetailed(target, profile, h.idGen))
+	detailed := entity.PackUserDetailed(target, profile, h.idGen)
+	if viewer != nil {
+		h.relation.Apply(&detailed, viewer.ID, target, profile)
+	}
+	return c.JSON(http.StatusOK, detailed)
 }
 
 // ListRequest is the request body for blocking/list.

--- a/internal/api/blocking/handler_test.go
+++ b/internal/api/blocking/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/userrelation"
 	coreblocking "github.com/shiroha-a/mk/internal/core/blocking"
 	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -55,6 +56,37 @@ func TestCreate_Success(t *testing.T) {
 	// upstream Misskey TS と同じ 200 + UserDetailed (= drop-in 互換、#870)。
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), `"id":"bob"`)
+}
+
+// #1802: create / delete のレスポンスに viewer→blockee の relation block が乗り、
+// block 後は isBlocking=true / unblock 後は isBlocking=false になる。
+func TestCreateDelete_ReturnsIsBlockingRelation(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	blockingRepo := testutil.NewMockBlockingRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := coreblocking.NewService(userRepo, blockingRepo, nil, idGen)
+	h := NewHandler(svc, userRepo, idGen)
+	// relation の Blocking は service と同一インスタンスを渡し、block 状態を反映させる。
+	h.SetRelationRepos(userrelation.Repos{Blocking: blockingRepo})
+	addUser(userRepo, "alice")
+	addUser(userRepo, "bob")
+
+	c, rec := newReq(t, `{"userId":"bob"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "bob", resp["id"])
+	assert.Equal(t, true, resp["isBlocking"], "block 後は isBlocking=true")
+	assert.Equal(t, false, resp["isBlocked"])
+
+	c, rec = newReq(t, `{"userId":"bob"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Delete(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["isBlocking"], "unblock 後は isBlocking=false")
 }
 
 func TestCreate_InvalidParam(t *testing.T) {

--- a/internal/api/userrelation/resolver.go
+++ b/internal/api/userrelation/resolver.go
@@ -1,0 +1,131 @@
+// Package userrelation computes the viewer->target relation block shared by
+// /api/users/show and /api/blocking/{create,delete}, mirroring upstream
+// UserEntityService's pack(target, me) relation fields (isFollowing, isFollowed,
+// isBlocking, isBlocked, isMuted, isRenoteMuted, hasPendingFollowRequest*,
+// notify, withReplies, followedMessage, memo). Centralizing the computation
+// keeps the two call sites from drifting (#1802).
+package userrelation
+
+import (
+	"sync"
+
+	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// Repos bundles the repositories needed to compute a viewer->target relation
+// block. Any nil repo skips its corresponding flags (= test fixtures / partial
+// wiring); production wires all of them so the full relation block is emitted.
+type Repos struct {
+	Following     repository.FollowingRepository
+	Blocking      repository.BlockingRepository
+	Muting        repository.MutingRepository
+	RenoteMuting  repository.RenoteMutingRepository
+	FollowRequest repository.FollowRequestRepository
+	Memo          repository.UserMemoRepository
+}
+
+// Apply computes the viewer->target relation flags and writes them onto
+// detailed, matching upstream UserEntityService relation block. It is a no-op
+// when detailed/target is nil, or when viewerID is empty (anonymous) or equals
+// target.ID (self view) — the same conditions under which upstream omits the
+// block. profile may be nil (followedMessage is then skipped). Returns whether
+// the viewer follows the target; callers gate follower/following count
+// visibility on it (#1558).
+//
+// 各リポジトリへのクエリは独立なので goroutine で並列実行し、全結果が揃ってから
+// detailed に反映する (元々 users/show にインラインだった実装を共有化、#1802)。
+func (r Repos) Apply(detailed *entity.UserDetailed, viewerID string, target *model.User, profile *model.UserProfile) bool {
+	if detailed == nil || target == nil || viewerID == "" || viewerID == target.ID {
+		return false
+	}
+
+	var (
+		isFollowing, isFollowed      bool
+		isBlocking, isBlocked        bool
+		isMuted, isRenoteMuted       bool
+		hasPendingFrom, hasPendingTo bool
+		followRec                    *model.Following
+		memo                         *model.UserMemo
+		wg                           sync.WaitGroup
+	)
+
+	if r.Following != nil {
+		wg.Add(3)
+		go func() { defer wg.Done(); isFollowing, _ = r.Following.Exists(viewerID, target.ID) }()
+		go func() { defer wg.Done(); isFollowed, _ = r.Following.Exists(target.ID, viewerID) }()
+		go func() { defer wg.Done(); followRec, _ = r.Following.FindByPair(viewerID, target.ID) }()
+	}
+	if r.Blocking != nil {
+		wg.Add(2)
+		go func() { defer wg.Done(); isBlocking, _ = r.Blocking.Exists(viewerID, target.ID) }()
+		go func() { defer wg.Done(); isBlocked, _ = r.Blocking.Exists(target.ID, viewerID) }()
+	}
+	if r.Muting != nil {
+		wg.Add(1)
+		go func() { defer wg.Done(); isMuted, _ = r.Muting.Exists(viewerID, target.ID) }()
+	}
+	if r.RenoteMuting != nil {
+		wg.Add(1)
+		go func() { defer wg.Done(); isRenoteMuted, _ = r.RenoteMuting.Exists(viewerID, target.ID) }()
+	}
+	if r.FollowRequest != nil {
+		wg.Add(2)
+		go func() { defer wg.Done(); hasPendingFrom, _ = r.FollowRequest.Exists(viewerID, target.ID) }()
+		go func() { defer wg.Done(); hasPendingTo, _ = r.FollowRequest.Exists(target.ID, viewerID) }()
+	}
+	if r.Memo != nil {
+		wg.Add(1)
+		go func() { defer wg.Done(); memo, _ = r.Memo.FindByPair(viewerID, target.ID) }()
+	}
+
+	wg.Wait()
+
+	viewerIsFollowing := false
+	if r.Following != nil {
+		detailed.IsFollowing = &isFollowing
+		detailed.IsFollowed = &isFollowed
+		viewerIsFollowing = isFollowing
+		// notify / withReplies は relation ブロックが存在する限り常に emit する。
+		// upstream は `notify: relation.following?.notify ?? 'none'` /
+		// `withReplies: relation.following?.withReplies ?? false` で、follow row が
+		// 無い / notify 未設定でも default を出す (#1558)。
+		none := "none"
+		withReplies := false
+		if followRec != nil {
+			if followRec.Notify != nil {
+				detailed.Notify = followRec.Notify
+			} else {
+				detailed.Notify = &none
+			}
+			withReplies = followRec.WithReplies
+		} else {
+			detailed.Notify = &none
+		}
+		detailed.WithReplies = &withReplies
+		// followedMessage は follower にだけ見せる (upstream relation ブロックの
+		// `relation.isFollowing ? profile.followedMessage : undefined`、#1558)。
+		if isFollowing && profile != nil {
+			detailed.FollowedMessage = profile.FollowedMessage
+		}
+	}
+	if r.Blocking != nil {
+		detailed.IsBlocking = &isBlocking
+		detailed.IsBlocked = &isBlocked
+	}
+	if r.Muting != nil {
+		detailed.IsMuted = &isMuted
+	}
+	if r.RenoteMuting != nil {
+		detailed.IsRenoteMuted = &isRenoteMuted
+	}
+	if r.FollowRequest != nil {
+		detailed.HasPendingFollowRequestFromYou = &hasPendingFrom
+		detailed.HasPendingFollowRequestToYou = &hasPendingTo
+	}
+	if r.Memo != nil && memo != nil {
+		detailed.Memo = &memo.Memo
+	}
+	return viewerIsFollowing
+}

--- a/internal/api/userrelation/resolver_test.go
+++ b/internal/api/userrelation/resolver_test.go
@@ -1,0 +1,146 @@
+package userrelation
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fullRepos wires every relation repo with the given (viewer, target) state and
+// returns a Repos plus the target user/profile.
+func fullRepos(t *testing.T) (Repos, *model.User, *model.UserProfile) {
+	t.Helper()
+	return Repos{
+		Following:     testutil.NewMockFollowingRepository(),
+		Blocking:      testutil.NewMockBlockingRepository(),
+		Muting:        testutil.NewMockMutingRepository(),
+		RenoteMuting:  testutil.NewMockRenoteMutingRepository(),
+		FollowRequest: testutil.NewMockFollowRequestRepository(),
+		Memo:          testutil.NewMockUserMemoRepository(),
+	}, &model.User{ID: "target"}, &model.UserProfile{UserID: "target"}
+}
+
+func TestApply_NoOpConditions(t *testing.T) {
+	r, target, profile := fullRepos(t)
+	d := entity.UserDetailed{}
+
+	// nil detailed
+	assert.False(t, r.Apply(nil, "viewer", target, profile))
+	// nil target
+	assert.False(t, r.Apply(&d, "viewer", nil, profile))
+	// empty viewerID (anonymous)
+	assert.False(t, r.Apply(&d, "", target, profile))
+	// self view
+	assert.False(t, r.Apply(&d, "target", target, profile))
+	// 何も書き込まれていないこと。
+	assert.Nil(t, d.IsFollowing)
+	assert.Nil(t, d.IsBlocking)
+}
+
+func TestApply_FullRelationBlock(t *testing.T) {
+	r, target, profile := fullRepos(t)
+	following := r.Following.(*testutil.MockFollowingRepository)
+	blocking := r.Blocking.(*testutil.MockBlockingRepository)
+	muting := r.Muting.(*testutil.MockMutingRepository)
+	renoteMuting := r.RenoteMuting.(*testutil.MockRenoteMutingRepository)
+	followReq := r.FollowRequest.(*testutil.MockFollowRequestRepository)
+	memo := r.Memo.(*testutil.MockUserMemoRepository)
+
+	// viewer follows target (notify=normal, withReplies=true), target blocks back,
+	// viewer mutes + renote-mutes target, mutual pending follow requests, memo.
+	notify := "normal"
+	require.NoError(t, following.Create(&model.Following{ID: "f1", FollowerID: "viewer", FolloweeID: "target", Notify: &notify, WithReplies: true}))
+	require.NoError(t, blocking.Create(&model.Blocking{ID: "b1", BlockerID: "target", BlockeeID: "viewer"}))
+	require.NoError(t, muting.Create(&model.Muting{ID: "m1", MuterID: "viewer", MuteeID: "target"}))
+	require.NoError(t, renoteMuting.Create(&model.RenoteMuting{ID: "rm1", MuterID: "viewer", MuteeID: "target"}))
+	require.NoError(t, followReq.Create(&model.FollowRequest{ID: "fr1", FollowerID: "viewer", FolloweeID: "target"}))
+	require.NoError(t, followReq.Create(&model.FollowRequest{ID: "fr2", FollowerID: "target", FolloweeID: "viewer"}))
+	require.NoError(t, memo.CreateOrUpdate(&model.UserMemo{ID: "memo1", UserID: "viewer", TargetUserID: "target", Memo: "a note"}))
+	msg := "thanks for following"
+	profile.FollowedMessage = &msg
+
+	d := entity.UserDetailed{}
+	got := r.Apply(&d, "viewer", target, profile)
+
+	assert.True(t, got, "Apply returns whether viewer follows target")
+	require.NotNil(t, d.IsFollowing)
+	assert.True(t, *d.IsFollowing)
+	require.NotNil(t, d.IsFollowed)
+	assert.False(t, *d.IsFollowed, "target does not follow viewer")
+	require.NotNil(t, d.Notify)
+	assert.Equal(t, "normal", *d.Notify)
+	require.NotNil(t, d.WithReplies)
+	assert.True(t, *d.WithReplies)
+	require.NotNil(t, d.FollowedMessage)
+	assert.Equal(t, "thanks for following", *d.FollowedMessage)
+	require.NotNil(t, d.IsBlocked)
+	assert.True(t, *d.IsBlocked, "target blocks viewer")
+	require.NotNil(t, d.IsBlocking)
+	assert.False(t, *d.IsBlocking)
+	require.NotNil(t, d.IsMuted)
+	assert.True(t, *d.IsMuted)
+	require.NotNil(t, d.IsRenoteMuted)
+	assert.True(t, *d.IsRenoteMuted)
+	require.NotNil(t, d.HasPendingFollowRequestFromYou)
+	assert.True(t, *d.HasPendingFollowRequestFromYou)
+	require.NotNil(t, d.HasPendingFollowRequestToYou)
+	assert.True(t, *d.HasPendingFollowRequestToYou)
+	require.NotNil(t, d.Memo)
+	assert.Equal(t, "a note", *d.Memo)
+}
+
+// 関係が無いときのデフォルト: notify='none' / withReplies=false / followedMessage 無し。
+func TestApply_NoRelationDefaults(t *testing.T) {
+	r, target, profile := fullRepos(t)
+	msg := "secret"
+	profile.FollowedMessage = &msg
+
+	d := entity.UserDetailed{}
+	got := r.Apply(&d, "viewer", target, profile)
+
+	assert.False(t, got)
+	require.NotNil(t, d.IsFollowing)
+	assert.False(t, *d.IsFollowing)
+	require.NotNil(t, d.Notify)
+	assert.Equal(t, "none", *d.Notify, "follow row が無くても notify は 'none' を出す")
+	require.NotNil(t, d.WithReplies)
+	assert.False(t, *d.WithReplies)
+	assert.Nil(t, d.FollowedMessage, "非 follower には followedMessage を出さない")
+	require.NotNil(t, d.IsBlocking)
+	assert.False(t, *d.IsBlocking)
+	assert.Nil(t, d.Memo)
+}
+
+// follow row はあるが notify 未設定なら notify='none' に default する。
+func TestApply_FollowWithoutNotify(t *testing.T) {
+	r, target, profile := fullRepos(t)
+	following := r.Following.(*testutil.MockFollowingRepository)
+	require.NoError(t, following.Create(&model.Following{ID: "f1", FollowerID: "viewer", FolloweeID: "target"}))
+
+	d := entity.UserDetailed{}
+	r.Apply(&d, "viewer", target, profile)
+	require.NotNil(t, d.Notify)
+	assert.Equal(t, "none", *d.Notify)
+	// follower なので followedMessage は出すが、profile に無いので nil のまま。
+	assert.Nil(t, d.FollowedMessage)
+}
+
+// nil repo は対応する flag を skip する (= omit)。
+func TestApply_PartialReposSkipFlags(t *testing.T) {
+	r := Repos{Blocking: testutil.NewMockBlockingRepository()} // blocking のみ wire
+	blocking := r.Blocking.(*testutil.MockBlockingRepository)
+	require.NoError(t, blocking.Create(&model.Blocking{ID: "b1", BlockerID: "viewer", BlockeeID: "target"}))
+
+	d := entity.UserDetailed{}
+	got := r.Apply(&d, "viewer", &model.User{ID: "target"}, nil)
+
+	assert.False(t, got, "following repo 未配線なので false")
+	assert.Nil(t, d.IsFollowing, "following 未配線なら isFollowing は omit")
+	assert.Nil(t, d.IsMuted, "muting 未配線なら isMuted は omit")
+	require.NotNil(t, d.IsBlocking, "blocking は wire 済みなので emit")
+	assert.True(t, *d.IsBlocking)
+}

--- a/internal/api/users/content_lists_test.go
+++ b/internal/api/users/content_lists_test.go
@@ -264,3 +264,15 @@ func TestPages_ResolvesDriveFiles(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "eye1", eye["id"])
 }
+
+// clampListLimit: 0/負値は 10、100 超は 100 に clamp、範囲内はそのまま (#1802 margin)。
+func TestClampListLimit(t *testing.T) {
+	cases := []struct{ in, want int }{
+		{0, 10}, {-5, 10}, {50, 50}, {100, 100}, {101, 100}, {1000, 100},
+	}
+	for _, c := range cases {
+		v := c.in
+		clampListLimit(&v)
+		assert.Equal(t, c.want, v, "clampListLimit(%d)", c.in)
+	}
+}

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/notehide"
 	"github.com/shiroha-a/mk/internal/api/pagination"
+	"github.com/shiroha-a/mk/internal/api/userrelation"
 	corefollowing "github.com/shiroha-a/mk/internal/core/following"
 	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	corerole "github.com/shiroha-a/mk/internal/core/role"
@@ -551,100 +552,22 @@ func (h *Handler) Show(c echo.Context) error {
 	// pinned note の myReaction を埋めるのに使う (#426)。
 	h.fillPinned(c.Request().Context(), viewer, bundle.User, bundle.Profile, &detailed)
 
-	// viewerがログインしている場合、viewer依存フィールドを並列取得する。
-	// 各リポジトリへのクエリは完全に独立しているためgoroutineで並列実行し、
-	// 全結果が揃ってからdetailedに反映する。
-	// viewerIsFollowing は relation ブロックで解決し、count / followedMessage の
-	// viewer-dependent gate (#1558) でも参照するため関数スコープに持つ。
-	viewerIsFollowing := false
-	if viewer != nil && viewer.ID != bundle.User.ID {
-		var (
-			isFollowing, isFollowed      bool
-			isBlocking, isBlocked        bool
-			isMuted, isRenoteMuted       bool
-			hasPendingFrom, hasPendingTo bool
-			followRec                    *model.Following
-			memo                         *model.UserMemo
-			wg                           sync.WaitGroup
-		)
-
-		if h.followingRepo != nil {
-			wg.Add(3)
-			go func() { defer wg.Done(); isFollowing, _ = h.followingRepo.Exists(viewer.ID, bundle.User.ID) }()
-			go func() { defer wg.Done(); isFollowed, _ = h.followingRepo.Exists(bundle.User.ID, viewer.ID) }()
-			go func() { defer wg.Done(); followRec, _ = h.followingRepo.FindByPair(viewer.ID, bundle.User.ID) }()
-		}
-		if h.blockingRepo != nil {
-			wg.Add(2)
-			go func() { defer wg.Done(); isBlocking, _ = h.blockingRepo.Exists(viewer.ID, bundle.User.ID) }()
-			go func() { defer wg.Done(); isBlocked, _ = h.blockingRepo.Exists(bundle.User.ID, viewer.ID) }()
-		}
-		if h.mutingRepo != nil {
-			wg.Add(1)
-			go func() { defer wg.Done(); isMuted, _ = h.mutingRepo.Exists(viewer.ID, bundle.User.ID) }()
-		}
-		if h.renoteMutingRepo != nil {
-			wg.Add(1)
-			go func() { defer wg.Done(); isRenoteMuted, _ = h.renoteMutingRepo.Exists(viewer.ID, bundle.User.ID) }()
-		}
-		if h.followRequestRepo != nil {
-			wg.Add(2)
-			go func() { defer wg.Done(); hasPendingFrom, _ = h.followRequestRepo.Exists(viewer.ID, bundle.User.ID) }()
-			go func() { defer wg.Done(); hasPendingTo, _ = h.followRequestRepo.Exists(bundle.User.ID, viewer.ID) }()
-		}
-		if h.memoRepo != nil {
-			wg.Add(1)
-			go func() { defer wg.Done(); memo, _ = h.memoRepo.FindByPair(viewer.ID, bundle.User.ID) }()
-		}
-
-		wg.Wait()
-
-		if h.followingRepo != nil {
-			detailed.IsFollowing = &isFollowing
-			detailed.IsFollowed = &isFollowed
-			viewerIsFollowing = isFollowing
-			// notify / withReplies は relation ブロックが存在する限り (= authed
-			// 非self viewer) 常に emit する。upstream は
-			// `notify: relation.following?.notify ?? 'none'` /
-			// `withReplies: relation.following?.withReplies ?? false` で、follow row
-			// が無い / notify 未設定でも default を出す (#1558)。
-			none := "none"
-			withReplies := false
-			if followRec != nil {
-				if followRec.Notify != nil {
-					detailed.Notify = followRec.Notify
-				} else {
-					detailed.Notify = &none
-				}
-				withReplies = followRec.WithReplies
-			} else {
-				detailed.Notify = &none
-			}
-			detailed.WithReplies = &withReplies
-			// followedMessage は follower にだけ見せる (upstream relation ブロックの
-			// `relation.isFollowing ? profile.followedMessage : undefined`、#1558)。
-			if isFollowing && bundle.Profile != nil {
-				detailed.FollowedMessage = bundle.Profile.FollowedMessage
-			}
-		}
-		if h.blockingRepo != nil {
-			detailed.IsBlocking = &isBlocking
-			detailed.IsBlocked = &isBlocked
-		}
-		if h.mutingRepo != nil {
-			detailed.IsMuted = &isMuted
-		}
-		if h.renoteMutingRepo != nil {
-			detailed.IsRenoteMuted = &isRenoteMuted
-		}
-		if h.followRequestRepo != nil {
-			detailed.HasPendingFollowRequestFromYou = &hasPendingFrom
-			detailed.HasPendingFollowRequestToYou = &hasPendingTo
-		}
-		if h.memoRepo != nil && memo != nil {
-			detailed.Memo = &memo.Memo
-		}
+	// viewer→target の relation block を共有 resolver で解決し detailed に反映する。
+	// blocking/create・delete と同じ計算で、二重実装を避けるため抽出した (#1802)。
+	// anonymous (viewer nil) / self は Apply 内で no-op。viewerIsFollowing は count /
+	// followedMessage の viewer-dependent gate (#1558) でも参照する。
+	viewerID := ""
+	if viewer != nil {
+		viewerID = viewer.ID
 	}
+	viewerIsFollowing := userrelation.Repos{
+		Following:     h.followingRepo,
+		Blocking:      h.blockingRepo,
+		Muting:        h.mutingRepo,
+		RenoteMuting:  h.renoteMutingRepo,
+		FollowRequest: h.followRequestRepo,
+		Memo:          h.memoRepo,
+	}.Apply(&detailed, viewerID, bundle.User, bundle.Profile)
 
 	// viewer===target の self-view では upstream `pack(user, me)` 互換で
 	// MeDetailed 拡張 field (isExplorable / noCrawle 等 11 個 + #985 で

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -58,6 +58,7 @@ import (
 	apitest "github.com/shiroha-a/mk/internal/api/test"
 	apiurl "github.com/shiroha-a/mk/internal/api/url"
 	apiuserlists "github.com/shiroha-a/mk/internal/api/userlists"
+	"github.com/shiroha-a/mk/internal/api/userrelation"
 	"github.com/shiroha-a/mk/internal/api/users"
 	apiwebhooks "github.com/shiroha-a/mk/internal/api/webhooks"
 	"github.com/shiroha-a/mk/internal/api/wellknown"
@@ -1643,6 +1644,16 @@ func (s *Server) setupRoutes() {
 
 	// Blocking endpoints
 	blockingHandler := blocking.NewHandler(blockingService, userRepo, idGen)
+	// blocking/create・delete のレスポンスに viewer→blockee の relation block
+	// (isBlocking 等) を載せるための共有 resolver 依存 (#1802)。
+	blockingHandler.SetRelationRepos(userrelation.Repos{
+		Following:     followingRepo,
+		Blocking:      blockingRepo,
+		Muting:        mutingRepo,
+		RenoteMuting:  renoteMutingRepo,
+		FollowRequest: followRequestRepo,
+		Memo:          repository.NewUserMemoRepository(s.db),
+	})
 	api.POST("/blocking/create", blockingHandler.Create, middleware.RequireAuth(), middleware.RequireScope("write:blocks"))
 	api.POST("/blocking/delete", blockingHandler.Delete, middleware.RequireAuth(), middleware.RequireScope("write:blocks"))
 	api.POST("/blocking/list", blockingHandler.List, middleware.RequireAuth(), middleware.RequireScope("read:blocks"))


### PR DESCRIPTION
## Summary

#1775 から分離した follow-up (M1)。blocking/create・delete のレスポンスを upstream `pack(blockee, blocker, {schema:'UserDetailedNotMe'})` 互換にし、viewer→blockee の relation block (isBlocking 等) を載せる。

## 主な変更点

- **共有 resolver の抽出**: viewer→target の relation 計算 (isFollowing / isFollowed / isBlocking / isBlocked / isMuted / isRenoteMuted / hasPendingFollowRequest* / notify / withReplies / followedMessage / memo) を新規 package `internal/api/userrelation` の `Repos.Apply` に抽出。`/api/users/show` にインラインで重複していたものを共有化し、2 箇所の drift を防ぐ (altitude: 特殊ケース追加でなく共通機構化)。
- **users/show**: インライン relation block を `userrelation.Repos.Apply` 呼び出しに置き換え (挙動は line-for-line 等価。anonymous / self は Apply 内で no-op)。
- **blocking/create・delete**: `respondPackedUser` に viewer (= blocker) を渡し relation block を付与。block 後は `isBlocking=true` / unblock 後は `false` が乗る。`SetRelationRepos` で 6 repo を配線。以前は relation block 全体が欠落し frontend の optimistic redraw が機能していなかった。

## レビュー (implement → review → fix → PR)

adversarial finder で抽出が元実装と**完全等価**であること (goroutine fan-out / `Exists` 引数方向 / nil guard / notify default / `viewerIsFollowing` semantics / guard 等価) を確認: **correctness bug 0件**。-race clean。修正工程は no-op。

## テスト

- `userrelation.Apply` の full relation 解決 / no-relation default / follow-without-notify / 部分 repo skip / no-op 条件 (nil/anonymous/self) を追加 (package 100% cover)。
- blocking create→`isBlocking=true` / delete→`isBlocking=false` を共有 blockingRepo 経由で検証。
- 既存 users/show テストは全 pass (回帰なし)。coverage: userrelation 100% / blocking 92.2% / users 90.1%。full `go vet` + gofmt クリーン。

Closes #1802

🤖 Generated with [Claude Code](https://claude.com/claude-code)