### PR TITLE
Fix signup parity (#1804): アカウント作成時に signin 副作用 (履歴/login 通知/main publish) を発火

### DIFF
--- a/internal/api/signin/handler.go
+++ b/internal/api/signin/handler.go
@@ -340,20 +340,7 @@ func (h *Handler) SigninFlow(c echo.Context) error {
 // ok returns the standard "logged in" response. 認証経路 (TOTP / WebAuthn /
 // pwd-only) すべてで同じ shape を返したいのでヘルパに切り出している。
 func (h *Handler) ok(c echo.Context, user *model.User) error {
-	if h.ipLoggingOn && h.ipLogger != nil {
-		go h.ipLogger.Upsert(user.ID, c.RealIP())
-	}
-	// signinレコードを非同期で記録
-	// Echoがリクエストを再利用する前にヘッダーをコピーする
-	if h.signinRepo != nil && h.idGen != nil {
-		hdrs := c.Request().Header.Clone()
-		go h.recordSignin(user.ID, c.RealIP(), hdrs, true)
-	}
-	// login 通知を本人へ送る (upstream SigninService、#1559)。signin の
-	// レイテンシに乗らないよう非同期で発火する。
-	if h.loginNotifier != nil {
-		go h.loginNotifier.OnLogin(user.ID)
-	}
+	h.RecordSuccessfulSignin(user.ID, c.RealIP(), c.Request().Header.Clone())
 	token := ""
 	if user.Token != nil {
 		token = *user.Token
@@ -363,6 +350,29 @@ func (h *Handler) ok(c echo.Context, user *model.User) error {
 		"id":       user.ID,
 		"i":        token,
 	})
+}
+
+// RecordSuccessfulSignin fires the side-effects of a successful login:
+// IP logging, signin history (success:true) + main-stream publish, and the
+// 'login' notification. Shared by every signin path (password / 2FA / passkey)
+// and by account creation (signup / signup-pending) so a freshly created
+// account also gets a login-history entry + notification, matching upstream
+// SigninService.signin (#1804)。全て非同期で発火し signin/signup のレイテンシに
+// 乗せない。headers は呼び出し元が Clone 済みのものを渡す前提
+// (Echo が request を再利用する前にコピーする)。
+//
+// NOTE: upstream の new-login email は mk-go の signin 自体が未実装のため本 helper
+// にも含めない (signin/signup 双方の今後の課題)。
+func (h *Handler) RecordSuccessfulSignin(userID, ip string, headers http.Header) {
+	if h.ipLoggingOn && h.ipLogger != nil {
+		go h.ipLogger.Upsert(userID, ip)
+	}
+	if h.signinRepo != nil && h.idGen != nil {
+		go h.recordSignin(userID, ip, headers, true)
+	}
+	if h.loginNotifier != nil {
+		go h.loginNotifier.OnLogin(userID)
+	}
 }
 
 // sanitizeHeaders removes sensitive headers in-place before persisting.

--- a/internal/api/signin/handler_test.go
+++ b/internal/api/signin/handler_test.go
@@ -116,6 +116,28 @@ func TestSignin_FiresLoginNotifier(t *testing.T) {
 	}
 }
 
+// #1804: RecordSuccessfulSignin は signin / signup 共有の成功時 side-effect
+// entrypoint。signin 履歴 (success:true) + login 通知を発火する。
+func TestRecordSuccessfulSignin_FiresHistoryAndNotifier(t *testing.T) {
+	h, _ := newTestHandler(t)
+	signinRepo := testutil.NewMockSigninRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	h.SetSigninRepo(signinRepo, idGen)
+	notifier := &chanLoginNotifier{ch: make(chan string, 1)}
+	h.SetLoginNotifier(notifier)
+
+	h.RecordSuccessfulSignin("u1", "1.2.3.4", http.Header{})
+
+	select {
+	case uid := <-notifier.ch:
+		assert.Equal(t, "u1", uid)
+	case <-time.After(2 * time.Second):
+		t.Fatal("login notifier was not fired")
+	}
+	require.Eventually(t, func() bool { return signinRepo.Len() == 1 }, 2*time.Second, 10*time.Millisecond)
+	assert.True(t, signinRepo.Signins[0].Success, "success:true で記録する")
+}
+
 func TestSignin_WrongPassword(t *testing.T) {
 	h, repo := newTestHandler(t)
 	createTestUser(repo, "admin", "pass123")

--- a/internal/api/signup/handler.go
+++ b/internal/api/signup/handler.go
@@ -26,6 +26,15 @@ type TicketStore interface {
 	MarkUsed(ticketID, userID string) error
 }
 
+// SigninRecorder fires the side-effects of a successful login (signin history,
+// login notification, main-stream publish) after account creation, matching
+// upstream SignupApiService -> signinService.signin (#1804)。実装は
+// internal/api/signin.Handler.RecordSuccessfulSignin。未配線なら副作用を発火しない
+// だけ (response shape は不変)。
+type SigninRecorder interface {
+	RecordSuccessfulSignin(userID, ip string, headers http.Header)
+}
+
 // Handler handles POST /api/signup.
 type Handler struct {
 	signupService *coresignup.Service
@@ -45,6 +54,25 @@ type Handler struct {
 	// emailValidationClient は verifymail / truemail SaaS API への outbound
 	// に使う SSRF-safe HTTP client (#638)。nil ならデフォルト client が使われる。
 	emailValidationClient *http.Client
+	// signinRecorder はアカウント作成成功時に signin 副作用 (履歴 / login 通知 /
+	// main publish) を発火する。upstream SignupApiService が signinService.signin を
+	// 呼ぶのに相当 (#1804)。未配線なら副作用なし。
+	signinRecorder SigninRecorder
+}
+
+// SetSigninRecorder wires the recorder used to fire login side-effects after
+// account creation (#1804)。
+func (h *Handler) SetSigninRecorder(r SigninRecorder) {
+	h.signinRecorder = r
+}
+
+// fireSigninSideEffects records the successful-login side-effects for a newly
+// created account (#1804). headers は Echo が request を再利用する前に Clone する。
+func (h *Handler) fireSigninSideEffects(c echo.Context, userID string) {
+	if h.signinRecorder == nil || userID == "" {
+		return
+	}
+	h.signinRecorder.RecordSuccessfulSignin(userID, c.RealIP(), c.Request().Header.Clone())
 }
 
 // SetTestMode enables test-mode bypass (本家 `process.env.NODE_ENV !== 'test'` 相当).
@@ -235,6 +263,8 @@ func (h *Handler) Signup(c echo.Context) error {
 		_ = h.ticketStore.MarkUsed(ticket.ID, result.User.ID)
 	}
 
+	// アカウント作成も signin 経路を通す (履歴 / login 通知 / main publish、#1804)。
+	h.fireSigninSideEffects(c, result.User.ID)
 	return c.JSON(http.StatusOK, packSignupResponse(result.User, result.Token, h.idGen))
 }
 
@@ -281,6 +311,8 @@ func (h *Handler) SignupPending(c echo.Context) error {
 	if result.InvitationTicketID != nil && !result.InvitationTicketConsumed && h.ticketStore != nil {
 		_ = h.ticketStore.MarkUsed(*result.InvitationTicketID, result.User.ID)
 	}
+	// signup-pending 完了も signin 経路を通す (履歴 / login 通知 / main publish、#1804)。
+	h.fireSigninSideEffects(c, result.User.ID)
 	return c.JSON(http.StatusOK, map[string]any{
 		"id": result.User.ID,
 		"i":  result.Token,

--- a/internal/api/signup/handler_test.go
+++ b/internal/api/signup/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -268,6 +269,67 @@ func TestSignupPending_Success(t *testing.T) {
 	assert.NotEmpty(t, resp["id"])
 	assert.NotEmpty(t, resp["i"])
 	assert.Empty(t, pendingRepo.Rows)
+}
+
+// stubSigninRecorder captures RecordSuccessfulSignin calls (#1804).
+type stubSigninRecorder struct {
+	mu      sync.Mutex
+	userIDs []string
+}
+
+func (s *stubSigninRecorder) RecordSuccessfulSignin(userID, _ string, _ http.Header) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.userIDs = append(s.userIDs, userID)
+}
+
+func (s *stubSigninRecorder) called() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.userIDs...)
+}
+
+// #1804: signup-pending 完了時に signin 副作用 (履歴 / login 通知 / main publish) を
+// 新規ユーザー ID で発火する。
+func TestSignupPending_FiresSigninSideEffects(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "x", EmailRequiredForSignup: true}
+	pendingRepo := testutil.NewMockUserPendingRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := coresignup.NewService(userRepo, metaRepo, idGen)
+	svc.SetUserPendingRepo(pendingRepo)
+	h := apisignup.NewHandler(svc, metaRepo, idGen)
+	rec := &stubSigninRecorder{}
+	h.SetSigninRecorder(rec)
+
+	row, err := svc.CreatePending("bob", "bob@example.com", "secret", nil)
+	require.NoError(t, err)
+
+	resp := parseResp(t, doPost(h.SignupPending, `{"code":"`+row.Code+`"}`))
+	require.NotEmpty(t, resp["id"])
+	called := rec.called()
+	require.Len(t, called, 1, "signup-pending 完了で signin 副作用を 1 回発火する")
+	assert.Equal(t, resp["id"], called[0], "新規ユーザー ID で発火する")
+}
+
+// #1804: 通常 signup 完了でも signin 副作用を発火する。
+func TestSignup_FiresSigninSideEffects(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "x"}
+	idGen, _ := id.NewGenerator("aidx")
+	svc := coresignup.NewService(userRepo, metaRepo, idGen)
+	h := apisignup.NewHandler(svc, metaRepo, idGen)
+	h.SetTestMode(true)
+	rec := &stubSigninRecorder{}
+	h.SetSigninRecorder(rec)
+
+	resp := parseResp(t, doPost(h.Signup, `{"username":"alice","password":"password123"}`))
+	require.NotEmpty(t, resp["id"])
+	called := rec.called()
+	require.Len(t, called, 1)
+	assert.Equal(t, resp["id"], called[0])
 }
 
 func TestSignupPending_InvalidParam(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1165,6 +1165,8 @@ func (s *Server) setupRoutes() {
 	signinRepo := repository.NewSigninRepository(s.db)
 	signinHandler.SetSigninRepo(signinRepo, idGen)
 	signinHandler.SetLoginNotifier(notificationHook)
+	// アカウント作成時も signin 副作用 (履歴 / login 通知 / main publish) を通す (#1804)。
+	signupHandler.SetSigninRecorder(signinHandler)
 	api.POST("/signin", signinHandler.Signin)
 	api.POST("/signin-flow", signinHandler.SigninFlow)
 	api.POST("/signin-with-passkey", signinHandler.SigninWithPasskey)


### PR DESCRIPTION
## Summary

#1776 から分離した follow-up (L1)。upstream `SignupApiService` が最後に `signinService.signin` を呼ぶのに合わせ、signup / signup-pending 完了時に signin の成功時 side-effect を発火する。

## 主な変更点

- **共有 entrypoint の抽出**: signin `Handler.ok()` の成功時 side-effect (IP logging / signin 履歴 `success:true` + main publish / login 通知) を `RecordSuccessfulSignin(userID, ip, headers)` に抽出。`ok()` はこれを呼ぶよう変更 (挙動不変)。
- **signup**: `SigninRecorder` 依存を追加し、`Signup` / `SignupPending` の成功 return 直前に新規ユーザー ID で発火。`EmailRequiredForSignup` の pending 経路 (204) はまだアカウントが無いので発火しない。
- **router**: `signupHandler.SetSigninRecorder(signinHandler)` を配線。

これにより、アカウント作成が `i/signin-history` に `success:true` で残り、login 通知 + main stream `signin` イベントが発火する。

## 範囲外 (既知の未実装)

- upstream の **new-login email** は mk-go の signin 自体が未実装のため本変更でも送らない (signin/signup 双方に跨る別機能)。`RecordSuccessfulSignin` のコメントに明記。#1804 の主眼である「signup を signin 副作用経路に通す + 共有化」は達成。

## レビュー (implement → review → fix → PR)

adversarial finder で `ok()` 挙動が完全保持・成功 path のみ発火 (error/pending 経路は不発)・nil-safe・配線/visibility・race 無しを確認: **correctness bug 0件**。修正工程は no-op。

## テスト

- `RecordSuccessfulSignin` の履歴 (success:true) + login 通知発火、`Signup` / `SignupPending` が新規ユーザー ID で recorder を呼ぶことを追加 (stub recorder)。
- 既存 signin success テスト (`ok()` 経路) は全 pass (回帰なし)。coverage: signin 94.7% / signup 95.3%。full `go vet` + gofmt クリーン。

Closes #1804

🤖 Generated with [Claude Code](https://claude.com/claude-code)