### PR TITLE
Fix ap/antennas parity (再監査): ap/show viewer relation + antennas sinceId 昇順 (#1778)

### DIFF
--- a/internal/api/ap/handler.go
+++ b/internal/api/ap/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/notehide"
+	"github.com/shiroha-a/mk/internal/api/userrelation"
 	corenote "github.com/shiroha-a/mk/internal/core/note"
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
 	"github.com/shiroha-a/mk/internal/entity"
@@ -65,6 +66,16 @@ type Handler struct {
 	// InsertIfAbsent を同 user ID で 1 回に集約する。多 goroutine が
 	// 同時に backfill しても entropy / CPU を浪費しない (#1081 review #1)。
 	backfillGroup singleflight.Group
+	// relation は ap/show が返す UserDetailedNotMe に viewer→target の relation
+	// block (isFollowing 等) を埋めるための repo 束 (#1778)。未配線なら relation は
+	// omit (= legacy 挙動)。
+	relation userrelation.Repos
+}
+
+// SetRelationRepos wires the repositories used to populate the viewer relation
+// block on ap/show user responses (#1778)。
+func (h *Handler) SetRelationRepos(r userrelation.Repos) {
+	h.relation = r
 }
 
 // SetRemote attaches remote AP fetcher and resolver.
@@ -397,7 +408,7 @@ func (h *Handler) APIShow(c echo.Context) error {
 		if err == nil && bundle.User.Host == nil {
 			return c.JSON(http.StatusOK, map[string]any{
 				"type":   "User",
-				"object": h.packUserForAPI(bundle.User, bundle.Profile),
+				"object": h.packUserForAPI(middleware.GetUser(c), bundle.User, bundle.Profile),
 			})
 		}
 	}
@@ -452,7 +463,7 @@ func (h *Handler) APIShow(c echo.Context) error {
 					if remoteUser, err := h.remoteResolver.ResolveActor(req.URI); err == nil {
 						return c.JSON(http.StatusOK, map[string]any{
 							"type":   "User",
-							"object": h.packUserForAPI(remoteUser, h.userService.GetProfile(remoteUser.ID)),
+							"object": h.packUserForAPI(middleware.GetUser(c), remoteUser, h.userService.GetProfile(remoteUser.ID)),
 						})
 					}
 				}
@@ -466,7 +477,7 @@ func (h *Handler) APIShow(c echo.Context) error {
 		if remoteUser, err := h.remoteResolver.ResolveActor(req.URI); err == nil {
 			return c.JSON(http.StatusOK, map[string]any{
 				"type":   "User",
-				"object": h.packUserForAPI(remoteUser, h.userService.GetProfile(remoteUser.ID)),
+				"object": h.packUserForAPI(middleware.GetUser(c), remoteUser, h.userService.GetProfile(remoteUser.ID)),
 			})
 		}
 	}
@@ -560,11 +571,18 @@ func (h *Handler) packNoteForAPI(viewer *model.User, n *model.Note) entity.NoteE
 // upstream ap/show which returns userEntityService.pack(user, me,
 // {schema:'UserDetailedNotMe'}) for the {type:'User', object} branch (#1557).
 // Previously this returned an ad-hoc minimal object (id/username/name/host).
-func (h *Handler) packUserForAPI(u *model.User, profile *model.UserProfile) any {
+func (h *Handler) packUserForAPI(viewer *model.User, u *model.User, profile *model.UserProfile) any {
 	if u == nil {
 		return map[string]any{}
 	}
-	return entity.PackUserDetailed(u, profile, h.idGen)
+	d := entity.PackUserDetailed(u, profile, h.idGen)
+	// upstream は pack(user, me, {schema:'UserDetailedNotMe'}) で me!=null のとき
+	// relation block (isFollowing/isBlocking 等) を埋める。authed viewer に同じ
+	// relation を載せる (#1778)。anonymous / self は Apply 内で no-op。
+	if viewer != nil {
+		h.relation.Apply(&d, viewer.ID, u, profile)
+	}
+	return d
 }
 
 // Note handles GET /notes/:id with ActivityPub content negotiation.

--- a/internal/api/ap/handler_test.go
+++ b/internal/api/ap/handler_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/activitypub"
+	"github.com/shiroha-a/mk/internal/api/userrelation"
 	corenote "github.com/shiroha-a/mk/internal/core/note"
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
 	"github.com/shiroha-a/mk/internal/entity"
@@ -594,7 +595,7 @@ func TestPackNoteForAPI_HidesNonVisibleEmbed(t *testing.T) {
 
 func TestPackUserForAPI_Nil(t *testing.T) {
 	h, _, _, _ := newHandler(t)
-	result := h.packUserForAPI(nil, nil)
+	result := h.packUserForAPI(nil, nil, nil)
 	m, ok := result.(map[string]any)
 	require.True(t, ok)
 	assert.Empty(t, m)
@@ -603,12 +604,28 @@ func TestPackUserForAPI_Nil(t *testing.T) {
 func TestPackUserForAPI_FullEntity(t *testing.T) {
 	h, _, _, _ := newHandler(t)
 	desc := "bio"
-	result := h.packUserForAPI(&model.User{ID: "u1", Username: "alice"}, &model.UserProfile{UserID: "u1", Description: &desc})
+	result := h.packUserForAPI(nil, &model.User{ID: "u1", Username: "alice"}, &model.UserProfile{UserID: "u1", Description: &desc})
 	d, ok := result.(entity.UserDetailed)
 	require.True(t, ok)
 	assert.Equal(t, "u1", d.ID)
 	require.NotNil(t, d.Description)
 	assert.Equal(t, "bio", *d.Description)
+	// anonymous viewer なので relation block は付かない。
+	assert.Nil(t, d.IsFollowing)
+}
+
+// #1778: authed viewer には relation block (isFollowing 等) を埋める。
+func TestPackUserForAPI_ViewerRelation(t *testing.T) {
+	h, _, _, _ := newHandler(t)
+	followRepo := testutil.NewMockFollowingRepository()
+	require.NoError(t, followRepo.Create(&model.Following{ID: "f1", FollowerID: "viewer", FolloweeID: "u1"}))
+	h.SetRelationRepos(userrelation.Repos{Following: followRepo})
+
+	result := h.packUserForAPI(&model.User{ID: "viewer"}, &model.User{ID: "u1", Username: "alice"}, nil)
+	d, ok := result.(entity.UserDetailed)
+	require.True(t, ok)
+	require.NotNil(t, d.IsFollowing)
+	assert.True(t, *d.IsFollowing, "viewer follows u1 → isFollowing=true")
 }
 
 func TestMustMarshal_Panics(t *testing.T) {

--- a/internal/api/fetchrss/handler.go
+++ b/internal/api/fetchrss/handler.go
@@ -354,6 +354,14 @@ func packFeed(feed *gofeed.Feed) map[string]any {
 	}
 	out["items"] = items
 
+	// upstream は RFC5005 の atom:link rel=self/first/next/last/prev を
+	// paginationLinks (optional) として返すが、gofeed の universal Feed は
+	// link の rel 属性を unified model に surface しない (Feed.Links は href のみ)。
+	// 取得には atom 専用 re-parse が必要だが、(1) optional かつ paging を advertise
+	// する feed は稀、(2) drop-in frontend は paginationLinks を消費しない
+	// (misskey-js autogen 型に存在するのみ) ため、本フィールドは意図的に omit する
+	// (#1778)。
+
 	return out
 }
 

--- a/internal/core/antenna/antenna_service.go
+++ b/internal/core/antenna/antenna_service.go
@@ -431,7 +431,20 @@ func (s *Service) Notes(ctx context.Context, ownerID, antennaID string, limit in
 			start = fmt.Sprintf("(%d-0", t.UnixMilli())
 		}
 	}
-	res, err := s.client.XRevRangeN(ctx, streamKey(antennaID), end, start, int64(limit)).Result()
+	// upstream notes.ts: sinceId 単独 (fetch-newer / scroll-up) は昇順
+	// (oldest-first) で sinceId 直後の最古 limit 件を返す。それ以外 (untilId /
+	// 無指定) は降順 (newest-first)。mk-go は常に XRevRange で newest-first だった
+	// ため sinceId 単独ページの並びと集合が逆になっていた (#1778)。
+	var (
+		res []redis.XMessage
+		err error
+	)
+	if sinceID != "" && untilID == "" {
+		// XRANGE は start<=stop の昇順。range は (sinceID, +]。
+		res, err = s.client.XRangeN(ctx, streamKey(antennaID), start, end, int64(limit)).Result()
+	} else {
+		res, err = s.client.XRevRangeN(ctx, streamKey(antennaID), end, start, int64(limit)).Result()
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/antenna/antenna_service_test.go
+++ b/internal/core/antenna/antenna_service_test.go
@@ -419,10 +419,17 @@ func TestNotes_PagingSinceID(t *testing.T) {
 	require.NoError(t, svc.pushNote(context.Background(), "a1", id2, t1.Add(time.Millisecond)))
 	require.NoError(t, svc.pushNote(context.Background(), "a1", id3, t1.Add(2*time.Millisecond)))
 
-	// sinceID = id1 → strictly newer → id3, id2 (newest first)
+	// #1778: sinceID 単独 (fetch-newer) は昇順 (oldest-first) で返す
+	// (upstream notes.ts の sinceId-only ascending sort)。strictly newer の
+	// 最古から id2, id3 の順。
 	rows, err := svc.Notes(context.Background(), "u1", "a1", 10, id1, "")
 	require.NoError(t, err)
-	assert.Equal(t, []string{id3, id2}, rows)
+	assert.Equal(t, []string{id2, id3}, rows)
+
+	// limit を絞ると sinceID 直後の最古 limit 件 (id2) を返す (newest ではなく)。
+	rows, err = svc.Notes(context.Background(), "u1", "a1", 1, id1, "")
+	require.NoError(t, err)
+	assert.Equal(t, []string{id2}, rows)
 }
 
 // #693 review #1: 同一 ms に同じアンテナへ複数回 pushNote しても XADD が

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1757,6 +1757,15 @@ func (s *Server) setupRoutes() {
 	// FEP-521a Multikey 対応で actor JSON に assertionMethod[] を expose する
 	// ため Ed25519 keypair repo を wire (#1067 / #1069)。
 	apHandler.SetKeypairExtraRepo(keypairExtraRepo)
+	// ap/show が返す UserDetailedNotMe に viewer relation block を埋める (#1778)。
+	apHandler.SetRelationRepos(userrelation.Repos{
+		Following:     followingRepo,
+		Blocking:      blockingRepo,
+		Muting:        mutingRepo,
+		RenoteMuting:  renoteMutingRepo,
+		FollowRequest: followRequestRepo,
+		Memo:          repository.NewUserMemoRepository(s.db),
+	})
 	// AP リソース系エンドポイントは Accept ヘッダで content negotiation する。
 	// ブラウザからのリロード (Accept: text/html など) では SPA 用の HTML を
 	// 返したいので、フォールバックとして frontendHTML を注入しておく。


### PR DESCRIPTION
## Summary

再監査 (#1778) の **ap/* + fetch-external + antennas/hashtags** 領域 LOW を解消する (0H 0M 4L)。

## 主な変更点

- **[LOW] ap/show viewer relation**: 解決した User に viewer relation block (isFollowing / isFollowed / isBlocking / isMuted / hasPendingFollowRequest* / notify / withReplies 等) を埋める。#1802 で抽出した共有 `userrelation.Repos.Apply` を ap handler に配線し、`packUserForAPI` に viewer を渡す。upstream は `pack(user, me, {schema:'UserDetailedNotMe'})` で me!=null のとき relation を返す。local/remote actor 双方に適用 (anonymous / self は no-op)。
- **[LOW] antennas/notes sinceId 昇順**: sinceId 単独指定 (fetch-newer / scroll-up) のとき upstream `notes.ts` に合わせ昇順 (oldest-first) で sinceId 直後の最古 `limit` 件を返す。core antenna Notes が常に XRevRange (newest-first) だったため sinceId 単独ページの並び・集合が逆だった。sinceId 単独時のみ XRange (昇順) に分岐。

## 意図的据え置き / 既知の制約

- **[LOW] ap/show が非公開ローカル note を隠す件**: documented fail-closed divergence (`note_query_service.go`) として維持 (authorized viewer にも leak しない方が安全。kind=other, intentional)。
- **[LOW] fetch-rss paginationLinks**: gofeed の universal model が RFC5005 の atom:link rel を surface しない制約 + drop-in frontend が未消費 (misskey-js autogen 型に存在するのみ) + 稀のため意図的に omit (`packFeed` にコメントで明記)。

## レビュー (implement → review → fix → PR)

adversarial finder で Redis stream 排他境界 (sinceId 除外) + front-trim の集合/順序、ap relation 配線の nil 安全 / remote 適用を upstream 照合: **correctness bug 0件**。修正工程は no-op。

## テスト

- antennas sinceId 昇順 (`[id2, id3]`) + limit=1 で最古 (`[id2]`) の order/set、ap/show の viewer relation (follow→isFollowing=true) / anonymous omit を追加・更新。
- coverage: core/antenna 95.3% / api/antennas 91.9% / api/ap 96.5%。full `go vet` + gofmt クリーン。

Closes #1778

🤖 Generated with [Claude Code](https://claude.com/claude-code)