### PR TITLE
Fix queue/stream parity (再監査): inbox unsuspend + 'channel' alias + roleTimeline anon gate (#1780)

### DIFF
--- a/internal/core/instance/instance_service.go
+++ b/internal/core/instance/instance_service.go
@@ -200,15 +200,36 @@ func (s *Service) MarkRequestReceived(host string) error {
 	}
 	s.mu.Unlock()
 
-	if _, err := s.repo.FindByHost(host); err != nil {
+	inst, err := s.repo.FindByHost(host)
+	if err != nil {
 		// 未登録 host はキャッシュせず次回も SELECT で確認する (登録後に窓集約が
 		// 効き始める)。
 		return nil
 	}
-	if err := s.repo.UpdateFields(host, map[string]any{
+	fields := map[string]any{
 		"latestRequestReceivedAt": &now,
-	}); err != nil {
+	}
+	// 正当な inbound を受けたら is-not-responding をクリアする (upstream
+	// performUpdateInstance は latestRequestReceivedAt と isNotResponding:false を
+	// 必ず書く、#1780)。
+	if inst.IsNotResponding {
+		fields["isNotResponding"] = false
+		fields["notRespondingSince"] = (*time.Time)(nil)
+	}
+	// autoSuspendedForNotResponding の instance から正当な inbound を受けたら
+	// suspensionState を none に自動復活させる (upstream の shouldUnsuspend)。
+	if inst.SuspensionState == model.SuspensionStateAutoSuspendedForNotResponding {
+		fields["suspensionState"] = string(model.SuspensionStateNone)
+	}
+	if err := s.repo.UpdateFields(host, fields); err != nil {
 		return err
+	}
+	// is-not-responding を clear したので、stale healthy-cache が回復 UPDATE を
+	// 取りこぼす逆経路を避けるため healthy-cache も整合させる。
+	if inst.IsNotResponding {
+		s.mu.Lock()
+		delete(s.responseHealthyCache, host)
+		s.mu.Unlock()
 	}
 	s.mu.Lock()
 	// 書き込みついでに期限切れ entry を amortized に掃除する (suspendCache と同方針)。

--- a/internal/core/instance/instance_service_test.go
+++ b/internal/core/instance/instance_service_test.go
@@ -62,6 +62,38 @@ func TestService_MarkRequestReceived(t *testing.T) {
 	require.NotNil(t, repo.Instances["alpha.example"].LatestRequestReceivedAt)
 }
 
+// #1780: 正当な inbound を受けたら isNotResponding をクリアする。
+func TestService_MarkRequestReceived_ClearsNotResponding(t *testing.T) {
+	svc, repo, _ := newService(t)
+	now := time.Now()
+	repo.Instances["alpha.example"] = &model.Instance{
+		ID: "i1", Host: "alpha.example", IsNotResponding: true, NotRespondingSince: &now,
+	}
+	require.NoError(t, svc.MarkRequestReceived("alpha.example"))
+	assert.False(t, repo.Instances["alpha.example"].IsNotResponding, "inbound でクリアする")
+	assert.Nil(t, repo.Instances["alpha.example"].NotRespondingSince)
+}
+
+// #1780: autoSuspendedForNotResponding の instance から正当な inbound を受けると
+// suspensionState を none に復活させる。
+func TestService_MarkRequestReceived_RevivesAutoSuspended(t *testing.T) {
+	svc, repo, _ := newService(t)
+	now := time.Now()
+	repo.Instances["alpha.example"] = &model.Instance{
+		ID: "i1", Host: "alpha.example", IsNotResponding: true, NotRespondingSince: &now,
+		SuspensionState: model.SuspensionStateAutoSuspendedForNotResponding,
+	}
+	require.NoError(t, svc.MarkRequestReceived("alpha.example"))
+	assert.Equal(t, model.SuspensionStateNone, repo.Instances["alpha.example"].SuspensionState)
+
+	// 手動 suspend (manuallySuspended) は inbound でも復活させない。
+	repo.Instances["beta.example"] = &model.Instance{
+		ID: "i2", Host: "beta.example", SuspensionState: model.SuspensionStateManuallySuspended,
+	}
+	require.NoError(t, svc.MarkRequestReceived("beta.example"))
+	assert.Equal(t, model.SuspensionStateManuallySuspended, repo.Instances["beta.example"].SuspensionState, "手動 suspend は復活させない")
+}
+
 func TestService_MarkRequestReceived_UnknownHost(t *testing.T) {
 	svc, _, _ := newService(t)
 	require.NoError(t, svc.MarkRequestReceived("missing.example"))

--- a/internal/queue/processors/reaction_flush.go
+++ b/internal/queue/processors/reaction_flush.go
@@ -13,6 +13,14 @@ type ReactionFlushProcessor struct {
 }
 
 // NewReactionFlushProcessor creates the processor.
+//
+// NOTE (#1780): upstream BakeBufferedReactionsProcessorService は process() 毎に
+// meta.enableReactionsBuffering を再評価して無効ならスキップするが、mk-go は
+// buffered/direct の writer 型を起動時に固定する設計で、ここで meta を見て Flush を
+// skip すると「起動時 buffering=ON → 実行時 OFF」のとき buffered writer が drain
+// されず Redis に delta が滞留する。よって本 processor は meta を見ず常に Flush する
+// (buffering OFF 起動時は direct writer で Flush が no-op)。実行時の buffering
+// hot-toggle (writer 差し替え + 即時 bake) は別 feature として未対応。
 func NewReactionFlushProcessor(writer reaction.ReactionCountWriter) *ReactionFlushProcessor {
 	return &ReactionFlushProcessor{writer: writer}
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -732,6 +732,10 @@ func (s *Server) setupRoutes() {
 	s.queueServer.Handle(queue.TaskTypeBlock, blockProcessor.Handle)
 	unblockProcessor := processors.NewUnblockProcessor(blockingService)
 	s.queueServer.Handle(queue.TaskTypeUnblock, unblockProcessor.Handle)
+	// buffering 有効起動時のみ 30s ごとに buffered reaction count を DB へ drain
+	// する。30s ticker は upstream の日次 cron より高頻度で反映遅延を抑える
+	// mk-go の運用。writer 型は起動時固定なので、実行時 OFF にしても ticker が
+	// buffered writer を drain し続け滞留しない (#1780)。
 	if bufMeta, err := metaRepo.Fetch(); err == nil && bufMeta.EnableReactionsBuffering {
 		go func() {
 			ticker := time.NewTicker(30 * time.Second)

--- a/internal/stream/channels/new_channels_test.go
+++ b/internal/stream/channels/new_channels_test.go
@@ -683,6 +683,26 @@ func TestRoleTimeline_ExplorablePublicEmitted(t *testing.T) {
 	assert.Equal(t, "note", ctx.sentType[0])
 }
 
+// #1780: anon viewer + 著者 requireSigninToViewContents の public note は drop する
+// (upstream role-timeline.ts:53-55、channel/hashtag と同じ gate が role-timeline に
+// だけ漏れていた)。
+func TestRoleTimeline_AnonRequireSigninDropped(t *testing.T) {
+	ctx := newCtx(nil) // anonymous
+	ch := newRoleCh(ctx, true)
+	ch.Init(json.RawMessage(`{"roleId":"r1"}`))
+	ch.OnRedisEvent([]byte(`{"id":"n1","visibility":"public","user":{"requireSigninToViewContents":true}}`))
+	assert.Empty(t, ctx.sentType, "anon viewer must not receive a requireSignin note")
+}
+
+// authed viewer なら requireSigninToViewContents の note でも受信する。
+func TestRoleTimeline_AuthedRequireSigninEmitted(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "viewer"})
+	ch := newRoleCh(ctx, true)
+	ch.Init(json.RawMessage(`{"roleId":"r1"}`))
+	ch.OnRedisEvent([]byte(`{"id":"n1","visibility":"public","user":{"requireSigninToViewContents":true}}`))
+	require.Len(t, ctx.sentType, 1)
+}
+
 // --- Admin ---
 
 func TestAdmin_Lifecycle(t *testing.T) {

--- a/internal/stream/channels/role_timeline.go
+++ b/internal/stream/channels/role_timeline.go
@@ -66,6 +66,12 @@ func (c *RoleTimelineChannel) OnRedisEvent(payload []byte) {
 	if noteVisibility(payload) != string(model.NoteVisibilityPublic) {
 		return
 	}
+	// anon viewer + 著者 requireSigninToViewContents は note を丸ごと drop する
+	// (upstream role-timeline.ts:53-55 の note/renote/reply 3 連 gate、channel /
+	// hashtag と同じ。role-timeline にだけ移植が漏れていた、#1780)。
+	if anonRequireSigninDrop(payload, viewerIDFromCtx(c.ctx)) {
+		return
+	}
 	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerIDFromCtx(c.ctx)) {
 		return
 	}

--- a/internal/stream/dispatcher.go
+++ b/internal/stream/dispatcher.go
@@ -102,7 +102,10 @@ func (d *Dispatcher) HandleClientMessage(msgType string, body json.RawMessage) {
 		d.handleConnect(body)
 	case "disconnect":
 		d.handleDisconnect(body)
-	case "ch":
+	case "ch", "channel":
+		// upstream Connection.ts は 'channel' と alias 'ch' を同じ
+		// onChannelMessageRequested に dispatch する。official misskey-js は 'ch' を
+		// 送るが、非標準クライアントの 'channel' も受ける (#1780)。
 		d.handleChannelMessage(body)
 	case "readNotification":
 		d.handleReadNotification()

--- a/internal/stream/dispatcher_test.go
+++ b/internal/stream/dispatcher_test.go
@@ -169,6 +169,16 @@ func TestDispatcher_HandleChannelMessage(t *testing.T) {
 	assert.Equal(t, []string{"ping"}, holder.Value.clientMsgs)
 }
 
+// #1780: top-level type 'channel' は 'ch' の alias として同じ
+// onChannelMessageRequested に dispatch する (upstream Connection.ts)。
+func TestDispatcher_HandleChannelMessage_ChannelAlias(t *testing.T) {
+	d, _, _, _, holder := newDispatcherWithFake(t)
+	d.HandleClientMessage("connect", json.RawMessage(`{"id":"abc","channel":"test"}`))
+	require.NotNil(t, holder.Value)
+	d.HandleClientMessage("channel", json.RawMessage(`{"id":"abc","type":"ping","body":{}}`))
+	assert.Equal(t, []string{"ping"}, holder.Value.clientMsgs)
+}
+
 func TestDispatcher_HandleChannelMessageBadJSON(t *testing.T) {
 	d, _, _, _, _ := newDispatcherWithFake(t)
 	d.HandleClientMessage("ch", json.RawMessage(`{bad`))


### PR DESCRIPTION
## Summary

再監査 (#1780) の **queue processors + stream channels** 領域 LOW 4 件を解消する (0H 2M 4L)。MEDIUM 2 件は cross-cutting なため follow-up に分離。

## 主な変更点

- **[LOW] WS client message 'channel' alias**: dispatcher が `'ch'` に加え alias `'channel'` も `handleChannelMessage` に dispatch (upstream `Connection.ts` は両方を同 handler に map)。非標準クライアント対応。
- **[LOW] inbox MarkRequestReceived の unsuspend**: 正当な inbound を受けたら `isNotResponding` をクリアし、`autoSuspendedForNotResponding` の instance を `suspensionState=none` に自動復活 (upstream `performUpdateInstance` の `isNotResponding:false` + `shouldUnsuspend`)。手動 suspend (`manuallySuspended`) は復活させない。
- **[LOW] roleTimeline anon gate**: `OnRedisEvent` に `anonRequireSigninDrop` を追加し、anon viewer + 著者 `requireSigninToViewContents` の public note を drop (upstream `role-timeline.ts` の 3 連 gate。channel/hashtag には移植済だったが role-timeline に漏れていた)。

## 意図的据え置き

- **[LOW] reaction flush の per-run meta 再評価**: upstream `BakeBufferedReactions` の `enableReactionsBuffering` skip は**適用しない**。mk-go は writer 型を起動時固定する設計で、Flush 側で meta を見て skip すると「起動時 ON → 実行時 OFF」のとき buffered writer が drain されず Redis に滞留するため。常時 Flush が正しい (`reaction_flush.go` に明記)。30s ticker は upstream 日次 cron より高頻度で反映遅延を抑える mk-go の運用。実行時 hot-toggle (writer 差替 + 即時 bake) は別 feature。

## Follow-up (deferred MEDIUM)

- **#1811**: deliver 配送失敗インスタンスの自動 suspend (`autoSuspendedForNotResponding` 7日 / `goneSuspended` sharedInbox+410)。`isSharedInbox` の配送経路 threading を伴う。
- **#1812**: timeline 系 channel (home/local/hybrid/global/userList/channel/hashtag/antenna/roleTimeline) の live note に `isNoteMutedOrBlocked` (user-mute/block/instance-mute/renote-mute/channel-mute) filter。~9 channel 横断 + snapshot スコープ拡張を伴う。

## レビュー (implement → review → fix → PR)

adversarial finder で L1-L4 を upstream 照合 (collapse-window と unsuspend の整合 / 排他 gate 等) し、さらに **L3 の当初実装が「buffering=ON 起動 → 実行時 OFF」で buffered delta が Redis に滞留する退行を検出 → revert** (常時 Flush に戻し意図的差分として明記)。最終 correctness bug 0。

## テスト

- 'channel' alias dispatch、`MarkRequestReceived` の isNotResponding clear / autoSuspend revive (manual suspend 非復活)、roleTimeline の anon drop / authed emit を追加。
- coverage: stream 90.8% / stream/channels 92.7% / queue/processors 91.3% / core/instance 92.1%。full `go vet` + gofmt クリーン。

Closes #1780

🤖 Generated with [Claude Code](https://claude.com/claude-code)