### PR TITLE
Fix deliver parity (#1811): 配送失敗インスタンスの自動 suspend (autoSuspendedForNotResponding / goneSuspended)

### DIFF
--- a/internal/core/federation/deliver_service.go
+++ b/internal/core/federation/deliver_service.go
@@ -150,7 +150,7 @@ func (s *DeliverService) SetSyncDeliverHookForTest(fn func(payload queue.Deliver
 // 場合は DeliverActivityWithRecipient を使うと FEP-521a Multikey 対応サーバー
 // 向けに Ed25519 sign が試行される (#1067 / #1071)。
 func (s *DeliverService) DeliverActivity(signerUserID string, body []byte, inboxes []string) error {
-	return s.deliverInternal(signerUserID, body, inboxes, nil)
+	return s.deliverInternal(signerUserID, body, inboxes, nil, nil)
 }
 
 // DeliverActivityWithRecipient is DeliverActivity + recipient capability based
@@ -159,10 +159,14 @@ func (s *DeliverService) DeliverActivity(signerUserID string, body []byte, inbox
 // 鍵情報も詰める (DeliverProcessor 側で実際の sign 分岐 + degrade safeguard
 // を担う)。recipient == nil なら DeliverActivity と等価動作 (#1067 / #1071)。
 func (s *DeliverService) DeliverActivityWithRecipient(signerUserID string, body []byte, inboxes []string, recipient *model.User) error {
-	return s.deliverInternal(signerUserID, body, inboxes, recipient)
+	return s.deliverInternal(signerUserID, body, inboxes, recipient, nil)
 }
 
-func (s *DeliverService) deliverInternal(signerUserID string, body []byte, inboxes []string, recipient *model.User) error {
+// deliverInternal enqueues one signed delivery per unique inbox. sharedInboxes
+// (optional) marks which inbox URLs are shared inboxes so the processor can
+// goneSuspend the instance on a 410 (#1811)。recipient の sharedInbox に一致する
+// inbox も shared 扱いにする。
+func (s *DeliverService) deliverInternal(signerUserID string, body []byte, inboxes []string, recipient *model.User, sharedInboxes map[string]bool) error {
 	if len(inboxes) == 0 {
 		return nil
 	}
@@ -190,6 +194,8 @@ func (s *DeliverService) deliverInternal(signerUserID string, body []byte, inbox
 			continue
 		}
 		seen[inbox] = struct{}{}
+		isShared := sharedInboxes[inbox] ||
+			(recipient != nil && recipient.SharedInbox != nil && *recipient.SharedInbox != "" && inbox == *recipient.SharedInbox)
 		payload := queue.DeliverPayload{
 			Inbox:          inbox,
 			Body:           body,
@@ -197,6 +203,7 @@ func (s *DeliverService) deliverInternal(signerUserID string, body []byte, inbox
 			KeyPEM:         keyPEM,
 			Ed25519KeyID:   edKeyID,
 			Ed25519PrivPEM: edPrivPEM,
+			IsSharedInbox:  isShared,
 		}
 		if s.syncDeliverHook != nil {
 			// test 経路 (#780): queue を経由せず inline で sign + POST。
@@ -301,11 +308,22 @@ func (s *DeliverService) isBlockedInbox(inbox string) bool {
 // DeliverToFollowers enqueues delivery to all remote followers of signerUserID.
 // sharedInbox は repository 側で集約済み。
 func (s *DeliverService) DeliverToFollowers(signerUserID string, body []byte) error {
-	inboxes, err := s.followingRepo.ListRemoteFollowerInboxes(signerUserID)
+	rows, err := s.followingRepo.ListRemoteFollowerInboxes(signerUserID)
 	if err != nil {
 		return err
 	}
-	return s.DeliverActivity(signerUserID, body, inboxes)
+	inboxes := make([]string, 0, len(rows))
+	var sharedInboxes map[string]bool
+	for _, row := range rows {
+		inboxes = append(inboxes, row.Inbox)
+		if row.Shared {
+			if sharedInboxes == nil {
+				sharedInboxes = make(map[string]bool)
+			}
+			sharedInboxes[row.Inbox] = true
+		}
+	}
+	return s.deliverInternal(signerUserID, body, inboxes, nil, sharedInboxes)
 }
 
 // DeliverToUser enqueues a delivery to a single recipient user. Local users

--- a/internal/core/federation/deliver_service_test.go
+++ b/internal/core/federation/deliver_service_test.go
@@ -457,6 +457,40 @@ func TestDeliverToFollowers(t *testing.T) {
 	assert.Len(t, enq.calls, 2)
 }
 
+// #1811: DeliverToFollowers は shared inbox を payload.IsSharedInbox=true で配送し、
+// 個別 inbox は false にする (goneSuspended 判定用)。
+func TestDeliverToFollowers_ThreadsSharedInboxFlag(t *testing.T) {
+	svc, enq, userRepo, followingRepo, keypairRepo := newDeliverService(t)
+	installLocalSigner(t, userRepo, keypairRepo)
+	sharedInbox := "https://remote.example/inbox"
+	personalInbox := "https://other.example/users/x/inbox"
+	followingRepo.RemoteInboxes["alice"] = []string{sharedInbox, personalInbox}
+	followingRepo.RemoteSharedInboxes[sharedInbox] = true
+
+	require.NoError(t, svc.DeliverToFollowers("alice", []byte(`{}`)))
+	require.Len(t, enq.calls, 2)
+	byInbox := map[string]bool{}
+	for _, c := range enq.calls {
+		byInbox[c.Inbox] = c.IsSharedInbox
+	}
+	assert.True(t, byInbox[sharedInbox], "shared inbox は IsSharedInbox=true")
+	assert.False(t, byInbox[personalInbox], "個別 inbox は IsSharedInbox=false")
+}
+
+// #1811: DeliverToUser は recipient の sharedInbox を IsSharedInbox=true にする。
+func TestDeliverToUser_ThreadsSharedInboxFlag(t *testing.T) {
+	svc, enq, userRepo, _, keypairRepo := newDeliverService(t)
+	installLocalSigner(t, userRepo, keypairRepo)
+	host := "remote.example"
+	shared := "https://remote.example/inbox"
+	personal := "https://remote.example/users/bob/inbox"
+	recipient := &model.User{ID: "bob", Host: &host, SharedInbox: &shared, Inbox: &personal}
+	require.NoError(t, svc.DeliverToUser("alice", recipient, []byte(`{}`)))
+	require.Len(t, enq.calls, 1)
+	assert.Equal(t, shared, enq.calls[0].Inbox)
+	assert.True(t, enq.calls[0].IsSharedInbox)
+}
+
 func TestDeliverToFollowers_RepoError(t *testing.T) {
 	svc, _, userRepo, _, keypairRepo := newDeliverService(t)
 	installLocalSigner(t, userRepo, keypairRepo)
@@ -472,7 +506,7 @@ type failingListInboxesRepo struct {
 	*testutil.MockFollowingRepository
 }
 
-func (f *failingListInboxesRepo) ListRemoteFollowerInboxes(_ string) ([]string, error) {
+func (f *failingListInboxesRepo) ListRemoteFollowerInboxes(_ string) ([]model.RemoteInbox, error) {
 	return nil, errors.New("db down")
 }
 

--- a/internal/core/instance/instance_service.go
+++ b/internal/core/instance/instance_service.go
@@ -19,6 +19,12 @@ import (
 	"github.com/shiroha-a/mk/internal/repository"
 )
 
+// autoSuspendNotRespondingThreshold is how long an instance must be
+// continuously not-responding before it is auto-suspended
+// (autoSuspendedForNotResponding)。upstream DeliverProcessorService の
+// `1000 * 60 * 60 * 24 * 7` (1 週間) と一致する (#1811)。
+const autoSuspendNotRespondingThreshold = 7 * 24 * time.Hour
+
 // hostMatchCaser folds host names case-insensitively in a Unicode-aware
 // manner. Misskey TS uses String.prototype.toLowerCase() which works on
 // arbitrary Unicode (e.g. \`Ä\` → \`ä\`); strings.ToLower in Go only handles
@@ -319,10 +325,23 @@ func (s *Service) RecordResponseError(host string) error {
 	if err != nil {
 		return nil
 	}
+	now := s.clock()
 	if inst.IsNotResponding {
+		// 既に not-responding。upstream DeliverProcessorService:
+		//   - notRespondingSince があり 1 週間以上不通 かつ suspensionState==none なら
+		//     autoSuspendedForNotResponding に自動 suspend する。
+		//   - notRespondingSince が無い (旧データ) なら backfill する。
+		if inst.NotRespondingSince == nil {
+			return s.repo.UpdateFields(host, map[string]any{"notRespondingSince": &now})
+		}
+		if inst.SuspensionState == model.SuspensionStateNone &&
+			!inst.NotRespondingSince.After(now.Add(-autoSuspendNotRespondingThreshold)) {
+			return s.repo.UpdateFields(host, map[string]any{
+				"suspensionState": string(model.SuspensionStateAutoSuspendedForNotResponding),
+			})
+		}
 		return nil
 	}
-	now := s.clock()
 	if err := s.repo.UpdateFields(host, map[string]any{
 		"isNotResponding":    true,
 		"notRespondingSince": &now,
@@ -337,6 +356,27 @@ func (s *Service) RecordResponseError(host string) error {
 	delete(s.responseHealthyCache, host)
 	s.mu.Unlock()
 	return nil
+}
+
+// MarkGoneSuspended suspends an instance whose shared inbox returned 410 Gone,
+// matching upstream DeliverProcessorService (isSharedInbox && 410 -> goneSuspended)
+// で以後の配送を止める (#1811)。既に同 state なら no-op。手動 suspend は上書き
+// しない (goneSuspended は自動判定で、admin の manuallySuspended を消さない)。
+func (s *Service) MarkGoneSuspended(host string) error {
+	if host == "" {
+		return nil
+	}
+	inst, err := s.repo.FindByHost(host)
+	if err != nil {
+		return nil
+	}
+	if inst.SuspensionState == model.SuspensionStateGoneSuspended ||
+		inst.SuspensionState == model.SuspensionStateManuallySuspended {
+		return nil
+	}
+	return s.repo.UpdateFields(host, map[string]any{
+		"suspensionState": string(model.SuspensionStateGoneSuspended),
+	})
 }
 
 // IsBlocked reports whether the host matches an entry in meta.blockedHosts.

--- a/internal/core/instance/instance_service_test.go
+++ b/internal/core/instance/instance_service_test.go
@@ -123,6 +123,75 @@ func TestService_RecordResponseError_AlreadyNotResponding(t *testing.T) {
 	assert.Equal(t, &since, repo.Instances["alpha.example"].NotRespondingSince)
 }
 
+// #1811: 1 週間以上 not-responding (suspensionState==none) なら
+// autoSuspendedForNotResponding に自動 suspend する。
+func TestService_RecordResponseError_AutoSuspendsAfter7Days(t *testing.T) {
+	svc, repo, _ := newService(t)
+	old := time.Now().Add(-8 * 24 * time.Hour)
+	repo.Instances["alpha.example"] = &model.Instance{
+		ID: "i1", Host: "alpha.example",
+		IsNotResponding: true, NotRespondingSince: &old,
+		SuspensionState: model.SuspensionStateNone,
+	}
+	require.NoError(t, svc.RecordResponseError("alpha.example"))
+	assert.Equal(t, model.SuspensionStateAutoSuspendedForNotResponding, repo.Instances["alpha.example"].SuspensionState)
+}
+
+// 7 日未満なら suspend しない。
+func TestService_RecordResponseError_NoSuspendBefore7Days(t *testing.T) {
+	svc, repo, _ := newService(t)
+	recent := time.Now().Add(-3 * 24 * time.Hour)
+	repo.Instances["alpha.example"] = &model.Instance{
+		ID: "i1", Host: "alpha.example",
+		IsNotResponding: true, NotRespondingSince: &recent,
+		SuspensionState: model.SuspensionStateNone,
+	}
+	require.NoError(t, svc.RecordResponseError("alpha.example"))
+	assert.Equal(t, model.SuspensionStateNone, repo.Instances["alpha.example"].SuspensionState)
+}
+
+// notRespondingSince が nil (旧データ) なら backfill する。
+func TestService_RecordResponseError_BackfillsNotRespondingSince(t *testing.T) {
+	svc, repo, _ := newService(t)
+	repo.Instances["alpha.example"] = &model.Instance{
+		ID: "i1", Host: "alpha.example", IsNotResponding: true, NotRespondingSince: nil,
+		SuspensionState: model.SuspensionStateNone,
+	}
+	require.NoError(t, svc.RecordResponseError("alpha.example"))
+	require.NotNil(t, repo.Instances["alpha.example"].NotRespondingSince)
+	assert.Equal(t, model.SuspensionStateNone, repo.Instances["alpha.example"].SuspensionState)
+}
+
+// 既に手動 suspend の instance は 7 日経過でも自動切替しない。
+func TestService_RecordResponseError_DoesNotOverrideManualSuspend(t *testing.T) {
+	svc, repo, _ := newService(t)
+	old := time.Now().Add(-8 * 24 * time.Hour)
+	repo.Instances["alpha.example"] = &model.Instance{
+		ID: "i1", Host: "alpha.example",
+		IsNotResponding: true, NotRespondingSince: &old,
+		SuspensionState: model.SuspensionStateManuallySuspended,
+	}
+	require.NoError(t, svc.RecordResponseError("alpha.example"))
+	assert.Equal(t, model.SuspensionStateManuallySuspended, repo.Instances["alpha.example"].SuspensionState)
+}
+
+// #1811: MarkGoneSuspended は goneSuspended に切替。手動 suspend / 既 gone は no-op。
+func TestService_MarkGoneSuspended(t *testing.T) {
+	svc, repo, _ := newService(t)
+	repo.Instances["alpha.example"] = &model.Instance{ID: "i1", Host: "alpha.example"}
+	require.NoError(t, svc.MarkGoneSuspended("alpha.example"))
+	assert.Equal(t, model.SuspensionStateGoneSuspended, repo.Instances["alpha.example"].SuspensionState)
+
+	// 手動 suspend は上書きしない。
+	repo.Instances["beta.example"] = &model.Instance{ID: "i2", Host: "beta.example", SuspensionState: model.SuspensionStateManuallySuspended}
+	require.NoError(t, svc.MarkGoneSuspended("beta.example"))
+	assert.Equal(t, model.SuspensionStateManuallySuspended, repo.Instances["beta.example"].SuspensionState)
+
+	// 未知 host / 空 host は no-op。
+	require.NoError(t, svc.MarkGoneSuspended("missing.example"))
+	require.NoError(t, svc.MarkGoneSuspended(""))
+}
+
 func TestService_RecordResponseError_UnknownHost(t *testing.T) {
 	svc, _, _ := newService(t)
 	require.NoError(t, svc.RecordResponseError("missing.example"))

--- a/internal/model/user_profile.go
+++ b/internal/model/user_profile.go
@@ -77,3 +77,13 @@ type FollowingBirthday struct {
 	// Birthday is the raw "YYYY-MM-DD" string as stored in user_profile.
 	Birthday string `gorm:"column:birthday"`
 }
+
+// RemoteInbox is a remote follower's delivery inbox plus whether it is the
+// instance's shared inbox (vs a personal inbox). Shared inboxes drive the
+// deliver goneSuspended decision on a 410 Gone (#1811)。query-result DTO なので
+// repository ではなく model に置く (testutil mock が repository を import すると
+// repository の internal test 経由で import cycle になるため)。
+type RemoteInbox struct {
+	Inbox  string
+	Shared bool
+}

--- a/internal/queue/processors/deliver.go
+++ b/internal/queue/processors/deliver.go
@@ -45,6 +45,9 @@ type HTTPSigner interface {
 type ResponseHook interface {
 	RecordResponseSuccess(host string) error
 	RecordResponseError(host string) error
+	// MarkGoneSuspended suspends an instance whose shared inbox returned 410
+	// (goneSuspended、#1811)。
+	MarkGoneSuspended(host string) error
 }
 
 // ChartHook is invoked after each HTTP attempt so the chart subsystem
@@ -260,6 +263,15 @@ func (p *DeliverProcessor) recordSuccess(inbox string) {
 	}
 }
 
+// recordGoneSuspended is a best-effort wrapper that suspends the instance whose
+// shared inbox returned 410 Gone (#1811)。
+func (p *DeliverProcessor) recordGoneSuspended(inbox string) {
+	host := hostFromInbox(inbox)
+	if p.responseHook != nil && host != "" {
+		_ = p.responseHook.MarkGoneSuspended(host)
+	}
+}
+
 // recordError is a best-effort wrapper that fires both the response
 // hook and the chart hook for a failed inbox POST.
 func (p *DeliverProcessor) recordError(inbox string) {
@@ -347,6 +359,13 @@ func (p *DeliverProcessor) Handle(_ context.Context, t driver.Task) error {
 		slog.Info("ap deliver: target gone",
 			"inbox", payload.Inbox, "status", resp.StatusCode)
 		p.recordSuccess(payload.Inbox)
+		// shared inbox が 410 Gone を返したらインスタンス全体が消滅したとみなし
+		// goneSuspended に切り替えて以後の配送を止める (upstream
+		// DeliverProcessorService の isSharedInbox && 410、#1811)。404 は個別 actor
+		// 不在の可能性があるので suspend しない。
+		if payload.IsSharedInbox && resp.StatusCode == http.StatusGone {
+			p.recordGoneSuspended(payload.Inbox)
+		}
 		return fmt.Errorf("target gone (%d): %w", resp.StatusCode, driver.SkipRetry)
 	case resp.StatusCode >= 400 && resp.StatusCode < 500:
 		// その他の4xxは受信側の不正リクエスト扱い。HTTP として応答が返って

--- a/internal/queue/processors/deliver_test.go
+++ b/internal/queue/processors/deliver_test.go
@@ -337,6 +337,7 @@ func TestDeliverProcessor_Ed25519_DegradeFlagSkipsEd25519(t *testing.T) {
 type stubResponseHook struct {
 	successes []string
 	errors    []string
+	goneHosts []string
 }
 
 func (s *stubResponseHook) RecordResponseSuccess(host string) error {
@@ -346,6 +347,11 @@ func (s *stubResponseHook) RecordResponseSuccess(host string) error {
 
 func (s *stubResponseHook) RecordResponseError(host string) error {
 	s.errors = append(s.errors, host)
+	return nil
+}
+
+func (s *stubResponseHook) MarkGoneSuspended(host string) error {
+	s.goneHosts = append(s.goneHosts, host)
 	return nil
 }
 
@@ -367,6 +373,44 @@ func TestDeliverProcessor_ResponseHook_Gone_RecordsSuccess(t *testing.T) {
 	err := p.Handle(context.Background(), makeTask(t, makePayload(t)))
 	require.Error(t, err)
 	assert.Equal(t, []string{"remote.example"}, hook.successes)
+}
+
+// #1811: shared inbox が 410 Gone を返したらインスタンス全体を goneSuspended にする。
+func TestDeliverProcessor_SharedInbox_Gone_SuspendsInstance(t *testing.T) {
+	signer := &stubSigner{resp: okResponse(http.StatusGone)}
+	p := processors.NewDeliverProcessor(signer)
+	hook := &stubResponseHook{}
+	p.SetResponseHook(hook)
+	payload := makePayload(t)
+	payload.IsSharedInbox = true
+	err := p.Handle(context.Background(), makeTask(t, payload))
+	require.Error(t, err)
+	assert.Equal(t, []string{"remote.example"}, hook.goneHosts, "shared inbox 410 -> goneSuspended")
+}
+
+// 個別 inbox の 410 はインスタンスを suspend しない (個別 actor 不在の可能性)。
+func TestDeliverProcessor_PersonalInbox_Gone_NoSuspend(t *testing.T) {
+	signer := &stubSigner{resp: okResponse(http.StatusGone)}
+	p := processors.NewDeliverProcessor(signer)
+	hook := &stubResponseHook{}
+	p.SetResponseHook(hook)
+	payload := makePayload(t) // IsSharedInbox=false
+	err := p.Handle(context.Background(), makeTask(t, payload))
+	require.Error(t, err)
+	assert.Empty(t, hook.goneHosts, "personal inbox 410 must not suspend the instance")
+}
+
+// shared inbox でも 404 は suspend しない (410 Gone のみが「消滅」シグナル)。
+func TestDeliverProcessor_SharedInbox_NotFound_NoSuspend(t *testing.T) {
+	signer := &stubSigner{resp: okResponse(http.StatusNotFound)}
+	p := processors.NewDeliverProcessor(signer)
+	hook := &stubResponseHook{}
+	p.SetResponseHook(hook)
+	payload := makePayload(t)
+	payload.IsSharedInbox = true
+	err := p.Handle(context.Background(), makeTask(t, payload))
+	require.Error(t, err)
+	assert.Empty(t, hook.goneHosts, "404 must not suspend (only 410 Gone)")
 }
 
 func TestDeliverProcessor_ResponseHook_ClientError_RecordsSuccess(t *testing.T) {

--- a/internal/queue/tasks.go
+++ b/internal/queue/tasks.go
@@ -154,6 +154,10 @@ type DeliverPayload struct {
 	Ed25519KeyID string `json:"ed25519KeyId,omitempty"`
 	// Ed25519PrivPEM is the PEM-encoded Ed25519 (PKCS8) private key.
 	Ed25519PrivPEM string `json:"ed25519PrivPem,omitempty"`
+	// IsSharedInbox marks deliveries to a remote instance's shared inbox. On a
+	// 410 Gone from a shared inbox the whole instance is suspended
+	// (goneSuspended)、upstream DeliverProcessorService と同じ (#1811)。
+	IsSharedInbox bool `json:"isSharedInbox,omitempty"`
 }
 
 // NewDeliverTask serializes the payload into a driver.Task ready to

--- a/internal/repository/following.go
+++ b/internal/repository/following.go
@@ -73,10 +73,11 @@ type FollowingRepository interface {
 	// either the follower or the followee. Returns the total affected rows.
 	// Used by cascade account deletion.
 	DeleteAllByUser(userID string) (int64, error)
-	// ListRemoteFollowerInboxes returns the deduplicated list of inbox URLs for
-	// remote followers of userID. sharedInbox を持つフォロワーは sharedInbox
-	// に集約され、無いフォロワーは個別inboxを返す。
-	ListRemoteFollowerInboxes(userID string) ([]string, error)
+	// ListRemoteFollowerInboxes returns the deduplicated inboxes for remote
+	// followers of userID. sharedInbox を持つフォロワーは sharedInbox に集約され
+	// (Shared=true)、無いフォロワーは個別 inbox (Shared=false)。Shared フラグは
+	// deliver の goneSuspended 判定 (shared inbox の 410) に使う (#1811)。
+	ListRemoteFollowerInboxes(userID string) ([]model.RemoteInbox, error)
 	// ListFollowingByBirthday returns the followees of followerID whose
 	// birthday (mmdd) falls in [beginMMDD, endMMDD] inclusive. Passing
 	// beginMMDD > endMMDD treats the range as year-wrapping (e.g. 1225..0105).
@@ -350,22 +351,27 @@ func (r *followingRepository) DeleteAllByUser(userID string) (int64, error) {
 //  1. follower がリモート (host IS NOT NULL) のフォロワーをjoin
 //  2. sharedInbox があれば sharedInbox、無ければ inbox を選択
 //  3. NULL/空文字列を除外し DISTINCT で重複排除
-func (r *followingRepository) ListRemoteFollowerInboxes(userID string) ([]string, error) {
-	var inboxes []string
+func (r *followingRepository) ListRemoteFollowerInboxes(userID string) ([]model.RemoteInbox, error) {
+	var rows []struct {
+		Inbox  string
+		Shared bool
+	}
+	// shared フラグは sharedInbox が非空のとき true (= COALESCE で sharedInbox 側を
+	// 選んだ行)。同 shared inbox を共有する複数フォロワーは DISTINCT で 1 行に集約。
 	err := r.db.
 		Table(`"following" AS f`).
-		Select(`DISTINCT COALESCE(NULLIF(u."sharedInbox", ''), u.inbox) AS inbox`).
+		Select(`DISTINCT COALESCE(NULLIF(u."sharedInbox", ''), u.inbox) AS inbox, (u."sharedInbox" IS NOT NULL AND u."sharedInbox" != '') AS shared`).
 		Joins(`JOIN "user" u ON u.id = f."followerId"`).
 		Where(`f."followeeId" = ? AND u.host IS NOT NULL AND (u."sharedInbox" IS NOT NULL OR u.inbox IS NOT NULL)`, userID).
-		Pluck("inbox", &inboxes).Error
+		Scan(&rows).Error
 	if err != nil {
 		return nil, err
 	}
 	// COALESCE が NULL を返す可能性があるため、空文字を除去
-	out := make([]string, 0, len(inboxes))
-	for _, inb := range inboxes {
-		if inb != "" {
-			out = append(out, inb)
+	out := make([]model.RemoteInbox, 0, len(rows))
+	for _, row := range rows {
+		if row.Inbox != "" {
+			out = append(out, model.RemoteInbox{Inbox: row.Inbox, Shared: row.Shared})
 		}
 	}
 	return out, nil

--- a/internal/repository/following_test.go
+++ b/internal/repository/following_test.go
@@ -377,7 +377,11 @@ func TestFollowingRepository_ListRemoteFollowerInboxes(t *testing.T) {
 
 	inboxes, err := repo.ListRemoteFollowerInboxes(followee.ID)
 	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{sharedInbox1, inbox3}, inboxes)
+	// #1811: sharedInbox 集約は Shared=true、個別 inbox は Shared=false。
+	assert.ElementsMatch(t, []model.RemoteInbox{
+		{Inbox: sharedInbox1, Shared: true},
+		{Inbox: inbox3, Shared: false},
+	}, inboxes)
 }
 
 func TestUserRepository_IncrementFollowingCount(t *testing.T) {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -5098,6 +5098,9 @@ type MockFollowingRepository struct {
 	// RemoteInboxes stores per-followee inbox lists used by
 	// ListRemoteFollowerInboxes. テスト側で明示的に登録する。
 	RemoteInboxes map[string][]string
+	// RemoteSharedInboxes maps an inbox URL to whether it is a shared inbox
+	// (#1811). 未登録の URL は Shared=false 扱い。
+	RemoteSharedInboxes map[string]bool
 	// Birthdays maps followeeID -> "YYYY-MM-DD" string used by
 	// ListFollowingByBirthday. 未登録のユーザーは誕生日なしとして扱う。
 	Birthdays map[string]string
@@ -5105,9 +5108,10 @@ type MockFollowingRepository struct {
 
 func NewMockFollowingRepository() *MockFollowingRepository {
 	return &MockFollowingRepository{
-		Followings:    make(map[string]*model.Following),
-		RemoteInboxes: make(map[string][]string),
-		Birthdays:     make(map[string]string),
+		Followings:          make(map[string]*model.Following),
+		RemoteInboxes:       make(map[string][]string),
+		RemoteSharedInboxes: make(map[string]bool),
+		Birthdays:           make(map[string]string),
 	}
 }
 
@@ -5124,8 +5128,13 @@ func (m *MockFollowingRepository) DeleteAllByUser(userID string) (int64, error) 
 	return n, nil
 }
 
-func (m *MockFollowingRepository) ListRemoteFollowerInboxes(userID string) ([]string, error) {
-	return m.RemoteInboxes[userID], nil
+func (m *MockFollowingRepository) ListRemoteFollowerInboxes(userID string) ([]model.RemoteInbox, error) {
+	urls := m.RemoteInboxes[userID]
+	out := make([]model.RemoteInbox, 0, len(urls))
+	for _, u := range urls {
+		out = append(out, model.RemoteInbox{Inbox: u, Shared: m.RemoteSharedInboxes[u]})
+	}
+	return out, nil
 }
 
 func (m *MockFollowingRepository) Create(f *model.Following) error {


### PR DESCRIPTION
## Summary

#1780 から分離した follow-up (M1)。upstream `DeliverProcessorService` に倣い、配送失敗インスタンスを自動 suspend する。これまで `SuspensionStateGoneSuspended` / `SuspensionStateAutoSuspendedForNotResponding` 定数はあるが production の書込経路が無く、リモートインスタンスが自動 suspend されなかった。

## 主な変更点

- **[autoSuspendedForNotResponding] 7日不通で自動 suspend**: `core/instance.RecordResponseError` を拡張。既に not-responding かつ `notRespondingSince` が 1 週間以上前 かつ `suspensionState==none` なら `autoSuspendedForNotResponding` に切替。`notRespondingSince` が nil の旧データは backfill。手動 suspend / goneSuspended は上書きしない。deliver は 5xx/network 失敗時に `RecordResponseError` を呼ぶため、7 日継続不通で自動 suspend される。
- **[goneSuspended] shared inbox 410 でインスタンス suspend**: shared inbox が 410 Gone を返したらインスタンス全体を `goneSuspended` に切替えて以後の配送停止。`DeliverPayload.IsSharedInbox` を追加し、deliver の 410 branch (404 は除外) で `MarkGoneSuspended` を呼ぶ。`isSharedInbox` を配送経路で threading: `ListRemoteFollowerInboxes` が `model.RemoteInbox{Inbox, Shared}` を返すよう変更 (`DeliverToFollowers` が shared-set 構築)、`DeliverToUser` は recipient.SharedInbox 一致で判定。

`RemoteInbox` は query-result DTO なので `model` パッケージに置く (testutil mock が repository を import すると repository internal test 経由で import cycle になるため)。

## レビュー (implement → review → fix → PR)

adversarial finder で 7 日閾値の比較方向 (`!notRespondingSince.After(now-7d)` = `<= now-7d`) / SQL の `(inbox, shared)` ペア整合 + safe bias / 410+recordSuccess+goneSuspended の field 非競合 / interface ripple 完全性 / import cycle 回避を upstream `DeliverProcessorService.ts` と照合: **correctness bug 0件**。`FollowingRepository` interface 変更は mock + fake へ波及反映済 (full `go vet` クリーン)。修正工程は no-op。

## 既知の非 bug

- 自動 suspend / goneSuspended 後、`suspendCache` (5分 TTL) が切れるまで最大 ~5分は配送が続きうる (fail-soft caching、最悪でも gone/不通 host への数回の再試行で無害)。

## テスト

- `RecordResponseError` の 7 日 auto-suspend / 7 日未満非 suspend / backfill / 手動 suspend 非上書き、`MarkGoneSuspended` (gone 切替 + manual/既 gone no-op)、deliver の shared 410→suspend / personal 410→非 suspend / shared 404→非 suspend、`DeliverToFollowers`・`DeliverToUser` の IsSharedInbox threading、repo の shared-ness を追加。
- coverage: core/instance 92.9% / queue/processors 91.3% / core/federation 90.2% / repository 90.1%。

Closes #1811

🤖 Generated with [Claude Code](https://claude.com/claude-code)