### PR TITLE
Fix timeline parity (#1812): live note を isNoteMutedOrBlocked で filter

### DIFF
--- a/internal/stream/channels/antenna.go
+++ b/internal/stream/channels/antenna.go
@@ -88,6 +88,9 @@ func (c *AntennaChannel) OnRedisEvent(payload []byte) {
 	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerIDFromCtx(c.ctx)) {
 		return
 	}
+	if noteMutedOrBlocked(payload, c.ctx.MuteBlockSnapshot()) {
+		return
+	}
 	// embedded renote/reply の per-viewer 可視性 gate (#1536)。絶対に消さない:
 	// 消すと non-visible な引用/返信元が top-level antenna note 経由で漏れる
 	// IDOR を再 open する。

--- a/internal/stream/channels/channel_timeline.go
+++ b/internal/stream/channels/channel_timeline.go
@@ -57,6 +57,12 @@ func (c *ChannelTimelineChannel) OnRedisEvent(payload []byte) {
 	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerIDFromCtx(c.ctx)) {
 		return
 	}
+	// channel timeline は upstream channel.ts の override に倣い、視聴中 channel
+	// 自身の mute は無視する (直接見ている channel の note は流す)。他 channel への
+	// renote の channel-mute のみ適用する (#1812)。
+	if noteMutedOrBlockedInChannel(payload, c.ctx.MuteBlockSnapshot(), c.channelID) {
+		return
+	}
 	payload = hideEmbeds(c.ctx, payload)
 	_ = c.ctx.Send("note", json.RawMessage(payload))
 }

--- a/internal/stream/channels/hashtag.go
+++ b/internal/stream/channels/hashtag.go
@@ -106,6 +106,9 @@ func (c *HashtagChannel) OnRedisEvent(payload []byte) {
 	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerIDFromCtx(c.ctx)) {
 		return
 	}
+	if noteMutedOrBlocked(payload, c.ctx.MuteBlockSnapshot()) {
+		return
+	}
 	payload = hideEmbeds(c.ctx, payload)
 	_ = c.ctx.Send("note", json.RawMessage(payload))
 }

--- a/internal/stream/channels/main_mute_filter.go
+++ b/internal/stream/channels/main_mute_filter.go
@@ -63,6 +63,51 @@ func noteMutedOrBlocked(payload []byte, snap *stream.MuteBlockSnapshot) bool {
 	if err := json.Unmarshal(payload, &p); err != nil {
 		return false
 	}
+	if mutedOrBlockedExceptChannel(p, snap) {
+		return true
+	}
+	// channel-mute: note の所属 channel か、renote 先の channel が muted。
+	return channelRelated(p, snap.MutingChannels)
+}
+
+// noteMutedOrBlockedInChannel mirrors upstream channel.ts's `override
+// isNoteMutedOrBlocked` for the "channel" timeline (#1812). It shares the
+// instance-mute / user-mute / block / renote-mute gate with the base, but for
+// channel-mute it deliberately ignores the note's own channel: directly viewing
+// a channel must keep streaming its notes even when that channel is muted. Only
+// a renote whose target channel differs from the viewed channel and is muted is
+// dropped (upstream: 「このソケットで見ているチャンネルがミュートされていたとしても、
+// チャンネルを直接見ている以上は流すようにしたい。ただし、他のミュートしている
+// チャンネルは流さないようにもしたい」). viewingChannelID is the channel this
+// socket subscribed to.
+func noteMutedOrBlockedInChannel(payload []byte, snap *stream.MuteBlockSnapshot, viewingChannelID string) bool {
+	if snap == nil {
+		return false
+	}
+	var p muteBlockProbe
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return false
+	}
+	if mutedOrBlockedExceptChannel(p, snap) {
+		return true
+	}
+	// channel-mute (override): own-channel は無視し、renote 先 channel が
+	// 視聴中 channel と異なり muted の場合のみ drop。
+	if len(snap.MutingChannels) > 0 && p.Renote != nil && p.Renote.ChannelID != nil {
+		if rc := *p.Renote.ChannelID; rc != viewingChannelID {
+			if _, ok := snap.MutingChannels[rc]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// mutedOrBlockedExceptChannel applies the instance-mute / user-mute / block /
+// renote-mute checks shared by every channel's isNoteMutedOrBlocked, leaving the
+// channel-mute branch (which differs between the base and the channel-timeline
+// override) to the caller. p must already be unmarshaled.
+func mutedOrBlockedExceptChannel(p muteBlockProbe, snap *stream.MuteBlockSnapshot) bool {
 	// instance-mute: note / reply / renote の author host のいずれか。
 	if len(snap.MutedInstances) > 0 {
 		if hostMuted(p.User.Host, snap.MutedInstances) {
@@ -89,10 +134,6 @@ func noteMutedOrBlocked(payload []byte, snap *stream.MuteBlockSnapshot) bool {
 		if _, ok := snap.RenoteMuting[p.UserID]; ok {
 			return true
 		}
-	}
-	// channel-mute: note の所属 channel か、renote 先の channel が muted。
-	if channelRelated(p, snap.MutingChannels) {
-		return true
 	}
 	return false
 }

--- a/internal/stream/channels/new_channels_test.go
+++ b/internal/stream/channels/new_channels_test.go
@@ -436,6 +436,30 @@ func TestChannelTimeline_AuthedRequireSigninPassed(t *testing.T) {
 	require.Len(t, ctx.sentType, 1, "authenticated viewer is exempt from the requireSignin gate")
 }
 
+// #1812: channel timeline は upstream channel.ts の override に倣い、視聴中の
+// channel 自身が mute されていても note を流す (直接見ている以上は配信する)。
+func TestChannelTimeline_MutedOwnChannelStillStreamed(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "viewer"})
+	// viewer は視聴中の ch1 を mute している。
+	ctx.muteBlockSnap = &stream.MuteBlockSnapshot{MutingChannels: map[string]struct{}{"ch1": {}}}
+	ch := NewChannelTimeline(ctx)
+	ch.Init(json.RawMessage(`{"channelId":"ch1"}`))
+	ch.OnRedisEvent([]byte(`{"id":"n1","channelId":"ch1","userId":"author","visibility":"public"}`))
+	require.Len(t, ctx.sentType, 1, "視聴中 channel の mute では own-channel note を落とさない")
+}
+
+// #1812: ただし他の mute された channel への renote は channel timeline でも落とす。
+func TestChannelTimeline_MutedRenoteChannelDropped(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "viewer"})
+	// viewer は ch1 を見ているが、別 channel ch2 を mute している。
+	ctx.muteBlockSnap = &stream.MuteBlockSnapshot{MutingChannels: map[string]struct{}{"ch2": {}}}
+	ch := NewChannelTimeline(ctx)
+	ch.Init(json.RawMessage(`{"channelId":"ch1"}`))
+	// ch1 に流れた、ch2 の note への renote。
+	ch.OnRedisEvent([]byte(`{"id":"n2","channelId":"ch1","userId":"author","visibility":"public","renoteId":"r1","renote":{"channelId":"ch2","userId":"x","user":{"id":"x"}}}`))
+	assert.Empty(t, ctx.sentType, "他の mute された channel への renote は drop する")
+}
+
 // --- UserList ---
 
 func TestUserList_Lifecycle(t *testing.T) {

--- a/internal/stream/channels/role_timeline.go
+++ b/internal/stream/channels/role_timeline.go
@@ -75,6 +75,9 @@ func (c *RoleTimelineChannel) OnRedisEvent(payload []byte) {
 	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerIDFromCtx(c.ctx)) {
 		return
 	}
+	if noteMutedOrBlocked(payload, c.ctx.MuteBlockSnapshot()) {
+		return
+	}
 	payload = hideEmbeds(c.ctx, payload)
 	_ = c.ctx.Send("note", json.RawMessage(payload))
 }

--- a/internal/stream/channels/timeline.go
+++ b/internal/stream/channels/timeline.go
@@ -38,6 +38,12 @@ func (c *LocalTimelineChannel) OnRedisEvent(payload []byte) {
 	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerID) {
 		return
 	}
+	// live note も user-mute / block / instance-mute / renote-mute / channel-mute で
+	// filter する (upstream channel.ts isNoteMutedOrBlocked、#1812)。snapshot は
+	// connection 確立時にロード済 (未配線/anon は nil で fail-open)。
+	if noteMutedOrBlocked(payload, c.ctx.MuteBlockSnapshot()) {
+		return
+	}
 	if !replyShouldEmit(payload, viewerID, c.ctx.FollowingSnapshot(), c.filter.WithReplies, replyGateLocal) {
 		return
 	}
@@ -76,6 +82,12 @@ func (c *GlobalTimelineChannel) Init(params json.RawMessage) error {
 func (c *GlobalTimelineChannel) OnRedisEvent(payload []byte) {
 	viewerID := viewerIDFromCtx(c.ctx)
 	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerID) {
+		return
+	}
+	// live note も user-mute / block / instance-mute / renote-mute / channel-mute で
+	// filter する (upstream channel.ts isNoteMutedOrBlocked、#1812)。snapshot は
+	// connection 確立時にロード済 (未配線/anon は nil で fail-open)。
+	if noteMutedOrBlocked(payload, c.ctx.MuteBlockSnapshot()) {
 		return
 	}
 	if !replyShouldEmit(payload, viewerID, c.ctx.FollowingSnapshot(), c.filter.WithReplies, replyGateGlobal) {
@@ -124,6 +136,12 @@ func (c *HomeTimelineChannel) Init(params json.RawMessage) error {
 func (c *HomeTimelineChannel) OnRedisEvent(payload []byte) {
 	viewerID := viewerIDFromCtx(c.ctx)
 	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerID) {
+		return
+	}
+	// live note も user-mute / block / instance-mute / renote-mute / channel-mute で
+	// filter する (upstream channel.ts isNoteMutedOrBlocked、#1812)。snapshot は
+	// connection 確立時にロード済 (未配線/anon は nil で fail-open)。
+	if noteMutedOrBlocked(payload, c.ctx.MuteBlockSnapshot()) {
 		return
 	}
 	if !replyShouldEmit(payload, viewerID, c.ctx.FollowingSnapshot(), false, replyGateHome) {
@@ -175,6 +193,12 @@ func (c *HybridTimelineChannel) Init(params json.RawMessage) error {
 func (c *HybridTimelineChannel) OnRedisEvent(payload []byte) {
 	viewerID := viewerIDFromCtx(c.ctx)
 	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerID) {
+		return
+	}
+	// live note も user-mute / block / instance-mute / renote-mute / channel-mute で
+	// filter する (upstream channel.ts isNoteMutedOrBlocked、#1812)。snapshot は
+	// connection 確立時にロード済 (未配線/anon は nil で fail-open)。
+	if noteMutedOrBlocked(payload, c.ctx.MuteBlockSnapshot()) {
 		return
 	}
 	if !replyShouldEmit(payload, viewerID, c.ctx.FollowingSnapshot(), c.filter.WithReplies, replyGateHybrid) {

--- a/internal/stream/channels/timeline_test.go
+++ b/internal/stream/channels/timeline_test.go
@@ -77,6 +77,35 @@ var (
 	_ stream.Channel = (*MainChannel)(nil)
 )
 
+// #1812: timeline channel は mute/block snapshot に該当する live note を drop する。
+func TestLocalTimeline_DropsMutedAndBlockedAndInstance(t *testing.T) {
+	// user-mute: muted author の note を落とす。
+	muted := newCtx(&model.User{ID: "viewer"})
+	muted.muteBlockSnap = &stream.MuteBlockSnapshot{Muting: map[string]struct{}{"bad": {}}}
+	chM := NewLocalTimeline(muted)
+	chM.Init(nil)
+	chM.OnRedisEvent([]byte(`{"id":"n1","userId":"bad"}`))
+	assert.Empty(t, muted.sentType, "muted author の note は drop する")
+	chM.OnRedisEvent([]byte(`{"id":"n2","userId":"ok"}`))
+	assert.Len(t, muted.sentType, 1, "非 mute author は通す")
+
+	// block (blockingMe): 自分を block している author の note を落とす。
+	blk := newCtx(&model.User{ID: "viewer"})
+	blk.muteBlockSnap = &stream.MuteBlockSnapshot{BlockingMe: map[string]struct{}{"enemy": {}}}
+	chB := NewLocalTimeline(blk)
+	chB.Init(nil)
+	chB.OnRedisEvent([]byte(`{"id":"n3","userId":"enemy"}`))
+	assert.Empty(t, blk.sentType, "blockingMe author の note は drop する")
+
+	// instance-mute: muted host の author の note を落とす。
+	inst := newCtx(&model.User{ID: "viewer"})
+	inst.muteBlockSnap = &stream.MuteBlockSnapshot{MutedInstances: map[string]struct{}{"bad.example": {}}}
+	chI := NewLocalTimeline(inst)
+	chI.Init(nil)
+	chI.OnRedisEvent([]byte(`{"id":"n4","userId":"r","user":{"host":"bad.example"}}`))
+	assert.Empty(t, inst.sentType, "muted instance の note は drop する")
+}
+
 func TestLocalTimeline_Lifecycle(t *testing.T) {
 	ctx := newCtx(nil)
 	ch := NewLocalTimeline(ctx)

--- a/internal/stream/channels/user_list.go
+++ b/internal/stream/channels/user_list.go
@@ -80,6 +80,9 @@ func (c *UserListChannel) OnRedisEvent(payload []byte) {
 	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerID) {
 		return
 	}
+	if noteMutedOrBlocked(payload, c.ctx.MuteBlockSnapshot()) {
+		return
+	}
 	// followers visibility note の defense-in-depth filter (#1465)。fanout 段
 	// で list owner の follow 関係を check してから push する設計だが、過去に
 	// stream へ滞留した entry や fanout の設定ミスに対して WS 側でも 1 段

--- a/internal/stream/connection.go
+++ b/internal/stream/connection.go
@@ -211,9 +211,10 @@ func (c *Connection) UpdateFollowingSnapshot(followeeID string, following bool) 
 }
 
 // SetMuteBlockSnapshot attaches the viewer's mute/block snapshot so the main /
-// notifications channels can drop notifications / mentions involving muted
-// instances, muted users, or users blocking the viewer (#1711). Called once at
-// connection setup. nil leaves the gate disabled (fail-open: nothing dropped),
+// notifications channels (#1711) and the timeline channels (#1812) can drop
+// notes / notifications / mentions involving muted instances, muted users,
+// users blocking the viewer, renote-muted users, or muted channels. Called once
+// at connection setup. nil leaves the gate disabled (fail-open: nothing dropped),
 // matching upstream の「Set が空 = 全通過」default。並行安全: 内部 pointer を
 // 全置換するだけで snapshot 内 map は mutate しない (reader は古い snapshot を
 // そのまま読み続けて GC される)。

--- a/internal/stream/dispatcher.go
+++ b/internal/stream/dispatcher.go
@@ -452,8 +452,9 @@ func (c *channelContext) UpdateFollowingSnapshot(followeeID string, following bo
 }
 
 // MuteBlockSnapshot forwards the connection-level mute/block snapshot so the
-// main / notifications channels can gate notification / mention delivery
-// (#1711).
+// main / notifications channels (#1711) and every timeline channel (#1812) can
+// gate delivery of muted / blocked / muted-instance / renote-muted /
+// channel-muted notes.
 func (c *channelContext) MuteBlockSnapshot() *MuteBlockSnapshot {
 	if c.dispatcher.conn == nil {
 		return nil

--- a/internal/stream/mute_block_snapshot.go
+++ b/internal/stream/mute_block_snapshot.go
@@ -1,9 +1,11 @@
 package stream
 
 // MuteBlockSnapshot captures the viewer's mute / block relationships at
-// connection setup so the main / notifications channels can apply upstream
-// `main.ts` の instance-mute / block / mute gate per-publish without a DB round
-// trip (#1711). It mirrors the Connection-level Sets that upstream Misskey
+// connection setup so the main / notifications channels (#1711) and the
+// timeline channels (home/local/hybrid/global/userList/channel/hashtag/antenna/
+// roleTimeline, #1812) can apply upstream's instance-mute / block / mute /
+// renote-mute / channel-mute gate per-publish without a DB round trip. It
+// mirrors the Connection-level Sets that upstream Misskey
 // fetches in `Connection#fetch` (userIdsWhoMeMuting / userIdsWhoBlockingMe /
 // userIdsWhoMeMutingRenotes / userMutedInstances / mutingChannels).
 //


### PR DESCRIPTION
## Summary

#1780 の MEDIUM 指摘 M2 (focused follow-up) を解消する。mk-go の timeline 系 channel (home/local/hybrid/global/userList/channel/hashtag/antenna/roleTimeline) は live-stream する note を `c.filter.shouldEmit` (hardmute words + renote/file) + replyShouldEmit + hideEmbeds でしか filter せず、**user-mute / block (blockingMe) / instance-mute / renote-mute / channel-mute** を適用していなかった。結果、mute したユーザー / 自分を block したユーザー / muted instance / renote-mute 対象 / muted channel の note が reload までライブ表示されていた (REST 取得時には除外される transient な UI leak)。

upstream `stream/channel.ts` は `isNoteMutedOrBlocked` を base Channel に定義し全 note-emitting channel が呼ぶ。mk-go では main/notifications channel (#1711) にしか配線されていなかった `noteMutedOrBlocked` を timeline 系へ展開した。per-connection の `MuteBlockSnapshot` は元々接続確立時 (manager.go) に load 済みで全 channel から参照可能だったため、各 channel の `OnRedisEvent` に gate を追加するだけで配線できた。

## 主な変更点

- `internal/stream/channels/{timeline,channel_timeline,hashtag,antenna,role_timeline,user_list}.go`: 各 `OnRedisEvent` の `shouldEmit` gate 後に `noteMutedOrBlocked(payload, snapshot)` を追加。
- `internal/stream/channels/main_mute_filter.go`:
  - 共有部 (instance-mute / user-mute / block / renote-mute) を `mutedOrBlockedExceptChannel` に抽出し base / channel-override で共用。
  - channel timeline 専用 variant `noteMutedOrBlockedInChannel` を追加。upstream channel.ts の `override isNoteMutedOrBlocked` に倣い、**視聴中の channel 自身が mute されていても note を流す** (直接見ている以上は配信する)。own-channel mute を無視し、他 channel への renote の channel-mute のみ適用する。
- `internal/stream/{connection,dispatcher,mute_block_snapshot}.go`: timeline channel が snapshot を使う旨の comment 追記。
- テスト追加:
  - `timeline_test.go`: `TestLocalTimeline_DropsMutedAndBlockedAndInstance` (user-mute / blockingMe / instance-mute drop)。
  - `new_channels_test.go`: `TestChannelTimeline_MutedOwnChannelStillStreamed` (視聴中 channel mute でも own-channel note は流す) / `TestChannelTimeline_MutedRenoteChannelDropped` (他 muted channel への renote は drop)。

## テスト

- `go test ./internal/stream/... -cover`: stream 90.8% / channels 91.8% green。
- `go vet ./...` / `gofmt -s -l` clean。

## Closes

Closes #1812

🤖 Generated with [Claude Code](https://claude.com/claude-code)