### PR TITLE
Fix entity packers parity (#1781): EmojiSimple/moderator trio/reactionEmojis/avatarDecoration/system-account avatarUrl

### DIFF
--- a/internal/api/emojis/handler.go
+++ b/internal/api/emojis/handler.go
@@ -38,12 +38,19 @@ func (h *Handler) Emojis(c echo.Context) error {
 			url = e.OriginalURL
 		}
 		item := map[string]any{
-			"name":        e.Name,
-			"category":    e.Category,
-			"aliases":     e.Aliases,
-			"url":         url,
-			"localOnly":   e.LocalOnly,
-			"isSensitive": e.IsSensitive,
+			"name":     e.Name,
+			"category": e.Category,
+			"aliases":  e.Aliases,
+			"url":      url,
+		}
+		// upstream packSimple は localOnly / isSensitive を `? true : undefined`
+		// で出すため、false のとき key 自体を省く (json-schema 上 optional)。
+		// 常に false を載せると shape が upstream とずれる (#1781)。
+		if e.LocalOnly {
+			item["localOnly"] = true
+		}
+		if e.IsSensitive {
+			item["isSensitive"] = true
 		}
 		// roleIdsThatCanBeUsedThisEmojiAsReaction は length>0 のときだけ emit
 		// (upstream packSimple、#1556)。reaction-role gating UI が使う。

--- a/internal/api/emojis/handler_test.go
+++ b/internal/api/emojis/handler_test.go
@@ -111,6 +111,48 @@ func TestEmojis_URLFallbackAndRoleIds(t *testing.T) {
 	assert.False(t, hasRole, "roleIds 空のとき省略される")
 }
 
+// #1781 localOnly / isSensitive は upstream packSimple の `? true : undefined`
+// に倣い、false のとき key 自体を省く。true のときだけ emit する。
+func TestEmojis_LocalOnlyIsSensitiveOmittedWhenFalse(t *testing.T) {
+	h, repo := setup()
+	repo.Emojis["plain@"] = &model.Emoji{
+		Name:        "plain",
+		PublicURL:   "https://example.com/emoji/plain.png",
+		Aliases:     []string{},
+		LocalOnly:   false,
+		IsSensitive: false,
+	}
+	repo.Emojis["flagged@"] = &model.Emoji{
+		Name:        "flagged",
+		PublicURL:   "https://example.com/emoji/flagged.png",
+		Aliases:     []string{},
+		LocalOnly:   true,
+		IsSensitive: true,
+	}
+
+	rec := doPost(h)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	arr := body["emojis"].([]any)
+	byName := map[string]map[string]any{}
+	for _, e := range arr {
+		m := e.(map[string]any)
+		byName[m["name"].(string)] = m
+	}
+
+	plain := byName["plain"]
+	_, hasLocalOnly := plain["localOnly"]
+	assert.False(t, hasLocalOnly, "localOnly=false は省略される")
+	_, hasIsSensitive := plain["isSensitive"]
+	assert.False(t, hasIsSensitive, "isSensitive=false は省略される")
+	shapetest.Assert(t, "EmojiSimple", plain)
+
+	flagged := byName["flagged"]
+	assert.Equal(t, true, flagged["localOnly"], "localOnly=true は emit される")
+	assert.Equal(t, true, flagged["isSensitive"], "isSensitive=true は emit される")
+	shapetest.Assert(t, "EmojiSimple", flagged)
+}
+
 // failingEmojiRepo always fails on ListLocal.
 type failingEmojiRepo struct {
 	*testutil.MockEmojiRepository

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -459,6 +459,7 @@ func (h *Handler) Show(c echo.Context) error {
 			resolver.FillUserLite(&detailed.UserLite)
 			h.populateUserEmojis(b.User, &detailed.UserLite)
 			h.applyModerationNote(&detailed, iAmModerator, b.Profile)
+			entity.ApplyModeratorSecurityFields(&detailed, iAmModerator, b.Profile)
 			// bulk は per-user の follow 関係を解決しないため isFollowing=false で
 			// gate する (#1558)。self / moderator は count を保持。non-public
 			// visibility の非 follower count は 0 化される (privacy 安全側)。
@@ -512,6 +513,10 @@ func (h *Handler) Show(c echo.Context) error {
 
 	detailed := entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen)
 	h.applyModerationNote(&detailed, iAmModerator, bundle.Profile)
+	// moderator が他ユーザーを見るときは twoFactorEnabled/usePasswordLessLogin/
+	// securityKeys を出す (upstream UserEntityService、#1781)。self-view は下の
+	// AsMeDetailed が MeDetailed で常に出すため、ここでの set は shadow されて無害。
+	entity.ApplyModeratorSecurityFields(&detailed, iAmModerator, bundle.Profile)
 
 	// movedTo / alsoKnownAs を URI→ローカルID 解決して埋める (#1255)。単一
 	// ユーザー path なので FindByURI は数回で済む。list path (followers 等) は
@@ -660,6 +665,7 @@ func (h *Handler) Search(c echo.Context) error {
 		h.populateUserEmojis(u, &d.UserLite)
 		// moderator viewer には moderationNote を出す (#1558、users/show と対称)。
 		h.applyModerationNote(&d, iAmModerator, profiles[u.ID])
+		entity.ApplyModeratorSecurityFields(&d, iAmModerator, profiles[u.ID])
 		// count visibility gate (#1558)。search は per-user の follow 関係を
 		// 解決しないため isFollowing=false。self / moderator は count を保持。
 		isMe := viewer != nil && viewer.ID == u.ID

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -1863,6 +1863,42 @@ func TestShow_SingleSuspended_ModeratorSees(t *testing.T) {
 	assert.Equal(t, "sus", resp["id"])
 }
 
+// #1781: moderator が他ユーザーを users/show で見ると twoFactorEnabled /
+// usePasswordLessLogin / securityKeys が emit される (upstream
+// `isDetailed && (isMe || iAmModerator)` ブロック)。非 moderator には omit。
+func TestShow_Single_ModeratorGetsSecurityFields(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Users["target"] = &model.User{ID: "target", Username: "target", UsernameLower: "target", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Profiles["target"] = &model.UserProfile{
+		UserID:                "target",
+		TwoFactorEnabled:      true,
+		UsePasswordLessLogin:  false,
+		SecurityKeysAvailable: true,
+	}
+	h.SetModeratorChecker(visibilityModStub{modID: "u_mod"})
+
+	t.Run("moderator viewer", func(t *testing.T) {
+		rec := postStub(h.Show, `{"userId":"target"}`, &model.User{ID: "u_mod"})
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var resp map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Equal(t, true, resp["twoFactorEnabled"])
+		assert.Equal(t, false, resp["usePasswordLessLogin"])
+		assert.Equal(t, true, resp["securityKeys"])
+	})
+
+	t.Run("non-moderator viewer omits the trio", func(t *testing.T) {
+		rec := postStub(h.Show, `{"userId":"target"}`, &model.User{ID: "u_plain"})
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var resp map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		_, hasTFA := resp["twoFactorEnabled"]
+		assert.False(t, hasTFA, "非 moderator には twoFactorEnabled を出さない")
+		_, hasSK := resp["securityKeys"]
+		assert.False(t, hasSK, "非 moderator には securityKeys を出さない")
+	})
+}
+
 // --- Internal error paths via failing repos ---
 
 type failingNoteRepo struct {

--- a/internal/entity/avatar_decoration.go
+++ b/internal/entity/avatar_decoration.go
@@ -35,12 +35,16 @@ func SetAvatarDecorationLookup(l AvatarDecorationLookup) {
 // AvatarDecorationItem is the per-entry shape sent to clients. Mirrors
 // upstream Misskey's UserEntityService output: {id, angle, flipH, offsetX,
 // offsetY, url}. `url` is resolved from the avatar_decoration catalog.
+//
+// angle / flipH / offsetX / offsetY は upstream UserEntityService が
+// `ud.angle || undefined` 等で falsy 値を省くため (#1781)、omitempty で
+// 0 / false のとき出力しない (json-schema 上 optional)。id / url は常に出す。
 type AvatarDecorationItem struct {
 	ID      string  `json:"id"`
-	Angle   float64 `json:"angle"`
-	FlipH   bool    `json:"flipH"`
-	OffsetX float64 `json:"offsetX"`
-	OffsetY float64 `json:"offsetY"`
+	Angle   float64 `json:"angle,omitempty"`
+	FlipH   bool    `json:"flipH,omitempty"`
+	OffsetX float64 `json:"offsetX,omitempty"`
+	OffsetY float64 `json:"offsetY,omitempty"`
 	URL     string  `json:"url"`
 }
 

--- a/internal/entity/avatar_decoration_test.go
+++ b/internal/entity/avatar_decoration_test.go
@@ -95,6 +95,48 @@ func TestPackUserLite_AvatarDecorations_EmptyOrNull(t *testing.T) {
 	}
 }
 
+// #1781: angle / flipH / offsetX / offsetY は falsy (0 / false) のとき
+// JSON から省く (upstream `ud.angle || undefined`)。非 falsy 値は残す。
+func TestPackUserLite_AvatarDecorations_OmitsFalsyFields(t *testing.T) {
+	SetAvatarDecorationLookup(&stubDecoLookup{urls: map[string]string{"dec1": "https://cdn.test/d1.png"}})
+	defer SetAvatarDecorationLookup(nil)
+
+	t.Run("all falsy fields omitted", func(t *testing.T) {
+		u := &model.User{
+			ID:                "u1",
+			Username:          "alice",
+			AvatarDecorations: datatypes.JSON([]byte(`[{"id":"dec1","angle":0,"flipH":false,"offsetX":0,"offsetY":0}]`)),
+		}
+		out := PackUserLite(u)
+		b, err := json.Marshal(out.AvatarDecorations)
+		require.NoError(t, err)
+		s := string(b)
+		assert.NotContains(t, s, "angle")
+		assert.NotContains(t, s, "flipH")
+		assert.NotContains(t, s, "offsetX")
+		assert.NotContains(t, s, "offsetY")
+		// id / url は常に残る。
+		assert.Contains(t, s, "\"id\":\"dec1\"")
+		assert.Contains(t, s, "\"url\":\"https://cdn.test/d1.png\"")
+	})
+
+	t.Run("non-falsy fields retained", func(t *testing.T) {
+		u := &model.User{
+			ID:                "u1",
+			Username:          "alice",
+			AvatarDecorations: datatypes.JSON([]byte(`[{"id":"dec1","angle":0.5,"flipH":true,"offsetX":-0.25,"offsetY":0.25}]`)),
+		}
+		out := PackUserLite(u)
+		b, err := json.Marshal(out.AvatarDecorations)
+		require.NoError(t, err)
+		s := string(b)
+		assert.Contains(t, s, "\"angle\":0.5")
+		assert.Contains(t, s, "\"flipH\":true")
+		assert.Contains(t, s, "\"offsetX\":-0.25")
+		assert.Contains(t, s, "\"offsetY\":0.25")
+	})
+}
+
 func TestPackUserLite_AvatarDecorations_DropsEmptyIDEntry(t *testing.T) {
 	u := &model.User{
 		ID:                "u1",

--- a/internal/entity/emoji_resolver.go
+++ b/internal/entity/emoji_resolver.go
@@ -187,6 +187,13 @@ func (r *EmojiResolver) PopulateNoteReactionEmojis(note *model.Note, entity *Not
 // unicode reactions are filtered out. Same-name-different-host pairs
 // are preserved as separate entries (a name-keyed map would collapse
 // them and lose remote emoji URLs).
+//
+// upstream NoteEntityService:389-391 は reactionEmojiNames を
+// `.filter(x => x.startsWith(':') && x.includes('@') && !x.includes('@.'))`
+// で remote custom emoji のみに絞る (コメント: リモートカスタム絵文字のみ)。
+// local custom emoji (bare `:name:` / canonical `:name@.:`、いずれも
+// host="") は frontend が instance の emoji registry から解決するため
+// reactionEmojis には載せない。そこで host="" の entry は除外する (#1781)。
 func collectReactionEmojiNames(raw []byte) []emojiNameHost {
 	if len(raw) == 0 {
 		return nil
@@ -198,7 +205,7 @@ func collectReactionEmojiNames(raw []byte) []emojiNameHost {
 	var out []emojiNameHost
 	for reaction := range counts {
 		name, host, ok := parseCustomEmojiReaction(reaction)
-		if !ok {
+		if !ok || host == "" {
 			continue
 		}
 		out = append(out, emojiNameHost{name: name, host: host})

--- a/internal/entity/emoji_resolver_test.go
+++ b/internal/entity/emoji_resolver_test.go
@@ -473,12 +473,16 @@ func TestPopulateNoteReactionEmojis(t *testing.T) {
 	// remote: key は frontend lookup `reaction.substring(1, length-1)` 仕様で "smile@remote.example"
 	assert.Equal(t, "https://remote.example/emoji/smile.png", entity.ReactionEmojis["smile@remote.example"])
 	assert.Equal(t, "https://remote.example/emoji/wave.png", entity.ReactionEmojis["wave@remote.example"])
-	// canonical local (`:local@.:`) は frontend lookup で "local@." に
-	// なるが、parser が `.` を空に戻すので map のキーは "local"
-	assert.Equal(t, "https://local.example/emoji/local.png", entity.ReactionEmojis["local"])
+	// canonical local (`:local@.:`) は upstream の `!x.includes('@.')` filter
+	// と同じく reactionEmojis に載せない (frontend が instance registry から
+	// 解決する、#1781)。host="" の entry は除外される。
+	_, hasLocal := entity.ReactionEmojis["local"]
+	assert.False(t, hasLocal, "local custom emoji should not appear in reactionEmojis")
 	// raw unicode は乗らない
 	_, hasHeart := entity.ReactionEmojis["❤️"]
 	assert.False(t, hasHeart, "raw unicode reactions should not appear in reactionEmojis")
+	// remote 2 件のみが残る
+	assert.Len(t, entity.ReactionEmojis, 2)
 }
 
 func TestPopulateNoteReactionEmojis_SameNameDifferentHosts(t *testing.T) {

--- a/internal/entity/mediaurl_test.go
+++ b/internal/entity/mediaurl_test.go
@@ -283,6 +283,32 @@ func TestAvatarBannerProxying(t *testing.T) {
 			t.Errorf("identicon changed: %s", got)
 		}
 	})
+	// #1781: local system account (username に '.' を含む) は meta.iconUrl が
+	// 設定されていれば identicon ではなくインスタンスアイコンを返す。
+	t.Run("local system account uses meta.iconUrl when set", func(t *testing.T) {
+		SetInstanceIconURLLookup(func() string { return "https://example.test/icon.png" })
+		defer SetInstanceIconURLLookup(nil)
+		u0 := &model.User{Username: "relay.actor"} // local, no avatar
+		if got := IdenticonURL(u0); got != "https://example.test/icon.png" {
+			t.Errorf("system account should use meta.iconUrl, got: %s", got)
+		}
+	})
+	t.Run("local system account falls back to identicon when meta.iconUrl empty", func(t *testing.T) {
+		SetInstanceIconURLLookup(func() string { return "" })
+		defer SetInstanceIconURLLookup(nil)
+		u0 := &model.User{Username: "instance.actor"}
+		if got := IdenticonURL(u0); got != "/identicon/instance.actor" {
+			t.Errorf("empty meta.iconUrl should fall back to identicon, got: %s", got)
+		}
+	})
+	t.Run("local non-system account ignores meta.iconUrl", func(t *testing.T) {
+		SetInstanceIconURLLookup(func() string { return "https://example.test/icon.png" })
+		defer SetInstanceIconURLLookup(nil)
+		u0 := &model.User{Username: "alice"} // no '.' in username
+		if got := IdenticonURL(u0); got != "/identicon/alice" {
+			t.Errorf("non-system account must use identicon, got: %s", got)
+		}
+	})
 	t.Run("remote banner is proxied", func(t *testing.T) {
 		u0 := &model.User{Username: "dave", Host: sp(remoteHost), BannerID: sp("b1"), BannerURL: sp("https://" + remoteHost + "/b.png")}
 		d := PackUserDetailed(u0, nil)

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -162,6 +162,15 @@ type UserDetailed struct {
 	// (upstream UserEntityService.ts:574: iAmModerator ? note ?? '' : undefined)。
 	// 非 moderator には omit する (#1547)。handler 側で viewer の role を見て set。
 	ModerationNote *string `json:"moderationNote,omitempty"`
+	// TwoFactorEnabled / UsePasswordLessLogin / SecurityKeys は upstream
+	// UserEntityService.ts:577-583 が `isDetailed && (isMe || iAmModerator)` で
+	// emit する。self-view は MeDetailed が plain bool で shadow して常に出すが
+	// (下記 MeDetailed)、moderator が他ユーザーを見る users/show では UserDetailed
+	// 側の本 field を handler が set する。非 moderator / 非 detailed には omit
+	// するため *bool + omitempty (#1781)。
+	TwoFactorEnabled     *bool `json:"twoFactorEnabled,omitempty"`
+	UsePasswordLessLogin *bool `json:"usePasswordLessLogin,omitempty"`
+	SecurityKeys         *bool `json:"securityKeys,omitempty"`
 }
 
 // MeDetailed extends UserDetailed with fields that upstream Misskey TS
@@ -433,6 +442,17 @@ func IdenticonURL(u *model.User) string {
 		// (ProxyAvatarURL は同一オリジン・相対 URL を wrap しない)。
 		return currentMediaURLContext().ProxyAvatarURL(*u.AvatarURL)
 	}
+	// upstream getIdenticonUrl (UserEntityService.ts:386-391): local かつ
+	// username に '.' を含むユーザー (= system account relay.actor /
+	// instance.actor / proxy.actor) は meta.iconUrl が設定されていれば
+	// identicon ではなくインスタンスアイコンを avatarUrl に使う (#1781)。
+	if u.Host == nil || *u.Host == "" {
+		if strings.Contains(u.Username, ".") {
+			if icon := resolveInstanceIconURL(); icon != "" {
+				return icon
+			}
+		}
+	}
 	host := ""
 	if u.Host != nil {
 		host = "@" + *u.Host
@@ -607,6 +627,25 @@ func GateCountVisibility(d *UserDetailed, isMe, isModerator, isFollowing bool) {
 	if !countVisible(d.FollowingVisibility, isMe, isModerator, isFollowing) {
 		d.FollowingCount = 0
 	}
+}
+
+// ApplyModeratorSecurityFields sets twoFactorEnabled / usePasswordLessLogin /
+// securityKeys on a UserDetailed when the viewer is a moderator, mirroring
+// upstream UserEntityService.ts:577-583 which emits them in the
+// `isDetailed && (isMe || iAmModerator)` block (#1781). The self-view path uses
+// MeDetailed (which always emits the trio as plain bool, shadowing these
+// pointers), so this only covers a moderator viewing another user. No-op for
+// non-moderator viewers or when profile is nil, leaving the fields omitted.
+func ApplyModeratorSecurityFields(d *UserDetailed, iAmModerator bool, profile *model.UserProfile) {
+	if !iAmModerator || profile == nil {
+		return
+	}
+	tfa := profile.TwoFactorEnabled
+	pwl := profile.UsePasswordLessLogin
+	sk := profile.SecurityKeysAvailable
+	d.TwoFactorEnabled = &tfa
+	d.UsePasswordLessLogin = &pwl
+	d.SecurityKeys = &sk
 }
 
 // backupCodesStock returns the 2FA backup-codes stock level. Mirrors upstream

--- a/internal/entity/user_roles.go
+++ b/internal/entity/user_roles.go
@@ -70,6 +70,39 @@ func resolveShowRemoteBadges() bool {
 	return fn()
 }
 
+// instanceIconURLLookup resolves meta.iconUrl so IdenticonURL can apply
+// upstream's local-system-account special case: a local user whose username
+// contains '.' (relay.actor / instance.actor / proxy.actor) uses the instance
+// icon as its avatarUrl instead of the identicon route (upstream
+// getIdenticonUrl, UserEntityService.ts:386-391、#1781)。Router wires this once
+// at startup with a closure reading the cached meta. nil / 未配線時は "" を返し
+// identicon route に fallback する。
+var (
+	instanceIconURLMu     sync.RWMutex
+	instanceIconURLLookup func() string
+)
+
+// SetInstanceIconURLLookup wires the meta.iconUrl accessor used by IdenticonURL
+// for the local-system-account avatarUrl special case (#1781)。Pass nil to clear
+// (used in tests).
+func SetInstanceIconURLLookup(fn func() string) {
+	instanceIconURLMu.Lock()
+	instanceIconURLLookup = fn
+	instanceIconURLMu.Unlock()
+}
+
+// resolveInstanceIconURL returns meta.iconUrl, or "" when the lookup is unwired
+// or meta.iconUrl is unset.
+func resolveInstanceIconURL() string {
+	instanceIconURLMu.RLock()
+	fn := instanceIconURLLookup
+	instanceIconURLMu.RUnlock()
+	if fn == nil {
+		return ""
+	}
+	return fn()
+}
+
 // resolveUserRolesSorted returns the user's assigned roles sorted by
 // displayOrder descending (= upstream sort key). Returns a fresh slice so
 // callers can iterate / filter freely without mutating the role service's

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -184,6 +184,53 @@ func TestPackUserDetailed(t *testing.T) {
 	assert.Equal(t, &lang, detailed.Lang)
 }
 
+// #1781: moderator が他ユーザーを見るとき twoFactorEnabled /
+// usePasswordLessLogin / securityKeys を emit する。非 moderator には omit。
+func TestApplyModeratorSecurityFields(t *testing.T) {
+	profile := &model.UserProfile{
+		UserID:                "u1",
+		TwoFactorEnabled:      true,
+		UsePasswordLessLogin:  false,
+		SecurityKeysAvailable: true,
+	}
+
+	t.Run("moderator gets the trio", func(t *testing.T) {
+		d := UserDetailed{}
+		ApplyModeratorSecurityFields(&d, true, profile)
+		require.NotNil(t, d.TwoFactorEnabled)
+		assert.True(t, *d.TwoFactorEnabled)
+		require.NotNil(t, d.UsePasswordLessLogin)
+		assert.False(t, *d.UsePasswordLessLogin)
+		require.NotNil(t, d.SecurityKeys)
+		assert.True(t, *d.SecurityKeys)
+		// JSON では key が emit される。
+		b, err := json.Marshal(d)
+		require.NoError(t, err)
+		assert.Contains(t, string(b), "\"twoFactorEnabled\":true")
+		assert.Contains(t, string(b), "\"usePasswordLessLogin\":false")
+		assert.Contains(t, string(b), "\"securityKeys\":true")
+	})
+
+	t.Run("non-moderator omits the trio", func(t *testing.T) {
+		d := UserDetailed{}
+		ApplyModeratorSecurityFields(&d, false, profile)
+		assert.Nil(t, d.TwoFactorEnabled)
+		assert.Nil(t, d.UsePasswordLessLogin)
+		assert.Nil(t, d.SecurityKeys)
+		b, err := json.Marshal(d)
+		require.NoError(t, err)
+		assert.NotContains(t, string(b), "twoFactorEnabled")
+		assert.NotContains(t, string(b), "usePasswordLessLogin")
+		assert.NotContains(t, string(b), "securityKeys")
+	})
+
+	t.Run("nil profile is a no-op", func(t *testing.T) {
+		d := UserDetailed{}
+		ApplyModeratorSecurityFields(&d, true, nil)
+		assert.Nil(t, d.TwoFactorEnabled)
+	})
+}
+
 func TestPackUserDetailed_MoveFields(t *testing.T) {
 	fetched := time.Date(2026, 5, 25, 1, 2, 3, 0, time.UTC)
 	movedURI := "https://remote.example/users/moved"

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1506,6 +1506,16 @@ func (s *Server) setupRoutes() {
 		m, err := metaRepo.Fetch()
 		return err == nil && m != nil && m.ShowRoleBadgesOfRemoteUsers
 	})
+	// local system account (relay.actor 等) の avatarUrl を meta.iconUrl に
+	// する upstream の特例 (#1781)。IdenticonURL が '.' を含む local username の
+	// fallback でのみ参照する。
+	entity.SetInstanceIconURLLookup(func() string {
+		m, err := metaRepo.Fetch()
+		if err != nil || m == nil || m.IconURL == nil {
+			return ""
+		}
+		return *m.IconURL
+	})
 	// PackDriveFile / IdenticonURL が remote origin の media URL (note 添付・
 	// avatar・banner 等) を pack 時に media proxy 経由へ書き換えられるよう
 	// context を登録する (#1529)。これが無いと remote の url/thumbnailUrl/


### PR DESCRIPTION
## Summary

#1781 (entity packers User/Note/misc 再監査、0H 1M 8L) の LOW 5 件を解消する。各指摘を現 develop コードで再検証した結果:

- **既に解消済み (stale)**: MEDIUM notifications read-time notifier filter は #1775 (`filterValidNotifiers` で muting set / mutedInstances / isSuspended を read 時に適用)、LOW Channel.lastNotedAt は #1770 (ISO ms 正規化) で解消済み。対象外。
- **本 PR で実装**: 下記 5 件。
- **#1816 へ defer**: LOW Note reply embed の detail:false 化 (packNoteAtDepth の hot path + `ClippedCount int→*int` で golden 波及大)、LOW reactions legacy text-alias 変換 (legacyMap の layer 跨ぎ relocation、entity↔core/reaction の import cycle 制約)。

## 主な変更点

- **EmojiSimple** (`internal/api/emojis/handler.go`): `localOnly` / `isSensitive` を false のとき key ごと省く (upstream packSimple の `? true : undefined`)。
- **users/show moderator trio** (`internal/entity/user.go` + `internal/api/users/handler.go`): `twoFactorEnabled` / `usePasswordLessLogin` / `securityKeys` を moderator が他ユーザーを見るときに emit (upstream UserEntityService の `isDetailed && (isMe || iAmModerator)`)。UserDetailed に `*bool` + omitempty で追加。self-view は MeDetailed の plain bool が shadow する (FollowedMessage と同じパターン)。`ApplyModeratorSecurityFields` を bulk / single / search の 3 pack site に配線。非 moderator には omit。
- **Note reactionEmojis** (`internal/entity/emoji_resolver.go`): local custom emoji (host="") を除外し remote custom emoji のみにする (upstream `!x.includes('@.')` filter)。
- **UserLite avatarDecorations** (`internal/entity/avatar_decoration.go`): `angle` / `flipH` / `offsetX` / `offsetY` を falsy (0 / false) のとき omit (upstream `ud.angle || undefined`)。`id` / `url` は常に出す。
- **UserLite avatarUrl** (`internal/entity/user.go` `IdenticonURL` + `user_roles.go` lookup + `router.go` 配線): local system account (relay.actor 等、username に '.' を含む local user) は meta.iconUrl が設定されていれば identicon ではなくインスタンスアイコンを avatarUrl に使う (upstream getIdenticonUrl)。`SetInstanceIconURLLookup` は既存の `SetShowRemoteBadgesLookup` と同じ meta-lookup パターンで配線し staleness を回避。

## テスト

- 追加: EmojiSimple omit テスト、ApplyModeratorSecurityFields + users/show moderator trio テスト、reactionEmojis local 除外テスト (既存テストの assertion 更新含む)、avatarDecorations falsy omit テスト、IdenticonURL system-account テスト。
- `go test ./internal/entity/... ./internal/api/emojis/...`: entity 96.2% / emojis 100% green。`internal/api/users` / `notes` / `i` も green。
- `go build ./...` / `go vet ./...` / `gofmt -s -l` clean。

## Closes

Closes #1781

(関連 follow-up: #1816)

🤖 Generated with [Claude Code](https://claude.com/claude-code)