### PR TITLE
Fix note packer parity (#1816): reply embed を detail:false 化 + legacy reaction text-alias 変換

### DIFF
--- a/internal/api/notes/resolve_viewer_fields_test.go
+++ b/internal/api/notes/resolve_viewer_fields_test.go
@@ -10,8 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// resolveViewerFields の MyReaction 解決が Renote / Reply の embed にも
-// 波及することを確認する (#416)。
+// resolveViewerFields の MyReaction 解決が outer / renote embed に波及すること
+// を確認する (#416)。reply embed は upstream で detail:false のため myReaction を
+// 持たない (#1816)。
 func TestResolveViewerFields_MyReactionEmbedded(t *testing.T) {
 	h, _ := newTestHandler(t)
 	reactionRepo := testutil.NewMockNoteReactionRepository()
@@ -38,8 +39,8 @@ func TestResolveViewerFields_MyReactionEmbedded(t *testing.T) {
 	assert.Equal(t, "👍", *notes[0].MyReaction)
 	require.NotNil(t, notes[0].Renote.MyReaction)
 	assert.Equal(t, "❤", *notes[0].Renote.MyReaction)
-	require.NotNil(t, notes[0].Reply.MyReaction)
-	assert.Equal(t, "🎉", *notes[0].Reply.MyReaction)
+	// reply embed (detail:false) は myReaction を持たない (#1816)。
+	assert.Nil(t, notes[0].Reply.MyReaction)
 }
 
 // Channel 解決も Renote / Reply の embed に波及する。

--- a/internal/core/reaction/reaction_service.go
+++ b/internal/core/reaction/reaction_service.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/misc/reactionlegacy"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
 )
@@ -57,22 +58,6 @@ type BlockingChecker interface {
 	IsBlocked(blockerID, blockeeID string) (bool, error)
 }
 
-// legacyMap converts legacy text reactions like "like" or "love" to their
-// Unicode equivalents. Misskey本家のReactionServiceと同じ表を使用する。
-var legacyMap = map[string]string{
-	"like":     "👍",
-	"love":     "\u2764",
-	"laugh":    "😆",
-	"hmm":      "🤔",
-	"surprise": "😮",
-	"congrats": "🎉",
-	"angry":    "💢",
-	"confused": "😥",
-	"rip":      "😇",
-	"pudding":  "🍮",
-	"star":     "⭐",
-}
-
 // customEmojiPattern matches a custom emoji shortcode like ":smile:" or
 // ":smile@example.com:".
 var customEmojiPattern = regexp.MustCompile(`^:([\w+\-]+)(?:@([\w.\-]+))?:$`)
@@ -84,7 +69,7 @@ var customEmojiPattern = regexp.MustCompile(`^:([\w+\-]+)(?:@([\w.\-]+))?:$`)
 // plain unicode pass through unchanged. Pure (no DB); used by read paths such as
 // users/reactions where the raw DB string must not leak (#1547)。
 func ConvertLegacy(raw string) string {
-	if v, ok := legacyMap[raw]; ok {
+	if v, ok := reactionlegacy.Convert(raw); ok {
 		return v
 	}
 	if m := customEmojiPattern.FindStringSubmatch(raw); m != nil {
@@ -484,7 +469,7 @@ func (s *Service) resolveReaction(raw string, actorHost *string) (string, *model
 	if raw == "" {
 		return FallbackReaction, nil
 	}
-	if v, ok := legacyMap[raw]; ok {
+	if v, ok := reactionlegacy.Convert(raw); ok {
 		return v, nil
 	}
 	if m := customEmojiPattern.FindStringSubmatch(raw); m != nil {

--- a/internal/entity/note.go
+++ b/internal/entity/note.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/misc/reactionlegacy"
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/datatypes"
 )
@@ -53,17 +54,22 @@ type NoteEntity struct {
 	ReactionEmojis     map[string]string `json:"reactionEmojis"`
 	RenoteCount        int16             `json:"renoteCount"`
 	RepliesCount       int16             `json:"repliesCount"`
-	ClippedCount       int               `json:"clippedCount"`
-	URI                *string           `json:"uri,omitempty"`
-	URL                *string           `json:"url,omitempty"`
-	ReplyID            *string           `json:"replyId"`
-	RenoteID           *string           `json:"renoteId"`
-	Reply              *NoteEntity       `json:"reply,omitempty"`
-	Renote             *NoteEntity       `json:"renote,omitempty"`
-	FileIDs            []string          `json:"fileIds"`
-	Files              []any             `json:"files"`
-	Tags               []string          `json:"tags,omitempty"`
-	Poll               *PollEntity       `json:"poll,omitempty"`
+	// ClippedCount は upstream の detail block (opts.detail) に属し、reply embed
+	// (detail:false) では key ごと省かれる (note.ts:255 optional:true)。pointer +
+	// omitempty で「detail のとき &n (0 含む) を出力 / reply embed では nil 省略」
+	// を表す (#1816)。plain int + omitempty だと detail 時の clippedCount:0 を
+	// 誤って落とすため pointer 必須。
+	ClippedCount *int        `json:"clippedCount,omitempty"`
+	URI          *string     `json:"uri,omitempty"`
+	URL          *string     `json:"url,omitempty"`
+	ReplyID      *string     `json:"replyId"`
+	RenoteID     *string     `json:"renoteId"`
+	Reply        *NoteEntity `json:"reply,omitempty"`
+	Renote       *NoteEntity `json:"renote,omitempty"`
+	FileIDs      []string    `json:"fileIds"`
+	Files        []any       `json:"files"`
+	Tags         []string    `json:"tags,omitempty"`
+	Poll         *PollEntity `json:"poll,omitempty"`
 	// Emojis は upstream NoteEntityService.ts:412 `host != null ? populateEmojis
 	// : undefined` に合わせ、remote note (author host != nil) のみ出力する
 	// (custom emoji が無くても `{}`)。local note は nil → omitempty で省略
@@ -126,7 +132,7 @@ const maxNoteEmbedDepth = 1
 // PackNote converts a model.Note to a NoteEntity. Renote / Reply の embed は
 // maxNoteEmbedDepth で制限する。
 func PackNote(n *model.Note, idGen id.Generator) NoteEntity {
-	return packNoteAtDepth(n, idGen, 0)
+	return packNoteAtDepth(n, idGen, 0, true)
 }
 
 // packPoll maps a preloaded model.Poll onto the Misskey-compatible PollEntity.
@@ -185,7 +191,14 @@ func HideNoteEntity(n *NoteEntity) {
 	n.IsHidden = true
 }
 
-func packNoteAtDepth(n *model.Note, idGen id.Generator, depth int) NoteEntity {
+// packNoteAtDepth packs a note at the given embed depth. detail mirrors
+// upstream NoteEntityService's `opts.detail`: when false (reply embeds) the
+// clippedCount / poll / myReaction fields and the reply/renote sub-embeds are
+// omitted. Top-level notes and renote embeds use detail:true; reply embeds use
+// detail:false (upstream NoteEntityService.ts:432-460, reply at :437 detail:false
+// / renote at :445 detail:true). myReaction is applied later by
+// note_field_resolver (which skips reply embeds), #1816.
+func packNoteAtDepth(n *model.Note, idGen id.Generator, depth int, detail bool) NoteEntity {
 	createdAt := ""
 	if t, err := idGen.ParseTime(n.ID); err == nil {
 		createdAt = t.UTC().Format("2006-01-02T15:04:05.000Z")
@@ -253,7 +266,6 @@ func packNoteAtDepth(n *model.Note, idGen id.Generator, depth int) NoteEntity {
 		ReactionEmojis:     make(map[string]string),
 		RenoteCount:        n.RenoteCount,
 		RepliesCount:       n.RepliesCount,
-		ClippedCount:       int(n.ClippedCount),
 		URI:                n.URI,
 		URL:                n.URL,
 		ReplyID:            n.ReplyID,
@@ -266,7 +278,15 @@ func packNoteAtDepth(n *model.Note, idGen id.Generator, depth int) NoteEntity {
 		VisibleUserIDs:     visibleUserIDs,
 		Mentions:           mentions,
 		HasPoll:            n.HasPoll,
-		Poll:               packPoll(n.Poll),
+	}
+
+	// clippedCount / poll は upstream の detail block (opts.detail) に属する。
+	// reply embed (detail:false) では出力しない (#1816)。hasPoll は detail 外なので
+	// 上の struct literal で常に出す。
+	if detail {
+		clipped := int(n.ClippedCount)
+		entity.ClippedCount = &clipped
+		entity.Poll = packPoll(n.Poll)
 	}
 
 	if n.User != nil {
@@ -277,13 +297,16 @@ func packNoteAtDepth(n *model.Note, idGen id.Generator, depth int) NoteEntity {
 	// Preload("Reply.User") されている前提で 1 段だけ展開する。preload が
 	// 無ければ n.Renote == nil になり、フロントエンドはこれを「削除された投稿」
 	// として描画する (renoteId だけが入ってる状態と区別するため #416)。
+	// renote embed は upstream で detail:true、reply embed は detail:false
+	// (NoteEntityService.ts:445 / :437)。reply embed では clippedCount/poll/
+	// myReaction を省く (#1816)。
 	if depth < maxNoteEmbedDepth {
 		if n.Renote != nil {
-			r := packNoteAtDepth(n.Renote, idGen, depth+1)
+			r := packNoteAtDepth(n.Renote, idGen, depth+1, true)
 			entity.Renote = &r
 		}
 		if n.Reply != nil {
-			r := packNoteAtDepth(n.Reply, idGen, depth+1)
+			r := packNoteAtDepth(n.Reply, idGen, depth+1, false)
 			entity.Reply = &r
 		}
 	}
@@ -496,9 +519,32 @@ func NormalizeReactionKey(key string) string {
 	return key
 }
 
-// normalizeReactionKeys rewrites reaction JSONB keys so that legacy
-// `:name:` entries are merged into `:name@.:`.
-// TS時代のレコードとmk時代のレコードが同一キーに集約される。
+// normalizeReactionWithLegacy applies the legacy text-alias conversion
+// (like→👍 等) and then the colon-form normalization (`:name:`→`:name@.:`),
+// the per-key transform shared by the reactions map and myReaction (#1816).
+// upstream NoteEntityService の reactions / populateMyReaction はどちらも
+// convertLegacyReaction を通すため、両者で同じ変換を使う。
+func normalizeReactionWithLegacy(raw string) string {
+	if u, ok := reactionlegacy.Convert(raw); ok {
+		raw = u
+	}
+	return NormalizeReactionKey(raw)
+}
+
+// normalizeReactionKeys rewrites reaction JSONB keys so that legacy text
+// aliases (like→👍 等) are converted to their Unicode equivalent and legacy
+// `:name:` entries are merged into `:name@.:`. Counts for keys that collapse
+// to the same canonical reaction are summed. TS時代のレコードとmk時代の
+// レコードが同一キーに集約される。
+//
+// upstream NoteEntityService.ts:373 は reactions を必ず convertLegacyReactions
+// (legacies map + decodeReaction) に通す (#1816)。upstream の `count>0` filter は
+// 適用しない: mk-native の write path (repository.IncrementReaction /
+// count_writer) は count が 0 以下になった key を削除するため 0-count entry が
+// 残らない。TS から移行直後の DB に TS が残した 0-count key が含まれる可能性は
+// あるが、それは別途扱う drop-in データ移行の話で本変換の対象外。なお
+// `:name:`→`:name@.:` の colon-form は mk-go の canonical (decodeReaction の逆)
+// で、reactions map の永続/出力形式として既存挙動を維持する。
 func normalizeReactionKeys(raw datatypes.JSON) datatypes.JSON {
 	if len(raw) == 0 {
 		// golden Note.reactions は Record (object) 必須。reactions 未設定の note
@@ -513,8 +559,9 @@ func normalizeReactionKeys(raw datatypes.JSON) datatypes.JSON {
 	}
 	normalized := make(map[string]float64, len(m))
 	for k, v := range m {
-		nk := NormalizeReactionKey(k)
-		normalized[nk] += v
+		// legacy text alias (like→👍 等) を Unicode へ変換し colon-form 正規化を
+		// 通す。同一 canonical key に集約される count は += でマージする。
+		normalized[normalizeReactionWithLegacy(k)] += v
 	}
 	data, err := json.Marshal(normalized)
 	if err != nil {

--- a/internal/entity/note_field_resolver.go
+++ b/internal/entity/note_field_resolver.go
@@ -340,9 +340,8 @@ func appendNoteIDs(dst []string, n *NoteEntity) []string {
 	if n.Renote != nil && n.Renote.ReactionCount > 0 {
 		dst = append(dst, n.Renote.ID)
 	}
-	if n.Reply != nil && n.Reply.ReactionCount > 0 {
-		dst = append(dst, n.Reply.ID)
-	}
+	// reply embed は detail:false で pack され myReaction を出さない (#1816) ので
+	// fetch 対象に含めない (applyMyReaction も reply には適用しない)。
 	return dst
 }
 
@@ -412,22 +411,21 @@ func applyMyReaction(n *NoteEntity, reactionMap map[string]*model.NoteReaction) 
 	if n == nil {
 		return
 	}
+	// myReaction も upstream populateMyReaction と同じく legacy text alias を
+	// Unicode に変換してから colon-form 正規化する (reactions map と一貫、#1816)。
 	if r, ok := reactionMap[n.ID]; ok {
-		nr := NormalizeReactionKey(r.Reaction)
+		nr := normalizeReactionWithLegacy(r.Reaction)
 		n.MyReaction = &nr
 	}
 	if n.Renote != nil {
 		if r, ok := reactionMap[n.Renote.ID]; ok {
-			nr := NormalizeReactionKey(r.Reaction)
+			nr := normalizeReactionWithLegacy(r.Reaction)
 			n.Renote.MyReaction = &nr
 		}
 	}
-	if n.Reply != nil {
-		if r, ok := reactionMap[n.Reply.ID]; ok {
-			nr := NormalizeReactionKey(r.Reaction)
-			n.Reply.MyReaction = &nr
-		}
-	}
+	// reply embed は upstream で detail:false の pack のため myReaction を持たない
+	// (NoteEntityService.ts:437 reply は detail:false / :453-459 myReaction は
+	// detail block 内、#1816)。renote embed (detail:true) のみ myReaction を出す。
 }
 
 func applyChannel(n *NoteEntity, chMap map[string]*model.Channel) {

--- a/internal/entity/note_field_resolver_test.go
+++ b/internal/entity/note_field_resolver_test.go
@@ -87,7 +87,8 @@ func TestNoteFieldResolver_ResolveFiles_EmbedsRenoteAndReply(t *testing.T) {
 	require.Len(t, notes[0].Reply.Files, 1)
 }
 
-// Renote / Reply の embed にも MyReaction / Channel が解決されることを確認。
+// renote embed には MyReaction / Channel が解決され、reply embed は detail:false
+// なので MyReaction を持たない (Channel は detail 外なので reply にも付く、#1816)。
 func TestNoteFieldResolver_ResolveViewerFields_EmbedsRenoteAndReply(t *testing.T) {
 	reactions := &stubNoteReactionLookup{rows: map[string]*model.NoteReaction{
 		"n1": {NoteID: "n1", Reaction: "👍"},
@@ -114,10 +115,26 @@ func TestNoteFieldResolver_ResolveViewerFields_EmbedsRenoteAndReply(t *testing.T
 
 	require.NotNil(t, notes[0].MyReaction)
 	require.NotNil(t, notes[0].Renote.MyReaction)
-	require.NotNil(t, notes[0].Reply.MyReaction)
+	// reply embed (detail:false) は myReaction を持たない (#1816)。
+	require.Nil(t, notes[0].Reply.MyReaction)
 	require.NotNil(t, notes[0].Channel)
 	assert.Equal(t, "general", notes[0].Channel.Name)
 	require.NotNil(t, notes[0].Renote.Channel)
+}
+
+// #1816: myReaction も legacy text alias (like→👍) を Unicode へ変換する
+// (upstream populateMyReaction、reactions map と一貫)。
+func TestNoteFieldResolver_MyReactionLegacyConverted(t *testing.T) {
+	reactions := &stubNoteReactionLookup{rows: map[string]*model.NoteReaction{
+		"n1": {NoteID: "n1", Reaction: "like"},
+	}}
+	r := NewNoteFieldResolver(nil, nil, nil, reactions, nil, makeIDGen(t))
+
+	notes := []NoteEntity{{ID: "n1", ReactionCount: 1}}
+	r.ResolveViewerFields(notes, &model.User{ID: "v1"})
+
+	require.NotNil(t, notes[0].MyReaction)
+	assert.Equal(t, "👍", *notes[0].MyReaction, "legacy text reaction は myReaction で Unicode に変換")
 }
 
 // nil receiver / nil viewer / 空 slice / nil lookup の網羅的 nil safe 確認。

--- a/internal/entity/note_test.go
+++ b/internal/entity/note_test.go
@@ -250,6 +250,34 @@ func TestPackNote_ReactionsKeyNormalized(t *testing.T) {
 	assert.Equal(t, 5, e.ReactionCount)
 }
 
+// #1816: legacy text reaction (like→👍 等) を packer で Unicode に変換する。
+// 既存の同 Unicode reaction とは count がマージされる。
+func TestPackNote_ReactionsLegacyTextAlias(t *testing.T) {
+	idGen := newTestIDGen(t)
+	noteID := idGen.Generate(time.Now())
+
+	// legacy "like" (2) + 既存 "👍" (3) → "👍":5 に集約。"love" (1) → "❤":1。
+	note := &model.Note{
+		ID:         noteID,
+		UserID:     "user1",
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte(`{"like":2,"👍":3,"love":1}`)),
+	}
+
+	e := PackNote(note, idGen)
+
+	var reactions map[string]float64
+	require.NoError(t, json.Unmarshal(e.Reactions, &reactions))
+	assert.Equal(t, float64(5), reactions["👍"], "like は 👍 に変換され既存 count とマージ")
+	assert.Equal(t, float64(1), reactions["❤"], "love は ❤ に変換")
+	_, hasLike := reactions["like"]
+	assert.False(t, hasLike, "legacy text key は残らない")
+	_, hasLove := reactions["love"]
+	assert.False(t, hasLove)
+	// reactionCount は変換しても総和は不変。
+	assert.Equal(t, 6, e.ReactionCount)
+}
+
 func TestPackNote_WithRenoteAndReply(t *testing.T) {
 	idGen := newTestIDGen(t)
 	renoteID := idGen.Generate(time.Now())
@@ -299,6 +327,69 @@ func TestPackNote_WithRenoteAndReply(t *testing.T) {
 	require.NotNil(t, e.Reply)
 	assert.Equal(t, replyID, e.Reply.ID)
 	assert.Equal(t, &replyText, e.Reply.Text)
+}
+
+// #1816: reply embed は upstream で detail:false なので clippedCount / poll を
+// 出力しない。renote embed は detail:true なので両方とも出す。
+func TestPackNote_ReplyEmbedDetailFalse(t *testing.T) {
+	idGen := newTestIDGen(t)
+	renoteID := idGen.Generate(time.Now())
+	replyID := idGen.Generate(time.Now())
+	noteID := idGen.Generate(time.Now())
+	text := "top"
+
+	poll := &model.Poll{Choices: pq.StringArray{"a", "b"}, Votes: pq.Int64Array{1, 2}}
+	note := &model.Note{
+		ID:         noteID,
+		UserID:     "user1",
+		Text:       &text,
+		RenoteID:   &renoteID,
+		ReplyID:    &replyID,
+		Visibility: model.NoteVisibilityPublic,
+		Reactions:  datatypes.JSON([]byte("{}")),
+		Renote: &model.Note{
+			ID:           renoteID,
+			UserID:       "user2",
+			Visibility:   model.NoteVisibilityPublic,
+			Reactions:    datatypes.JSON([]byte("{}")),
+			ClippedCount: 2,
+			HasPoll:      true,
+			Poll:         poll,
+		},
+		Reply: &model.Note{
+			ID:           replyID,
+			UserID:       "user3",
+			Visibility:   model.NoteVisibilityPublic,
+			Reactions:    datatypes.JSON([]byte("{}")),
+			ClippedCount: 3,
+			HasPoll:      true,
+			Poll:         poll,
+		},
+	}
+
+	e := PackNote(note, idGen)
+
+	// top-level (detail:true): clippedCount / poll を出す。
+	require.NotNil(t, e.ClippedCount)
+
+	// renote embed (detail:true): clippedCount / poll を出す。
+	require.NotNil(t, e.Renote)
+	require.NotNil(t, e.Renote.ClippedCount)
+	assert.Equal(t, 2, *e.Renote.ClippedCount)
+	assert.NotNil(t, e.Renote.Poll)
+
+	// reply embed (detail:false): clippedCount / poll を省く。hasPoll は detail 外
+	// なので残る。
+	require.NotNil(t, e.Reply)
+	assert.Nil(t, e.Reply.ClippedCount, "reply embed は clippedCount を出さない")
+	assert.Nil(t, e.Reply.Poll, "reply embed は poll を出さない")
+	assert.True(t, e.Reply.HasPoll, "hasPoll は detail 外なので reply にも残る")
+
+	// JSON でも reply embed から clippedCount / poll の key が消える。
+	b, err := json.Marshal(e.Reply)
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), "clippedCount")
+	assert.NotContains(t, string(b), "\"poll\"")
 }
 
 func TestPackNotes_EmbeddedRenoteHasInstanceAndEmoji(t *testing.T) {

--- a/internal/entity/parity_1561_test.go
+++ b/internal/entity/parity_1561_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 // #1561 [MEDIUM] clippedCount は model 実値を出す (旧: 0 ハードコード)。
+// #1816: top-level note は detail:true なので clippedCount を *int で出力する。
 func TestPackNote_ClippedCountRealValue(t *testing.T) {
 	idGen := newTestIDGen(t)
 	n := &model.Note{
@@ -19,7 +20,9 @@ func TestPackNote_ClippedCountRealValue(t *testing.T) {
 		Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}")),
 		ClippedCount: 5,
 	}
-	assert.Equal(t, 5, PackNote(n, idGen).ClippedCount)
+	packed := PackNote(n, idGen)
+	require.NotNil(t, packed.ClippedCount)
+	assert.Equal(t, 5, *packed.ClippedCount)
 }
 
 // #1561 [MEDIUM] visibleUserIds は specified のときだけ出力する。

--- a/internal/misc/reactionlegacy/legacy.go
+++ b/internal/misc/reactionlegacy/legacy.go
@@ -1,0 +1,35 @@
+// Package reactionlegacy holds the frozen legacy text-reaction alias table
+// shared by the reaction service (core/reaction) and the note entity packer
+// (internal/entity). It lives in its own low-level package so the entity layer
+// can reference it without importing core/reaction (which would create an
+// import cycle, since core/reaction transitively depends on internal/entity).
+//
+// 本テーブルは pre-2018 の text reaction (like / love 等) を Unicode 絵文字へ
+// 写像する。Misskey 本家 ReactionService の `legacies` 表と同一で、upstream 側
+// でも凍結済み (新規 entry は追加されない) のため共有定数として切り出している。
+package reactionlegacy
+
+// legacies maps a legacy text reaction like "like" or "love" to its Unicode
+// equivalent. Mirrors upstream ReactionService `legacies` (ReactionService.ts).
+// Frozen: do not add entries — new reactions use custom emoji, not text keys.
+var legacies = map[string]string{
+	"like":     "👍",
+	"love":     "❤", // ハート、異体字セレクタを入れない
+	"laugh":    "😆",
+	"hmm":      "🤔",
+	"surprise": "😮",
+	"congrats": "🎉",
+	"angry":    "💢",
+	"confused": "😥",
+	"rip":      "😇",
+	"pudding":  "🍮",
+	"star":     "⭐",
+}
+
+// Convert maps a legacy text reaction (e.g. "like") to its Unicode equivalent.
+// ok is false when key is not a legacy alias, in which case the caller should
+// leave the reaction unchanged.
+func Convert(key string) (string, bool) {
+	v, ok := legacies[key]
+	return v, ok
+}

--- a/internal/misc/reactionlegacy/legacy_test.go
+++ b/internal/misc/reactionlegacy/legacy_test.go
@@ -1,0 +1,38 @@
+package reactionlegacy
+
+import "testing"
+
+// The legacy table is frozen and must match upstream ReactionService `legacies`
+// exactly. This locks the entries (via Convert) so an accidental edit is caught.
+func TestConvert_FrozenEntries(t *testing.T) {
+	want := map[string]string{
+		"like":     "👍",
+		"love":     "❤",
+		"laugh":    "😆",
+		"hmm":      "🤔",
+		"surprise": "😮",
+		"congrats": "🎉",
+		"angry":    "💢",
+		"confused": "😥",
+		"rip":      "😇",
+		"pudding":  "🍮",
+		"star":     "⭐",
+	}
+	for k, v := range want {
+		got, ok := Convert(k)
+		if !ok {
+			t.Errorf("Convert(%q) ok=false, want true", k)
+		}
+		if got != v {
+			t.Errorf("Convert(%q) = %q, want %q", k, got, v)
+		}
+	}
+}
+
+func TestConvert_NonLegacyKeysUnchanged(t *testing.T) {
+	for _, k := range []string{"👍", ":smile:", ":smile@.:", ":smile@remote.example:", ""} {
+		if got, ok := Convert(k); ok {
+			t.Errorf("Convert(%q) ok=true (got %q), want false", k, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

#1781 (entity packers 再監査) から focused follow-up として defer した Note packer の 2 件を解消する。いずれも `internal/entity/note.go` の hot path / struct 形状に踏み込むため #1781 本体から分離していた。

## 主な変更点

### 1. reply embed を detail:false にする (upstream `opts.detail`)

upstream `NoteEntityService.ts` は `reply` embed を `{detail:false}` (:437)、`renote` embed と top-level を `{detail:true}` (:445) で pack し、detail block (:432-460) の `clippedCount` / `poll` / `myReaction` (および `reply`/`renote` の再帰) を detail:false では省く。`hasPoll` / `reactionCount` / `reactions` / `reactionEmojis` は detail 外で常に出す。

- `packNoteAtDepth` に `detail bool` を追加。`PackNote`→true、renote embed→true、reply embed→false。
- `NoteEntity.ClippedCount` を `int` → `*int` (`omitempty`) に変更し detail のときだけ `&n` を set (plain `int + omitempty` だと detail 時の `clippedCount:0` を誤って落とすため pointer 必須、`note.ts:255` optional:true)。`Poll` も detail のときだけ set。
- `note_field_resolver.go` の `applyMyReaction` / `appendNoteIDs` から reply 分岐を除去 (reply embed に myReaction を付けず、fetch 対象にもしない)。`hasPoll` は detail 外なので reply embed でも残す。
- depth-cap (`maxNoteEmbedDepth=1`) との関係は変更なし (renote embed の reply/renote 再帰省略は本 PR 以前からの既存挙動)。

### 2. legacy reaction text-alias の変換 (upstream `convertLegacyReactions`)

upstream は `note.reactions` を必ず `convertLegacyReactions` (legacies map `like→👍` 等 + count マージ) に通すが、mk-go の note packer は legacy text alias を変換していなかった。

- 凍結された legacy 表を新 package `internal/misc/reactionlegacy` に切り出す (entity が `core/reaction` を import すると import cycle になるため下位 package に配置)。`core/reaction` も同 package を参照し single source of truth 化。
- `normalizeReactionKeys` で legacy alias を Unicode へ変換してから colon-form 正規化を通す。同一 canonical key の count はマージ (`like`:2 + `👍`:3 → `👍`:5)。
- `myReaction` も同じ変換を通し reactions map と一貫させる (upstream `populateMyReaction`)。
- upstream の `count>0` filter は適用しない: mk-native の write path (`IncrementReaction` / `count_writer`) が 0 以下の count の key を削除するため 0-count entry が残らない (TS 移行直後データの 0-count は別途扱う drop-in 移行の話で本変換の対象外)。

## テスト

- 追加: `TestPackNote_ReplyEmbedDetailFalse` (reply embed が clippedCount/poll を省き renote embed は出す)、`TestPackNote_ReactionsLegacyTextAlias` (like→👍 + count マージ)、`TestNoteFieldResolver_MyReactionLegacyConverted`、`reactionlegacy` package test (frozen 表)。既存テスト (`parity_1561` / `note_field_resolver` / `resolve_viewer_fields`) を新挙動に更新。
- `go test`: entity 96.2% / core/reaction 94.2% / reactionlegacy 100% green。api/notes / api/i / api/users / stream も green。
- `go build ./...` / `go vet ./...` / `gofmt -s -l` clean。

## Closes

Closes #1816

🤖 Generated with [Claude Code](https://claude.com/claude-code)