### PR TITLE
Fix ap-inbound parity (#1819): Update(Note) で activity.actor が note 著者と一致することを検証

### DIFF
--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -1575,7 +1575,8 @@ func (p *Processor) handleUpdate(act genericActivity) error {
 		return nil
 	}
 	if strings.EqualFold(objectType, "note") {
-		_, err := p.resolver.UpdateRemoteNote(act.Object)
+		// act.Actor を渡して note 著者との一致を検証させる (#1819、Question 経路と対称)。
+		_, err := p.resolver.UpdateRemoteNote(act.Object, act.Actor)
 		// ErrInvalidNote は受信側の不備として skip 扱い (200 を返す)。
 		if errors.Is(err, ErrInvalidNote) {
 			return nil

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -1306,8 +1306,10 @@ func (r *Resolver) UpdateRemoteQuestion(object json.RawMessage, actorURI string)
 // 動作:
 //   - URI でノートを引いて見つからなければ何もせず nil
 //   - 見つかったが著者がローカルなら何もしない (ローカルノートは変更不可)
-//   - 著者がリモートなら text/cw/sensitive/mentions を更新
-func (r *Resolver) UpdateRemoteNote(body []byte) (*model.Note, error) {
+//   - Update activity の actor (actorURI) が note 著者と一致しなければ無視
+//     (別 remote 著者の note URI を狙った改ざんを拒否、UpdateRemoteQuestion と対称、#1819)
+//   - 著者がリモートで actor が一致すれば text/cw/sensitive/mentions を更新
+func (r *Resolver) UpdateRemoteNote(body []byte, actorURI string) (*model.Note, error) {
 	if r.noteRepo == nil {
 		return nil, ErrInvalidNote
 	}
@@ -1327,6 +1329,15 @@ func (r *Resolver) UpdateRemoteNote(body []byte) (*model.Note, error) {
 	if existing.UserHost == nil {
 		// ローカルノートに対する Update は無視 (Misskey は編集機能を持たない)。
 		return existing, nil
+	}
+	// attribution: Update の actor は note 著者と一致必須。別 remote 著者の note URI を
+	// 指定した改ざん (text/cw/sensitive/mentions 上書き) を拒否する。inbox 層の
+	// authorizeActor は signer==activity.actor と activity.id host の整合しか保証
+	// しないため、ここで対象 note の著者まで照合する (#1819、UpdateRemoteQuestion と対称)。
+	if actorURI != "" && r.userRepo != nil {
+		if author, aerr := r.userRepo.FindByID(existing.UserID); aerr == nil && author != nil && author.URI != nil && *author.URI != actorURI {
+			return existing, nil
+		}
 	}
 	fields := map[string]any{}
 	// IngestNoteと同じ3段フォールバックでtext抽出

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -1125,13 +1125,61 @@ func TestUpdateRemoteNote_HappyPath(t *testing.T) {
 	idGen, _ := id.NewGenerator("aidx")
 	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
 
-	got, err := r.UpdateRemoteNote([]byte(remoteNoteUpdateBody))
+	got, err := r.UpdateRemoteNote([]byte(remoteNoteUpdateBody), "")
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.NotNil(t, got.Text)
 	assert.Equal(t, "edited content", *got.Text)
 	require.NotNil(t, got.CW)
 	assert.Equal(t, "edited cw", *got.CW)
+}
+
+// #1819: Update の actor が note 著者と一致しない場合、本文を改ざんさせない
+// (別 remote 著者の note URI を狙った Update(Note) を拒否、Question 経路と対称)。
+func TestUpdateRemoteNote_ActorMismatchRejected(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	uri := "https://remote.example/notes/n1"
+	host := "remote.example"
+	authorURI := "https://remote.example/users/alice"
+	original := "original"
+	repo.Users["alice-id"] = &model.User{ID: "alice-id", URI: &authorURI, Host: &host}
+	noteRepo.Notes["n1"] = &model.Note{
+		ID: "n1", URI: &uri, UserID: "alice-id", UserHost: &host, Text: &original,
+	}
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+
+	// 別 actor (mallory) が alice の note を Update しようとする → 拒否 (本文不変)。
+	got, err := r.UpdateRemoteNote([]byte(remoteNoteUpdateBody), "https://evil.example/users/mallory")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.Text)
+	assert.Equal(t, "original", *got.Text, "actor 不一致の Update は本文を改ざんしない")
+}
+
+// #1819: actor が note 著者と一致すれば従来どおり更新される。
+func TestUpdateRemoteNote_ActorMatchProceeds(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	uri := "https://remote.example/notes/n1"
+	host := "remote.example"
+	authorURI := "https://remote.example/users/alice"
+	original := "original"
+	repo.Users["alice-id"] = &model.User{ID: "alice-id", URI: &authorURI, Host: &host}
+	noteRepo.Notes["n1"] = &model.Note{
+		ID: "n1", URI: &uri, UserID: "alice-id", UserHost: &host, Text: &original,
+	}
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
+
+	got, err := r.UpdateRemoteNote([]byte(remoteNoteUpdateBody), authorURI)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.Text)
+	assert.Equal(t, "edited content", *got.Text, "actor 一致の Update は反映される")
 }
 
 // #679: UpdateRemoteNote が note.tags を再計算する。tag 配列が変わった場合に
@@ -1158,7 +1206,7 @@ func TestUpdateRemoteNote_RecalculatesHashtags(t *testing.T) {
 			{"type": "Hashtag", "name": "#federation"}
 		]
 	}`
-	got, err := r.UpdateRemoteNote([]byte(body))
+	got, err := r.UpdateRemoteNote([]byte(body), "")
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.ElementsMatch(t, []string{"federation", "news"}, []string(got.Tags), "古い tags は捨て、tag 配列 + 本文 fallback で再構築")
@@ -1186,7 +1234,7 @@ func TestUpdateRemoteNote_ClearsTagsToEmptyNotNull(t *testing.T) {
 		"attributedTo": "https://remote.example/users/alice",
 		"content": "edited, no more hashtags"
 	}`
-	got, err := r.UpdateRemoteNote([]byte(body))
+	got, err := r.UpdateRemoteNote([]byte(body), "")
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.NotNil(t, got.Tags, "tags は非nilの空配列でなければ SQL NULL で NOT NULL 違反 (#1372)")
@@ -1198,7 +1246,7 @@ func TestUpdateRemoteNote_NoNoteRepo(t *testing.T) {
 	urls := activitypub.NewURLBuilder("https://example.com")
 	idGen, _ := id.NewGenerator("aidx")
 	r := federation.NewResolver(repo, nil, urls, &stubFetcher{}, idGen)
-	_, err := r.UpdateRemoteNote([]byte(remoteNoteUpdateBody))
+	_, err := r.UpdateRemoteNote([]byte(remoteNoteUpdateBody), "")
 	assert.ErrorIs(t, err, federation.ErrInvalidNote)
 }
 
@@ -1208,7 +1256,7 @@ func TestUpdateRemoteNote_BadJSON(t *testing.T) {
 	urls := activitypub.NewURLBuilder("https://example.com")
 	idGen, _ := id.NewGenerator("aidx")
 	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
-	_, err := r.UpdateRemoteNote([]byte(`{not json`))
+	_, err := r.UpdateRemoteNote([]byte(`{not json`), "")
 	assert.ErrorIs(t, err, federation.ErrInvalidNote)
 }
 
@@ -1218,7 +1266,7 @@ func TestUpdateRemoteNote_MissingID(t *testing.T) {
 	urls := activitypub.NewURLBuilder("https://example.com")
 	idGen, _ := id.NewGenerator("aidx")
 	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
-	_, err := r.UpdateRemoteNote([]byte(`{"type":"Note"}`))
+	_, err := r.UpdateRemoteNote([]byte(`{"type":"Note"}`), "")
 	assert.ErrorIs(t, err, federation.ErrInvalidNote)
 }
 
@@ -1228,7 +1276,7 @@ func TestUpdateRemoteNote_NotFound(t *testing.T) {
 	urls := activitypub.NewURLBuilder("https://example.com")
 	idGen, _ := id.NewGenerator("aidx")
 	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
-	got, err := r.UpdateRemoteNote([]byte(remoteNoteUpdateBody))
+	got, err := r.UpdateRemoteNote([]byte(remoteNoteUpdateBody), "")
 	require.NoError(t, err)
 	assert.Nil(t, got)
 }
@@ -1246,7 +1294,7 @@ func TestUpdateRemoteNote_LocalNoteSkipped(t *testing.T) {
 	idGen, _ := id.NewGenerator("aidx")
 	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
 
-	got, err := r.UpdateRemoteNote([]byte(remoteNoteUpdateBody))
+	got, err := r.UpdateRemoteNote([]byte(remoteNoteUpdateBody), "")
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	// Text は変わらない
@@ -1272,7 +1320,7 @@ func TestUpdateRemoteNote_EmptyContentNoOp(t *testing.T) {
 		"type": "Note",
 		"attributedTo": "https://remote.example/users/alice"
 	}`)
-	got, err := r.UpdateRemoteNote(body)
+	got, err := r.UpdateRemoteNote(body, "")
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.NotNil(t, got.Text)
@@ -1298,7 +1346,7 @@ func TestUpdateRemoteNote_SensitiveWithoutSummary(t *testing.T) {
 		"content": "nsfw",
 		"sensitive": true
 	}`)
-	got, err := r.UpdateRemoteNote(body)
+	got, err := r.UpdateRemoteNote(body, "")
 	require.NoError(t, err)
 	require.NotNil(t, got.CW)
 	assert.Equal(t, "", *got.CW)
@@ -1325,7 +1373,7 @@ func TestUpdateRemoteNote_UpdateFieldsError(t *testing.T) {
 	urls := activitypub.NewURLBuilder("https://example.com")
 	idGen, _ := id.NewGenerator("aidx")
 	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{}, idGen)
-	_, err := r.UpdateRemoteNote([]byte(remoteNoteUpdateBody))
+	_, err := r.UpdateRemoteNote([]byte(remoteNoteUpdateBody), "")
 	assert.Error(t, err)
 }
 
@@ -1986,7 +2034,7 @@ func TestUpdateRemoteNote_HashtagHookFiresOnTagsChange(t *testing.T) {
 		"attributedTo": "https://remote.example/users/alice",
 		"content": "edited and now tagged #news"
 	}`
-	_, err := r.UpdateRemoteNote([]byte(body))
+	_, err := r.UpdateRemoteNote([]byte(body), "")
 	require.NoError(t, err)
 	require.Len(t, hook.calls, 1)
 	assert.Equal(t, "hh3", hook.calls[0].noteID)
@@ -2016,7 +2064,7 @@ func TestUpdateRemoteNote_HashtagHookSkipsWhenTagsUnchanged(t *testing.T) {
 		"attributedTo": "https://remote.example/users/alice",
 		"content": "edit body but tag unchanged #news"
 	}`
-	_, err := r.UpdateRemoteNote([]byte(body))
+	_, err := r.UpdateRemoteNote([]byte(body), "")
 	require.NoError(t, err)
 	assert.Empty(t, hook.calls, "tags が変化しなければ hook は呼ばれない")
 }
@@ -3011,7 +3059,7 @@ func TestUpdateRemoteNote_EmojiTagExtraction(t *testing.T) {
 			}
 		]
 	}`)
-	got, err := r.UpdateRemoteNote(updateBody)
+	got, err := r.UpdateRemoteNote(updateBody, "")
 	require.NoError(t, err)
 	require.NotNil(t, got)
 
@@ -3065,7 +3113,7 @@ func TestUpdateRemoteNote_EmojiTagExtraction_ExistingEmoji(t *testing.T) {
 			}
 		]
 	}`)
-	got, err := r.UpdateRemoteNote(updateBody)
+	got, err := r.UpdateRemoteNote(updateBody, "")
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.Len(t, got.Emojis, 1)
@@ -3792,7 +3840,7 @@ func TestUpdateRemoteNote_MentionsRecomputed(t *testing.T) {
 			{"type": "Mention", "href": "https://example.com/users/alice", "name": "@alice"}
 		]
 	}`)
-	got, err := r.UpdateRemoteNote(body)
+	got, err := r.UpdateRemoteNote(body, "")
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, []string{"alice"}, []string(got.Mentions))


### PR DESCRIPTION
## Summary

再監査(2) の HIGH。inbound `Update(Note)` が `activity.actor` と Update 対象 note の著者の一致を検証しておらず、**署名済みの remote actor が DB 上の別 remote 著者の note 本文 (text/cw/sensitive/mentions/emojis/tags 等) を改ざんできる**認可ギャップがあった。同 `handleUpdate` の Question 分岐は `UpdateRemoteQuestion(object, actor)` で著者 URI 一致を検証しており、Note 経路だけが非対称に検証を欠いていた。inbox 層の `authorizeActor` は signer==activity.actor と activity.id host の整合しか保証しないため、Update 対象 object の著者照合は resolver 層で行う必要がある。

## 主な変更点

- `internal/core/federation/resolver.go`: `Resolver.UpdateRemoteNote` に `actorURI` 引数を追加。remote note 取得後・field 適用前に `author.URI != actorURI` なら no-op で返す gate を入れる (poll の `UpdateRemoteQuestion` 著者照合と対称)。`actorURI` 空 / `userRepo` nil / `author.URI` nil は fail-open (Question 経路と同挙動)。
- `internal/core/federation/processor.go`: Note 分岐が `act.Actor` を渡すよう変更。
- `internal/core/federation/resolver_test.go`: 既存呼び出しを `actorURI=""` (gate skip = 従来挙動維持) に更新。actor 不一致で本文が改ざんされないこと (`TestUpdateRemoteNote_ActorMismatchRejected`) / actor 一致で更新されること (`TestUpdateRemoteNote_ActorMatchProceeds`) のテストを追加。

## テスト

- `go test ./internal/core/federation/... -cover`: 90.2% green。
- `go build ./...` / `go vet ./...` / `gofmt -s -l` clean。

## Closes

Closes #1819

🤖 Generated with [Claude Code](https://claude.com/claude-code)