### PR TITLE
Fix ap-resolver parity (#1820): fetch した AP object の id-host を取得 host に bind (object-spoofing 防止)

### DIFF
--- a/internal/activitypub/client.go
+++ b/internal/activitypub/client.go
@@ -97,30 +97,48 @@ func (c *Client) GetSigned(url string, key *PrivateKey, acceptOverride string) (
 	return c.httpClient.Do(req)
 }
 
-// FetchJSON performs a signed GET and returns the response body. Non-2xx
-// responses produce a *StatusError so callers can branch on status (e.g.
-// authorized-fetch fallback on 401/403, #419)。
-func (c *Client) FetchJSON(url string, key *PrivateKey) ([]byte, error) {
+// finalURLOf returns the response's final request URL (after redirects). Go's
+// http client points resp.Request at the last request in the redirect chain,
+// so this is the URL the body was actually served from — used to bind a fetched
+// AP object's id host to the host that served it (#1820)。fallback は要求 URL。
+func finalURLOf(resp *http.Response, fallback string) string {
+	if resp != nil && resp.Request != nil && resp.Request.URL != nil {
+		return resp.Request.URL.String()
+	}
+	return fallback
+}
+
+// FetchJSONWithURL is FetchJSON but also returns the final response URL (after
+// redirects) so callers can verify the fetched object's id host against the
+// host that served it (#1820)。
+func (c *Client) FetchJSONWithURL(url string, key *PrivateKey) ([]byte, string, error) {
 	resp, err := c.GetSigned(url, key, "")
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		drainBody(resp)
-		return nil, &StatusError{StatusCode: resp.StatusCode, Status: resp.Status, URL: url}
+		return nil, "", &StatusError{StatusCode: resp.StatusCode, Status: resp.Status, URL: url}
 	}
-	return safehttp.ReadAllLimit(resp.Body, MaxBodyBytes)
+	body, rerr := safehttp.ReadAllLimit(resp.Body, MaxBodyBytes)
+	return body, finalURLOf(resp, url), rerr
 }
 
-// FetchUnsigned performs a plain GET without HTTP signing. 多くのAPサーバーは
-// アクター取得を未署名で許可するため、resolver の初回 fetch 用に使う。
-// Non-2xx responses produce a *StatusError so callers can branch on status
-// (e.g. authorized-fetch fallback on 401/403, #419)。
-func (c *Client) FetchUnsigned(url string) ([]byte, error) {
+// FetchJSON performs a signed GET and returns the response body. Non-2xx
+// responses produce a *StatusError so callers can branch on status (e.g.
+// authorized-fetch fallback on 401/403, #419)。
+func (c *Client) FetchJSON(url string, key *PrivateKey) ([]byte, error) {
+	body, _, err := c.FetchJSONWithURL(url, key)
+	return body, err
+}
+
+// FetchUnsignedWithURL is FetchUnsigned but also returns the final response URL
+// (after redirects) for object-host verification (#1820)。
+func (c *Client) FetchUnsignedWithURL(url string) ([]byte, string, error) {
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	req.Header.Set("Accept", MimeType+`, `+LDMimeType)
 	if c.userAgent != "" {
@@ -128,14 +146,24 @@ func (c *Client) FetchUnsigned(url string) ([]byte, error) {
 	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		drainBody(resp)
-		return nil, &StatusError{StatusCode: resp.StatusCode, Status: resp.Status, URL: url}
+		return nil, "", &StatusError{StatusCode: resp.StatusCode, Status: resp.Status, URL: url}
 	}
-	return safehttp.ReadAllLimit(resp.Body, MaxBodyBytes)
+	body, rerr := safehttp.ReadAllLimit(resp.Body, MaxBodyBytes)
+	return body, finalURLOf(resp, url), rerr
+}
+
+// FetchUnsigned performs a plain GET without HTTP signing. 多くのAPサーバーは
+// アクター取得を未署名で許可するため、resolver の初回 fetch 用に使う。
+// Non-2xx responses produce a *StatusError so callers can branch on status
+// (e.g. authorized-fetch fallback on 401/403, #419)。
+func (c *Client) FetchUnsigned(url string) ([]byte, error) {
+	body, _, err := c.FetchUnsignedWithURL(url)
+	return body, err
 }
 
 // FetchUnsignedJSON performs an unsigned GET with `Accept: application/json, */*`.

--- a/internal/core/federation/fetcher.go
+++ b/internal/core/federation/fetcher.go
@@ -48,10 +48,10 @@ func (f *APFetcher) SetSigner(s SignerProvider) {
 	f.signer = s
 }
 
-// FetchObject performs a default-signed GET against uri, falling back to
-// unsigned GET on 401/403. Resolver でアクター取得やリモート Note 取得に
-// 共通で使う (#419)。
-func (f *APFetcher) FetchObject(uri string) ([]byte, error) {
+// FetchObjectWithFinalURL is FetchObject but also returns the final response URL
+// (after redirects) so the resolver can bind a fetched object's id host to the
+// host that served it (object-spoofing 防止、#1820)。
+func (f *APFetcher) FetchObjectWithFinalURL(uri string) ([]byte, string, error) {
 	if f.signer != nil {
 		key, err := f.signer.Signer()
 		switch {
@@ -63,21 +63,29 @@ func (f *APFetcher) FetchObject(uri string) ([]byte, error) {
 			slog.Debug("ap fetcher: signer unavailable, falling back to unsigned",
 				"uri", uri, "err", err)
 		case key != nil:
-			body, ferr := f.client.FetchJSON(uri, key)
+			body, finalURL, ferr := f.client.FetchJSONWithURL(uri, key)
 			if ferr == nil {
-				return body, nil
+				return body, finalURL, nil
 			}
 			// 4xx の中でも 401/403 だけがフォールバック対象。404/410 は
 			// 「リソース不在」を意味するので unsigned で再リクエストしても
 			// 結果は同じ (#419 Devin review)。
 			if !shouldFallbackToUnsigned(ferr) {
-				return nil, ferr
+				return nil, "", ferr
 			}
 			slog.Debug("ap fetcher: signed fetch unauthorized, falling back to unsigned",
 				"uri", uri, "err", ferr)
 		}
 	}
-	return f.client.FetchUnsigned(uri)
+	return f.client.FetchUnsignedWithURL(uri)
+}
+
+// FetchObject performs a default-signed GET against uri, falling back to
+// unsigned GET on 401/403. Resolver でアクター取得やリモート Note 取得に
+// 共通で使う (#419)。
+func (f *APFetcher) FetchObject(uri string) ([]byte, error) {
+	body, _, err := f.FetchObjectWithFinalURL(uri)
+	return body, err
 }
 
 // FetchObjectUnsigned performs an explicit unsigned GET. nodeinfo /

--- a/internal/core/federation/host_match_internal_test.go
+++ b/internal/core/federation/host_match_internal_test.go
@@ -1,0 +1,42 @@
+package federation
+
+import "testing"
+
+// #1820: assertResponseHostMatches は upstream assertActivityMatchesUrl の
+// hard requirement (id host == final URL host, id 必須, https downgrade 拒否) を
+// 表す。finalURL が空 (最終 URL 不明 = テストダブル) のときは skip する。
+func TestAssertResponseHostMatches(t *testing.T) {
+	cases := []struct {
+		name     string
+		finalURL string
+		objectID string
+		wantErr  bool
+	}{
+		{"host match", "https://remote.example/users/alice", "https://remote.example/users/alice", false},
+		{"host match different path", "https://remote.example/x", "https://remote.example/users/alice", false},
+		{"host mismatch (spoof)", "https://evil.example/users/alice", "https://remote.example/users/alice", true},
+		{"id missing", "https://remote.example/users/alice", "", true},
+		{"https downgrade", "https://remote.example/users/alice", "http://remote.example/users/alice", true},
+		{"http final allows http id (no downgrade)", "http://remote.example/x", "http://remote.example/users/alice", false},
+		{"empty finalURL skips check", "", "https://remote.example/users/alice", false},
+		{"case-insensitive host", "https://Remote.Example/x", "https://remote.example/users/alice", false},
+		// #1820 review: upstream URL.host は default port を除去するので :443 と無印は一致。
+		{"default https port equivalent", "https://remote.example:443/x", "https://remote.example/users/alice", false},
+		{"default http port equivalent", "http://remote.example:80/x", "http://remote.example/users/alice", false},
+		{"non-default port mismatch", "https://remote.example:8443/x", "https://remote.example/users/alice", true},
+		// #1820 review: 先頭 www. は synonymous subdomain として除去して一致扱い。
+		{"www synonymous subdomain", "https://www.remote.example/x", "https://remote.example/users/alice", false},
+		{"www both sides", "https://www.remote.example/x", "https://www.remote.example/users/alice", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := assertResponseHostMatches(tc.finalURL, tc.objectID)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("expected nil, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -77,6 +77,11 @@ var (
 	// ingest content from a host that the local instance's federation policy
 	// (federation: none / specified, blockedHosts) does not allow.
 	ErrHostNotAllowed = errors.New("host not allowed by federation policy")
+	// ErrObjectHostMismatch is returned when a fetched AP object's id host does
+	// not match the host that actually served it (after redirects). Mirrors
+	// upstream assertActivityMatchesUrl の hard requirement で object-spoofing を
+	// 防ぐ (#1820)。
+	ErrObjectHostMismatch = errors.New("fetched object id host does not match response host")
 )
 
 // DefaultActorTTL is the default duration after which a cached actor (and its
@@ -685,7 +690,7 @@ func (r *Resolver) fetchActor(uri string) (*activitypub.Person, error) {
 	if !r.hostAllowedForURI(uri) {
 		return nil, ErrHostNotAllowed
 	}
-	body, err := r.fetcher.FetchObject(uri)
+	body, finalURL, err := r.fetchObjectWithFinalURL(uri)
 	if err != nil {
 		return nil, err
 	}
@@ -695,6 +700,13 @@ func (r *Resolver) fetchActor(uri string) (*activitypub.Person, error) {
 	}
 	if actor.ID == "" || actor.PreferredUsername == "" {
 		return nil, ErrInvalidActor
+	}
+	// actor.ID host が body を返した host と一致するか検証 (object-spoofing 防止、
+	// #1820)。以降 resolveActorOnce は actor.ID から host/URI を導出するため、
+	// ここで bind しておかないと別 host になりすました actor が作られる。
+	if err := assertResponseHostMatches(finalURL, actor.ID); err != nil {
+		slog.Warn("federation: actor id host mismatch", "uri", uri, "finalURL", finalURL, "id", actor.ID)
+		return nil, err
 	}
 	if !activitypub.IsValidActorType(actor.Type) {
 		// Note/Activity 等 Actor でない object が actor として参照された場合の
@@ -871,8 +883,19 @@ func (r *Resolver) resolveNoteOnce(uri string) (*model.Note, error) {
 	if !r.hostAllowedForURI(uri) {
 		return nil, ErrHostNotAllowed
 	}
-	body, err := r.fetcher.FetchObject(uri)
+	body, finalURL, err := r.fetchObjectWithFinalURL(uri)
 	if err != nil {
+		return nil, err
+	}
+	// note.id host が body を返した host と一致するか検証 (object-spoofing 防止、
+	// #1820)。IngestNote は apNote.ID をそのまま note.URI に採用するため、ここで
+	// bind しておく。
+	var idProbe struct {
+		ID string `json:"id"`
+	}
+	_ = json.Unmarshal(body, &idProbe)
+	if err := assertResponseHostMatches(finalURL, idProbe.ID); err != nil {
+		slog.Warn("federation: note id host mismatch", "uri", uri, "finalURL", finalURL, "id", idProbe.ID)
 		return nil, err
 	}
 	return r.IngestNote(body)
@@ -1849,6 +1872,69 @@ func hostFromURI(uri string) (string, error) {
 		return "", fmt.Errorf("missing host in %q", uri)
 	}
 	return u.Host, nil
+}
+
+// finalURLFetcher は redirect 後の最終 URL も返せる fetcher。本番 APFetcher が
+// 実装し、resolver が fetch 元 host と object id host の一致検証に使う (#1820)。
+// テストダブル (stubFetcher) は実装しなくてよく、その場合 resolver は最終 URL
+// 不明として host 検証を skip する (本番 APFetcher は必ず最終 URL を返すので
+// production では常に検証される)。
+type finalURLFetcher interface {
+	FetchObjectWithFinalURL(uri string) ([]byte, string, error)
+}
+
+// fetchObjectWithFinalURL fetches uri and returns (body, finalURL). finalURL は
+// fetcher が finalURLFetcher を実装する場合のみ非空。未実装 (テスト) では ""
+// を返し、呼び出し側の host 検証を skip させる。
+func (r *Resolver) fetchObjectWithFinalURL(uri string) ([]byte, string, error) {
+	if ff, ok := r.fetcher.(finalURLFetcher); ok {
+		return ff.FetchObjectWithFinalURL(uri)
+	}
+	body, err := r.fetcher.FetchObject(uri)
+	return body, "", err
+}
+
+// assertResponseHostMatches enforces upstream assertActivityMatchesUrl の hard
+// requirement: fetch した AP object の id host が、実際に body を返した最終 URL
+// の host と一致すること。これにより evil.example の AP サーバーが
+// `{"id":"https://victim.example/..."}` を返して別 host になりすます
+// object-spoofing を防ぐ。id 欠落 / https→http downgrade も拒否する (#1820)。
+// finalURL が空 (最終 URL 不明) の場合は検証を skip する。
+func assertResponseHostMatches(finalURL, objectID string) error {
+	if finalURL == "" {
+		return nil
+	}
+	if objectID == "" {
+		return ErrObjectHostMismatch
+	}
+	fu, ferr := url.Parse(finalURL)
+	iu, ierr := url.Parse(objectID)
+	if ferr != nil || ierr != nil || fu.Hostname() == "" || iu.Hostname() == "" {
+		return ErrObjectHostMismatch
+	}
+	// https で取得したのに id が http の場合は downgrade 拒否 (upstream と同じ)。
+	if fu.Scheme == "https" && iu.Scheme != "https" {
+		return ErrObjectHostMismatch
+	}
+	if normalizeMatchHost(fu) != normalizeMatchHost(iu) {
+		return ErrObjectHostMismatch
+	}
+	return nil
+}
+
+// normalizeMatchHost canonicalizes a URL host for object-host comparison,
+// mirroring upstream の URL.host (default port を除去) + normalizeSynonymousSubdomain
+// (先頭 www. を除去)。これが無いと `remote.example:443` vs `remote.example` や
+// `www.remote.example` vs `remote.example` を誤って弾く (#1820 review)。
+func normalizeMatchHost(u *url.URL) string {
+	host := strings.ToLower(u.Hostname())
+	host = strings.TrimPrefix(host, "www.")
+	port := u.Port()
+	isDefaultPort := (u.Scheme == "https" && port == "443") || (u.Scheme == "http" && port == "80")
+	if port != "" && !isDefaultPort {
+		return host + ":" + port
+	}
+	return host
 }
 
 // extractAttachments parses the AP `attachment` array (heterogeneous []any

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -86,6 +86,51 @@ func TestResolveActor_NewUser(t *testing.T) {
 	assert.Contains(t, pem, "FAKE")
 }
 
+// finalURLStubFetcher は redirect 後の最終 URL を制御できる test fetcher。
+// resolver の unexported finalURLFetcher を構造的に満たす (#1820)。
+type finalURLStubFetcher struct {
+	body     []byte
+	finalURL string
+}
+
+func (f *finalURLStubFetcher) FetchObject(_ string) ([]byte, error) {
+	return f.body, nil
+}
+
+func (f *finalURLStubFetcher) FetchObjectWithFinalURL(_ string) ([]byte, string, error) {
+	return f.body, f.finalURL, nil
+}
+
+func newResolverWithFetcher(t *testing.T, f federation.HTTPFetcher) (*federation.Resolver, *testutil.MockUserRepository) {
+	t.Helper()
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	return federation.NewResolver(repo, noteRepo, urls, f, idGen), repo
+}
+
+// #1820: evil.example が victim(remote.example) になりすました actor を返しても、
+// 取得元 host (finalURL) と actor.id host が一致しないので拒否する (object-spoofing)。
+func TestResolveActor_HostSpoofRejected(t *testing.T) {
+	// body の id は remote.example だが、実際に body を返したのは evil.example。
+	f := &finalURLStubFetcher{body: []byte(sampleActor), finalURL: "https://evil.example/users/alice"}
+	r, repo := newResolverWithFetcher(t, f)
+	_, err := r.ResolveActor("https://evil.example/users/alice")
+	require.Error(t, err, "id host != fetch host の actor は拒否されるべき")
+	assert.Empty(t, repo.Users, "なりすまし actor を DB に作ってはいけない")
+}
+
+// #1820: 取得元 host と actor.id host が一致すれば従来どおり解決される。
+func TestResolveActor_HostMatchAccepted(t *testing.T) {
+	f := &finalURLStubFetcher{body: []byte(sampleActor), finalURL: "https://remote.example/users/alice"}
+	r, repo := newResolverWithFetcher(t, f)
+	user, err := r.ResolveActor("https://remote.example/users/alice")
+	require.NoError(t, err)
+	assert.Equal(t, "alice", user.Username)
+	assert.Len(t, repo.Users, 1)
+}
+
 // #692: 新規 fetch で `_misskey_canChat` を chatScope に翻訳する。
 // 欠落 / true は "everyone"、false は "none" にマップ。
 func TestResolveActor_NewUserCanChatTranslation(t *testing.T) {


### PR DESCRIPTION
## Summary

再監査(2) の HIGH(セキュリティ)。mk-go の AP resolver は remote URI を fetch した後、返ってきた object の `id` をそのまま local 行の host/URI に採用しており、**fetch 元 host と object id host の一致を検証していなかった**。そのため `evil.example` の AP サーバーが `{"id":"https://victim.example/users/alice"}` を返すと Host=victim.example の user/note を作成でき、別 host になりすます **object-spoofing** が成立した。upstream は `assertActivityMatchesUrl` (`core/activitypub/misc/check-against-url.ts`) で `id host == final-response-URL host` を厳格に要求する。`allowExternalApRedirect` 既定 true で redirect を追従するため、faithful な検証には redirect 後の最終 URL が必要。

## 主な変更点

- `internal/activitypub/client.go`: `FetchJSONWithURL` / `FetchUnsignedWithURL` を追加し、redirect 後の最終 URL (`resp.Request.URL`) を返す。既存 `FetchJSON`/`FetchUnsigned` は委譲 (挙動不変)。
- `internal/core/federation/fetcher.go`: `APFetcher.FetchObjectWithFinalURL` を追加 (signed→unsigned-on-401/403 fallback を保ったまま最終 URL を返す)。`FetchObject` は委譲。
- `internal/core/federation/resolver.go`:
  - optional interface `finalURLFetcher` を type-assert して最終 URL を取得。**本番 `APFetcher` は実装するので production では常に検証**、テストダブルは未実装→最終 URL 不明として検証 skip (fail-open は test のみ、本番では発生しない)。
  - `assertResponseHostMatches`: id 必須 / `https→http` downgrade 拒否 / `id host == final host`。default port (`:443`/`:80`) と先頭 `www.` は upstream `URL.host` / `normalizeSynonymousSubdomain` と同じく正規化して誤 reject を防ぐ。
  - `fetchActor` と `resolveNoteOnce` の fetch-path に適用 (これらが fetch して id を信頼する唯一の経路)。

## テスト

- `assertResponseHostMatches` の unit test (match / mismatch=spoof / id欠落 / downgrade / default-port / www / 非default-port mismatch / skip)。
- resolver integration test: spoof (id host != fetch host) 拒否 + host 一致許可 (production の finalURLFetcher 経路を実際に通る stub で検証)。
- `go test ./internal/core/federation/... ./internal/activitypub/...`: federation 90.2% / activitypub 90.8% green。`go build ./...` / `go vet ./...` / `gofmt -s -l` clean。

## レビューで分離した follow-up

敵対的レビューで判明した別 control を分離:
- **#1839 (HIGH)**: inbound `Create(Note)` の attribution 偽装 (別 upstream control = `validateNote`、`attributedTo`==配送 actor 未検証)。本 PR の fetch-path 修正とは別経路。
- **#1828 追記 (MAJOR)**: request-URL ↔ final-URL の Strict host binding (cross-host redirect 経由の victim 解決誘発)。ap/show 緩和の兼ね合いで follow-up 化。

## Closes

Closes #1820

🤖 Generated with [Claude Code](https://claude.com/claude-code)