### PR TITLE
Fix ap-inbound parity (#1839): inbound Create(Note) の attribution を検証し note なりすましを防ぐ

### DIFF
--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -1108,7 +1108,9 @@ func (p *Processor) handleCreate(act genericActivity) error {
 	// fail-closed に倒すため union 後の object を ingest に渡す。union に失敗した
 	// 場合は元の object を使う (= 既存挙動へ degrade)。
 	object := mergeCreateAudience(act)
-	note, created, err := p.resolver.IngestNoteWithCreated(object)
+	// act.Actor を配送 actor として渡し、note の著者 (attributedTo) が配送者本人で
+	// あることを検証させる (なりすまし forge 防止、#1839)。
+	note, created, err := p.resolver.IngestNoteWithCreated(object, act.Actor)
 	if errors.Is(err, corenote.ErrContainsTooManyMentions) {
 		// upstream Misskey #17167 (= 2026.5.0 fix / triage #1004): role policy
 		// 由来の "note contains too many mentions" は永続的に解決しない error な
@@ -1125,6 +1127,14 @@ func (p *Processor) handleCreate(act genericActivity) error {
 		// (#1419 review)。handleAnnounce 等は isPermanentSkipError で吸収する
 		// が、handleCreate は他の error を retry に乗せる方針なので明示分岐。
 		slog.Info("federation: dropping inbound Create(Note) from non-federated host",
+			"actor", act.Actor)
+		return nil
+	}
+	if errors.Is(err, ErrNoteAttributionMismatch) {
+		// id/attributedTo host 不一致・attribution≠配送actor (なりすまし forge) は
+		// retry で解消しないため ack して drop する (#1839)。malformed note
+		// (ErrInvalidNote) は従来どおり下の err 分岐で surface する。
+		slog.Info("federation: dropping forged inbound Create(Note) (attribution mismatch)",
 			"actor", act.Actor)
 		return nil
 	}

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -82,6 +82,12 @@ var (
 	// upstream assertActivityMatchesUrl の hard requirement で object-spoofing を
 	// 防ぐ (#1820)。
 	ErrObjectHostMismatch = errors.New("fetched object id host does not match response host")
+	// ErrNoteAttributionMismatch is returned when an inbound Note's id host does
+	// not match its attributedTo host, or its attributedTo does not match the
+	// delivering actor. Mirrors upstream ApNoteService.validateNote で note 偽装
+	// (なりすまし) を防ぐ (#1839)。malformed note (ErrInvalidNote) と違い、これは
+	// retry しても解消しないため caller は ack して drop する。
+	ErrNoteAttributionMismatch = errors.New("note attribution does not match delivering actor or id host")
 )
 
 // DefaultActorTTL is the default duration after which a cached actor (and its
@@ -963,7 +969,9 @@ func (r *Resolver) resolveQuoteURI(uri string) *model.Note {
 // `created` フラグが必要な caller (e.g. processor.handleCreate の chart hook 発火
 // 判定) は IngestNoteWithCreated を直接呼ぶこと。
 func (r *Resolver) IngestNote(body []byte) (*model.Note, error) {
-	note, _, err := r.IngestNoteWithCreated(body)
+	// fetch 経由は配送 actor が無いので attribution==actor 検証は skip ("")。
+	// id host == attributedTo host 検証は IngestNoteWithCreated 側で常に行う。
+	note, _, err := r.IngestNoteWithCreated(body, "")
 	return note, err
 }
 
@@ -984,7 +992,12 @@ func (r *Resolver) IngestNote(body []byte) (*model.Note, error) {
 // with `created == false`; callers MUST check `created` before firing any
 // non-idempotent hook (chart counters, notification, etc.) since the dedup
 // path otherwise looks indistinguishable from a fresh ingest at the call site.
-func (r *Resolver) IngestNoteWithCreated(body []byte) (*model.Note, bool, error) {
+// IngestNoteWithCreated は note body を取り込み、新規作成かどうかも返す。
+// deliveringActorURI は inbound Create(Note) の配送 actor URI で、note の著者
+// (attributedTo) が配送者本人であることの検証に使う (なりすまし防止、#1839)。
+// fetch 経由 (IngestNote) では空文字を渡し、この検証を skip する (upstream
+// validateNote が actor 未指定時に attribution==actor を skip するのと同じ)。
+func (r *Resolver) IngestNoteWithCreated(body []byte, deliveringActorURI string) (*model.Note, bool, error) {
 	if r.noteRepo == nil {
 		return nil, false, ErrInvalidNote
 	}
@@ -997,6 +1010,21 @@ func (r *Resolver) IngestNoteWithCreated(body []byte) (*model.Note, bool, error)
 	}
 	if existing, err := r.noteRepo.FindByURI(apNote.ID); err == nil {
 		return existing, false, nil
+	}
+	// upstream ApNoteService.validateNote 相当の attribution 検証 (#1839):
+	//   1. note の id host と著者 (attributedTo) host が一致すること
+	//      (別 host の著者を詐称する cross-host forge を弾く)。
+	//   2. inbound Create では note の著者が配送 actor 本人であること
+	//      (alice@a が bob@b になりすました note を作る forge を弾く)。
+	idHost, idErr := hostFromURI(apNote.ID)
+	attrHost, attrErr := hostFromURI(apNote.AttributedTo)
+	if idErr != nil || attrErr != nil || !strings.EqualFold(idHost, attrHost) {
+		slog.Warn("federation: note id/attributedTo host mismatch", "id", apNote.ID, "attributedTo", apNote.AttributedTo)
+		return nil, false, ErrNoteAttributionMismatch
+	}
+	if deliveringActorURI != "" && apNote.AttributedTo != deliveringActorURI {
+		slog.Warn("federation: note attribution does not match delivering actor", "attributedTo", apNote.AttributedTo, "actor", deliveringActorURI)
+		return nil, false, ErrNoteAttributionMismatch
 	}
 	// quote cycle 遮断用に、この note URI を ingest 中として mark する (#1527)。
 	// quote 解決が fetch するネストした ingest から、この URI への再 fetch を

--- a/internal/core/federation/resolver_allowlist_test.go
+++ b/internal/core/federation/resolver_allowlist_test.go
@@ -111,7 +111,7 @@ func TestIngestNote_HostNotAllowedByAttributedTo(t *testing.T) {
 	blocker := &stubHostBlocker{disallowed: map[string]bool{"remote.example": true}}
 	r, _, noteRepo := newGatedResolver(t, sampleActor, blocker)
 
-	_, _, err := r.IngestNoteWithCreated([]byte(sampleRemoteNote))
+	_, _, err := r.IngestNoteWithCreated([]byte(sampleRemoteNote), "")
 	require.ErrorIs(t, err, federation.ErrHostNotAllowed)
 	assert.Empty(t, noteRepo.Notes, "blocked host の note は DB に作らない")
 }
@@ -124,7 +124,7 @@ func TestIngestNote_DedupHitPassesEvenIfHostBlocked(t *testing.T) {
 	uri := "https://remote.example/notes/n1"
 	noteRepo.Notes["existing"] = &model.Note{ID: "existing", URI: &uri}
 
-	got, created, err := r.IngestNoteWithCreated([]byte(sampleRemoteNote))
+	got, created, err := r.IngestNoteWithCreated([]byte(sampleRemoteNote), "")
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "existing", got.ID)

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -575,7 +575,7 @@ func TestIngestNoteWithCreated_FreshIngest(t *testing.T) {
 	urls := activitypub.NewURLBuilder("https://example.com")
 	idGen, _ := id.NewGenerator("aidx")
 	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
-	got, created, err := r.IngestNoteWithCreated([]byte(sampleRemoteNote))
+	got, created, err := r.IngestNoteWithCreated([]byte(sampleRemoteNote), "")
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.True(t, created, "fresh ingest must report created=true so caller can fire chart hooks")
@@ -589,11 +589,53 @@ func TestIngestNoteWithCreated_DedupReturnsFalse(t *testing.T) {
 	urls := activitypub.NewURLBuilder("https://example.com")
 	idGen, _ := id.NewGenerator("aidx")
 	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
-	got, created, err := r.IngestNoteWithCreated([]byte(sampleRemoteNote))
+	got, created, err := r.IngestNoteWithCreated([]byte(sampleRemoteNote), "")
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "existing", got.ID)
 	assert.False(t, created, "dedup hit must report created=false so caller can skip non-idempotent chart hooks")
+}
+
+// #1839: inbound Create で note の著者 (attributedTo) が配送 actor と異なる場合、
+// なりすまし forge として拒否する (ErrNoteAttributionMismatch)。
+func TestIngestNoteWithCreated_AttributionMismatchRejected(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+	// note の著者は remote.example/users/alice だが、配送 actor は別人。
+	_, _, err := r.IngestNoteWithCreated([]byte(sampleRemoteNote), "https://other.example/users/mallory")
+	require.ErrorIs(t, err, federation.ErrNoteAttributionMismatch)
+	assert.Empty(t, noteRepo.Notes, "なりすまし note を作ってはいけない")
+}
+
+// #1839: note の id host と attributedTo host が異なる場合も cross-host forge と
+// して拒否する。
+func TestIngestNoteWithCreated_CrossHostIDRejected(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+	// id は a.example、attributedTo は b.example。
+	body := `{"id":"https://a.example/notes/x","type":"Note","attributedTo":"https://b.example/users/y","content":"forge"}`
+	_, _, err := r.IngestNoteWithCreated([]byte(body), "")
+	require.ErrorIs(t, err, federation.ErrNoteAttributionMismatch)
+	assert.Empty(t, noteRepo.Notes)
+}
+
+// #1839: 著者が配送 actor 本人で id/attributedTo host が一致すれば従来どおり取り込む。
+func TestIngestNoteWithCreated_LegitAttributionAccepted(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+	got, created, err := r.IngestNoteWithCreated([]byte(sampleRemoteNote), "https://remote.example/users/alice")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.True(t, created)
 }
 
 func TestIngestNote_ResolveActorError(t *testing.T) {
@@ -4885,7 +4927,7 @@ func TestIngestNote_DedupRaceOnUniqueViolation(t *testing.T) {
 	idGen, _ := id.NewGenerator("aidx")
 	r := federation.NewResolver(repo, raceRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
 
-	got, created, err := r.IngestNoteWithCreated([]byte(sampleRemoteNote))
+	got, created, err := r.IngestNoteWithCreated([]byte(sampleRemoteNote), "")
 	require.NoError(t, err, "unique violation should be treated as dedup hit, not an error")
 	assert.False(t, created, "race loser must be created=false so hooks/renoteCount don't double-fire")
 	require.NotNil(t, got)
@@ -4902,7 +4944,7 @@ func TestIngestNote_CreateErrorNonDedupPropagates(t *testing.T) {
 	idGen, _ := id.NewGenerator("aidx")
 	r := federation.NewResolver(repo, raceRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
 
-	_, _, err := r.IngestNoteWithCreated([]byte(sampleRemoteNote))
+	_, _, err := r.IngestNoteWithCreated([]byte(sampleRemoteNote), "")
 	assert.Error(t, err, "non-dedup create error must propagate")
 }
 
@@ -4928,7 +4970,7 @@ func TestIngestNote_DedupRaceOnQuoteNoDoubleRenoteCount(t *testing.T) {
 		"_misskey_quote": "https://example.com/notes/q1",
 		"to": ["https://www.w3.org/ns/activitystreams#Public"]
 	}`
-	got, created, err := r.IngestNoteWithCreated([]byte(body))
+	got, created, err := r.IngestNoteWithCreated([]byte(body), "")
 	require.NoError(t, err)
 	assert.False(t, created)
 	assert.Equal(t, "winner", got.ID)


### PR DESCRIPTION
## Summary

#1820 (fetch-path object-spoofing) の敵対的レビューで発見した、別経路の同クラス脆弱性。inbound `Create(Note)` は wire から届く note body の attribution を検証しておらず、**署名済みの actor (`alice@a`) が `object.attributedTo` を別人 (`bob@b`) に設定した Create を送ると、mk-go が bob を解決して「bob 作の note」(URI=victim host) を作成できた**(なりすまし/impersonation)。`authorizeActor` は外側 Create activity の actor/id host しか検証せず、note の attribution までは見ていなかった。

## 主な変更点 (upstream `ApNoteService.validateNote` 相当)

`internal/core/federation/resolver.go` `IngestNoteWithCreated` に `deliveringActorURI` 引数を追加し検証:
1. **`note.id` host == `attributedTo` host**(cross-host forge 防止、常時適用)。
2. **`attributedTo` == 配送 actor**(inbound Create のみ。`handleCreate` が `act.Actor` を渡す)。fetch 経由(`IngestNote` / `handleAnnounce`→`ResolveNote`)は配送 actor が無い(announcer ≠ 著者)ため attribution==actor は skip し、id-host==attributedTo-host のみ適用。

forge は専用 sentinel **`ErrNoteAttributionMismatch`** とし `handleCreate` で **ack+drop**(retry で解消しないため)。malformed note(`ErrInvalidNote`)は従来どおり error を surface(`TestProcess_CreateNoteIngestError` の契約を維持)。

## テスト

- `TestIngestNoteWithCreated_AttributionMismatchRejected`(attributedTo ≠ 配送actor → 拒否・note 不作成)
- `TestIngestNoteWithCreated_CrossHostIDRejected`(id host ≠ attributedTo host → 拒否)
- `TestIngestNoteWithCreated_LegitAttributionAccepted`(著者==配送actor・同一host → 取込)
- 既存の inbound Create / IngestNote 系テストは `deliveringActorURI=""` で従来挙動維持。
- `go test ./internal/core/federation/... -cover`: 90.2% green。`go build ./...` / `go vet ./...` / `gofmt -s -l` clean。

## Closes

Closes #1839

🤖 Generated with [Claude Code](https://claude.com/claude-code)