### PR TITLE
Fix notes parity (#1821): 他人の followers note / specified note の renote を拒否

### DIFF
--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -514,6 +514,17 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 		if !CanSeeNote(in.User, t, s.followingRepo) {
 			return nil, ErrCannotRenoteInvisibleNote
 		}
+		// renote 対象の可視性 gate (upstream NoteCreateService、#1821)。CanSeeNote は
+		// follower なら他人の followers note でも true を返すため、それだけだと
+		// followers 限定 note を renote 経由で公開 TL / 連合へ漏洩させられる。
+		// upstream は follow 関係を問わず「他人の followers note」と「(自分のもの
+		// 含む) specified note」を無条件 reject する。
+		if t.Visibility == model.NoteVisibilityFollowers && t.UserID != in.User.ID {
+			return nil, ErrCannotRenoteInvisibleNote
+		}
+		if t.Visibility == model.NoteVisibilitySpecified {
+			return nil, ErrCannotRenoteInvisibleNote
+		}
 		// pure renoteを更にrenoteするのは禁止 (TS: isRenote && !isQuote)
 		if IsPureRenote(t) {
 			return nil, ErrCannotRenoteToAPureRenote

--- a/internal/core/note/note_create_service_test.go
+++ b/internal/core/note/note_create_service_test.go
@@ -623,6 +623,49 @@ func TestCreateService_CannotRenoteInvisibleNote(t *testing.T) {
 	require.ErrorIs(t, err, note.ErrCannotRenoteInvisibleNote)
 }
 
+// #1821: follower であっても他人の followers note は renote 不可。CanSeeNote は
+// follower に true を返すが、renote すると公開 TL / 連合へ漏洩するため reject する。
+func TestCreateService_CannotRenoteOthersFollowersNoteEvenIfFollower(t *testing.T) {
+	svc, noteRepo, followingRepo := newCreateServiceWithFollowing(t)
+	noteRepo.Notes["secret"] = &model.Note{
+		ID: "secret", UserID: "author", Visibility: model.NoteVisibilityFollowers,
+	}
+	// follower は author を follow している (= CanSeeNote は true)。
+	followingRepo.Followings["f1"] = &model.Following{FollowerID: "follower", FolloweeID: "author"}
+
+	user := &model.User{ID: "follower"}
+	renoteID := "secret"
+	_, err := svc.Create(note.CreateInput{User: user, RenoteID: &renoteID})
+	require.ErrorIs(t, err, note.ErrCannotRenoteInvisibleNote, "follower でも他人の followers note は renote 不可")
+	assert.Equal(t, int16(0), noteRepo.Notes["secret"].RenoteCount)
+}
+
+// #1821: 自分の followers note は renote (boost) 可能。
+func TestCreateService_CanRenoteOwnFollowersNote(t *testing.T) {
+	svc, noteRepo, _ := newCreateServiceWithFollowing(t)
+	noteRepo.Notes["mine"] = &model.Note{
+		ID: "mine", UserID: "author", Visibility: model.NoteVisibilityFollowers,
+	}
+	user := &model.User{ID: "author"}
+	renoteID := "mine"
+	created, err := svc.Create(note.CreateInput{User: user, RenoteID: &renoteID})
+	require.NoError(t, err)
+	assert.Equal(t, &renoteID, created.RenoteID)
+}
+
+// #1821: specified (DM) note は自分のものでも renote 不可 (upstream は無条件 reject)。
+func TestCreateService_CannotRenoteSpecifiedNote(t *testing.T) {
+	svc, noteRepo, _ := newCreateServiceWithFollowing(t)
+	noteRepo.Notes["dm"] = &model.Note{
+		ID: "dm", UserID: "author", Visibility: model.NoteVisibilitySpecified,
+		VisibleUserIDs: []string{"author"},
+	}
+	user := &model.User{ID: "author"}
+	renoteID := "dm"
+	_, err := svc.Create(note.CreateInput{User: user, RenoteID: &renoteID})
+	require.ErrorIs(t, err, note.ErrCannotRenoteInvisibleNote, "specified note は自分のものでも renote 不可")
+}
+
 func TestCreateService_ReplyHappyPath(t *testing.T) {
 	svc, noteRepo, _ := newCreateService(t)
 	noteRepo.Notes["target"] = &model.Note{


### PR DESCRIPTION
## Summary

再監査(2) の HIGH(IDOR)。`notes/create` の renote 検証が `CanSeeNote` のみで、`CanSeeNote` は **follower に対し他人の followers note でも `true` を返す**ため、follower が他人の followers 限定 note を renote でき、**公開 TL / 連合へ漏洩**していた。upstream `NoteCreateService` は follow 関係を問わず renote 対象の可視性を gate する。

## 主な変更点

`internal/core/note/note_create_service.go` の renote 検証に upstream 相当の gate を追加(`CanSeeNote` の後):
- `visibility == followers && userId != me` → reject(他人の followers note)
- `visibility == specified` → reject(自分のものでも DM は renote 不可)

いずれも既存の `ErrCannotRenoteInvisibleNote` → `CANNOT_RENOTE_DUE_TO_VISIBILITY`(be9529e9、upstream と同一 error code)を返す。自分の followers note は従来どおり renote(boost)可能。

## テスト

- `TestCreateService_CannotRenoteOthersFollowersNoteEvenIfFollower`(follow 済みでも他人の followers note は不可)
- `TestCreateService_CanRenoteOwnFollowersNote`(自分の followers note は可)
- `TestCreateService_CannotRenoteSpecifiedNote`(specified は不可)
- `go test ./internal/core/note/... -cover`: 94.7% green。`go vet ./...` / `gofmt -s -l` clean。

## Closes

Closes #1821

🤖 Generated with [Claude Code](https://claude.com/claude-code)