### PR TITLE
Fix admin parity (#1822): admin/roles/users を UserDetailed で pack し email 漏洩を塞ぐ

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -2172,7 +2172,11 @@ func (h *Handler) RolesUsers(c echo.Context) error {
 		result = append(result, map[string]any{
 			"id":        a.ID,
 			"createdAt": createdAt,
-			"user":      h.packAdminUser(a.User, profileByUser[a.User.ID]),
+			// upstream users.ts:95 は packMany(users, me, {schema:'UserDetailed'})。
+			// packAdminUser を使うと email / signins / roleAssigns 等の admin 専用
+			// field が read:admin:roles scope に漏れる (show-user の admin guard 迂回)。
+			// ShowUsers と同様 UserDetailed に揃えて過剰露出を防ぐ (#1822)。
+			"user":      entity.PackUserDetailed(a.User, profileByUser[a.User.ID], h.idGen),
 			"expiresAt": expiresAt,
 		})
 	}

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -1657,6 +1657,32 @@ func TestRolesUsers_Success_ReturnsAssignmentEnvelope(t *testing.T) {
 	assert.Nil(t, resp[0]["expiresAt"])
 }
 
+// #1822: admin/roles/users は UserDetailed で pack し、email など includeSecrets
+// 限定 field を read:admin:roles scope に漏らさない。
+func TestRolesUsers_DoesNotLeakSecrets(t *testing.T) {
+	h, userRepo, roleRepo, assignRepo := rolesUsersFixture(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1"}
+	require.NoError(t, userRepo.Create(&model.User{ID: "u1", Username: "alice"}))
+	email := "alice@example.com"
+	userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1", Email: &email, EmailVerified: true}
+	require.NoError(t, assignRepo.Create(&model.RoleAssignment{ID: "9c2bw9q5fa0000000000000099", UserID: "u1", RoleID: "r1"}))
+
+	rec := doPost(h.RolesUsers, `{"roleId":"r1","limit":10}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	user, _ := resp[0]["user"].(map[string]any)
+	require.NotNil(t, user)
+	assert.Equal(t, "u1", user["id"])
+	_, hasEmail := user["email"]
+	assert.False(t, hasEmail, "email を read:admin:roles に漏らさない")
+	_, hasEmailVerified := user["emailVerified"]
+	assert.False(t, hasEmailVerified, "emailVerified を漏らさない")
+	_, hasSecurityKeysList := user["securityKeysList"]
+	assert.False(t, hasSecurityKeysList, "securityKeysList を漏らさない")
+}
+
 // upstream users.ts:101 は expiresAt: assign.expiresAt?.toISOString() を含める (#1542)。
 func TestRolesUsers_IncludesExpiresAt(t *testing.T) {
 	h, userRepo, roleRepo, assignRepo := rolesUsersFixture(t)


### PR DESCRIPTION
## Summary

再監査(2) の HIGH(IDOR / secrets leak)。`admin/roles/users` が `packAdminUser` を使い、profile があると **email / emailVerified / securityKeysList 等の includeSecrets 限定 field をロールメンバー一覧で返していた**。本 endpoint の gate は `RequireModerator` + `read:admin:roles` のみなので、`read:admin:roles` しか持たない token / moderator がロールメンバーの email を列挙でき、`show-user` の admin guard を迂回できた。

upstream `admin/roles/users`(users.ts:95)は `packMany(users, me, {schema:'UserDetailed'})` で UserDetailed を返す(email 等は includeSecrets ブロック限定)。sibling の `ShowUsers` は同じ漏洩を避けるため意図的に UserDetailed を使う旨コメント済みで、`RolesUsers` だけ packer 選択がずれていた。

## 主な変更点

- `internal/api/admin/handler.go`: `RolesUsers` の assignment envelope の `user` を `h.packAdminUser(...)` → `entity.PackUserDetailed(...)` に変更(ShowUsers と同じ)。envelope の `{id, createdAt, user, expiresAt}` 形状と既存の id/username は不変。

## テスト

- `TestRolesUsers_DoesNotLeakSecrets`: profile に email を持つメンバーでも `user` object に `email`/`emailVerified`/`securityKeysList` が出ないこと。既存の envelope/expiresAt テストは id/username のみ参照なので不変で pass。
- `go test ./internal/api/admin/... -cover`: 89.5% green。`go vet ./...` / `gofmt -s -l` clean。

## Closes

Closes #1822

🤖 Generated with [Claude Code](https://claude.com/claude-code)