### PR TITLE
Fix admin parity (#1823): admin/roles/update-default-policies の jsonb 書込み 500 を修正

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -1500,13 +1500,22 @@ func coerceMetaArrayFields(fields map[string]any) {
 // metaJSONBColumns lists meta jsonb columns whose update-meta payload arrives as
 // a decoded []any / map[string]any and must be json.Marshal された []byte に
 // 変換しないと jsonb 列の UPDATE が型不一致で失敗する (#1732 deliverSuspendedSoftware)。
+// policies は object 形 jsonb で update-default-policies / update-meta の両経路から
+// 来る (#1823)。
 var metaJSONBColumns = map[string]struct{}{
 	"deliverSuspendedSoftware": {},
+	"policies":                 {},
+}
+
+// metaJSONBObjectColumns は metaJSONBColumns のうち object ({}) 形のもの。nil の
+// とき array 形は `[]`、object 形は `{}` を default にするための区別 (#1823)。
+var metaJSONBObjectColumns = map[string]struct{}{
+	"policies": {},
 }
 
 // coerceMetaJSONBFields marshals decoded JSON values for known jsonb meta
 // columns into datatypes.JSON ([]byte) so GORM/pgx can write them. nil は
-// 空配列扱い、既に []byte/string のものはそのまま流す。
+// 空 default (array→`[]` / object→`{}`)、既に []byte/string のものはそのまま流す。
 func coerceMetaJSONBFields(fields map[string]any) {
 	for k, v := range fields {
 		if _, ok := metaJSONBColumns[k]; !ok {
@@ -1514,7 +1523,11 @@ func coerceMetaJSONBFields(fields map[string]any) {
 		}
 		switch v.(type) {
 		case nil:
-			fields[k] = datatypes.JSON([]byte("[]"))
+			if _, isObj := metaJSONBObjectColumns[k]; isObj {
+				fields[k] = datatypes.JSON([]byte("{}"))
+			} else {
+				fields[k] = datatypes.JSON([]byte("[]"))
+			}
 		case []byte, string, datatypes.JSON:
 			// 既に raw JSON。そのまま流す。
 		default:
@@ -2195,8 +2208,13 @@ func (h *Handler) RolesUpdateDefaultPolicies(c echo.Context) error {
 	// moderationLogService.log('updateServerSettings', {before, after}) を記録する
 	// (#1542)。before snapshot を Update 前に取得する。
 	beforeMeta, _ := h.metaRepo.Fetch()
-	// Meta の policies フィールドを更新
-	if err := h.metaRepo.Update(map[string]any{"policies": req.Policies}); err != nil {
+	// Meta の policies フィールドを更新。policies は jsonb 列なので decoded map を
+	// そのまま渡すと UPDATE が型不一致で失敗する (#1823)。coerceMetaJSONBFields で
+	// datatypes.JSON ([]byte) に変換してから渡す (RolesCreate/Update の Marshal と
+	// 同じ動機、UpdateMeta 経路と共通化)。
+	policyFields := map[string]any{"policies": req.Policies}
+	coerceMetaJSONBFields(policyFields)
+	if err := h.metaRepo.Update(policyFields); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 	// moderation log (before/after policies)。TS は policies のみを記録する。

--- a/internal/api/admin/meta_array_columns_test.go
+++ b/internal/api/admin/meta_array_columns_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
 )
 
 // TestMetaArrayColumns_CoversAllStringArrayFields は metaArrayColumns set が
@@ -73,4 +75,40 @@ func diffSorted(a, b map[string]struct{}) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// #1823: coerceMetaJSONBFields は policies (object 形 jsonb) を decoded map から
+// datatypes.JSON ([]byte) に変換し、jsonb 列の UPDATE 型不一致 500 を防ぐ。
+func TestCoerceMetaJSONBFields_Policies(t *testing.T) {
+	t.Run("decoded map is marshaled to datatypes.JSON", func(t *testing.T) {
+		fields := map[string]any{"policies": map[string]any{"driveCapacityMb": float64(500)}}
+		coerceMetaJSONBFields(fields)
+		got, ok := fields["policies"].(datatypes.JSON)
+		if !assert.True(t, ok, "policies must be coerced to datatypes.JSON, got %T", fields["policies"]) {
+			return
+		}
+		assert.JSONEq(t, `{"driveCapacityMb":500}`, string(got))
+	})
+
+	t.Run("nil policies defaults to empty object not array", func(t *testing.T) {
+		fields := map[string]any{"policies": nil}
+		coerceMetaJSONBFields(fields)
+		got, ok := fields["policies"].(datatypes.JSON)
+		require.True(t, ok)
+		assert.Equal(t, "{}", string(got), "object 形 jsonb の nil default は {} (array の [] ではない)")
+	})
+
+	t.Run("array column nil still defaults to empty array", func(t *testing.T) {
+		fields := map[string]any{"deliverSuspendedSoftware": nil}
+		coerceMetaJSONBFields(fields)
+		got, ok := fields["deliverSuspendedSoftware"].(datatypes.JSON)
+		require.True(t, ok)
+		assert.Equal(t, "[]", string(got))
+	})
+
+	t.Run("already-raw JSON passes through", func(t *testing.T) {
+		fields := map[string]any{"policies": datatypes.JSON([]byte(`{"x":1}`))}
+		coerceMetaJSONBFields(fields)
+		assert.Equal(t, datatypes.JSON([]byte(`{"x":1}`)), fields["policies"])
+	})
 }


### PR DESCRIPTION
## Summary

再監査(2) の HIGH(behavior_diff / DB write bug)。`RolesUpdateDefaultPolicies` が decoded `map[string]any` をそのまま `metaRepo.Update` に渡しており、**`policies` は jsonb 列のため本番 Postgres では UPDATE が型不一致で失敗(500 / default policies 未永続化)**していた。`RolesCreate`/`RolesUpdate` は policies を `json.Marshal` してから書くが、本 handler だけ marshal を欠いていた。`UpdateMeta` 経由の `policies` も `metaJSONBColumns` 未登録で同じ落とし穴だった(#1732 の coerce 対象に policies が入っていなかった)。

## 主な変更点

- `metaJSONBColumns` に `policies` を追加(`UpdateMeta` 経由も coerce される)。
- `policies` は object 形 jsonb なので `metaJSONBObjectColumns` を新設し、`coerceMetaJSONBFields` の nil default を array の `[]` でなく object の `{}` にする(`deliverSuspendedSoftware` の array nil default は維持)。
- `RolesUpdateDefaultPolicies` は `coerceMetaJSONBFields` を通してから `Update` する。

## テスト

mock metaRepo は in-memory 格納で型不一致を検出しないため、`coerceMetaJSONBFields` の内部 unit test で回帰担保:
- `TestCoerceMetaJSONBFields_Policies`(map→datatypes.JSON / nil→`{}` / array列 nil→`[]` / raw passthrough)
- 既存 `TestRolesUpdateDefaultPolicies_*` は status/moderation-log のみ参照で不変。
- `go test ./internal/api/admin/... -cover`: 89.6% green。`go vet ./...` / `gofmt -s -l` clean。

## Closes

Closes #1823

🤖 Generated with [Claude Code](https://claude.com/claude-code)