### PR TITLE
Fix i-self parity (#1824): /api/i の email/securityKeysList を OAuth app token に漏らさない

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -857,10 +857,21 @@ func (h *Handler) Me(c echo.Context) error {
 	// 同一 roleService なので値は一致)。
 	resp["isSilenced"] = h.isSilenced(u.ID)
 
+	// isSecure: native login token (cookie / i param) のときだけ true。OAuth /
+	// MiAuth の app access token では false (RequireSecure と同一判定)。upstream
+	// i.ts の `isSecure = token == null` 相当で、email / emailVerified /
+	// securityKeysList を includeSecrets ブロックとして gate する (#1824)。これが
+	// 無いと read:account scope の app token だけで email・WebAuthn キー一覧が読めた。
+	isSecure := u.Token != nil && *u.Token == middleware.GetToken(c)
+
 	// Private fields from profile (MeDetailed scope 外)
 	if profile != nil {
-		resp["email"] = profile.Email
-		resp["emailVerified"] = profile.EmailVerified
+		if isSecure {
+			// email / emailVerified は includeSecrets 限定 (upstream
+			// UserEntityService.ts:624-626)。app token には出さない。
+			resp["email"] = profile.Email
+			resp["emailVerified"] = profile.EmailVerified
+		}
 		resp["twoFactorEnabled"] = profile.TwoFactorEnabled
 		resp["usePasswordLessLogin"] = profile.UsePasswordLessLogin
 		// mutedWords / mutedInstances は PackMeDetailed (AsMeDetailed) が profile
@@ -918,23 +929,27 @@ func (h *Handler) Me(c echo.Context) error {
 	h.fillPinnedFields(c.Request().Context(), u, profile, resp)
 	resp["policies"] = userPolicies
 	resp["roles"] = userRoles
-	// securityKeysList: WebAuthnキーの一覧
-	if h.securityKeyRepo != nil {
-		if keys, err := h.securityKeyRepo.ListByUser(u.ID); err == nil && len(keys) > 0 {
-			list := make([]map[string]any, len(keys))
-			for i, k := range keys {
-				list[i] = map[string]any{
-					"id":       k.ID,
-					"name":     k.Name,
-					"lastUsed": k.LastUsed.UTC().Format("2006-01-02T15:04:05.000Z"),
+	// securityKeysList: WebAuthnキーの一覧。includeSecrets 限定 (upstream
+	// UserEntityService.ts:627-639) なので native session のときだけ出す。app token
+	// では key 自体を省く (#1824、misskey-js golden で optional)。
+	if isSecure {
+		if h.securityKeyRepo != nil {
+			if keys, err := h.securityKeyRepo.ListByUser(u.ID); err == nil && len(keys) > 0 {
+				list := make([]map[string]any, len(keys))
+				for i, k := range keys {
+					list[i] = map[string]any{
+						"id":       k.ID,
+						"name":     k.Name,
+						"lastUsed": k.LastUsed.UTC().Format("2006-01-02T15:04:05.000Z"),
+					}
 				}
+				resp["securityKeysList"] = list
+			} else {
+				resp["securityKeysList"] = []any{}
 			}
-			resp["securityKeysList"] = list
 		} else {
 			resp["securityKeysList"] = []any{}
 		}
-	} else {
-		resp["securityKeysList"] = []any{}
 	}
 	// MeDetailed の notification-related 3 field (#985) は PackMeDetailed 経由で
 	// base 展開済 (#971 で集約)。ここで追加 override は不要。

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -148,6 +148,11 @@ func TestMe_Success(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 	c.Set(string(middleware.UserContextKey), user)
+	// native session token を配線して isSecure=true にする (#1824)。これが無いと
+	// email / securityKeysList は app token 扱いで省かれる。
+	nativeTok := "native-session-token"
+	user.Token = &nativeTok
+	c.Set(string(middleware.TokenContextKey), nativeTok)
 
 	err := h.Me(c)
 	require.NoError(t, err)
@@ -199,6 +204,48 @@ func TestMe_Success(t *testing.T) {
 	assert.Equal(t, false, resp["securityKeys"])
 	assert.Nil(t, resp["movedTo"])
 	assert.Nil(t, resp["alsoKnownAs"])
+}
+
+// #1824: OAuth/MiAuth の app access token (request token != user.Token) で /api/i を
+// 呼んだとき、email / emailVerified / securityKeysList を返さない (includeSecrets
+// 限定)。twoFactorEnabled 等の MeDetailed field は引き続き出す。
+func TestMe_AppTokenOmitsSecrets(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	nativeTok := "native-login-token"
+	user := &model.User{
+		ID: "user1", Username: "testuser", Token: &nativeTok,
+		AvatarDecorations: datatypes.JSON([]byte("[]")), ChatScope: "mutual",
+	}
+	require.NoError(t, userRepo.Create(user))
+	email := "secret@example.com"
+	userRepo.Profiles["user1"] = &model.UserProfile{
+		UserID: "user1", Email: &email, EmailVerified: true,
+		TwoFactorEnabled: true, Fields: datatypes.JSON([]byte("[]")),
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/i", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), user)
+	// app access token: request token は user.Token (native) と一致しない。
+	c.Set(string(middleware.TokenContextKey), "app-access-token-xyz")
+
+	require.NoError(t, h.Me(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	// secrets は省かれる。
+	_, hasEmail := resp["email"]
+	assert.False(t, hasEmail, "app token に email を漏らさない")
+	_, hasEmailVerified := resp["emailVerified"]
+	assert.False(t, hasEmailVerified, "app token に emailVerified を漏らさない")
+	_, hasSecurityKeysList := resp["securityKeysList"]
+	assert.False(t, hasSecurityKeysList, "app token に securityKeysList を漏らさない")
+	// MeDetailed の非 secret field は引き続き出る。
+	assert.Equal(t, "user1", resp["id"])
+	assert.Equal(t, true, resp["twoFactorEnabled"])
 }
 
 // TestMe_CanChatFromRolePolicy: #988 — Me handler が canChat を role policy
@@ -479,6 +526,10 @@ func TestMe_AvatarAndBannerIDs(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 	c.Set(string(middleware.UserContextKey), user)
+	// native session token を配線して isSecure=true にする (#1824)。
+	nativeTok := "native-session-token"
+	user.Token = &nativeTok
+	c.Set(string(middleware.TokenContextKey), nativeTok)
 
 	err := h.Me(c)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

再監査(2) の HIGH(IDOR / secrets leak)。`/api/i`(Me handler)が profile があれば**無条件に `email` / `emailVerified` / `securityKeysList` を返しており、`read:account` scope の OAuth/MiAuth app access token だけでユーザーの email・登録 WebAuthn キー一覧を読み取れた**。`Me()` は `/api/i/pin`・`/api/i/unpin` でも再利用されるため `write:account` app でも同じ secret が漏れていた。

upstream `i.ts` は `isSecure = (token == null)` を算出し `pack(..., includeSecrets: isSecure)` で `email`/`emailVerified`/`securityKeysList` を native session 限定にする(UserEntityService.ts:624-639)。

## 主な変更点

- `internal/api/i/handler.go` `Me()`: `isSecure := u.Token != nil && *u.Token == middleware.GetToken(c)`(`RequireSecure` と同一判定 = native login token のみ true)を算出。`email`/`emailVerified`/`securityKeysList` を `isSecure` で gate(app token では key 自体を省く、misskey-js golden で optional)。`twoFactorEnabled`/`usePasswordLessLogin`/`securityKeys` は isMe block 由来で従来どおり self-view で出す。

## テスト

- `TestMe_Success` / `TestMe_AvatarAndBannerIDs`: native session token を配線(isSecure=true 維持)。
- `TestMe_AppTokenOmitsSecrets`(新規): app token で email/emailVerified/securityKeysList が省かれ、twoFactorEnabled は残ること。
- `go test ./internal/api/i/... -cover`: 90.1% green。`go build ./...` / `go vet ./...` / `gofmt -s -l` clean。

## Closes

Closes #1824

🤖 Generated with [Claude Code](https://claude.com/claude-code)