### PR TITLE
Fix admin parity (#1846): clientOptions を metaJSONBColumns に登録し update-meta 書込み 500 を防ぐ

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -1501,16 +1501,22 @@ func coerceMetaArrayFields(fields map[string]any) {
 // a decoded []any / map[string]any and must be json.Marshal された []byte に
 // 変換しないと jsonb 列の UPDATE が型不一致で失敗する (#1732 deliverSuspendedSoftware)。
 // policies は object 形 jsonb で update-default-policies / update-meta の両経路から
-// 来る (#1823)。
+// 来る (#1823)。clientOptions も object 形 jsonb で update-meta が whitelist 無しで
+// 受理するため、未登録だと同じ型不一致 500 になる (#1846)。
+//
+// model.Meta に datatypes.JSON 列を追加したらここにも登録すること。漏れは
+// TestMetaJSONBColumns_CoversAllJSONColumns (reflection guard) が検出する。
 var metaJSONBColumns = map[string]struct{}{
 	"deliverSuspendedSoftware": {},
 	"policies":                 {},
+	"clientOptions":            {},
 }
 
 // metaJSONBObjectColumns は metaJSONBColumns のうち object ({}) 形のもの。nil の
-// とき array 形は `[]`、object 形は `{}` を default にするための区別 (#1823)。
+// とき array 形は `[]`、object 形は `{}` を default にするための区別 (#1823 / #1846)。
 var metaJSONBObjectColumns = map[string]struct{}{
-	"policies": {},
+	"policies":      {},
+	"clientOptions": {},
 }
 
 // coerceMetaJSONBFields marshals decoded JSON values for known jsonb meta

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -733,6 +733,20 @@ func TestUpdateMeta_DeliverSuspendedSoftware(t *testing.T) {
 	assert.Equal(t, "*", entries[0].VersionRange)
 }
 
+// #1846: clientOptions は object 形 jsonb 列。decoded map を coerce せず repo に
+// 渡すと本番 Postgres で型不一致 500 になるため、handler→repo の経路で datatypes.JSON
+// に正規化され永続化されることを確認する (deliverSuspendedSoftware と同じ動機)。
+func TestUpdateMeta_ClientOptions(t *testing.T) {
+	h, _, metaRepo, _ := newTestHandler(t)
+	rec := doPost(h.UpdateMeta, `{"clientOptions":{"entrancePageStyle":"simple","foo":1}}`, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.NotEmpty(t, metaRepo.Meta.ClientOptions, "object 形 jsonb 列が永続化される")
+	var obj map[string]any
+	require.NoError(t, json.Unmarshal(metaRepo.Meta.ClientOptions, &obj))
+	assert.Equal(t, "simple", obj["entrancePageStyle"])
+	assert.Equal(t, float64(1), obj["foo"])
+}
+
 // JSON で送られてくる array は []any{...} に decode されるが、そのまま
 // repo.Update に流すと lib/pq が varchar[] 列に書けず "expression is of
 // type record" で UPDATE 全体が落ちる。handler 側の coerceMetaArrayFields

--- a/internal/api/admin/meta_array_columns_test.go
+++ b/internal/api/admin/meta_array_columns_test.go
@@ -77,6 +77,62 @@ func diffSorted(a, b map[string]struct{}) []string {
 	return out
 }
 
+// extractGormDefault は GORM tag から `default:...` 値を抽出する ("'{}'" 等)。
+func extractGormDefault(tag string) string {
+	for _, kv := range strings.Split(tag, ";") {
+		if v, ok := strings.CutPrefix(kv, "default:"); ok {
+			return v
+		}
+	}
+	return ""
+}
+
+// #1846: model.Meta の全 datatypes.JSON (jsonb) 列が metaJSONBColumns を被覆し、
+// default が object (`'{}'`) の列は metaJSONBObjectColumns にも登録されている
+// ことを reflection で担保する。これが無いと jsonb 列を追加したとき登録漏れで
+// update-meta 書込みが型不一致 500 になる (#1732 / #1823 / #1846 と同じ failure)。
+func TestMetaJSONBColumns_CoversAllJSONColumns(t *testing.T) {
+	metaType := reflect.TypeOf(model.Meta{})
+	jsonType := reflect.TypeOf(datatypes.JSON{})
+
+	expected := map[string]struct{}{}
+	objectCols := map[string]struct{}{}
+	for i := 0; i < metaType.NumField(); i++ {
+		f := metaType.Field(i)
+		if f.Type != jsonType {
+			continue
+		}
+		tag := f.Tag.Get("gorm")
+		col := extractGormColumn(tag)
+		if col == "" {
+			t.Fatalf("model.Meta.%s に column タグが無い", f.Name)
+		}
+		expected[col] = struct{}{}
+		// default が '{...}' で始まれば object 形、'[...]' なら array 形。
+		// 将来 default:'{"x":1}' のような非空 object default が来ても誤分類しない
+		// よう、Contains ではなく trim 後の先頭文字で判定する。
+		if def := strings.Trim(extractGormDefault(tag), "'"); strings.HasPrefix(def, "{") {
+			objectCols[col] = struct{}{}
+		}
+	}
+
+	missing := diffSorted(expected, metaJSONBColumns)
+	assert.Empty(t, missing,
+		"metaJSONBColumns に未登録の jsonb 列がある。新しい datatypes.JSON 列を追加した際は handler.go の metaJSONBColumns も更新してください (#1846)")
+
+	extra := diffSorted(metaJSONBColumns, expected)
+	assert.Empty(t, extra,
+		"metaJSONBColumns に model.Meta に無い列が混入している (typo / 列削除し忘れ)")
+
+	missingObj := diffSorted(objectCols, metaJSONBObjectColumns)
+	assert.Empty(t, missingObj,
+		"default '{}' の object 形 jsonb 列が metaJSONBObjectColumns に未登録 (nil default が [] になり不正、#1846)")
+
+	extraObj := diffSorted(metaJSONBObjectColumns, objectCols)
+	assert.Empty(t, extraObj,
+		"metaJSONBObjectColumns に object 形 ('{}') でない列が混入している")
+}
+
 // #1823: coerceMetaJSONBFields は policies (object 形 jsonb) を decoded map から
 // datatypes.JSON ([]byte) に変換し、jsonb 列の UPDATE 型不一致 500 を防ぐ。
 func TestCoerceMetaJSONBFields_Policies(t *testing.T) {

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -2556,6 +2556,14 @@ func (m *MockMetaRepository) Update(fields map[string]any) error {
 			case []byte:
 				m.Meta.DeliverSuspendedSoftware = datatypes.JSON(b)
 			}
+		case "clientOptions":
+			// object 形 jsonb 列 (#1846)。coerceMetaJSONBFields 正規化済みを反映。
+			switch b := v.(type) {
+			case datatypes.JSON:
+				m.Meta.ClientOptions = b
+			case []byte:
+				m.Meta.ClientOptions = datatypes.JSON(b)
+			}
 		case "silencedHosts":
 			setStrArr(&m.Meta.SilencedHosts, k, v)
 		case "mediaSilencedHosts":


### PR DESCRIPTION
## Summary

#1823 の個別敵対的レビューで発見した、同クラスの未解消 latent 500。`clientOptions` は object 形 jsonb 列(`model.Meta`、default `'{}'`)だが `metaJSONBColumns` 未登録で、`UpdateMeta` が field whitelist 無しで decoded `map[string]any` を `metaRepo.Update` に流すため、`POST /api/admin/update-meta` に `{"clientOptions":{...}}` を送ると jsonb 列 UPDATE が型不一致で **500**(#1732/#1823 と同じ failure)になっていた。

## 主な変更点

- `internal/api/admin/handler.go`: `metaJSONBColumns` + `metaJSONBObjectColumns` に `clientOptions` を追加。
- `internal/api/admin/meta_array_columns_test.go`: `TestMetaJSONBColumns_CoversAllJSONColumns`(reflection guard)を追加 — `model.Meta` の全 `datatypes.JSON` 列が `metaJSONBColumns` を被覆し、object default(`'{}'`)列が `metaJSONBObjectColumns` にも登録されていることを担保(将来の jsonb 列追加時の登録漏れを検出)。
- `internal/api/admin/handler_test.go`: `TestUpdateMeta_ClientOptions`(handler→repo の e2e で object が永続化されること)。
- `internal/testutil/mock_repository.go`: `MockMetaRepository.Update` に `clientOptions` の jsonb case を追加。

## レビュー(2ラウンド、収束)

実装→敵対的レビュー→修正を指摘ゼロまで反復。round-1 で NIT(object/array 分類の堅牢化)+ e2e テスト追加を指摘 → 反映。round-2 で **CLEAN(must-fix なし)**。out-of-scope の clientOptions merge-vs-replace semantics は **#1851** に分離。

## テスト

- `go test ./internal/api/admin/... -cover`: 89.6% green。`go build ./...` / `go vet ./...` / `gofmt -s -l` clean。

## Closes

Closes #1846

🤖 Generated with [Claude Code](https://claude.com/claude-code)