### PR TITLE
Fix admin parity (#1847): admin/accounts/find-by-email を UserDetailed で pack し email 漏洩を塞ぐ

### DIFF
--- a/internal/api/admin/accounts.go
+++ b/internal/api/admin/accounts.go
@@ -8,6 +8,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/moderationlog"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/queue"
 )
 
@@ -52,11 +53,13 @@ func (h *Handler) AccountsFindByEmail(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("USER_NOT_FOUND", "User not found.", "cb865949-8af5-4062-a88c-ef55e8786d1d"))
 	}
-	// 他の admin エンドポイント (ShowUser 等) と同じ packAdminUser を通して
-	// Misskey 本家互換のレスポンス整形をする。生 model.User を返すと
-	// inbox / sharedInbox / usernameLower 等の内部フィールドが漏れ、
-	// createdAt / roles / policies 等のフロントが期待するフィールドが欠落する。
-	return c.JSON(http.StatusOK, h.packAdminUser(user, profile))
+	// upstream admin/accounts/find-by-email.ts は pack(user, null,
+	// {schema:'UserDetailedNotMe'}) (includeSecrets 無し) を返すため email /
+	// emailVerified / securityKeysList は含めない。packAdminUser を使うとこれら
+	// includeSecrets 限定 field が漏れる (#1847、#1822 と同 class)。UserDetailed に
+	// 揃えて過剰露出を防ぐ (ShowUsers と同方針)。生 model.User の内部 field
+	// (inbox/sharedInbox/usernameLower) も UserDetailed では出ない。
+	return c.JSON(http.StatusOK, entity.PackUserDetailed(user, profile, h.idGen))
 }
 
 // DeleteAccount handles POST /api/admin/delete-account. AccountsDelete と

--- a/internal/api/admin/accounts_test.go
+++ b/internal/api/admin/accounts_test.go
@@ -241,9 +241,11 @@ func TestAccountsFindByEmail_Found(t *testing.T) {
 }
 
 // TestAccountsFindByEmail_ResponseShape verifies that AccountsFindByEmail
-// returns the packAdminUser format: frontend-expected fields (createdAt,
-// roles, policies) must be present, and internal model fields (inbox,
-// sharedInbox, usernameLower) must NOT leak.
+// returns the UserDetailedNotMe shape (#1847): frontend-expected fields
+// (createdAt, roles) present; internal model fields (inbox, sharedInbox,
+// usernameLower) NOT leaked; and includeSecrets-only fields (email,
+// emailVerified, securityKeysList) NOT leaked. policies is a MeDetailed-only
+// field absent from UserDetailedNotMe (matches upstream).
 func TestAccountsFindByEmail_ResponseShape(t *testing.T) {
 	h, userRepo, _, _ := newTestHandler(t)
 
@@ -278,11 +280,21 @@ func TestAccountsFindByEmail_ResponseShape(t *testing.T) {
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 
-	// packAdminUser が付与する frontend 必須フィールドの存在確認
+	// UserDetailed が付与する frontend 必須フィールドの存在確認
 	assert.Equal(t, uid, resp["id"])
 	assert.NotNil(t, resp["createdAt"], "createdAt must be present")
 	assert.NotNil(t, resp["roles"], "roles must be present")
-	assert.NotNil(t, resp["policies"], "policies must be present")
+	// policies は MeDetailed 限定 field で UserDetailedNotMe には無い (upstream 一致)。
+	_, hasPolicies := resp["policies"]
+	assert.False(t, hasPolicies, "policies must NOT be present (UserDetailedNotMe shape)")
+
+	// includeSecrets 限定 field が漏れていないこと (#1847)。
+	_, hasEmail := resp["email"]
+	assert.False(t, hasEmail, "email must not be exposed (#1847)")
+	_, hasEmailVerified := resp["emailVerified"]
+	assert.False(t, hasEmailVerified, "emailVerified must not be exposed (#1847)")
+	_, hasSecurityKeysList := resp["securityKeysList"]
+	assert.False(t, hasSecurityKeysList, "securityKeysList must not be exposed (#1847)")
 
 	// 内部フィールドが response に漏れていないことを確認
 	_, hasInbox := resp["inbox"]


### PR DESCRIPTION
## Summary

#1822 の個別敵対的レビューで発見した、同 `packAdminUser` 由来の隣接過剰露出。`admin/accounts/find-by-email` は `packAdminUser` を使い `email`/`emailVerified`(+ `securityKeysList`)を返していたが、upstream `find-by-email.ts` は `pack(user, null, {schema:'UserDetailedNotMe'})`(includeSecrets 無し)でこれらを返さない。gate は `read:admin:account` + `RequireAdmin`(administrator 限定)のため #1822 より低リスクだが、real な email 露出 / shape parity drift。

## 主な変更点

- `internal/api/admin/accounts.go`: `AccountsFindByEmail` を `entity.PackUserDetailed(user, profile, h.idGen)` に切替(#1822 / ShowUsers と同方針)。
- `internal/api/admin/accounts_test.go`: `TestAccountsFindByEmail_ResponseShape` を更新 — `email`/`emailVerified`/`securityKeysList` 非露出 + `policies` は UserDetailedNotMe に無い(MeDetailed 限定)ことを assert。`roles`/`createdAt` present、内部 field(inbox/sharedInbox/usernameLower)非露出は維持。

これで `packAdminUser` で secrets を出す経路は `show-user`(admin guard 付き・upstream も email を res に宣言、意図的)のみとなり、secrets-leak class が closeします。

## レビュー

実装→敵対的レビュー(round-1 で **CORRECT & COMPLETE, ship it** = must-fix なし)。レビューが全 `packAdminUser` 呼出を列挙し、本 PR 後に残る leak が無いことを確認。

## テスト

- `go test ./internal/api/admin/... -cover`: 89.6% green。`go build` / `go vet` / `gofmt -s -l` clean。

## Closes

Closes #1847

🤖 Generated with [Claude Code](https://claude.com/claude-code)