### PR TITLE
Fix ap-inbound parity (#1848): Update(Person) を配送 actor 本人に限定 (forced-refresh amplification 防止)

### DIFF
--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -1613,6 +1613,13 @@ func (p *Processor) handleUpdate(act genericActivity) error {
 		// Note / Question / Game は上で dispatch 済。残り (Article 等) は未対応。
 		return nil
 	}
+	// upstream ApInboxService.update は配送 actor 本人 (actor.uri) のみを再取得・
+	// 更新する。object の id が配送 actor と異なる Update(Person) は、別 actor の
+	// TTL-bypass 強制再取得 (amplification) を誘発するため拒否する (Note/Question
+	// 経路と対称、#1848)。act.Actor は authorizeActor で署名者と一致を検証済み。
+	if act.Actor != "" && person.ID != act.Actor {
+		return nil
+	}
 	if _, err := p.userRepo.FindByURI(person.ID); err != nil {
 		// 未取得のリモートユーザーなら無視 (次回 follow/inbox などで取り込まれる)
 		return nil

--- a/internal/core/federation/processor_step_f_test.go
+++ b/internal/core/federation/processor_step_f_test.go
@@ -1086,6 +1086,36 @@ func TestProcess_UpdatePerson(t *testing.T) {
 	assert.True(t, updated.IsLocked, "manuallyApprovesFollowers must update isLocked (full refresh)")
 }
 
+// #1848: 配送 actor と異なる object.id の Update(Person) は、対象 actor の
+// TTL-bypass 強制再取得 (amplification) を誘発させない。
+func TestProcess_UpdatePerson_CrossActorRejected(t *testing.T) {
+	// fetcher は呼ばれたら alice を "Hijacked" に書き換える doc を返す。gate が
+	// 効いていれば ForceResolveActor 自体が呼ばれず、alice は再取得されない。
+	refreshedDoc := `{
+		"@context": "https://www.w3.org/ns/activitystreams",
+		"id": "https://remote.example/users/alice",
+		"type": "Service",
+		"preferredUsername": "alice",
+		"name": "Hijacked",
+		"inbox": "https://remote.example/users/alice/inbox"
+	}`
+	env := newFullProcessor(t, refreshedDoc)
+	aliceURI := "https://remote.example/users/alice"
+	origName := "Alice Original"
+	env.userRepo.Users["alice-id"] = &model.User{ID: "alice-id", Username: "alice", URI: &aliceURI, Name: &origName}
+	// 配送 actor は別人 mallory、object.id は alice。
+	body := []byte(`{
+		"type": "Update",
+		"actor": "https://evil.example/users/mallory",
+		"object": {"id":"https://remote.example/users/alice","type":"Person","name":"Hijacked"}
+	}`)
+	require.NoError(t, env.processor.Process(body))
+	updated := env.userRepo.Users["alice-id"]
+	require.NotNil(t, updated.Name)
+	assert.Equal(t, "Alice Original", *updated.Name, "別 actor の Update(Person) は対象を再取得・改変しない")
+	assert.False(t, updated.IsBot, "別 actor の Update では full refresh も起きない")
+}
+
 func TestProcess_UpdateUnknownActor(t *testing.T) {
 	env := newFullProcessor(t, aliceActor)
 	body := []byte(`{


### PR DESCRIPTION
## Summary

#1819 の個別敵対的レビューで発見した非対称。`handleUpdate` の Person 分岐は `ForceResolveActor(person.ID)` を **object の claimed id** で呼び、配送 actor との一致を検証していなかった。署名 actor B が `Update{actor:B, object:{type:Person, id:A}}` を送ると、A の **TTL-bypass 強制再取得 (amplification)** を誘発できた(データは A の origin から authoritative に取得されるため content injection ではない)。upstream `ApInboxService.update` は actor 本人(`actor.uri`)のみを更新する。

## 主な変更点

- `internal/core/federation/processor.go`: Person 分岐に `person.ID != act.Actor` の Update を drop するゲートを追加(Note #1819 / Question #1779 経路と対称)。`act.Actor` は `authorizeActor` で署名者と一致検証済み。embedded-Person / object-as-URI の両形式に適用。
- `internal/core/federation/processor_step_f_test.go`: `TestProcess_UpdatePerson_CrossActorRejected`(別 actor の Update が対象を再取得・改変しないこと、true negative control)。自分自身の Update は従来どおり full refresh(`TestProcess_UpdatePerson`)。

## レビュー

実装→敵対的レビュー(round-1 で **CORRECT & COMPLETE, merge** = must-fix なし)。reviewer が gate を外して test の negative-control 性も確認。他の forced-refresh 経路(handleMove は act.Actor を使うので安全)に残存 amplification 無しと確認。

## テスト

- `go test ./internal/core/federation/... -cover`: 90.2% green。`go build` / `go vet` / `gofmt -s -l` clean。

## Closes

Closes #1848

🤖 Generated with [Claude Code](https://claude.com/claude-code)