### PR TITLE
Fix notes parity (#1849): renote 対象の可視性に応じて renote 自身の visibility/localOnly を調整

### DIFF
--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -380,6 +380,9 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 	if visibility == "" {
 		visibility = model.NoteVisibilityPublic
 	}
+	// localOnly は renote 対象が local-only のとき伝播させる (#1849)。reply 対象の
+	// 伝播 / reply visibility 降格 / channel note の強制は #1855 で別途。
+	localOnly := in.LocalOnly
 
 	// canPublicNote=false の user が channel 外の public note を投げた場合、
 	// upstream Misskey TS の NoteCreateService と同様に visibility を home
@@ -525,6 +528,25 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 		if t.Visibility == model.NoteVisibilitySpecified {
 			return nil, ErrCannotRenoteInvisibleNote
 		}
+		// 拒否を通過した renote 対象の可視性に応じて renote 自身の可視性を調整する
+		// (upstream NoteCreateService の switch、#1849)。silencing/sensitive 降格の
+		// 後に走らせるのは upstream と同順。
+		switch t.Visibility {
+		case model.NoteVisibilityHome:
+			// home 対象を public で renote したら home に降格 (home 以下のみ可)。
+			if visibility == model.NoteVisibilityPublic {
+				visibility = model.NoteVisibilityHome
+			}
+		case model.NoteVisibilityFollowers:
+			// ここに来るのは自分の followers note のみ (他人は上で reject)。
+			// upstream は renote 自身も followers に強制する。
+			visibility = model.NoteVisibilityFollowers
+		}
+		// local-only な対象を renote したら local-only にする (channel 外のみ、
+		// upstream `data.renote.localOnly && data.channel == null`)。
+		if t.LocalOnly && in.ChannelID == nil {
+			localOnly = true
+		}
 		// pure renoteを更にrenoteするのは禁止 (TS: isRenote && !isQuote)
 		if IsPureRenote(t) {
 			return nil, ErrCannotRenoteToAPureRenote
@@ -569,7 +591,7 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 		Text:               in.Text,
 		CW:                 in.CW,
 		Visibility:         visibility,
-		LocalOnly:          in.LocalOnly,
+		LocalOnly:          localOnly,
 		ReactionAcceptance: in.ReactionAcceptance,
 		ReplyID:            in.ReplyID,
 		RenoteID:           in.RenoteID,

--- a/internal/core/note/note_create_service_test.go
+++ b/internal/core/note/note_create_service_test.go
@@ -666,6 +666,44 @@ func TestCreateService_CannotRenoteSpecifiedNote(t *testing.T) {
 	require.ErrorIs(t, err, note.ErrCannotRenoteInvisibleNote, "specified note は自分のものでも renote 不可")
 }
 
+// #1849: renote 対象の可視性に応じて renote 自身の可視性 / localOnly を調整する
+// (upstream NoteCreateService の switch + localOnly 伝播)。
+func TestCreateService_RenoteVisibilityAdjustment(t *testing.T) {
+	t.Run("home target downgrades public renote to home", func(t *testing.T) {
+		svc, noteRepo, _ := newCreateService(t)
+		noteRepo.Notes["h"] = &model.Note{ID: "h", UserID: "other", Visibility: model.NoteVisibilityHome}
+		rid := "h"
+		created, err := svc.Create(note.CreateInput{User: &model.User{ID: "u1"}, RenoteID: &rid, Visibility: model.NoteVisibilityPublic})
+		require.NoError(t, err)
+		assert.Equal(t, model.NoteVisibilityHome, created.Visibility, "home note の public renote は home に降格")
+	})
+	t.Run("own followers target forces renote to followers", func(t *testing.T) {
+		svc, noteRepo, _ := newCreateServiceWithFollowing(t)
+		noteRepo.Notes["f"] = &model.Note{ID: "f", UserID: "u1", Visibility: model.NoteVisibilityFollowers}
+		rid := "f"
+		created, err := svc.Create(note.CreateInput{User: &model.User{ID: "u1"}, RenoteID: &rid, Visibility: model.NoteVisibilityPublic})
+		require.NoError(t, err)
+		assert.Equal(t, model.NoteVisibilityFollowers, created.Visibility, "自分の followers note の renote は followers に強制")
+	})
+	t.Run("localOnly target propagates to renote", func(t *testing.T) {
+		svc, noteRepo, _ := newCreateService(t)
+		noteRepo.Notes["lo"] = &model.Note{ID: "lo", UserID: "other", Visibility: model.NoteVisibilityPublic, LocalOnly: true}
+		rid := "lo"
+		created, err := svc.Create(note.CreateInput{User: &model.User{ID: "u1"}, RenoteID: &rid, Visibility: model.NoteVisibilityPublic})
+		require.NoError(t, err)
+		assert.True(t, created.LocalOnly, "local-only note の renote は local-only に伝播")
+	})
+	t.Run("public target keeps public renote (no adjustment)", func(t *testing.T) {
+		svc, noteRepo, _ := newCreateService(t)
+		noteRepo.Notes["p"] = &model.Note{ID: "p", UserID: "other", Visibility: model.NoteVisibilityPublic}
+		rid := "p"
+		created, err := svc.Create(note.CreateInput{User: &model.User{ID: "u1"}, RenoteID: &rid, Visibility: model.NoteVisibilityPublic})
+		require.NoError(t, err)
+		assert.Equal(t, model.NoteVisibilityPublic, created.Visibility)
+		assert.False(t, created.LocalOnly)
+	})
+}
+
 func TestCreateService_ReplyHappyPath(t *testing.T) {
 	svc, noteRepo, _ := newCreateService(t)
 	noteRepo.Notes["target"] = &model.Note{


### PR DESCRIPTION
## Summary

#1821 の個別敵対的レビューで判明した隣接 parity gap(pre-existing、#1821 で観測可能になった)。mk-go は upstream `NoteCreateService` の renote-target visibility 調整 switch を欠いており、**自分の followers note を public 指定で renote すると public のまま**(followers note を指す public renote)になっていた。

## 主な変更点

`internal/core/note/note_create_service.go` の renote gate(#1821)通過後に、upstream `NoteCreateService.ts:492-516` + `:536-538` 相当の調整を追加:
- `home` 対象を public で renote → `home` に降格(home 以下のみ)
- 自分の `followers` 対象 → renote を `followers` に強制(他人 / specified は #1821 で reject 済)
- `local-only` 対象(channel 外)→ renote を `local-only` に伝播

silencing/sensitive 降格の後に走らせるのは upstream と同順。adjust 後の `visibility`/`localOnly` が永続 note と federation hook(`note_delivery_hook`)に反映され、public 指定の renote が対象の可視性に応じて wire 上で正しく制限される。

## レビュー

実装→敵対的レビュー(round-1 で **CORRECT & COMPLETE (renote scope), ship it**)。MINOR(コメント文言)を修正。reply-target の visibility 降格 / localOnly 伝播 / channel note 強制は本 PR の renote スコープ外として **#1855** に分離。

## テスト

- `TestCreateService_RenoteVisibilityAdjustment`(home→home / 自分followers→followers / localOnly 伝播 / public 据え置きの4ケース)。
- `go test ./internal/core/note/... -cover`: 94.8% green。`go build` / `go vet` / `gofmt -s -l` clean。

## Closes

Closes #1849

🤖 Generated with [Claude Code](https://claude.com/claude-code)