### PR TITLE
Fix ap parity (#1850): AP host 一致比較を idna 正規化し Unicode/punycode mixed-form の誤 reject を解消

### DIFF
--- a/internal/core/federation/host_match_internal_test.go
+++ b/internal/core/federation/host_match_internal_test.go
@@ -27,6 +27,13 @@ func TestAssertResponseHostMatches(t *testing.T) {
 		// #1820 review: 先頭 www. は synonymous subdomain として除去して一致扱い。
 		{"www synonymous subdomain", "https://www.remote.example/x", "https://remote.example/users/alice", false},
 		{"www both sides", "https://www.remote.example/x", "https://www.remote.example/users/alice", false},
+		// #1850: Unicode IDN と punycode の mixed-form は idna 正規化で一致扱い。
+		{"IDN unicode final vs punycode id", "https://bücher.example/x", "https://xn--bcher-kva.example/users/a", false},
+		{"IDN punycode final vs unicode id", "https://xn--bcher-kva.example/x", "https://bücher.example/users/a", false},
+		{"IDN different domain still mismatch", "https://bücher.example/x", "https://xn--nxasmq6b.example/users/a", true},
+		// #1850 review: ideographic dot (U+3002) は `.` に畳まれない = victim.example へ
+		// なりすませない (spoofing regression guard)。Go idna は Node と異なり安全側。
+		{"ideographic dot does not collapse to victim host", "https://victim.example/x", "https://victim.example。evil.example/users/a", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -38,5 +45,29 @@ func TestAssertResponseHostMatches(t *testing.T) {
 				t.Errorf("expected nil, got %v", err)
 			}
 		})
+	}
+}
+
+// #1850: punyHost は idna.ToASCII(lowercase) で Unicode IDN と punycode を同一
+// 正規形にし、id↔attributedTo / id↔final-host 比較の mixed-form 誤 reject を防ぐ。
+func TestPunyHost(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"bücher.example", "xn--bcher-kva.example"},
+		{"xn--bcher-kva.example", "xn--bcher-kva.example"},
+		{"Bücher.Example", "xn--bcher-kva.example"}, // 大文字も正規化
+		{"REMOTE.EXAMPLE", "remote.example"},        // ASCII は小文字化のみ
+		{"remote.example", "remote.example"},        // 既に正規形
+	}
+	for _, tc := range cases {
+		if got := punyHost(tc.in); got != tc.want {
+			t.Errorf("punyHost(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+	// Unicode と punycode が同一正規形に畳まれる (= 比較で一致する) こと。
+	if punyHost("bücher.example") != punyHost("xn--bcher-kva.example") {
+		t.Errorf("Unicode と punycode の同一 host が一致しない")
 	}
 }

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -23,6 +23,7 @@ import (
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
+	"golang.org/x/net/idna"
 	"golang.org/x/sync/singleflight"
 	"gorm.io/gorm"
 )
@@ -1018,7 +1019,8 @@ func (r *Resolver) IngestNoteWithCreated(body []byte, deliveringActorURI string)
 	//      (alice@a が bob@b になりすました note を作る forge を弾く)。
 	idHost, idErr := hostFromURI(apNote.ID)
 	attrHost, attrErr := hostFromURI(apNote.AttributedTo)
-	if idErr != nil || attrErr != nil || !strings.EqualFold(idHost, attrHost) {
+	// idna 正規化して Unicode/punycode mixed-form の同一 host を誤 reject しない (#1850)。
+	if idErr != nil || attrErr != nil || punyHost(idHost) != punyHost(attrHost) {
 		slog.Warn("federation: note id/attributedTo host mismatch", "id", apNote.ID, "attributedTo", apNote.AttributedTo)
 		return nil, false, ErrNoteAttributionMismatch
 	}
@@ -1902,6 +1904,25 @@ func hostFromURI(uri string) (string, error) {
 	return u.Host, nil
 }
 
+// punyHost normalizes a host for comparison the way upstream
+// UtilityService.toPuny does (idna.ToASCII(lowercase), UTS#46)。Unicode IDN と
+// punycode の mixed-form (例: `パイ.example` vs `xn--eckve.example`) を同一視
+// するため host 一致比較の両辺に適用する (#1850)。idna が失敗する不正入力のみ
+// 小文字化で返す (Go default の lenient UTS#46 profile では port 付き host も
+// 成功し ASCII tail はそのまま残るため、fallback は実質ほぼ発生しない)。これは
+// 比較専用で、保存側 host (resolveActorOnce / hostAllowedForURI /
+// RegisterFromHost) の正規化統一は別スコープ。
+//
+// なお Go の idna は ideographic/fullwidth dot (U+3002 等) を `.` に畳まない
+// (Node の domainToASCII と異なるが、別 authority を同一視しない安全側)。
+func punyHost(host string) string {
+	lower := strings.ToLower(host)
+	if ascii, err := idna.ToASCII(lower); err == nil {
+		return ascii
+	}
+	return lower
+}
+
 // finalURLFetcher は redirect 後の最終 URL も返せる fetcher。本番 APFetcher が
 // 実装し、resolver が fetch 元 host と object id host の一致検証に使う (#1820)。
 // テストダブル (stubFetcher) は実装しなくてよく、その場合 resolver は最終 URL
@@ -1955,7 +1976,8 @@ func assertResponseHostMatches(finalURL, objectID string) error {
 // (先頭 www. を除去)。これが無いと `remote.example:443` vs `remote.example` や
 // `www.remote.example` vs `remote.example` を誤って弾く (#1820 review)。
 func normalizeMatchHost(u *url.URL) string {
-	host := strings.ToLower(u.Hostname())
+	// idna 正規化で Unicode IDN と punycode の mixed-form を同一視する (#1850)。
+	host := punyHost(u.Hostname())
 	host = strings.TrimPrefix(host, "www.")
 	port := u.Port()
 	isDefaultPort := (u.Scheme == "https" && port == "443") || (u.Scheme == "http" && port == "80")


### PR DESCRIPTION
## Summary

#1820 / #1839 の個別敵対的レビューで判明した interop divergence。AP の host 一致比較が raw `url.Hostname()`(小文字化のみ)で、**片側が Unicode IDN・他方が punycode の同一 host**(例: `bücher.example` vs `xn--bcher-kva.example`)を誤って reject していた(fail-closed なので security hole ではなく interop 後退)。upstream は `domainToASCII(host.toLowerCase())`(UTS#46)で正規化してから比較する。

## 主な変更点

- `internal/core/federation/resolver.go`: `punyHost(host) = idna.ToASCII(strings.ToLower(host))` helper を追加(admin の `toPunyHost` と同方針、idna 失敗時は小文字化 fallback)。比較2箇所に適用 — `normalizeMatchHost`(#1820 fetch id↔final host)と `IngestNoteWithCreated` の id↔attributedTo host 比較(#1839)。保存側 host(`hostAllowedForURI` / `resolveActorOnce` / `RegisterFromHost`)は storage/block-list 概念で別スコープのため変更せず。

## セキュリティ確認(re-open しないこと)

レビューで、別 authority を同一視しないことを実機検証:Go の idna は **ideographic/fullwidth dot(U+3002 等)を `.` に畳まない**(Node の `domainToASCII` と異なるが、別 authority を同一視しない安全側)、homoglyph も別 punycode、両辺対称適用で asymmetry なし。spoofing regression guard として ideographic-dot が victim host に畳まれない負テストを追加。

## レビュー

実装→敵対的レビュー(round-1 で **SAFE, does NOT re-open spoofing, merge**)。MINOR(コメントの事実誤り)+ NIT(spoof 負テスト)を反映。

## テスト

- `assertResponseHostMatches`: IDN mixed-form 一致 / 別ドメイン不一致 / ideographic-dot 非畳み込み + `TestPunyHost`。
- `go test ./internal/core/federation/... -cover`: 90.1% green。`go build` / `go vet` / `gofmt -s -l` clean。

## Closes

Closes #1850

🤖 Generated with [Claude Code](https://claude.com/claude-code)