### PR TITLE
Fix admin parity (#1851): update-meta の clientOptions を replace でなく shallow merge にする

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -1261,8 +1261,27 @@ func (h *Handler) UpdateMeta(c echo.Context) error {
 	// すべての varchar[] 列に影響していたバグで、admin が whitelist 連合や
 	// host ブロックを保存しても永続化されない原因だった。
 	coerceMetaArrayFields(fields)
-	// jsonb 列 (deliverSuspendedSoftware) は decoded []any を []byte に marshal
-	// しないと UPDATE が型不一致で失敗する (#1732)。
+	// clientOptions は upstream update-meta.ts と同じく既存値への shallow merge
+	// (`{...serverSettings.clientOptions, ...ps.clientOptions}`) にする (#1851)。
+	// replace だと partial update で未指定キーが消える。incoming が map なら既存
+	// meta.clientOptions に上書きマージ、null (= map でない) なら incoming 無し
+	// として既存を維持する (upstream の `{...existing, ...null}` と同じ)。coerce
+	// 前に行い、merge 後の map を coerceMetaJSONBFields が datatypes.JSON 化する。
+	if raw, ok := fields["clientOptions"]; ok {
+		merged := map[string]any{}
+		if m, err := h.metaRepo.Fetch(); err == nil && m != nil && len(m.ClientOptions) > 0 {
+			_ = json.Unmarshal(m.ClientOptions, &merged)
+		}
+		if incoming, isMap := raw.(map[string]any); isMap {
+			for k, v := range incoming {
+				merged[k] = v
+			}
+		}
+		fields["clientOptions"] = merged
+	}
+	// jsonb 列 (deliverSuspendedSoftware / policies / clientOptions) は decoded
+	// []any / map を []byte に marshal しないと UPDATE が型不一致で失敗する
+	// (#1732 / #1823 / #1846)。
 	coerceMetaJSONBFields(fields)
 
 	// VAPID 鍵 auto-generate (#492): Service Worker 有効化時に

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -747,6 +747,37 @@ func TestUpdateMeta_ClientOptions(t *testing.T) {
 	assert.Equal(t, float64(1), obj["foo"])
 }
 
+// #1851: clientOptions は upstream と同じく既存値に shallow merge する。partial
+// update で未指定キーが消えず、incoming キーが既存値を上書きする。
+func TestUpdateMeta_ClientOptionsMerge(t *testing.T) {
+	h, _, metaRepo, _ := newTestHandler(t)
+	// 既存 clientOptions: keep="A" (未指定で保持) / override="old" (上書き対象)。
+	metaRepo.Meta.ClientOptions = datatypes.JSON([]byte(`{"keep":"A","override":"old"}`))
+
+	rec := doPost(h.UpdateMeta, `{"clientOptions":{"override":"new","added":"B"}}`, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	var obj map[string]any
+	require.NoError(t, json.Unmarshal(metaRepo.Meta.ClientOptions, &obj))
+	assert.Equal(t, "A", obj["keep"], "未指定の既存キーは保持される")
+	assert.Equal(t, "new", obj["override"], "incoming が既存キーを上書きする")
+	assert.Equal(t, "B", obj["added"], "incoming の新規キーが追加される")
+}
+
+// #1851: clientOptions:null は incoming 無し = 既存維持 (upstream の
+// {...existing, ...null} と同じ spread セマンティクス)。
+func TestUpdateMeta_ClientOptionsNullKeepsExisting(t *testing.T) {
+	h, _, metaRepo, _ := newTestHandler(t)
+	metaRepo.Meta.ClientOptions = datatypes.JSON([]byte(`{"keep":"A"}`))
+
+	rec := doPost(h.UpdateMeta, `{"clientOptions":null}`, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	var obj map[string]any
+	require.NoError(t, json.Unmarshal(metaRepo.Meta.ClientOptions, &obj))
+	assert.Equal(t, "A", obj["keep"], "clientOptions:null は既存を維持する")
+}
+
 // JSON で送られてくる array は []any{...} に decode されるが、そのまま
 // repo.Update に流すと lib/pq が varchar[] 列に書けず "expression is of
 // type record" で UPDATE 全体が落ちる。handler 側の coerceMetaArrayFields


### PR DESCRIPTION
## Summary

#1846 の個別敵対的レビューで判明した semantics divergence。upstream `update-meta.ts:342-346` は `clientOptions` を既存値に **shallow merge**(`{...serverSettings.clientOptions, ...ps.clientOptions}`)するが、mk-go は coerce 後の値で全置換しており、partial update で未指定キーが消えていた。

## 主な変更点

- `internal/api/admin/handler.go` `UpdateMeta`: coerce 前に、`fields["clientOptions"]` が map なら既存 `meta.ClientOptions` を読んで incoming を上書きマージ。`null`(map でない)のときは incoming 無しとして既存維持(upstream の `{...existing, ...null}` spread と同じ)。merge 後の map を `coerceMetaJSONBFields` が datatypes.JSON 化する(#1846 の coerce 経路に乗る)。

## レビュー

実装→敵対的レビュー(round-1 で **CORRECT & COMPLETE, ship it**)。shallow vs deep、null/undefined/empty の各ケースを upstream と一致と実機検証。MINOR(既存値が非 object の corner = jsonb default '{}'・型定義上あり得ない)は reachable でなく upstream spread と同様のため対象外。

## テスト

- `TestUpdateMeta_ClientOptionsMerge`(既存キー保持 + incoming 上書き + 新規追加)、`TestUpdateMeta_ClientOptionsNullKeepsExisting`(null で既存維持)。
- `go test ./internal/api/admin/... -cover`: 89.6% green。`go build` / `go vet` / `gofmt -s -l` clean。

## Closes

Closes #1851

🤖 Generated with [Claude Code](https://claude.com/claude-code)