### PR TITLE
Fix notes parity (#1855): reply-target visibility 調整 + channel note の public/localOnly 強制

### DIFF
--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -380,9 +380,20 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 	if visibility == "" {
 		visibility = model.NoteVisibilityPublic
 	}
-	// localOnly は renote 対象が local-only のとき伝播させる (#1849)。reply 対象の
-	// 伝播 / reply visibility 降格 / channel note の強制は #1855 で別途。
+	// localOnly は renote / reply 対象が local-only のとき伝播させる (#1849 / #1855)。
 	localOnly := in.LocalOnly
+
+	// channel note は upstream NoteCreateService:463-465 と同じく visibility=public /
+	// localOnly=true を強制し、visibleUserIds を空にする (channel 機構が露出範囲を
+	// 管理するため、#1855)。channel 判定は channel membership 操作 (EnsureChannelExists
+	// / OnNotePosted) と同じ `in.ChannelID != nil && *in.ChannelID != ""` を採用する。
+	// 空文字 channelID は不正入力で実際の channel ではないため強制対象外
+	// (upstream は misskey:id schema で "" を 400 reject、その正規化は #1859)。
+	isChannelNote := in.ChannelID != nil && *in.ChannelID != ""
+	if isChannelNote {
+		visibility = model.NoteVisibilityPublic
+		localOnly = true
+	}
 
 	// canPublicNote=false の user が channel 外の public note を投げた場合、
 	// upstream Misskey TS の NoteCreateService と同様に visibility を home
@@ -507,6 +518,16 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 				return nil, err
 			}
 		}
+		// 返信対象が public でなければ visibility を home に降格する (upstream
+		// NoteCreateService:531-533、#1855)。renote の home 降格と同種。
+		if t.Visibility != model.NoteVisibilityPublic && visibility == model.NoteVisibilityPublic {
+			visibility = model.NoteVisibilityHome
+		}
+		// local-only な対象への reply は local-only にする (channel 外のみ、
+		// upstream:541-543)。
+		if t.LocalOnly && in.ChannelID == nil {
+			localOnly = true
+		}
 	}
 	if in.RenoteID != nil {
 		if renoteFetchErr != nil {
@@ -612,7 +633,9 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 		note.RenoteChannelID = renoteTarget.ChannelID
 	}
 
-	if in.VisibleUserIDs != nil {
+	// channel note は visibleUserIds を空にする (upstream:464、#1855)。public 強制
+	// 済なので visibleUserIds は無意味だが、stray な指定を残さない。
+	if in.VisibleUserIDs != nil && !isChannelNote {
 		note.VisibleUserIDs = in.VisibleUserIDs
 	}
 

--- a/internal/core/note/note_create_service_test.go
+++ b/internal/core/note/note_create_service_test.go
@@ -704,6 +704,42 @@ func TestCreateService_RenoteVisibilityAdjustment(t *testing.T) {
 	})
 }
 
+// #1855: reply 対象の可視性 / localOnly に応じた調整 + channel note の強制。
+func TestCreateService_ReplyAndChannelVisibilityAdjustment(t *testing.T) {
+	t.Run("reply to non-public downgrades public to home", func(t *testing.T) {
+		svc, noteRepo, _ := newCreateService(t)
+		noteRepo.Notes["h"] = &model.Note{ID: "h", UserID: "other", Visibility: model.NoteVisibilityHome}
+		text := "re"
+		rid := "h"
+		created, err := svc.Create(note.CreateInput{User: &model.User{ID: "u1"}, Text: &text, ReplyID: &rid, Visibility: model.NoteVisibilityPublic})
+		require.NoError(t, err)
+		assert.Equal(t, model.NoteVisibilityHome, created.Visibility, "非 public note への public reply は home に降格")
+	})
+	t.Run("reply to localOnly propagates localOnly", func(t *testing.T) {
+		svc, noteRepo, _ := newCreateService(t)
+		noteRepo.Notes["lo"] = &model.Note{ID: "lo", UserID: "other", Visibility: model.NoteVisibilityPublic, LocalOnly: true}
+		text := "re"
+		rid := "lo"
+		created, err := svc.Create(note.CreateInput{User: &model.User{ID: "u1"}, Text: &text, ReplyID: &rid, Visibility: model.NoteVisibilityPublic})
+		require.NoError(t, err)
+		assert.True(t, created.LocalOnly, "local-only note への reply は local-only に伝播")
+	})
+	t.Run("channel note forces public + localOnly + empty visibleUserIds", func(t *testing.T) {
+		svc, _, _ := newCreateService(t)
+		text := "ch"
+		cid := "ch1"
+		created, err := svc.Create(note.CreateInput{
+			User: &model.User{ID: "u1"}, Text: &text, ChannelID: &cid,
+			// channel note なのに followers + visibleUserIds を指定 → 強制で上書きされる。
+			Visibility: model.NoteVisibilityFollowers, VisibleUserIDs: []string{"x"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, model.NoteVisibilityPublic, created.Visibility, "channel note は public に強制")
+		assert.True(t, created.LocalOnly, "channel note は localOnly に強制")
+		assert.Empty(t, created.VisibleUserIDs, "channel note は visibleUserIds を空にする")
+	})
+}
+
 func TestCreateService_ReplyHappyPath(t *testing.T) {
 	svc, noteRepo, _ := newCreateService(t)
 	noteRepo.Notes["target"] = &model.Note{


### PR DESCRIPTION
## Summary

#1849 の個別敵対的レビューで判明した、`NoteCreateService` の visibility/localOnly 調整のうち renote 限定(#1849)で未対応だった残りを移植。

## 主な変更点

- **channel note の強制**(upstream `:463-465`): `in.ChannelID` が実 channel(非 nil かつ非空文字)のとき `visibility=public` / `localOnly=true` を強制し `visibleUserIds` を空にする。→ **mk-go が従来 channel note を followers 配送で連合させていた drop-in 乖離も解消**(upstream の channel note は常に local-only で非連合)。channel 判定は channel membership 操作(`EnsureChannelExists`/`OnNotePosted`)と同じ `!= nil && != ""`。
- **reply visibility 降格**(upstream `:531-533`): reply 先が非 public で本 note が public なら `home` に降格。
- **reply localOnly 伝播**(upstream `:541-543`): local-only な対象への reply(channel 外)は local-only に。

downgrade / localOnly OR は monotonic なので block 順(mk-go は reply→renote、upstream は renote→reply)で最終結果は不変。adjust 後の値が永続 note と federation hook に反映。

## レビュー

実装→敵対的レビュー(round-1: **CORRECT & FAITHFUL**、#1 concern の federation は「mk-go の従来連合が誤りで本 fix が upstream に正す」と確認)。NIT(空文字 channelId)を channel-membership gating に合わせて修正。channel-reply re-scoping + 空文字正規化は **#1859** に分離。

## テスト

- `TestCreateService_ReplyAndChannelVisibilityAdjustment`(reply→home / reply localOnly / channel forcing)。既存 channel/notes/stream テストに regression 無し。
- `go test ./internal/core/note/... -cover`: 94.8% green。`go build` / `go vet` / `gofmt -s -l` clean。

## Closes

Closes #1855

🤖 Generated with [Claude Code](https://claude.com/claude-code)