### PR TITLE
admin/reset-password を upstream 互換の {password:8文字} に統一 (#1825)

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -117,8 +117,6 @@ type Handler struct {
 	inviteRepo              repository.RegistrationTicketRepository
 	promoNoteRepo           repository.PromoNoteRepository
 	noteFinder              NoteFinder
-	resetReqRepo            repository.PasswordResetRequestRepository
-	emailSender             EmailSender
 	smtpProxyURL            string
 	serverURL               string
 	idGen                   id.Generator
@@ -242,11 +240,6 @@ func (h *Handler) invalidateUserTokenCache(userID string) {
 	h.userTokenInvalidator.InvalidateTokensForUser(userID)
 }
 
-// EmailSender sends a plain-text email (to, subject, body). Same signature
-// as the one used by internal/api/resetpassword so the router can share its
-// SMTP closure with admin.
-type EmailSender func(to, subject, body string)
-
 // NoteFinder is the minimal subset of repository.NoteRepository that admin
 // handlers need to validate a noteId. Kept narrow so tests can supply a tiny
 // fake without implementing the full NoteRepository surface.
@@ -347,17 +340,6 @@ func (h *Handler) SetPromoNoteRepo(r repository.PromoNoteRepository) { h.promoNo
 
 // SetNoteFinder attaches a NoteFinder used to validate noteId inputs.
 func (h *Handler) SetNoteFinder(r NoteFinder) { h.noteFinder = r }
-
-// SetPasswordResetRepo attaches the repository used by admin/reset-password
-// to persist reset tokens.
-func (h *Handler) SetPasswordResetRepo(r repository.PasswordResetRequestRepository) {
-	h.resetReqRepo = r
-}
-
-// SetEmailSender attaches the closure used to deliver admin-issued password
-// reset emails. If nil, admin/reset-password falls back to returning a
-// temporary password.
-func (h *Handler) SetEmailSender(s EmailSender) { h.emailSender = s }
 
 // SetSMTPProxyURL forwards admin/send-email TCP connections through the
 // configured proxy (cfg.ProxySmtp). Empty string disables the proxy and

--- a/internal/api/admin/password_reset.go
+++ b/internal/api/admin/password_reset.go
@@ -1,28 +1,25 @@
 package admin
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"net/http"
-	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/moderationlog"
 	"github.com/shiroha-a/mk/internal/misc"
-	"github.com/shiroha-a/mk/internal/model"
 	"golang.org/x/crypto/bcrypt"
 )
 
 // ResetPassword handles POST /api/admin/reset-password.
 //
-// 優先: 対象ユーザーに verified email があれば reset token を発行してメール
-// リンクを送り、HTTP 200 で {"sent": true} を返す (ユーザーが自分で新パス
-// ワードを設定する本家互換フロー #186)。
+// upstream reset-password.ts は常に secureRndstr(8) で 8 文字の英数字パスワードを
+// 生成し、その場で対象ユーザーの password を更新して {"password": "..."} を返す
+// (res schema は minLength/maxLength=8)。標準管理 UI (admin-user.vue) は返却を
+// `const {password} = ...` で分割代入して表示するため、mk-go もこれに揃える (#1825)。
 //
-// Fallback: email が verify されていない、repo / sender が未配線、
-// etc. の場合は従来どおりランダムなテンポラリパスワードを生成してその場で
-// 更新し、{"password": "..."} を返す。旧管理 UI との互換を保つ最後の砦。
+// 旧 #186 の verified-email 経路 ({"sent": true} を返し reset link を送る) は標準 UI で
+// password が undefined になり drop-in を壊すため撤去した。ユーザー自身が行う
+// パスワードリセット (/request-reset-password → /reset-password) は別経路で存続する。
 func (h *Handler) ResetPassword(c echo.Context) error {
 	var req struct {
 		UserID string `json:"userId"`
@@ -38,54 +35,17 @@ func (h *Handler) ResetPassword(c echo.Context) error {
 			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Cannot reset the password of a root account.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 		}
 	}
-	if sent := h.sendPasswordResetEmail(req.UserID); sent {
-		h.logUserAction(c, moderationlog.LogResetPassword, req.UserID)
-		return c.JSON(http.StatusOK, map[string]any{"sent": true})
+	// upstream secureRndstr(8) = 英数字 8 文字。
+	newPass := misc.SecureRandomString(8, misc.AlphanumericChars)
+	hash, err := bcrypt.GenerateFromPassword([]byte(newPass), bcrypt.DefaultCost)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 	}
-	return h.issueTemporaryPassword(c, req.UserID)
-}
-
-// sendPasswordResetEmail attempts the token+email flow. Returns true only
-// when a reset token was persisted and the email handed off to the sender.
-// Any missing dependency / unverified email triggers false for the caller
-// to pick up the legacy path.
-func (h *Handler) sendPasswordResetEmail(userID string) bool {
-	if h.resetReqRepo == nil || h.emailSender == nil || h.userRepo == nil {
-		return false
-	}
-	profile, err := h.userRepo.FindProfileByUserID(userID)
-	if err != nil || profile.Email == nil || *profile.Email == "" || !profile.EmailVerified {
-		return false
-	}
-	token := misc.SecureRandomHex(64)
-	now := time.Now()
-	resetReq := &model.PasswordResetRequest{
-		ID:     h.idGen.Generate(now),
-		Token:  token,
-		UserID: userID,
-	}
-	if err := h.resetReqRepo.Create(resetReq); err != nil {
-		return false
-	}
-	link := h.serverURL + "/reset-password/" + token
-	go h.emailSender(*profile.Email, "Password reset",
-		"An administrator initiated a password reset for your account.\n"+
-			"Use the following link within 30 minutes to set a new password:\n"+link)
-	return true
-}
-
-// issueTemporaryPassword is the legacy path retained for installations where
-// email is not configured or the user has no verified address. Generates a
-// random password, updates the profile, and returns it to the admin.
-func (h *Handler) issueTemporaryPassword(c echo.Context, userID string) error {
-	b := make([]byte, 8)
-	_, _ = rand.Read(b)
-	newPass := hex.EncodeToString(b)
-	hash, _ := bcrypt.GenerateFromPassword([]byte(newPass), bcrypt.DefaultCost)
 	if h.userRepo != nil {
-		if err := h.userRepo.UpdateProfile(userID, map[string]any{"password": string(hash)}); err == nil {
-			h.logUserAction(c, moderationlog.LogResetPassword, userID)
+		if err := h.userRepo.UpdateProfile(req.UserID, map[string]any{"password": string(hash)}); err != nil {
+			return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 		}
 	}
+	h.logUserAction(c, moderationlog.LogResetPassword, req.UserID)
 	return c.JSON(http.StatusOK, map[string]any{"password": newPass})
 }

--- a/internal/api/admin/password_reset_test.go
+++ b/internal/api/admin/password_reset_test.go
@@ -2,60 +2,19 @@ package admin_test
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/shiroha-a/mk/internal/core/moderationlog"
+	"github.com/shiroha-a/mk/internal/misc"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-type stubPasswordResetRepo struct {
-	created *model.PasswordResetRequest
-	err     error
-}
-
-func (s *stubPasswordResetRepo) Create(req *model.PasswordResetRequest) error {
-	if s.err != nil {
-		return s.err
-	}
-	s.created = req
-	return nil
-}
-
-func (s *stubPasswordResetRepo) FindByToken(_ string) (*model.PasswordResetRequest, error) {
-	return s.created, nil
-}
-
-func (s *stubPasswordResetRepo) Delete(_ string) error { return nil }
-
-type capturedEmail struct {
-	mu      sync.Mutex
-	to      string
-	subject string
-	body    string
-	called  int
-}
-
-func (c *capturedEmail) send(to, subject, body string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.called++
-	c.to = to
-	c.subject = subject
-	c.body = body
-}
-
-func (c *capturedEmail) snapshot() capturedEmail {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return capturedEmail{to: c.to, subject: c.subject, body: c.body, called: c.called}
-}
 
 // attachModLog wires a fresh moderation log service backed by the
 // shared race-safe testutil mock and returns the mock so the test can
@@ -81,13 +40,38 @@ func TestResetPasswordAdmin_Empty(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, doPost(h.ResetPassword, `{}`, adminUser).Code)
 }
 
+// upstream reset-password.ts は常に secureRndstr(8) で 8 文字の英数字パスワードを
+// その場で再設定して {password} を返す (res schema は min/maxLength=8)。mk-go も
+// shape を揃える (#1825)。
 func TestResetPasswordAdmin_Success(t *testing.T) {
 	h, userRepo, _, _ := newTestHandler(t)
 	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "testuser"}
 	userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1"}
 	rec := doPost(h.ResetPassword, `{"userId":"u1"}`, adminUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Contains(t, rec.Body.String(), "password")
+
+	var resp struct {
+		Password string `json:"password"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Password, 8, "upstream secureRndstr(8) は 8 文字")
+	for _, c := range resp.Password {
+		assert.Contains(t, misc.AlphanumericChars, string(c),
+			"password chars must be alphanumeric (LU_CHARS)")
+	}
+}
+
+// password 永続化に失敗したら 500 を返し、ハッシュ未保存のまま password を
+// 返してしまわないことを保証する (#1825 で error を握り潰さなくした)。
+func TestResetPasswordAdmin_UpdateProfileError(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "testuser"}
+	userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1"}
+	userRepo.UpdateProfileErr = errors.New("db down")
+
+	rec := doPost(h.ResetPassword, `{"userId":"u1"}`, adminUser)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "password")
 }
 
 // #1539: root アカウントのパスワードはリセットできない (upstream root guard)。
@@ -99,87 +83,10 @@ func TestResetPasswordAdmin_RootRejected(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "ACCESS_DENIED")
 }
 
-func TestResetPasswordAdmin_VerifiedEmailSendsResetLink(t *testing.T) {
-	h, userRepo, _, _ := newTestHandler(t)
-	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "testuser"}
-	email := "alice@example.com"
-	userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1", Email: &email, EmailVerified: true}
-
-	resetRepo := &stubPasswordResetRepo{}
-	captured := &capturedEmail{}
-	h.SetPasswordResetRepo(resetRepo)
-	h.SetEmailSender(captured.send)
-	h.SetServerURL("https://example.com")
-
-	rec := doPost(h.ResetPassword, `{"userId":"u1"}`, adminUser)
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Contains(t, rec.Body.String(), `"sent":true`)
-	assert.NotContains(t, rec.Body.String(), "password")
-
-	// Email は goroutine で送られるので少し待つ
-	deadline := time.Now().Add(500 * time.Millisecond)
-	var snap capturedEmail
-	for time.Now().Before(deadline) {
-		snap = captured.snapshot()
-		if snap.called > 0 {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	assert.Equal(t, 1, snap.called)
-	assert.Equal(t, email, snap.to)
-	assert.Equal(t, "Password reset", snap.subject)
-	require.NotNil(t, resetRepo.created, "reset token should be persisted")
-	assert.Contains(t, snap.body, resetRepo.created.Token,
-		"body should contain the persisted token in the reset link")
-	assert.Contains(t, snap.body, "https://example.com/reset-password/")
-}
-
-func TestResetPasswordAdmin_UnverifiedEmailFallsBack(t *testing.T) {
-	h, userRepo, _, _ := newTestHandler(t)
-	userRepo.Users["u1"] = &model.User{ID: "u1"}
-	email := "alice@example.com"
-	userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1", Email: &email, EmailVerified: false}
-
-	h.SetPasswordResetRepo(&stubPasswordResetRepo{})
-	captured := &capturedEmail{}
-	h.SetEmailSender(captured.send)
-
-	rec := doPost(h.ResetPassword, `{"userId":"u1"}`, adminUser)
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Contains(t, rec.Body.String(), "password")
-	assert.Equal(t, 0, captured.called, "unverified email must not trigger sender")
-}
-
-func TestResetPasswordAdmin_MissingEmailFallsBack(t *testing.T) {
-	h, userRepo, _, _ := newTestHandler(t)
-	userRepo.Users["u1"] = &model.User{ID: "u1"}
-	userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1"} // email = nil
-	h.SetPasswordResetRepo(&stubPasswordResetRepo{})
-	h.SetEmailSender(func(string, string, string) {})
-
-	rec := doPost(h.ResetPassword, `{"userId":"u1"}`, adminUser)
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Contains(t, rec.Body.String(), "password")
-}
-
-func TestResetPasswordAdmin_NoRepoFallsBack(t *testing.T) {
-	h, userRepo, _, _ := newTestHandler(t)
-	userRepo.Users["u1"] = &model.User{ID: "u1"}
-	email := "a@b.c"
-	userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1", Email: &email, EmailVerified: true}
-	h.SetEmailSender(func(string, string, string) {})
-	// Repo 未設定 → fallback
-
-	rec := doPost(h.ResetPassword, `{"userId":"u1"}`, adminUser)
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Contains(t, rec.Body.String(), "password")
-}
-
-func TestResetPasswordAdmin_WritesModerationLog_FallbackPath(t *testing.T) {
+func TestResetPasswordAdmin_WritesModerationLog(t *testing.T) {
 	h, userRepo, _, _ := newTestHandler(t)
 	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
-	userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1"} // email 未設定 → fallback
+	userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1"}
 
 	repo := attachModLog(t, h)
 
@@ -200,33 +107,6 @@ func TestResetPasswordAdmin_WritesModerationLog_FallbackPath(t *testing.T) {
 	assert.Equal(t, "alice", info["userUsername"])
 }
 
-func TestResetPasswordAdmin_WritesModerationLog_EmailPath(t *testing.T) {
-	h, userRepo, _, _ := newTestHandler(t)
-	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "bob"}
-	email := "bob@example.com"
-	userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1", Email: &email, EmailVerified: true}
-
-	h.SetPasswordResetRepo(&stubPasswordResetRepo{})
-	h.SetEmailSender(func(string, string, string) {})
-	repo := attachModLog(t, h)
-
-	rec := doPost(h.ResetPassword, `{"userId":"u1"}`, adminUser)
-	require.Equal(t, http.StatusOK, rec.Code)
-	assert.Contains(t, rec.Body.String(), `"sent":true`)
-
-	require.Eventually(t, func() bool {
-		return len(repo.Snapshot()) == 1
-	}, 500*time.Millisecond, 5*time.Millisecond, "moderation log should be written on email path")
-
-	logs := repo.Snapshot()
-	assert.Equal(t, "admin1", logs[0].UserID)
-	assert.Equal(t, "resetPassword", logs[0].Type)
-	var info map[string]any
-	require.NoError(t, json.Unmarshal(logs[0].Info, &info))
-	assert.Equal(t, "u1", info["userId"])
-	assert.Equal(t, "bob", info["userUsername"])
-}
-
 func TestResetPasswordAdmin_NoLogWhenServiceUnwired(t *testing.T) {
 	// service が未配線 (production で誤って setter を忘れた等) でも
 	// API 自体は機能し続けることを保証する。fire-and-forget の趣旨は
@@ -240,10 +120,9 @@ func TestResetPasswordAdmin_NoLogWhenServiceUnwired(t *testing.T) {
 }
 
 func TestResetPasswordAdmin_NoLogWhenTargetMissing(t *testing.T) {
-	// targetUserId が DB に存在しないケース。issueTemporaryPassword の
-	// UpdateProfile が成功しても logUserAction の FindByID が失敗して
-	// log は書かれない。レアケースだが logUserAction の lookup-failure
-	// branch を guard する。
+	// targetUserId が DB に存在しないケース。logUserAction の FindByID が
+	// 失敗して log は書かれない。レアケースだが logUserAction の
+	// lookup-failure branch を guard する。
 	h, _, _, _ := newTestHandler(t)
 	// u1 を userRepo に登録しない → FindByID は error 返す
 	repo := attachModLog(t, h)
@@ -272,18 +151,4 @@ func TestResetPasswordAdmin_NoLogWhenActorMissing(t *testing.T) {
 	require.Never(t, func() bool {
 		return len(repo.Snapshot()) > 0
 	}, 100*time.Millisecond, 10*time.Millisecond, "actor missing → log must not be written")
-}
-
-func TestResetPasswordAdmin_ResetRepoErrorFallsBack(t *testing.T) {
-	h, userRepo, _, _ := newTestHandler(t)
-	userRepo.Users["u1"] = &model.User{ID: "u1"}
-	email := "a@b.c"
-	userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1", Email: &email, EmailVerified: true}
-	h.SetPasswordResetRepo(&stubPasswordResetRepo{err: assertError{}})
-	h.SetEmailSender(func(string, string, string) {})
-
-	rec := doPost(h.ResetPassword, `{"userId":"u1"}`, adminUser)
-	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Contains(t, rec.Body.String(), "password",
-		"reset repo failure should fall back to legacy temp-password path")
 }

--- a/internal/misc/random.go
+++ b/internal/misc/random.go
@@ -18,3 +18,27 @@ func SecureRandomHex(n int) string {
 	}
 	return hex.EncodeToString(b)[:n]
 }
+
+// AlphanumericChars mirrors upstream secureRndstr's default LU_CHARS
+// (digits + lower + upper, 62 chars)。admin-issued temporary password 等で
+// upstream と shape を揃えるために使う (#1825)。
+const AlphanumericChars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+// SecureRandomString returns a cryptographically random string of length
+// characters drawn from chars. Mirrors upstream secureRndstr (62-char
+// alphanumeric set では modulo bias は無視できる程度で、upstream の
+// floor(byte/0xFF*len) と同程度)。RNG 失敗時は panic する。
+func SecureRandomString(length int, chars string) string {
+	if length <= 0 || len(chars) == 0 {
+		return ""
+	}
+	buf := make([]byte, length)
+	if _, err := io.ReadFull(randReader, buf); err != nil {
+		panic("crypto/rand failed: " + err.Error())
+	}
+	// 乱数バイト列をそのまま charset の index に写像して in-place で書き戻す。
+	for i := range buf {
+		buf[i] = chars[int(buf[i])%len(chars)]
+	}
+	return string(buf)
+}

--- a/internal/misc/random_test.go
+++ b/internal/misc/random_test.go
@@ -3,6 +3,7 @@ package misc
 import (
 	"errors"
 	"io"
+	"strings"
 	"testing"
 )
 
@@ -53,6 +54,52 @@ func TestSecureRandomHex_PanicsOnRandFailure(t *testing.T) {
 		}
 	}()
 	_ = SecureRandomHex(16)
+}
+
+func TestSecureRandomString_LengthAndCharset(t *testing.T) {
+	for _, n := range []int{1, 8, 16, 64} {
+		s := SecureRandomString(n, AlphanumericChars)
+		if len(s) != n {
+			t.Errorf("SecureRandomString(%d) returned length %d", n, len(s))
+		}
+		for _, c := range s {
+			if !strings.ContainsRune(AlphanumericChars, c) {
+				t.Errorf("char %q not in AlphanumericChars", c)
+			}
+		}
+	}
+}
+
+func TestSecureRandomString_EmptyInputs(t *testing.T) {
+	if got := SecureRandomString(0, AlphanumericChars); got != "" {
+		t.Errorf("length 0 should return empty, got %q", got)
+	}
+	if got := SecureRandomString(-1, AlphanumericChars); got != "" {
+		t.Errorf("negative length should return empty, got %q", got)
+	}
+	if got := SecureRandomString(8, ""); got != "" {
+		t.Errorf("empty charset should return empty, got %q", got)
+	}
+}
+
+func TestSecureRandomString_SingleCharCharset(t *testing.T) {
+	// 単一文字の charset では全桁がその文字になる (modulo が常に 0)。
+	if got := SecureRandomString(5, "x"); got != "xxxxx" {
+		t.Errorf("expected xxxxx, got %q", got)
+	}
+}
+
+func TestSecureRandomString_PanicsOnRandFailure(t *testing.T) {
+	orig := randReader
+	randReader = failingReader{}
+	defer func() { randReader = orig }()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic, got none")
+		}
+	}()
+	_ = SecureRandomString(8, AlphanumericChars)
 }
 
 // limitedReader returns exactly n bytes then io.EOF, useful for verifying

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2281,14 +2281,9 @@ func (s *Server) setupRoutes() {
 	// Undo(Delete) を remote instances へ配信する (#1759)。
 	adminHandler.SetUserModerationFederationHook(corefederation.NewUserModerationDeliveryHook(deliverService, apRenderer, userRepo))
 	adminHandler.SetDeleteAccountEnqueuer(s.queueClient)
-	adminHandler.SetPasswordResetRepo(resetReqRepo)
 	adminHandler.SetServerURL(s.config.URL)
 	adminHandler.SetConfigSetupPassword(s.config.SetupPassword)
 	adminHandler.SetSMTPProxyURL(s.config.ProxySmtp)
-	// admin/reset-password の確認メール送信。per-call 再 Fetch (#1112) +
-	// smtpSecure 反映 (#1111)。admin.EmailSender は (to, subject, body)
-	// 形式なので SubjectBodySenderFromMeta で wrap する。
-	adminHandler.SetEmailSender(miscsmtp.SubjectBodySenderFromMeta(metaRepo, s.config.ProxySmtp))
 	modLogService := coremodlog.New(modLogRepo, idGen)
 	adminHandler.SetModLogService(modLogService)
 	// #1765: moderator が他人の note を削除したとき deleteNote moderation log を残す。

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -23,6 +23,9 @@ type MockUserRepository struct {
 	// from ListUserRecommendations. Set by tests to emulate the "already
 	// following" filter.
 	RecommendationFollowing map[string][]string
+	// UpdateProfileErr, when non-nil, is returned by UpdateProfile so tests
+	// can exercise persistence-failure branches.
+	UpdateProfileErr error
 }
 
 func NewMockUserRepository() *MockUserRepository {
@@ -462,6 +465,9 @@ func (m *MockUserRepository) ListUserRecommendations(viewerID string, activeSinc
 }
 
 func (m *MockUserRepository) UpdateProfile(userID string, fields map[string]any) error {
+	if m.UpdateProfileErr != nil {
+		return m.UpdateProfileErr
+	}
 	p, ok := m.Profiles[userID]
 	if !ok {
 		// 既存プロフィールがなければ作成する(本物のDBではFK制約があるが、テストのモックでは緩い)


### PR DESCRIPTION
## Summary

全面マルチエージェント parity 再監査 (#1825, admin 領域 MEDIUM) の修正。`admin/reset-password` のレスポンス shape を upstream Misskey に揃える。

upstream `reset-password.ts` は常に `secureRndstr(8)` で 8 文字の英数字パスワードをその場で再設定し `{"password": "<8文字>"}` を返す (res schema は `minLength/maxLength=8`)。標準管理 UI `admin-user.vue` は `const {password} = ...` で分割代入して表示するため、mk-go の旧挙動が drop-in を壊していた:

- verified email がある場合 → reset link メールを送り `{"sent": true}` を返す (#186 拡張) → 標準 UI で `password` が undefined になり「新しいパスワードは undefined」と表示。
- fallback → `hex.EncodeToString(8 bytes)` = **16 文字** を返し、upstream の 8 文字制約から逸脱。

## 主な変更点

- `internal/api/admin/password_reset.go`: 常に `misc.SecureRandomString(8, misc.AlphanumericChars)` で 8 文字英数字を生成しその場で `UpdateProfile`、`{password}` を返す。email 経路 (`sendPasswordResetEmail`) を撤去。bcrypt / UpdateProfile の error を握り潰さず 500 を返すよう修正。
- `internal/misc/random.go`: upstream `LU_CHARS` 相当の `AlphanumericChars` 定数 + `SecureRandomString(length, chars)` を追加。
- `internal/api/admin/handler.go`: 不要になった `resetReqRepo` / `emailSender` field + `SetPasswordResetRepo` / `SetEmailSender` setter + `EmailSender` 型を撤去。
- `internal/server/router.go`: admin の `SetPasswordResetRepo` / `SetEmailSender` wiring を撤去。
- `internal/testutil/mock_repository.go`: `MockUserRepository.UpdateProfileErr` 注入 hook を追加。

ユーザー自身が行うパスワードリセット (`/request-reset-password` → `/reset-password`, `internal/api/resetpassword`) は独立に配線されており**無変更**。

## 注意点 / スコープ

- #1825 の LOW (find-by-email が UserDetailedNotMe でなく admin packer を返す) は **#1847 で修正済み**のため本 PR の対象外。
- 敵対的レビューで surface した「存在しない userId に偽 password を 200 で返す」隣接 divergence (pre-existing) は **#1862** に分離。

## テスト

- `internal/api/admin/password_reset_test.go`: email 経路のテストを撤去し、8 文字英数字 shape の assert / UpdateProfile error → 500 / moderation log / root guard をカバー。
- `internal/misc/random_test.go`: `SecureRandomString` の length・charset・空入力・単一文字 charset・panic をカバー。
- `make fmt && make lint` green。`go test ./internal/misc/ ./internal/api/admin/ ./internal/testutil/` green (misc 100% / admin 89.5% [gate 80%])。

Closes #1825

🤖 Generated with [Claude Code](https://claude.com/claude-code)