### PR TITLE
ap-inbound: inbound Follow の local-followee gate + Announce visibility を audience 由来に (#1826)

### DIFF
--- a/internal/core/federation/inbound_follow_block_test.go
+++ b/internal/core/federation/inbound_follow_block_test.go
@@ -126,3 +126,41 @@ func TestProcess_FollowBlockingWithoutBlockingServiceErrors(t *testing.T) {
 	assert.Error(t, p.Process(inboundFollowBody),
 		"without blockingService the ErrBlocking must propagate as before")
 }
+
+// inbound Follow が remote followee を対象にしている場合、local DB に
+// remote->remote の Following 行を作らず skip して ack する (#1826、upstream
+// follow() の `if (followee.host != null) return 'skip: ...'` gate)。これが無いと
+// relay / 悪意ある remote actor が Follow(actor=remoteA, object=既知 remoteB) を
+// 送るだけで following graph を汚染できる。
+func TestProcess_FollowRemoteFolloweeSkipped(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	resolver := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(aliceActor)}, idGen)
+	followingSvc := corefollowing.NewService(repo, followingRepo, testutil.NewMockFollowRequestRepository(), idGen)
+	p := federation.NewProcessor(resolver, followingSvc, nil, nil, repo, noteRepo)
+	p.SetLocalBaseURL("https://example.com")
+	acceptor := &stubInboundFollowAcceptor{}
+	p.SetInboundFollowAcceptor(acceptor)
+
+	// remote follower alice + remote followee charlie を URI 付きで pre-seed
+	host := "remote.example"
+	aliceURI := "https://remote.example/users/alice"
+	charlieURI := "https://remote.example/users/charlie"
+	repo.Users["alice1"] = &model.User{ID: "alice1", Username: "alice", UsernameLower: "alice", URI: &aliceURI, Host: &host}
+	repo.Users["charlie1"] = &model.User{ID: "charlie1", Username: "charlie", UsernameLower: "charlie", URI: &charlieURI, Host: &host}
+
+	body := []byte(`{
+		"type": "Follow",
+		"id": "https://remote.example/follows/remote1",
+		"actor": "https://remote.example/users/alice",
+		"object": "https://remote.example/users/charlie"
+	}`)
+
+	require.NoError(t, p.Process(body), "inbound follow targeting a remote followee must ack, not error")
+	assert.Empty(t, followingRepo.Followings, "no following row must be created for a remote followee")
+	assert.Empty(t, acceptor.calls, "no Accept for a remote followee")
+	assert.Empty(t, acceptor.rejects, "no Reject for a remote followee")
+}

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -590,6 +590,17 @@ func (p *Processor) handleFollow(act genericActivity) error {
 	if err != nil {
 		return errors.New("unknown followee")
 	}
+	// upstream follow() は followee が remote の場合 'skip: フォローしようと
+	// しているユーザーはローカルユーザーではありません' で明示的に拒否する
+	// (ApInboxService.ts)。これが無いと relay / 悪意ある remote actor が
+	// Follow(actor=remoteA, object=既知 remoteB) を送るだけで local DB に
+	// remoteA->remoteB の Following 行が作られ、フォロワー数や timeline fanout を
+	// 汚染できる。skip は error にせず ack して終わる (inbox retry を防ぐ) (#1826)。
+	if !followee.IsLocal() {
+		slog.Info("federation: skipping inbound Follow targeting a remote followee",
+			"follower", act.Actor, "followee", followeeURI)
+		return nil
+	}
 	// inbound AP Follow は AP protocol で withReplies を運ばないので
 	// FollowOptions{} (default false) で作成する (#1056)。remote follower の
 	// per-followee withReplies preference は AP protocol 範囲外。
@@ -1387,12 +1398,29 @@ func (p *Processor) handleAnnounce(act genericActivity) error {
 	// 遅延配送 Announce では activity.published を採用して timeline 並びを
 	// origin と揃える (#940)。空 / parse 不可なら nowFn にフォールバック。
 	now := parseAPPublishedTime(act.Published, nowFn())
+	// upstream announceNote は activity の to/cc から renote の visibility を決める。
+	// 旧実装は public 固定で、home renote 由来の Announce (Misskey renderAnnounce は
+	// home を to=[followers], cc=[Public] で送る) が public 化され public TL / RSS /
+	// 連合配送に乗っていた (#1826)。inbound Note と同じ deriveVisibility で揃える
+	// (Misskey renderAnnounce の public=to[Public] / home=to[followers]+cc[Public] /
+	// followers=to[followers] shape を正しく判定する)。実装が送らない exotic shape
+	// (cc のみ Public 等) での upstream parseAudience との差、および specified renote の
+	// visibleUsers / 通知の扱いは #1864 で別途対応する。
+	renoteVisibility := deriveVisibility(decodeAudience(act.To), decodeAudience(act.CC))
+	// upstream NoteCreateService は renote の visibility を対象 note 以下に clamp する
+	// (home note は public で renote できず home に落ちる)。target は上の gate で
+	// public/home に限定済みなので、home target に対する public boost を home に
+	// 落とす。これが無いと crafted Announce(to=[Public], object=home note) で home
+	// note を global timeline に leak させられる。
+	if target.Visibility == model.NoteVisibilityHome && renoteVisibility == model.NoteVisibilityPublic {
+		renoteVisibility = model.NoteVisibilityHome
+	}
 	renote := &model.Note{
 		ID:         p.resolver.idGen.Generate(now),
 		UserID:     announcer.ID,
 		UserHost:   announcer.Host,
 		RenoteID:   &target.ID,
-		Visibility: model.NoteVisibilityPublic,
+		Visibility: renoteVisibility,
 	}
 	if act.ID != "" {
 		uri := act.ID

--- a/internal/core/federation/processor_chart_test.go
+++ b/internal/core/federation/processor_chart_test.go
@@ -156,3 +156,98 @@ func TestProcess_NoteChartHook_NilSafe(t *testing.T) {
 	}`)
 	require.NoError(t, env.processor.Process(announce))
 }
+
+// handleAnnounce の renote visibility は activity の to/cc 由来で決まること
+// (#1826)。旧実装は public 固定で、Mastodon の unlisted boost
+// (to=[followers], cc=[Public]) 等が public 化され public TL / 連合配送に乗って
+// いた。inbound Note と同じ deriveVisibility (parseAudience 相当) で揃える。
+func TestProcess_AnnounceVisibilityFromAudience(t *testing.T) {
+	const followers = "https://remote.example/users/alice/followers"
+	const public = "https://www.w3.org/ns/activitystreams#Public"
+	cases := []struct {
+		name string
+		id   string
+		to   string
+		cc   string
+		want model.NoteVisibility
+	}{
+		{
+			name: "public boost (Public in to)",
+			id:   "vis-public",
+			to:   `["` + public + `"]`,
+			cc:   `["` + followers + `"]`,
+			want: model.NoteVisibilityPublic,
+		},
+		{
+			name: "unlisted boost (Public in cc, followers in to)",
+			id:   "vis-home",
+			to:   `["` + followers + `"]`,
+			cc:   `["` + public + `"]`,
+			want: model.NoteVisibilityHome,
+		},
+		{
+			name: "followers boost (followers only, no Public)",
+			id:   "vis-followers",
+			to:   `["` + followers + `"]`,
+			cc:   `[]`,
+			want: model.NoteVisibilityFollowers,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newFullProcessor(t, aliceActor)
+			hook := newRecordingNoteChartHook()
+			env.processor.SetNoteChartHook(hook)
+			env.noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "bob", Visibility: model.NoteVisibilityPublic}
+			env.userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob"}
+
+			body := []byte(`{
+				"type": "Announce",
+				"id": "https://remote.example/announces/` + tc.id + `",
+				"actor": "https://remote.example/users/alice",
+				"object": "https://example.com/notes/n1",
+				"to": ` + tc.to + `,
+				"cc": ` + tc.cc + `
+			}`)
+			require.NoError(t, env.processor.Process(body))
+
+			renoteID := hook.waitForOne(t)
+			renote := env.noteRepo.Notes[renoteID]
+			require.NotNil(t, renote, "renote must be persisted")
+			require.NotNil(t, renote.RenoteID)
+			assert.Equal(t, "n1", *renote.RenoteID, "renote must target n1")
+			assert.Equal(t, tc.want, renote.Visibility,
+				"renote visibility must be derived from the Announce audience")
+		})
+	}
+}
+
+// home target に対する public-audience boost は home に clamp される (#1826、
+// upstream NoteCreateService の renote visibility clamp)。これが無いと crafted
+// Announce(to=[Public], object=home note) で home note が global timeline に
+// leak する。
+func TestProcess_AnnounceVisibilityClampedToHomeTarget(t *testing.T) {
+	env := newFullProcessor(t, aliceActor)
+	hook := newRecordingNoteChartHook()
+	env.processor.SetNoteChartHook(hook)
+	// target note は home
+	env.noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "bob", Visibility: model.NoteVisibilityHome}
+	env.userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob"}
+
+	// Announce の audience は public (to=[Public]) だが target が home なので home に clamp
+	body := []byte(`{
+		"type": "Announce",
+		"id": "https://remote.example/announces/clamp-1",
+		"actor": "https://remote.example/users/alice",
+		"object": "https://example.com/notes/n1",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"],
+		"cc": ["https://remote.example/users/alice/followers"]
+	}`)
+	require.NoError(t, env.processor.Process(body))
+
+	renoteID := hook.waitForOne(t)
+	renote := env.noteRepo.Notes[renoteID]
+	require.NotNil(t, renote, "renote must be persisted")
+	assert.Equal(t, model.NoteVisibilityHome, renote.Visibility,
+		"public boost of a home target must be clamped to home")
+}


### PR DESCRIPTION
## Summary

全面マルチエージェント parity 再監査(2) の `ap-inbound` 領域 2 MEDIUM divergence の修正。

## 主な変更点

### 1. inbound Follow が remote followee を弾かない (following graph 汚染) — `handleFollow`

`internal/core/federation/processor.go` の `handleFollow` は followee を `resolveTargetUser` で引いた後 local かを検査せず `followingService.Follow` を呼んでいた。`followingService.Follow` 側も followee の local 性を検査しない (self-follow / block / already gate のみ)。

そのため relay / 悪意ある remote actor が `Follow(actor=remoteA, object=DB に既知の remoteB の URI)` を送るだけで、local DB に `remoteA->remoteB` の Following 行が作られ、フォロワー数や timeline fanout を汚染できた。

upstream `ApInboxService.follow()` の `if (followee.host != null) return 'skip: ...'` に倣い、remote followee の inbound Follow は skip して ack する (error にすると inbox retry → dead-letter になり、相手の pending follow が解消されないため)。`handleUndoFollow` 側は remote->remote 行が作られなくなるため `Unfollow` が `ErrNotFollowing`→nil で no-op となり、追加 gate は不要。

### 2. Announce(renote) の visibility を public 固定にしていた — `handleAnnounce`

renote を常に `Visibility=public` で生成していたため、home renote 由来の Announce (Misskey `renderAnnounce` は home を `to=[followers], cc=[Public]` で送る) 等が public 化され public TL / RSS / 連合配送に乗っていた。

inbound Note と同じ `deriveVisibility` で activity の `to`/`cc` から visibility を判定するよう変更。さらに upstream `NoteCreateService` の renote visibility clamp に倣い、home target への public boost を home に落とす (`crafted Announce(to=[Public], object=home note)` による home note の global timeline leak も防ぐ)。

`deriveVisibility` は Misskey `renderAnnounce` の public/home/followers 3 shape を正しく判定する (敵対的レビューで Mastodon/Pleroma/Firefish/Sharkey 等の実 shape も specified に落ちないことを確認済み)。

## スコープ / 分離した follow-up

- 実装が送らない exotic audience shape (`cc` のみ Public、`as:Public` alias 等) での `parseAudience` との差、および exotic な specified renote の `visibleUsers` / 通知 (`notifyVisibleToTarget` の renote-gate が upstream の無条件 `nm.push` と乖離) は **#1864** に分離。実トラフィックでは発生しない shape のため本 PR の対象外。

## テスト

- `TestProcess_FollowRemoteFolloweeSkipped`: remote followee の inbound Follow で Following 行が作られず ack されること。
- `TestProcess_AnnounceVisibilityFromAudience`: public (`to=[Public]`) / home (`to=[followers], cc=[Public]`) / followers (`to=[followers]`) の 3 ケースで renote visibility が audience 由来になること。
- `TestProcess_AnnounceVisibilityClampedToHomeTarget`: home target への public boost が home に clamp されること。
- `make fmt && make lint` green。`go test ./internal/core/federation/` green (coverage 90.2%)。

Closes #1826

🤖 Generated with [Claude Code](https://claude.com/claude-code)