### PR TITLE
admin/reset-password が存在しない userId に偽 password を返すのを NO_SUCH_USER に (#1862)

### DIFF
--- a/internal/api/admin/modlog_helpers_internal_test.go
+++ b/internal/api/admin/modlog_helpers_internal_test.go
@@ -40,3 +40,23 @@ func TestLogUserActionWithUser_NilTargetIsNoop(t *testing.T) {
 		t.Errorf("expected no log writes, got %d", len(got))
 	}
 }
+
+// logUserAction が targetUserID を FindByID で引けない (= 削除済 / bogus id) 場合は
+// debug ログだけ残して何も書かないことを直接 guard する。reset-password が
+// 存在チェックを前段に持つようになり (#1862) このパスを踏まなくなったので
+// helper 単体で覆う。
+func TestLogUserAction_MissingTargetIsNoop(t *testing.T) {
+	repo := testutil.NewMockModerationLogRepository()
+	gen, err := id.NewGenerator("aidx")
+	if err != nil {
+		t.Fatalf("idgen: %v", err)
+	}
+	// userRepo は空 → FindByID は ErrNotFound を返す。
+	h := &Handler{userRepo: testutil.NewMockUserRepository(), modLogService: moderationlog.New(repo, gen)}
+
+	h.logUserAction(newCtx(), moderationlog.LogResetPassword, "ghost")
+
+	if got := repo.Snapshot(); len(got) != 0 {
+		t.Errorf("expected no log writes for a missing target, got %d", len(got))
+	}
+}

--- a/internal/api/admin/password_reset.go
+++ b/internal/api/admin/password_reset.go
@@ -7,6 +7,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/moderationlog"
 	"github.com/shiroha-a/mk/internal/misc"
+	"github.com/shiroha-a/mk/internal/model"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -27,13 +28,23 @@ func (h *Handler) ResetPassword(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.UserID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "userId is required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
-	// upstream reset-password.ts は rootUserId===target で 'cannot reset password
-	// of root' を投げる。mk-go は他の admin guard (suspend-user) と揃えて root を
-	// ACCESS_DENIED で弾く (#1539)。userRepo 未配線時は guard を skip。
+	// upstream reset-password.ts は findOneBy({id}) で対象を引き、user==null なら
+	// 'user not found' を throw する。mk-go は他の admin user-lookup (#1542 の roles
+	// assign 等) と揃えて NO_SUCH_USER を返す (#1862)。これが無いと存在しない userId
+	// でも UpdateProfile の 0 行 UPDATE が no-op で成功し、実際には設定されていない
+	// 偽の password を 200 で返してしまう。root は他の admin guard (suspend-user) と
+	// 揃えて ACCESS_DENIED で弾く (#1539)。userRepo 未配線時は guard を skip
+	// (production では常に配線済み)。
+	var target *model.User
 	if h.userRepo != nil {
-		if user, err := h.userRepo.FindByID(req.UserID); err == nil && user.IsRoot {
+		user, err := h.userRepo.FindByID(req.UserID)
+		if err != nil || user == nil {
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "2b730f78-1179-461b-88ad-d24c9af1a5ce"))
+		}
+		if user.IsRoot {
 			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Cannot reset the password of a root account.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 		}
+		target = user
 	}
 	// upstream secureRndstr(8) = 英数字 8 文字。
 	newPass := misc.SecureRandomString(8, misc.AlphanumericChars)
@@ -46,6 +57,7 @@ func (h *Handler) ResetPassword(c echo.Context) error {
 			return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 		}
 	}
-	h.logUserAction(c, moderationlog.LogResetPassword, req.UserID)
+	// 存在チェックで既に target を引いているので二度引きしない (logUserActionWithUser)。
+	h.logUserActionWithUser(c, moderationlog.LogResetPassword, target)
 	return c.JSON(http.StatusOK, map[string]any{"password": newPass})
 }

--- a/internal/api/admin/password_reset_test.go
+++ b/internal/api/admin/password_reset_test.go
@@ -119,16 +119,17 @@ func TestResetPasswordAdmin_NoLogWhenServiceUnwired(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
-func TestResetPasswordAdmin_NoLogWhenTargetMissing(t *testing.T) {
-	// targetUserId が DB に存在しないケース。logUserAction の FindByID が
-	// 失敗して log は書かれない。レアケースだが logUserAction の
-	// lookup-failure branch を guard する。
+func TestResetPasswordAdmin_TargetMissing(t *testing.T) {
+	// 存在しない userId への reset-password は upstream の 'user not found' に倣い
+	// NO_SUCH_USER を返し、password を再設定せず moderation log も残さない (#1862)。
 	h, _, _, _ := newTestHandler(t)
 	// u1 を userRepo に登録しない → FindByID は error 返す
 	repo := attachModLog(t, h)
 
 	rec := doPost(h.ResetPassword, `{"userId":"u1"}`, adminUser)
-	assert.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_USER")
+	assert.NotContains(t, rec.Body.String(), "password")
 
 	require.Never(t, func() bool {
 		return len(repo.Snapshot()) > 0


### PR DESCRIPTION
## Summary

#1825 (admin/reset-password の shape 修正) の敵対的レビューで surface した隣接 divergence の修正。

upstream `reset-password.ts` は `findOneBy({id})` で対象を引き、`user == null` なら `'user not found'` を throw する。mk-go は root guard の `FindByID` が error を返しても (`err == nil && user.IsRoot` の条件のため) guard を skip して先へ進み、`UpdateProfile` の 0 行 UPDATE が no-op で nil error を返すため、**存在しない userId に対して「実際にはどこにも設定されていない偽の 8 文字 password」を HTTP 200 で返していた**。

## 主な変更点

- `internal/api/admin/password_reset.go`: root guard の `FindByID` を存在チェックに昇格。`user` 不在なら他の admin user-lookup (#1542 の roles assign/unassign 等) と揃えて `NO_SUCH_USER` (404) を返す。
- 既に存在チェックで `target` を引いているので、`logUserAction` (内部で再 `FindByID`) ではなく `logUserActionWithUser(c, ..., target)` を使い二度引きを避ける (purpose-built helper の想定用途)。
- `internal/api/admin/modlog_helpers_internal_test.go`: reset-password が前段で存在チェックするようになり `logUserAction` の missing-target branch を経由しなくなるため、helper 単体テスト `TestLogUserAction_MissingTargetIsNoop` を追加して coverage を維持 (`logUserAction` 57.1%→85.7%)。

## テスト

- `TestResetPasswordAdmin_TargetMissing`: 存在しない userId → 404 NO_SUCH_USER、password を返さず moderation log も残さない。
- `TestLogUserAction_MissingTargetIsNoop`: helper の lookup-failure branch を直接 guard。
- 既存の reset-password テスト (Success / RootRejected / WritesModerationLog / UpdateProfileError / NoLogWhenServiceUnwired / NoLogWhenActorMissing) は不変で pass。
- `make fmt && make lint` green。`go test ./internal/api/admin/` green (coverage 89.5%、gate 80%)。

Closes #1862

🤖 Generated with [Claude Code](https://claude.com/claude-code)