### PR TITLE
deriveVisibility を upstream parseAudience に忠実化 + renote 通知 gate の re-verify (#1864)

### DIFF
--- a/internal/core/federation/create_audience_internal_test.go
+++ b/internal/core/federation/create_audience_internal_test.go
@@ -238,3 +238,33 @@ func TestEncodeAudienceIfChanged(t *testing.T) {
 		assert.JSONEq(t, `["a"]`, string(out))
 	})
 }
+
+// TestDeriveVisibility seals the parseAudience-faithful mapping (#1864):
+// to-Public→public, cc-Public→home (no followers-in-to requirement),
+// followers in to OR cc→followers, else specified. Also covers the
+// as:Public / bare Public aliases upstream isPublic accepts.
+func TestDeriveVisibility(t *testing.T) {
+	const followers = "https://remote.example/users/alice/followers"
+	cases := []struct {
+		name string
+		to   []string
+		cc   []string
+		want string
+	}{
+		{"to has Public", []string{activitypub.Public}, []string{followers}, "public"},
+		{"unlisted: followers in to, Public in cc", []string{followers}, []string{activitypub.Public}, "home"},
+		{"cc-only Public, no followers in to", nil, []string{activitypub.Public}, "home"},
+		{"cc-only Public with mention in to", []string{"https://x/u1"}, []string{activitypub.Public}, "home"},
+		{"followers in to only", []string{followers}, nil, "followers"},
+		{"followers in cc only", nil, []string{followers}, "followers"},
+		{"specified: only mentions", []string{"https://x/u1"}, nil, "specified"},
+		{"empty audience", nil, nil, "specified"},
+		{"as:Public alias in to", []string{"as:Public"}, nil, "public"},
+		{"bare Public alias in cc", nil, []string{"Public"}, "home"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, string(deriveVisibility(tc.to, tc.cc)))
+		})
+	}
+}

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -1865,12 +1865,21 @@ func (r *Resolver) upsertEmojis(tags []activitypub.EmojiTag, host string) pq.Str
 	return names
 }
 
-// deriveVisibility maps an AS to/cc audience pair to a Misskey visibility.
+// deriveVisibility maps an AS to/cc audience pair to a Misskey visibility,
+// mirroring upstream ApAudienceService.parseAudience (#1864):
 //
 //   - to に Public があれば public
-//   - cc に Public があり to に followers があれば home
-//   - to に followers のみ (Public 無し) なら followers
+//   - cc に Public があれば home
+//   - to / cc のいずれかに followers があれば followers
 //   - それ以外 (specific actor 列挙) は specified
+//
+// Public は upstream isPublic と同じく full IRI / as:Public / 裸 Public の 3 形式を
+// 受ける。followers collection の判定は upstream isFollowers のような actor の
+// followersUri 厳密一致ではなく /followers サフィックスで近似する。このため別 actor の
+// followers URL が to/cc に入っていると upstream の specified でなく followers になる等の
+// 差は出るが、to/cc は note の author (Announce では announcer) が自分の note/boost に
+// 対して設定するものなので、緩めても自分のコンテンツの可視性が変わるだけで第三者の
+// note を露出させることはない。
 func deriveVisibility(to, cc []string) model.NoteVisibility {
 	hasFollowers := func(list []string) bool {
 		for _, v := range list {
@@ -1880,16 +1889,27 @@ func deriveVisibility(to, cc []string) model.NoteVisibility {
 		}
 		return false
 	}
-	if slices.Contains(to, activitypub.Public) {
+	if hasPublicAudience(to) {
 		return model.NoteVisibilityPublic
 	}
-	if slices.Contains(cc, activitypub.Public) && hasFollowers(to) {
+	if hasPublicAudience(cc) {
 		return model.NoteVisibilityHome
 	}
-	if hasFollowers(to) {
+	if hasFollowers(to) || hasFollowers(cc) {
 		return model.NoteVisibilityFollowers
 	}
 	return model.NoteVisibilitySpecified
+}
+
+// hasPublicAudience reports whether list contains the AS public collection in
+// any of the forms upstream ApAudienceService.isPublic accepts (#1864)。
+func hasPublicAudience(list []string) bool {
+	for _, v := range list {
+		if v == activitypub.Public || v == "as:Public" || v == "Public" {
+			return true
+		}
+	}
+	return false
 }
 
 // hostFromURI extracts the host portion from an actor URI.

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -1034,6 +1034,23 @@ func TestIngestNote_HomeVisibility(t *testing.T) {
 	assert.Equal(t, model.NoteVisibilityHome, got.Visibility)
 }
 
+// cc にのみ Public があり to に followers が無い shape も home に解決する。旧
+// deriveVisibility は home 判定に followers-in-to を要求していたため specified に
+// 落としていたが、upstream parseAudience は cc に Public があれば home とする (#1864)。
+func TestIngestNote_CCOnlyPublicVisibility(t *testing.T) {
+	// to=[], cc=[Public] → home
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+
+	body := makeNoteJSON("vis-cc-public", []string{}, []string{"https://www.w3.org/ns/activitystreams#Public"})
+	got, err := r.IngestNote(body)
+	require.NoError(t, err)
+	assert.Equal(t, model.NoteVisibilityHome, got.Visibility)
+}
+
 func TestIngestNote_FollowersVisibility(t *testing.T) {
 	// to=[followers], cc=[] → followers
 	repo := testutil.NewMockUserRepository()


### PR DESCRIPTION
## Summary

#1826 (ap-inbound Announce) の敵対的レビューで分離した visibility-edge parity refinement。2 項目あり、着手時の現コード再検証で内訳が変わった。

## 項目 1 (実装): deriveVisibility を upstream parseAudience に忠実化

`internal/core/federation/resolver.go` の `deriveVisibility` は inbound Note ingest (resolver.go:1058) と Announce renote (handleAnnounce) の to/cc → visibility 判定に共用される。旧実装は upstream `ApAudienceService.parseAudience` と以下が乖離していた:

- home 判定に `followers in to` を要求していた (upstream は `cc に Public` だけで home)。
- followers を `to` のみで判定 (upstream は `to OR cc`)。
- Public を canonical IRI のみ照合し `as:Public` / 裸 `Public` alias を拾わなかった (upstream `isPublic` は 3 形式)。

このため `cc=[Public], to=[]` のような shape が `specified` に落ち、sender の unlisted 意図に反して非公開化されていた。parseAudience 同等の分岐 (`to`∋Public→public / `cc`∋Public→home / followers∋(to|cc)→followers / else specified) に修正し、Public 3 形式は `hasPublicAudience` helper で判定する。

followers collection の判定は upstream `isFollowers` の `actor.followersUri` 厳密一致まではせず `/followers` サフィックスで近似する。to/cc は note の author (Announce では announcer) が自分の note/boost に対して設定するものなので、緩めても自分のコンテンツの可視性が変わるだけで第三者の note を露出させることはない (コメントに明記)。

## 項目 2 (再検証で false positive 確定): renote 通知の visibility-gate

`notifyVisibleToTarget` (`internal/core/notification/hooks.go`) が renote-target 通知を visibility-gate しているのは upstream との乖離、という指摘だったが、**現コード再検証の結果 false positive**。

upstream `NoteCreateService` の `NotificationManager.notify()` は queue した通知を note visibility で filter する (#17335/#17363、2026.5.x): public/home/followers→filter なし、specified→`visibleUserIds` のみ、default→誰にも通知しない。renote 通知 (`reason === 'renote'`) もこの filter の内側にある。`push()` は queue するだけで filter は `notify()` 側 (= #1826 round-1 review が `push` call site だけ見て誤認した箇所)。

mk-go の `notifyVisibleToTarget` はこの filter を renote 含め忠実に複製済みで、gate を外すと #17335 が塞いだ specified note の情報漏洩 (通知から本文 URL が辿れる) を再発させる。よって**変更せず維持**する。

specified Announce renote の visibleUsers 未設定は、boost を特定ユーザー宛だけにする shape (mainstream fedi 実装は emit しない degenerate) でのみ問題化し、その場合も upstream の「visibleUserIds 空 → 誰にも通知しない」と一致するため追加対応不要。

## テスト

- `TestDeriveVisibility`: 10 ケース (divergent shape `cc-only Public→home` / `followers-in-cc→followers`、`as:Public`/裸 `Public` alias、specified/empty)。
- `TestIngestNote_CCOnlyPublicVisibility`: `cc=[Public], to=[]` → home の end-to-end ingest。
- 既存の inbound Note / Announce visibility テストは全 pass (canonical shape は judgement 不変)。
- `make fmt && make lint` green。`go test ./internal/core/federation/` green (coverage 90.2%)。

Closes #1864

🤖 Generated with [Claude Code](https://claude.com/claude-code)