### PR TITLE
localOnly カスタム絵文字を AP tag から除外する (#1868)

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -623,6 +623,13 @@ func (r *Renderer) addEmojiTags(tags *[]any, emojiNames []string, host *string) 
 		if err != nil {
 			continue
 		}
+		// localOnly 絵文字は『この instance 限定』の明示意図なので AP tag から
+		// 除外する (upstream renderNote/renderPerson の emojis.filter(e => !e.localOnly)
+		// / renderLike の !emoji.localOnly と同じ、#1868)。FindByNameAndHost は
+		// 表示/リアクション経路とも共有するので gate は render 側に置く。
+		if emoji.LocalOnly {
+			continue
+		}
 		tag := EmojiTag{
 			Type: "Emoji",
 			Name: ":" + emoji.Name + ":",

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -985,6 +985,48 @@ func TestRenderer_RenderPerson_EmojiTag(t *testing.T) {
 	assert.Equal(t, ":verified:", et.Name)
 }
 
+// localOnly 絵文字は連合させない意図なので note/Person/Like の AP tag から
+// 除外する (#1868、upstream renderer の localOnly filter と一致)。
+func TestRenderer_RenderNote_LocalOnlyEmojiExcluded(t *testing.T) {
+	r := newRenderer()
+	r.SetEmojiResolver(&stubEmojiResolver{emojis: map[string]*model.Emoji{
+		"pub":    {Name: "pub", PublicURL: "https://example.com/files/pub.webp"},
+		"secret": {Name: "secret", PublicURL: "https://example.com/files/secret.webp", LocalOnly: true},
+	}})
+	idGen := newIDGen(t)
+	n := &model.Note{
+		ID:         idGen.Generate(time.Now()),
+		UserID:     "author",
+		Visibility: model.NoteVisibilityPublic,
+		Emojis:     pq.StringArray{"pub", "secret"},
+	}
+	out := r.RenderNote(n, idGen)
+	require.Len(t, out.Tag, 1, "localOnly emoji must be excluded")
+	et, ok := out.Tag[0].(EmojiTag)
+	require.True(t, ok)
+	assert.Equal(t, ":pub:", et.Name)
+}
+
+func TestRenderer_RenderPerson_LocalOnlyEmojiExcluded(t *testing.T) {
+	r := newRenderer()
+	r.SetEmojiResolver(&stubEmojiResolver{emojis: map[string]*model.Emoji{
+		"secret": {Name: "secret", PublicURL: "https://example.com/files/secret.webp", LocalOnly: true},
+	}})
+	u := &model.User{ID: "u1", Username: "alice", Emojis: pq.StringArray{"secret"}}
+	p := r.RenderPerson(u, nil, "PUBKEY", nil)
+	assert.Empty(t, p.Tag, "localOnly emoji must be excluded from Person tag")
+}
+
+func TestRenderer_RenderLike_LocalOnlyEmojiNoTag(t *testing.T) {
+	r := newRenderer()
+	r.SetEmojiResolver(&stubEmojiResolver{emojis: map[string]*model.Emoji{
+		"secret": {Name: "secret", PublicURL: "https://example.com/files/secret.webp", LocalOnly: true},
+	}})
+	reactor := &model.User{ID: "alice"}
+	l := r.RenderLike(reactor, "https://remote.example/notes/n1", ":secret@.:", "https://example.com/likes/l9")
+	assert.Empty(t, l.Tag, "localOnly emoji must not be emitted as Like tag")
+}
+
 func TestRenderer_RenderNote_ContextIncludesMisskey(t *testing.T) {
 	r := newRenderer()
 	idGen := newIDGen(t)


### PR DESCRIPTION
## Summary

#1827 (ap-outbound 再監査(2)) を sub-issue 分割した 1 件目。

`internal/activitypub/renderer.go` の `addEmojiTags` は `FindByNameAndHost` で引いた絵文字を無条件に `EmojiTag` として append しており、`localOnly=true` (この instance 限定の明示意図) の custom emoji が note / Person / Like の `tag` として remote へ送出され、受信側のローカル絵文字テーブルへ upsert される意図外 leak になっていた。

upstream `ApRendererService` は renderNote/renderPerson で `emojis.filter(e => !e.localOnly)`、renderLike で `if (emoji && !emoji.localOnly)` と localOnly を除外する。

## 主な変更点

- `addEmojiTags` に `if emoji.LocalOnly { continue }` gate を追加。note(:464) / Person(:320) / Like(:992) の全 emit 経路がこの共有 helper を通るため 1 箇所で 3 サイトを upstream の 3 filter と同等にカバー。
- gate は `FindByNameAndHost` (表示・リアクション解決・画像 redirect 等の非連合経路と共有) ではなく render 側に置き、localOnly 絵文字のローカル表示は壊さない。

## テスト

- `TestRenderer_RenderNote_LocalOnlyEmojiExcluded`: public + localOnly 混在で public のみ tag に残る。
- `TestRenderer_RenderPerson_LocalOnlyEmojiExcluded` / `TestRenderer_RenderLike_LocalOnlyEmojiNoTag`: localOnly のみ → tag 空。
- 既存の emoji-tag テスト (非 localOnly は emit される) は不変で pass。
- `make fmt && make lint` green。`go test ./internal/activitypub/` green (coverage 90.9%)。

Closes #1868

🤖 Generated with [Claude Code](https://claude.com/claude-code)