### PR TITLE
Person.url を /@<username> の human-facing profile URL にする (#1869)

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -33,6 +33,13 @@ func (b *URLBuilder) UserURI(userID string) string {
 	return b.baseURL + "/users/" + userID
 }
 
+// UserProfileURL returns the human-facing profile page URL (/@username),
+// used as the actor's `url` field distinct from its `id` (/users/<id>)。
+// upstream renderPerson の url: `${config.url}/@${user.username}` に揃える (#1869)。
+func (b *URLBuilder) UserProfileURL(username string) string {
+	return b.baseURL + "/@" + username
+}
+
 // UserInbox returns the inbox URL for a user.
 func (b *URLBuilder) UserInbox(userID string) string {
 	return b.UserURI(userID) + "/inbox"
@@ -254,9 +261,13 @@ func (r *Renderer) RenderPerson(u *model.User, profile *model.UserProfile, publi
 		Followers:         r.urls.UserFollowers(u.ID),
 		Following:         r.urls.UserFollowing(u.ID),
 		PreferredUsername: u.Username,
-		URL:               uri,
-		SharedInbox:       r.urls.SharedInbox(), // top-level (#1560)
-		Endpoints:         Endpoints{SharedInbox: r.urls.SharedInbox()},
+		// url は id (/users/<id>) と区別し、人間向け profile ページ /@<username> を
+		// 指す (#1869、upstream renderPerson)。連合向け caller は local user (Host==nil)
+		// のみ RenderPerson に渡す前提なので自ドメインの /@username で正しい
+		// (admin debug 経路 resolveLocal の host guard 欠落は #1873 で別途対応)。
+		URL:         r.urls.UserProfileURL(u.Username),
+		SharedInbox: r.urls.SharedInbox(), // top-level (#1560)
+		Endpoints:   Endpoints{SharedInbox: r.urls.SharedInbox()},
 		PublicKey: PublicKey{
 			ID:           r.urls.UserKeyURI(u.ID),
 			Owner:        uri,

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -23,6 +23,7 @@ func newRenderer() *Renderer {
 func TestURLBuilder_Helpers(t *testing.T) {
 	b := NewURLBuilder("https://example.com")
 	assert.Equal(t, "https://example.com/users/u1", b.UserURI("u1"))
+	assert.Equal(t, "https://example.com/@alice", b.UserProfileURL("alice"))
 	assert.Equal(t, "https://example.com/users/u1/inbox", b.UserInbox("u1"))
 	assert.Equal(t, "https://example.com/users/u1/outbox", b.UserOutbox("u1"))
 	assert.Equal(t, "https://example.com/users/u1/followers", b.UserFollowers("u1"))
@@ -154,6 +155,9 @@ func TestRenderer_RenderPerson(t *testing.T) {
 	}
 	p := r.RenderPerson(u, nil, "PUBKEY", nil)
 	assert.Equal(t, "https://example.com/users/u1", p.ID)
+	// url は id と区別し、人間向け profile ハンドル /@<username> を指す (#1869)。
+	assert.Equal(t, "https://example.com/@alice", p.URL)
+	assert.NotEqual(t, p.ID, p.URL, "actor url must differ from id")
 	assert.Equal(t, "Person", p.Type)
 	assert.Equal(t, "alice", p.PreferredUsername)
 	assert.Equal(t, "Alice", p.Name)


### PR DESCRIPTION
## Summary

#1827 (ap-outbound 再監査(2)) sub-issue 2 件目 (LOW / cosmetic)。

`RenderPerson` は actor の `url` に actor URI (`/users/<id>`) をそのまま入れており `id` と `url` が同値だった。upstream `ApRendererService.renderPerson` は `url: ${config.url}/@${user.username}` (ブラウザ向け profile ページ) にし `id` と区別する。一部 client が `url` を人間向けリンクとして表示する際の shape drift。

## 主な変更点

- `URLBuilder.UserProfileURL(username)` (`baseURL + "/@" + username`) を追加。
- `RenderPerson` の `URL` を actor URI から `/@<username>` に変更。

local username は `^[a-zA-Z0-9_]{1,20}$` で URL-safe のため raw 補間で安全 (webfinger / `i/handler` も同じ `/@username` を使用済み)。連合向け 3 caller (UserByID / UserByAcct / profile_update_delivery_hook) は `Host==nil` を guard するため自ドメインの /@username で正しい。

## スコープ / follow-up

- 敵対的レビューで surface した「admin-only `POST /api/ap/get` の `resolveLocal` が remote user を host guard 無しで RenderPerson に渡す」pre-existing gap は **#1873** に分離 (連合配送されない debug 経路、LOW)。

## テスト

- `TestURLBuilder_Helpers` に `UserProfileURL("alice") == /@alice` を追加。
- `TestRenderer_RenderPerson` に `p.URL == /@alice` / `p.URL != p.ID` を追加。
- `make fmt && make lint` green。`go test ./internal/activitypub/` green (coverage 90.9%)。

Closes #1869

🤖 Generated with [Claude Code](https://claude.com/claude-code)