### PR TITLE
relay 配送に RsaSignature2017 LD-Signature を付与する (#1870)

### DIFF
--- a/internal/activitypub/ld/sign.go
+++ b/internal/activitypub/ld/sign.go
@@ -1,0 +1,96 @@
+package ld
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"time"
+)
+
+// ldNonceRand is the randomness source for the signature nonce. テスト時に
+// 差し替え可能にするためパッケージ変数として公開。
+var ldNonceRand io.Reader = rand.Reader
+
+// SignRsaSignature2017 attaches an RsaSignature2017 LD-Signature to activity,
+// authored by the holder of privateKeyPEM. creator is the signing key URI
+// (e.g. "https://example.com/users/<id>#main-key").
+//
+// Mirrors upstream Misskey TS `JsonLdService.signRsaSignature2017` byte-for-byte
+// (= options{type,creator,nonce,created} → createVerifyData → sha256 →
+// RSA-PKCS1v15 SHA-256 sign → signatureValue base64)。出力は
+// VerifyRsaSignature2017 および remote Misskey/Mastodon の LD-Signature verifier で
+// 検証可能。
+//
+// activity は変更せず、`signature` field を加えたコピーを返す。
+func (p *Processor) SignRsaSignature2017(activity map[string]any, privateKeyPEM, creator string, created time.Time) (map[string]any, error) {
+	nonceBytes := make([]byte, 16)
+	if _, err := io.ReadFull(ldNonceRand, nonceBytes); err != nil {
+		return nil, fmt.Errorf("ld-sig: nonce generation failed: %w", err)
+	}
+	// createVerifyData は options から type/id/signatureValue を除き、nonce/created/
+	// creator は残して normalize する。verify 側も同じ処理をするので、これらを
+	// 後段で attach する signature object に同値で含めれば検証が通る。
+	options := map[string]any{
+		"type":    LDSignatureType,
+		"creator": creator,
+		"nonce":   hex.EncodeToString(nonceBytes),
+		"created": created.UTC().Format("2006-01-02T15:04:05.000Z07:00"),
+	}
+
+	verifyData, err := p.createVerifyData(activity, options)
+	if err != nil {
+		return nil, err
+	}
+	priv, err := parseRSAPrivateKey(privateKeyPEM)
+	if err != nil {
+		return nil, err
+	}
+	finalHash := sha256.Sum256([]byte(verifyData))
+	sigBytes, err := rsa.SignPKCS1v15(rand.Reader, priv, crypto.SHA256, finalHash[:])
+	if err != nil {
+		return nil, fmt.Errorf("ld-sig: sign: %w", err)
+	}
+
+	signature := make(map[string]any, len(options)+1)
+	for k, v := range options {
+		signature[k] = v
+	}
+	signature["signatureValue"] = base64.StdEncoding.EncodeToString(sigBytes)
+
+	out := make(map[string]any, len(activity)+1)
+	for k, v := range activity {
+		out[k] = v
+	}
+	out["signature"] = signature
+	return out, nil
+}
+
+// parseRSAPrivateKey decodes a PEM-encoded RSA private key, accepting both
+// PKCS1 ("BEGIN RSA PRIVATE KEY") and PKCS8 ("BEGIN PRIVATE KEY") encodings.
+// Kept local to the ld package to avoid an import cycle with the activitypub
+// package (which depends on ld for inbox verify).
+func parseRSAPrivateKey(pemStr string) (*rsa.PrivateKey, error) {
+	blk, _ := pem.Decode([]byte(pemStr))
+	if blk == nil {
+		return nil, fmt.Errorf("%w: pem decode failed", ErrInvalidSignaturePEM)
+	}
+	if key, err := x509.ParsePKCS1PrivateKey(blk.Bytes); err == nil {
+		return key, nil
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(blk.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("%w: private key parse: %v", ErrInvalidSignaturePEM, err)
+	}
+	rsaKey, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("%w: not an RSA private key", ErrInvalidSignaturePEM)
+	}
+	return rsaKey, nil
+}

--- a/internal/activitypub/ld/sign_test.go
+++ b/internal/activitypub/ld/sign_test.go
@@ -1,0 +1,119 @@
+package ld
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func rsaPrivPEMPKCS1(t *testing.T, priv *rsa.PrivateKey) string {
+	t.Helper()
+	der := x509.MarshalPKCS1PrivateKey(priv)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: der}))
+}
+
+func sampleActivity() map[string]any {
+	return map[string]any{
+		"@context": "https://www.w3.org/ns/activitystreams",
+		"id":       "https://example.com/notes/n1/activity",
+		"type":     "Create",
+		"actor":    "https://example.com/users/alice",
+		"to":       []any{"https://www.w3.org/ns/activitystreams#Public"},
+		"object": map[string]any{
+			"id":      "https://example.com/notes/n1",
+			"type":    "Note",
+			"content": "hello world",
+		},
+	}
+}
+
+// SignRsaSignature2017 が生成した署名が production verify path
+// (VerifyRsaSignature2017) を通ること = sign/verify が byte 対称であること (#1870)。
+func TestSignRsaSignature2017_RoundTrip(t *testing.T) {
+	p := NewProcessor()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	activity := sampleActivity()
+	creator := "https://example.com/users/alice#main-key"
+	created := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+
+	signed, err := p.SignRsaSignature2017(activity, rsaPrivPEMPKCS1(t, priv), creator, created)
+	require.NoError(t, err)
+
+	// 元 activity は変更されない (signature を持たない)
+	_, hadSig := activity["signature"]
+	assert.False(t, hadSig, "input activity must not be mutated")
+
+	sig, ok := signed["signature"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, LDSignatureType, sig["type"])
+	assert.Equal(t, creator, sig["creator"])
+	assert.NotEmpty(t, sig["nonce"], "nonce must be present (upstream parity)")
+	assert.NotEmpty(t, sig["created"])
+	assert.NotEmpty(t, sig["signatureValue"])
+
+	require.NoError(t, p.VerifyRsaSignature2017(signed, rsaPubPEM(t, priv)),
+		"production-signed activity must verify under the production verifier")
+}
+
+// 署名後に document を改竄すると verify が必ず失敗する。
+func TestSignRsaSignature2017_TamperedFailsVerify(t *testing.T) {
+	p := NewProcessor()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	signed, err := p.SignRsaSignature2017(sampleActivity(), rsaPrivPEMPKCS1(t, priv),
+		"https://example.com/users/alice#main-key", time.Now())
+	require.NoError(t, err)
+
+	signed["actor"] = "https://evil.example/users/mallory"
+	assert.Error(t, p.VerifyRsaSignature2017(signed, rsaPubPEM(t, priv)),
+		"tampered actor must break verification")
+}
+
+// PKCS8 形式の private key でも署名できる。
+func TestSignRsaSignature2017_PKCS8Key(t *testing.T) {
+	p := NewProcessor()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	require.NoError(t, err)
+	privPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+
+	signed, err := p.SignRsaSignature2017(sampleActivity(), privPEM,
+		"https://example.com/users/alice#main-key", time.Now())
+	require.NoError(t, err)
+	require.NoError(t, p.VerifyRsaSignature2017(signed, rsaPubPEM(t, priv)))
+}
+
+func TestSignRsaSignature2017_BadPrivateKey(t *testing.T) {
+	p := NewProcessor()
+	_, err := p.SignRsaSignature2017(sampleActivity(), "not a pem",
+		"https://example.com/users/alice#main-key", time.Now())
+	assert.ErrorIs(t, err, ErrInvalidSignaturePEM)
+}
+
+type failingNonceReader struct{}
+
+func (failingNonceReader) Read([]byte) (int, error) { return 0, errors.New("rand failure") }
+
+func TestSignRsaSignature2017_NonceError(t *testing.T) {
+	orig := ldNonceRand
+	ldNonceRand = failingNonceReader{}
+	defer func() { ldNonceRand = orig }()
+
+	p := NewProcessor()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	_, err = p.SignRsaSignature2017(sampleActivity(), rsaPrivPEMPKCS1(t, priv),
+		"https://example.com/users/alice#main-key", time.Now())
+	assert.Error(t, err)
+}

--- a/internal/core/relay/relay.go
+++ b/internal/core/relay/relay.go
@@ -42,6 +42,18 @@ type Deliverer interface {
 	DeliverActivity(signerUserID string, body []byte, inboxes []string) error
 }
 
+// KeypairProvider resolves a local user's RSA keypair for LD signing.
+// repository.UserKeypairRepository がこれを満たす。
+type KeypairProvider interface {
+	FindByUserID(userID string) (*model.UserKeypair, error)
+}
+
+// LdSigner attaches an RsaSignature2017 LD-Signature to a JSON-LD activity map.
+// *activitypub/ld.Processor がこの signature を構造的に満たす。
+type LdSigner interface {
+	SignRsaSignature2017(activity map[string]any, privateKeyPEM, creator string, created time.Time) (map[string]any, error)
+}
+
 // Service orchestrates add/remove/mark/list/deliver operations against
 // the local relay table and the AP delivery pipeline.
 type Service struct {
@@ -51,6 +63,12 @@ type Service struct {
 	deliver  Deliverer
 	idGen    id.Generator
 	clock    func() time.Time
+
+	// LD-Signature 配送 (optional)。3 つとも揃ったときだけ relay 配送 activity に
+	// RsaSignature2017 を付与する (#1870)。未配線なら従来どおり HTTP-sig のみ。
+	keypairRepo KeypairProvider
+	ldSigner    LdSigner
+	baseURL     string
 
 	// accepted list cache with 10-minute TTL, matching upstream.
 	cacheMu     sync.RWMutex
@@ -83,6 +101,16 @@ func (s *Service) SetClock(now func() time.Time) {
 	if now != nil {
 		s.clock = now
 	}
+}
+
+// SetLdSigning wires the RsaSignature2017 LD-Signature path for relay delivery
+// (upstream deliverToRelays → attachLdSignature, #1870)。baseURL は creator key
+// URI 構築用 (例: "https://example.com")。引数のいずれかが nil/空なら LD 署名は
+// 無効化され、従来どおり HTTP-sig のみで配送する。
+func (s *Service) SetLdSigning(keypairRepo KeypairProvider, signer LdSigner, baseURL string) {
+	s.keypairRepo = keypairRepo
+	s.ldSigner = signer
+	s.baseURL = baseURL
 }
 
 // SetCacheMaxAge overrides the default 10-minute TTL on the accepted
@@ -183,15 +211,58 @@ func (s *Service) DeliverToAccepted(ctx context.Context, signerUserID string, ac
 	if len(relays) == 0 {
 		return nil
 	}
-	body, err := json.Marshal(activity)
+	body, err := s.marshalForRelay(ctx, signerUserID, activity)
 	if err != nil {
-		return fmt.Errorf("relay: marshal activity: %w", err)
+		return err
 	}
 	inboxes := make([]string, 0, len(relays))
 	for _, r := range relays {
 		inboxes = append(inboxes, r.Inbox)
 	}
 	return s.deliver.DeliverActivity(signerUserID, body, inboxes)
+}
+
+// marshalForRelay serializes activity for relay delivery, attaching an
+// RsaSignature2017 LD-Signature authored by signerUserID when LD signing is
+// wired (upstream deliverToRelays → attachLdSignature, #1870)。relay は
+// downstream subscriber へ転送する際に元 activity の HTTP signature を保持
+// できないため、LD-Signature が無いと downstream (Mastodon relay / 署名検証する
+// Misskey 等) が relay 経由 note の真正性を検証できず reject する。
+//
+// 署名は best-effort: keypair 解決や sign に失敗したら警告ログを残して unsigned で
+// 配送する (= 従来挙動。署名できないことを理由に relay 配送自体を止めない)。
+func (s *Service) marshalForRelay(ctx context.Context, signerUserID string, activity any) ([]byte, error) {
+	raw, err := json.Marshal(activity)
+	if err != nil {
+		return nil, fmt.Errorf("relay: marshal activity: %w", err)
+	}
+	// LD 署名が未配線なら従来どおりそのまま配送。
+	if s.ldSigner == nil || s.keypairRepo == nil || s.baseURL == "" {
+		return raw, nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		// object でない activity (理論上発生しない) は署名対象外。
+		return raw, nil
+	}
+	// upstream: to が無ければ Public を補完してから署名する (空配列は尊重)。
+	if v, ok := m["to"]; !ok || v == nil {
+		m["to"] = []any{activitypub.Public}
+	}
+	kp, kerr := s.keypairRepo.FindByUserID(signerUserID)
+	if kerr != nil || kp == nil {
+		slog.WarnContext(ctx, "relay: LD signing skipped (keypair unavailable)",
+			"signerUserId", signerUserID, "err", kerr)
+		return json.Marshal(m)
+	}
+	creator := s.baseURL + "/users/" + signerUserID + "#main-key"
+	signed, serr := s.ldSigner.SignRsaSignature2017(m, kp.PrivateKey, creator, s.clock())
+	if serr != nil {
+		slog.WarnContext(ctx, "relay: LD signing failed, delivering unsigned",
+			"signerUserId", signerUserID, "err", serr)
+		return json.Marshal(m)
+	}
+	return json.Marshal(signed)
 }
 
 // sendFollow renders a Follow-Relay activity and enqueues it, signed by

--- a/internal/core/relay/relay_test.go
+++ b/internal/core/relay/relay_test.go
@@ -2,13 +2,18 @@ package relay_test
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/shiroha-a/mk/internal/activitypub"
+	"github.com/shiroha-a/mk/internal/activitypub/ld"
 	"github.com/shiroha-a/mk/internal/core/relay"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -340,4 +345,161 @@ func TestIsRelayActor(t *testing.T) {
 		assert.True(t, svc.IsRelayActor(&model.User{ID: "u4", Inbox: &other, SharedInbox: &shared}),
 			"actor.SharedInbox が登録済み relay の Inbox と一致 → true")
 	})
+}
+
+// stubLdSigner records its inputs and attaches a marker signature.
+type stubLdSigner struct {
+	gotActivity   map[string]any
+	gotPrivateKey string
+	gotCreator    string
+	err           error
+}
+
+func (s *stubLdSigner) SignRsaSignature2017(activity map[string]any, privateKeyPEM, creator string, _ time.Time) (map[string]any, error) {
+	s.gotActivity = activity
+	s.gotPrivateKey = privateKeyPEM
+	s.gotCreator = creator
+	if s.err != nil {
+		return nil, s.err
+	}
+	out := make(map[string]any, len(activity)+1)
+	for k, v := range activity {
+		out[k] = v
+	}
+	out["signature"] = map[string]any{"type": "RsaSignature2017", "stub": true}
+	return out, nil
+}
+
+type stubKeypairProvider struct {
+	kp  *model.UserKeypair
+	err error
+}
+
+func (s *stubKeypairProvider) FindByUserID(string) (*model.UserKeypair, error) {
+	return s.kp, s.err
+}
+
+func acceptedRelaySvc(t *testing.T) (*relay.Service, *fakeDeliverer) {
+	t.Helper()
+	svc, _, _, deliv := newService(t)
+	rel, err := svc.Add(context.Background(), "https://r.example/inbox")
+	require.NoError(t, err)
+	require.NoError(t, svc.MarkAccepted(context.Background(), rel.ID))
+	return svc, deliv
+}
+
+func lastDeliveredBody(t *testing.T, deliv *fakeDeliverer) map[string]any {
+	t.Helper()
+	deliv.mu.Lock()
+	defer deliv.mu.Unlock()
+	require.NotEmpty(t, deliv.calls)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(deliv.calls[len(deliv.calls)-1].Body, &m))
+	return m
+}
+
+// LD 署名が配線されていると relay 配送 activity に to=Public 補完 + RsaSignature2017
+// が付与され、署名は author の keypair + creator key URI で行われる (#1870)。
+func TestDeliverToAccepted_AttachesLdSignature(t *testing.T) {
+	svc, deliv := acceptedRelaySvc(t)
+	signer := &stubLdSigner{}
+	kpr := &stubKeypairProvider{kp: &model.UserKeypair{UserID: "alice", PrivateKey: "PRIVPEM"}}
+	svc.SetLdSigning(kpr, signer, "https://example.com")
+
+	// to を持たない activity → Public 補完 + 署名
+	err := svc.DeliverToAccepted(context.Background(), "alice",
+		map[string]any{"type": "Create", "actor": "https://example.com/users/alice"})
+	require.NoError(t, err)
+
+	// signer が author の private key + creator key URI で呼ばれる
+	assert.Equal(t, "PRIVPEM", signer.gotPrivateKey)
+	assert.Equal(t, "https://example.com/users/alice#main-key", signer.gotCreator)
+	// signer に渡る activity は to 補完済み
+	assert.Equal(t, []any{activitypub.Public}, signer.gotActivity["to"])
+
+	// 配送 body に signature が乗り、to も補完されている
+	sent := lastDeliveredBody(t, deliv)
+	assert.Contains(t, sent, "signature")
+	assert.Equal(t, []any{activitypub.Public}, sent["to"])
+}
+
+// keypair が引けないときは署名を諦めて unsigned で配送する (best-effort、
+// relay 配送自体は止めない)。to 補完は適用される。
+func TestDeliverToAccepted_LdSigningKeypairMissing_UnsignedFallback(t *testing.T) {
+	svc, deliv := acceptedRelaySvc(t)
+	signer := &stubLdSigner{}
+	svc.SetLdSigning(&stubKeypairProvider{err: errors.New("not found")}, signer, "https://example.com")
+
+	require.NoError(t, svc.DeliverToAccepted(context.Background(), "alice",
+		map[string]any{"type": "Create"}))
+
+	assert.Empty(t, signer.gotCreator, "signer must not be called when keypair is missing")
+	sent := lastDeliveredBody(t, deliv)
+	assert.NotContains(t, sent, "signature", "keypair missing → unsigned fallback")
+	assert.Contains(t, sent, "to", "to is still completed")
+}
+
+// 署名処理がエラーになっても unsigned で配送する。
+func TestDeliverToAccepted_LdSigningError_UnsignedFallback(t *testing.T) {
+	svc, deliv := acceptedRelaySvc(t)
+	signer := &stubLdSigner{err: errors.New("sign boom")}
+	svc.SetLdSigning(&stubKeypairProvider{kp: &model.UserKeypair{UserID: "alice", PrivateKey: "PRIVPEM"}}, signer, "https://example.com")
+
+	require.NoError(t, svc.DeliverToAccepted(context.Background(), "alice",
+		map[string]any{"type": "Create"}))
+
+	sent := lastDeliveredBody(t, deliv)
+	assert.NotContains(t, sent, "signature", "sign error → unsigned fallback")
+}
+
+// LD 署名が未配線なら従来どおり unsigned で配送する (existing 挙動の regression guard)。
+func TestDeliverToAccepted_NoLdSigning_Unsigned(t *testing.T) {
+	svc, deliv := acceptedRelaySvc(t)
+	require.NoError(t, svc.DeliverToAccepted(context.Background(), "alice",
+		map[string]any{"type": "Create"}))
+	sent := lastDeliveredBody(t, deliv)
+	assert.NotContains(t, sent, "signature")
+}
+
+// end-to-end: 実 ld.Processor + 実 RSA keypair で marshalForRelay 経由に署名し、
+// 配送 body が production verifier (VerifyRsaSignature2017) を通ることを確認する。
+// stub signer ではなく実署名経路を drop-in critical path として封じる (#1870)。
+func TestDeliverToAccepted_LdSignature_VerifiesEndToEnd(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	privPEM := string(pem.EncodeToMemory(&pem.Block{
+		Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv),
+	}))
+	pubDER, err := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	require.NoError(t, err)
+	pubPEM := string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER}))
+
+	svc, deliv := acceptedRelaySvc(t)
+	svc.SetLdSigning(
+		&stubKeypairProvider{kp: &model.UserKeypair{UserID: "alice", PrivateKey: privPEM}},
+		ld.NewProcessor(),
+		"https://example.com",
+	)
+
+	// to を持たない実 shape (@context 付き Create) を流す。
+	activity := map[string]any{
+		"@context": "https://www.w3.org/ns/activitystreams",
+		"id":       "https://example.com/notes/n1/activity",
+		"type":     "Create",
+		"actor":    "https://example.com/users/alice",
+		"object": map[string]any{
+			"id":      "https://example.com/notes/n1",
+			"type":    "Note",
+			"content": "hello relay",
+		},
+	}
+	require.NoError(t, svc.DeliverToAccepted(context.Background(), "alice", activity))
+
+	sent := lastDeliveredBody(t, deliv)
+	require.Contains(t, sent, "signature", "real signer must attach a signature")
+	assert.Equal(t, []any{activitypub.Public}, sent["to"], "to は Public に補完される")
+
+	// production verifier で検証が通る = downstream が真正性を検証できる shape。
+	require.NoError(t, ld.NewProcessor().VerifyRsaSignature2017(sent, pubPEM),
+		"relay-signed activity must verify under the production LD verifier")
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/activitypub"
+	"github.com/shiroha-a/mk/internal/activitypub/ld"
 	apiadmin "github.com/shiroha-a/mk/internal/api/admin"
 	apiannouncements "github.com/shiroha-a/mk/internal/api/announcements"
 	"github.com/shiroha-a/mk/internal/api/antennas"
@@ -622,6 +623,11 @@ func (s *Server) setupRoutes() {
 	// 投稿を受信できるようにする enqueuer。push / create-from-public で使う。
 	listProxyFollow := coreuserlist.NewProxyFollower(sysAcctSvc, s.queueClient)
 	relaySvc := corerelay.NewService(repository.NewRelayRepository(s.db), sysAcctSvc, apRenderer, deliverService, idGen)
+	// relay 配送 activity に RsaSignature2017 LD-Signature を付与する (#1870)。
+	// relay は downstream へ転送する際に元 HTTP-sig を保持できないので、LD-sig が
+	// 無いと downstream が真正性を検証できず reject する。署名者は activity の
+	// author (local user)。
+	relaySvc.SetLdSigning(keypairRepo, ld.NewProcessor(), s.config.URL)
 
 	// AP fetch のデフォルト signer に instance.actor を配線する (#419)。
 	// IceShrimp.NET 等の authorized-fetch peer では未署名 GET が 401 で


### PR DESCRIPTION
## Summary

#1827 (ap-outbound 再監査(2)) sub-issue 3 件目。

upstream `RelayService.deliverToRelays` は relay 配送前に (1) `to` が無ければ `[Public]` を補完、(2) `attachLdSignature` で **activity author の keypair** による `RsaSignature2017` LD-Signature を埋め込む。mk-go の `DeliverToAccepted` は activity を marshal して **HTTP signature だけ**で relay inbox へ送っていた。

relay は downstream subscriber へ転送する際に元 activity の HTTP signature を保持できないため、LD-Signature が無いと downstream (Mastodon relay / 署名検証する Misskey 等) が relay 経由 note の真正性を検証できず reject する。mk-go の `ld` パッケージは verify のみで sign 関数が無かった。

## 主な変更点

- **`internal/activitypub/ld/sign.go`** (新規): `SignRsaSignature2017(activity, privateKeyPEM, creator, created)` を追加。`options{type,creator,nonce(16 byte hex),created(ISO)}` → 既存 `createVerifyData` → sha256 → `RSA-PKCS1v15 SHA-256` sign → `signatureValue` base64。既存 `VerifyRsaSignature2017` と byte 対称で、inbound verify と同じ URDNA2015 normalize を使うため downstream でも検証可能。`parseRSAPrivateKey` (PKCS1/PKCS8) も追加。
- **`internal/core/relay/relay.go`**: `KeypairProvider` / `LdSigner` interface + `SetLdSigning` setter を追加。`marshalForRelay` で `to=Public` 補完 + author keypair による LD 署名。keypair 解決や sign 失敗時は warn ログを残して unsigned で配送 (best-effort、現状維持で regression なし)。
- **`internal/server/router.go`**: `relaySvc.SetLdSigning(keypairRepo, ld.NewProcessor(), s.config.URL)` を配線。署名者は activity の author (local user)。

## テスト

- `ld/sign_test.go`: sign↔verify round-trip / 改竄で verify 失敗 / PKCS8 / bad-key / nonce-error。
- `relay_test.go`: 署名付与 (author key + creator URI + to 補完) / keypair 欠落 fallback / sign 失敗 fallback / 未配線 unsigned、および**実 `ld.Processor` + 実 RSA keypair で `marshalForRelay` 経由の署名が production verifier を通る end-to-end**。
- `make fmt && make lint` green。`go test ./internal/activitypub/ld/ ./internal/core/relay/` green (ld 90.6% / relay 91.8%)。

Closes #1870

🤖 Generated with [Claude Code](https://claude.com/claude-code)