### PR TITLE
AP collections/featured endpoint + OrderedCollection + RenderPerson featured (#1876)

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -60,6 +60,12 @@ func (b *URLBuilder) UserFollowing(userID string) string {
 	return b.UserURI(userID) + "/following"
 }
 
+// UserFeatured returns the pinned-notes (featured) collection URL
+// (upstream: `${id}/collections/featured`, #1876)。
+func (b *URLBuilder) UserFeatured(userID string) string {
+	return b.UserURI(userID) + "/collections/featured"
+}
+
 // UserKeyURI returns the public key fragment URI used in HTTP signatures.
 func (b *URLBuilder) UserKeyURI(userID string) string {
 	return b.UserURI(userID) + "#main-key"
@@ -208,6 +214,27 @@ func NewRenderer(urls *URLBuilder) *Renderer {
 	return &Renderer{urls: urls}
 }
 
+// URLs exposes the URLBuilder so handlers can construct canonical collection
+// URLs (outbox/followers/following/featured) without holding a separate
+// builder (#1876)。
+func (r *Renderer) URLs() *URLBuilder {
+	return r.urls
+}
+
+// RenderOrderedCollection builds an AS OrderedCollection (#1876)。upstream
+// ApRendererService.renderOrderedCollection と同じく first/last/orderedItems は
+// 空なら省略する。@context は呼び出し側 (handler) が AddContext で付与する。
+func (r *Renderer) RenderOrderedCollection(id string, totalItems int, first, last string, orderedItems []any) *OrderedCollection {
+	return &OrderedCollection{
+		ID:           id,
+		Type:         "OrderedCollection",
+		TotalItems:   totalItems,
+		First:        first,
+		Last:         last,
+		OrderedItems: orderedItems,
+	}
+}
+
 // SetMentionResolver attaches a MentionResolver used by RenderNote to populate
 // the `tag` field and additional `to` audience entries. nil で無効化できる。
 func (r *Renderer) SetMentionResolver(mr MentionResolver) {
@@ -309,9 +336,10 @@ func (r *Renderer) RenderPerson(u *model.User, profile *model.UserProfile, publi
 	if u.AlsoKnownAs != nil && *u.AlsoKnownAs != "" {
 		p.AlsoKnownAs = APStringList(strings.Split(*u.AlsoKnownAs, ","))
 	}
-	if u.Featured != nil && *u.Featured != "" {
-		p.Featured = *u.Featured
-	}
+	// upstream renderPerson は local actor に必ず featured: ${id}/collections/featured を
+	// 出力する。RenderPerson は local user 専用なので無条件に自ドメインの featured
+	// collection URI を入れる (pinned note を連合先へ公開する、#1876)。
+	p.Featured = r.urls.UserFeatured(u.ID)
 	p.MisskeyRequireSigninToViewContents = u.RequireSigninToViewContents
 	p.MisskeyMakeNotesFollowersOnlyBefore = u.MakeNotesFollowersOnlyBefore
 	p.MisskeyMakeNotesHiddenBefore = u.MakeNotesHiddenBefore

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -3,6 +3,7 @@ package activitypub
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -24,6 +25,7 @@ func TestURLBuilder_Helpers(t *testing.T) {
 	b := NewURLBuilder("https://example.com")
 	assert.Equal(t, "https://example.com/users/u1", b.UserURI("u1"))
 	assert.Equal(t, "https://example.com/@alice", b.UserProfileURL("alice"))
+	assert.Equal(t, "https://example.com/users/u1/collections/featured", b.UserFeatured("u1"))
 	assert.Equal(t, "https://example.com/users/u1/inbox", b.UserInbox("u1"))
 	assert.Equal(t, "https://example.com/users/u1/outbox", b.UserOutbox("u1"))
 	assert.Equal(t, "https://example.com/users/u1/followers", b.UserFollowers("u1"))
@@ -158,6 +160,8 @@ func TestRenderer_RenderPerson(t *testing.T) {
 	// url は id と区別し、人間向け profile ハンドル /@<username> を指す (#1869)。
 	assert.Equal(t, "https://example.com/@alice", p.URL)
 	assert.NotEqual(t, p.ID, p.URL, "actor url must differ from id")
+	// featured は local actor に無条件出力される (#1876)。
+	assert.Equal(t, "https://example.com/users/u1/collections/featured", p.Featured)
 	assert.Equal(t, "Person", p.Type)
 	assert.Equal(t, "alice", p.PreferredUsername)
 	assert.Equal(t, "Alice", p.Name)
@@ -166,6 +170,35 @@ func TestRenderer_RenderPerson(t *testing.T) {
 	assert.True(t, p.Discoverable)
 	require.NotNil(t, p.Icon)
 	assert.Equal(t, avatar, p.Icon.URL)
+}
+
+func TestRenderer_URLs(t *testing.T) {
+	r := newRenderer()
+	require.NotNil(t, r.URLs())
+	assert.Equal(t, "https://example.com/users/u1/collections/featured", r.URLs().UserFeatured("u1"))
+}
+
+func TestRenderer_RenderOrderedCollection(t *testing.T) {
+	r := newRenderer()
+
+	// inline items (featured 相当): orderedItems を持ち first/last は省略。
+	col := r.RenderOrderedCollection("https://example.com/users/u1/collections/featured", 2, "", "",
+		[]any{map[string]any{"id": "n1"}, map[string]any{"id": "n2"}})
+	assert.Equal(t, "OrderedCollection", col.Type)
+	assert.Equal(t, "https://example.com/users/u1/collections/featured", col.ID)
+	assert.Equal(t, 2, col.TotalItems)
+	assert.Len(t, col.OrderedItems, 2)
+	assert.Empty(t, col.First)
+	assert.Empty(t, col.Last)
+
+	// first/last omitempty + orderedItems 無し → JSON に first/last/orderedItems が出ない。
+	base := r.RenderOrderedCollection("https://example.com/users/u1/outbox", 5, "", "", nil)
+	b, err := json.Marshal(base)
+	require.NoError(t, err)
+	js := string(b)
+	assert.Contains(t, js, `"totalItems":5`)
+	assert.NotContains(t, js, "first")
+	assert.NotContains(t, js, "orderedItems")
 }
 
 func TestRenderer_RenderPerson_NoOptionalFields(t *testing.T) {

--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -102,6 +102,20 @@ type Object struct {
 	Name    string `json:"name,omitempty"`
 }
 
+// OrderedCollection is an AS OrderedCollection used for actor-advertised
+// collections (outbox / followers / following / collections/featured)。upstream
+// ApRendererService.renderOrderedCollection と同 shape。orderedItems は inline 提供時
+// (featured 等) のみ、first/last は paginate 時のみ出力する (#1876)。
+type OrderedCollection struct {
+	Context      any    `json:"@context,omitempty"`
+	ID           string `json:"id"`
+	Type         string `json:"type"`
+	TotalItems   int    `json:"totalItems"`
+	First        string `json:"first,omitempty"`
+	Last         string `json:"last,omitempty"`
+	OrderedItems []any  `json:"orderedItems,omitempty"`
+}
+
 // PublicKey is the embedded JSON-LD object describing a user's signing key.
 type PublicKey struct {
 	ID           string `json:"id"`
@@ -598,6 +612,8 @@ func AddContext(o any) {
 	case *Flag:
 		v.Context = ctx
 	case *Move:
+		v.Context = ctx
+	case *OrderedCollection:
 		v.Context = ctx
 	}
 }

--- a/internal/api/ap/handler.go
+++ b/internal/api/ap/handler.go
@@ -605,3 +605,43 @@ func (h *Handler) Note(c echo.Context) error {
 	note := h.renderer.RenderNote(n, h.idGen)
 	return writeActivityJSON(c, note)
 }
+
+// Featured handles GET /users/:id/collections/featured, serving the local
+// user's pinned notes as an OrderedCollection (upstream
+// ActivityPubServerService.featured, #1876)。actor が advertise する featured URI に
+// 対応する。pinned note は inline 出力 (pagination 無し、upstream と同じ)。
+//
+// upstream と同じく !localOnly かつ visibility ∈ {public, home} の note のみ serve し、
+// followers/specified/localOnly な pinned note を unauthenticated AP へ leak させない。
+func (h *Handler) Featured(c echo.Context) error {
+	c.Response().Header().Set("Vary", "Accept")
+	id := c.Param("id")
+	bundle, err := h.userService.ShowByID(id)
+	if err != nil {
+		return c.NoContent(http.StatusNotFound)
+	}
+	// local user 専用 (remote actor の featured collection は serve しない)。
+	if !bundle.User.IsLocal() {
+		return c.NoContent(http.StatusNotFound)
+	}
+	notes, err := h.userService.ListPinnedNotes(id)
+	if err != nil {
+		return c.NoContent(http.StatusInternalServerError)
+	}
+	items := make([]any, 0, len(notes))
+	for _, n := range notes {
+		// upstream featured の filter: !localOnly && visibility ∈ {public, home}。
+		if n.LocalOnly || (n.Visibility != model.NoteVisibilityPublic && n.Visibility != model.NoteVisibilityHome) {
+			continue
+		}
+		rn := h.renderer.RenderNote(n, h.idGen)
+		// collection 直下に embed するので per-note @context は外す
+		// (upstream renderNote は bare object を返し、@context は collection 側のみ)。
+		rn.Context = nil
+		items = append(items, rn)
+	}
+	// totalItems は filter 後の件数 (upstream は renderedNotes.length)。
+	col := h.renderer.RenderOrderedCollection(h.renderer.URLs().UserFeatured(id), len(items), "", "", items)
+	activitypub.AddContext(col)
+	return writeActivityJSON(c, col)
+}

--- a/internal/api/ap/handler_test.go
+++ b/internal/api/ap/handler_test.go
@@ -992,3 +992,103 @@ func TestAPIGet_RemoteInvalidJSON(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 	assert.Contains(t, rec.Body.String(), "NO_SUCH_OBJECT")
 }
+
+// newHandlerWithPining is like newHandler but also exposes the pining + note
+// repos so featured-collection tests can seed pinned notes (#1876)。
+func newHandlerWithPining(t *testing.T) (*Handler, *testutil.MockUserRepository, *testutil.MockNoteRepository, *testutil.MockUserNotePiningRepository) {
+	t.Helper()
+	userRepo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	piningRepo := testutil.NewMockUserNotePiningRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	userSvc := coreuser.NewService(userRepo, noteRepo, piningRepo, idGen)
+	querySvc := corenote.NewQueryService(noteRepo, nil)
+	keypairRepo := &memoryKeypairRepo{items: map[string]*model.UserKeypair{}}
+	h := NewHandler(activitypub.NewRenderer(activitypub.NewURLBuilder("https://example.com")), userSvc, querySvc, keypairRepo, idGen)
+	return h, userRepo, noteRepo, piningRepo
+}
+
+func TestFeatured_ReturnsPinnedNotes(t *testing.T) {
+	h, userRepo, noteRepo, piningRepo := newHandlerWithPining(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic}
+	require.NoError(t, piningRepo.Create(&model.UserNotePining{ID: "p1", UserID: "u1", NoteID: "n1"}))
+
+	c, rec := newReq(t, "id", "u1")
+	require.NoError(t, h.Featured(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var col map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &col))
+	assert.Equal(t, "OrderedCollection", col["type"])
+	assert.Equal(t, "https://example.com/users/u1/collections/featured", col["id"])
+	assert.Equal(t, float64(1), col["totalItems"])
+	items, _ := col["orderedItems"].([]any)
+	require.Len(t, items, 1)
+	assert.NotNil(t, col["@context"], "served collection must carry @context")
+}
+
+func TestFeatured_NoPins_EmptyCollection(t *testing.T) {
+	h, userRepo, _, _ := newHandlerWithPining(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+
+	c, rec := newReq(t, "id", "u1")
+	require.NoError(t, h.Featured(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var col map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &col))
+	assert.Equal(t, float64(0), col["totalItems"])
+	// mk-go は orderedItems を omitempty で省略する (upstream は空でも []
+	// を出すが、consumer は absent を空集合として扱うため harmless な MINOR 差。
+	// omitempty は後続の base collection (outbox/followers の first/last のみ) で
+	// orderedItems を出さないために必要)。
+	_, hasItems := col["orderedItems"]
+	assert.False(t, hasItems, "empty featured omits orderedItems (accepted divergence)")
+}
+
+// upstream featured は !localOnly && visibility ∈ {public, home} のみ serve する。
+// followers/specified/localOnly な pinned note は unauthenticated AP へ leak しない (#1876)。
+func TestFeatured_ExcludesNonPublicAndLocalOnly(t *testing.T) {
+	h, userRepo, noteRepo, piningRepo := newHandlerWithPining(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	noteRepo.Notes["pub"] = &model.Note{ID: "pub", UserID: "u1", Visibility: model.NoteVisibilityPublic}
+	noteRepo.Notes["home"] = &model.Note{ID: "home", UserID: "u1", Visibility: model.NoteVisibilityHome}
+	noteRepo.Notes["fol"] = &model.Note{ID: "fol", UserID: "u1", Visibility: model.NoteVisibilityFollowers}
+	noteRepo.Notes["spec"] = &model.Note{ID: "spec", UserID: "u1", Visibility: model.NoteVisibilitySpecified}
+	noteRepo.Notes["lo"] = &model.Note{ID: "lo", UserID: "u1", Visibility: model.NoteVisibilityPublic, LocalOnly: true}
+	for i, nid := range []string{"pub", "home", "fol", "spec", "lo"} {
+		require.NoError(t, piningRepo.Create(&model.UserNotePining{ID: "p" + string(rune('1'+i)), UserID: "u1", NoteID: nid}))
+	}
+
+	c, rec := newReq(t, "id", "u1")
+	require.NoError(t, h.Featured(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var col map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &col))
+	// public + home の 2 件のみ。followers / specified / localOnly は除外。
+	assert.Equal(t, float64(2), col["totalItems"], "totalItems must be the post-filter count")
+	items, _ := col["orderedItems"].([]any)
+	require.Len(t, items, 2)
+	body := rec.Body.String()
+	assert.NotContains(t, body, `/notes/fol`, "followers-only pinned note must not leak")
+	assert.NotContains(t, body, `/notes/spec`, "specified pinned note must not leak")
+	assert.NotContains(t, body, `/notes/lo`, "localOnly pinned note must not leak")
+}
+
+func TestFeatured_NotFound(t *testing.T) {
+	h, _, _, _ := newHandlerWithPining(t)
+	c, rec := newReq(t, "id", "ghost")
+	require.NoError(t, h.Featured(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestFeatured_Remote(t *testing.T) {
+	h, userRepo, _, _ := newHandlerWithPining(t)
+	host := "remote.example"
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", Host: &host}
+	c, rec := newReq(t, "id", "u1")
+	require.NoError(t, h.Featured(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code, "remote actor featured must 404")
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1791,6 +1791,7 @@ func (s *Server) setupRoutes() {
 	// 返したいので、フォールバックとして frontendHTML を注入しておく。
 	apHandler.SetNonAPFallback(frontend)
 	s.echo.GET("/users/:id", apHandler.User)
+	s.echo.GET("/users/:id/collections/featured", apHandler.Featured) // #1876 pinned notes
 	s.echo.GET("/notes/:id", apHandler.Note)
 	s.echo.GET("/@:acct", apHandler.UserByAcct)
 


### PR DESCRIPTION
## Summary

#1827 → #1871 (AP collection endpoints) を実装規模で再分割した 1 件目。F2 の featured + F3 を実装。

`RenderPerson` は inbox/outbox/followers/following を URI として advertise するのに対応 GET endpoint が無く、さらに `featured` field を local actor に出していなかった (local user の `Featured` カラムは常に NULL)。そのため remote から pinned note を発見する経路が無かった。

## 主な変更点

- **types.go**: `OrderedCollection` 型 (upstream `renderOrderedCollection` と同 shape、first/last/orderedItems は omitempty) + `AddContext` 対応。
- **renderer.go**: `URLBuilder.UserFeatured(id)` (`${id}/collections/featured`) / `Renderer.RenderOrderedCollection` / `Renderer.URLs()` accessor。`RenderPerson` は local actor に `featured: ${id}/collections/featured` を**無条件出力** (F3、upstream renderPerson 同等。RenderPerson は local 専用)。
- **ap/handler.go**: `GET /users/:id/collections/featured`。pinned note を OrderedCollection として inline 出力 (pagination 無し、upstream featured handler)。**upstream と同じく `!localOnly && visibility ∈ {public, home}` のみ serve** し、followers/specified/localOnly な pinned note を unauthenticated AP へ leak させない。`totalItems` は filter 後の件数。embed する note は collection の `@context` を共有するため per-note `@context` を外す。local user 専用 (`!IsLocal()` → 404)。
- **router.go**: route 配線。

## レビュー指摘の対応

敵対的レビュー round-1 で **BLOCKER (followers/specified/localOnly pinned note の AP leak)** を検出し、upstream の visibility filter を実装して修正 (round-2 で RESOLVED 確認)。embed note の `@context` 除去・`IsLocal()` 化も対応。

## スコープ / follow-up

- federation 無効時に AP serve handler が 403 を返さない project-wide gap (User/Note 含む pre-existing) は **#1879** に分離。
- 残る #1871 sub: #1877 (followers/following)、#1878 (outbox)。

## テスト

- renderer: `RenderOrderedCollection` shape + omitempty / `RenderPerson.featured` / `UserFeatured` / `URLs()` accessor。
- ap handler: pinned 出力 / 空 collection / **非public+localOnly 除外 (totalItems=2、leak 無し)** / not-found / remote→404。
- `make fmt && make lint` green。`go test ./internal/activitypub/ ./internal/api/ap/` green (activitypub 90.8% / ap 96.3%)。

Closes #1876

🤖 Generated with [Claude Code](https://claude.com/claude-code)