### PR TITLE
AP followers / following collection endpoints (#1877)

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -235,6 +235,24 @@ func (r *Renderer) RenderOrderedCollection(id string, totalItems int, first, las
 	}
 }
 
+// RenderOrderedCollectionPage builds a single OrderedCollectionPage (#1877)。
+// upstream renderOrderedCollectionPage と同じく orderedItems は常に出力 (空でも []),
+// prev/next は空なら省略する。@context は呼び出し側が AddContext で付与する。
+func (r *Renderer) RenderOrderedCollectionPage(id string, totalItems int, orderedItems []any, partOf, prev, next string) *OrderedCollectionPage {
+	if orderedItems == nil {
+		orderedItems = []any{}
+	}
+	return &OrderedCollectionPage{
+		ID:           id,
+		Type:         "OrderedCollectionPage",
+		PartOf:       partOf,
+		TotalItems:   totalItems,
+		OrderedItems: orderedItems,
+		Prev:         prev,
+		Next:         next,
+	}
+}
+
 // SetMentionResolver attaches a MentionResolver used by RenderNote to populate
 // the `tag` field and additional `to` audience entries. nil で無効化できる。
 func (r *Renderer) SetMentionResolver(mr MentionResolver) {

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -201,6 +201,30 @@ func TestRenderer_RenderOrderedCollection(t *testing.T) {
 	assert.NotContains(t, js, "orderedItems")
 }
 
+func TestRenderer_RenderOrderedCollectionPage(t *testing.T) {
+	r := newRenderer()
+	partOf := "https://example.com/users/u1/followers"
+
+	// next あり: prev は空なので省略、orderedItems は空でも出力。
+	page := r.RenderOrderedCollectionPage(partOf+"?page=true", 7,
+		[]any{"https://a.example/users/x"}, partOf, "", partOf+"?page=true&cursor=c1")
+	assert.Equal(t, "OrderedCollectionPage", page.Type)
+	assert.Equal(t, partOf, page.PartOf)
+	assert.Equal(t, 7, page.TotalItems)
+	assert.Equal(t, partOf+"?page=true&cursor=c1", page.Next)
+	assert.Empty(t, page.Prev)
+
+	// nil items は [] に正規化され、JSON に必ず orderedItems が出る (prev は省略)。
+	empty := r.RenderOrderedCollectionPage(partOf+"?page=true", 0, nil, partOf, "", "")
+	require.NotNil(t, empty.OrderedItems)
+	b, err := json.Marshal(empty)
+	require.NoError(t, err)
+	js := string(b)
+	assert.Contains(t, js, `"orderedItems":[]`)
+	assert.NotContains(t, js, `"prev"`)
+	assert.NotContains(t, js, `"next"`)
+}
+
 func TestRenderer_RenderPerson_NoOptionalFields(t *testing.T) {
 	r := newRenderer()
 	u := &model.User{ID: "u1", Username: "alice"}

--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -116,6 +116,20 @@ type OrderedCollection struct {
 	OrderedItems []any  `json:"orderedItems,omitempty"`
 }
 
+// OrderedCollectionPage is a single page of an OrderedCollection (paginated
+// followers/following/outbox)。upstream ApRendererService.renderOrderedCollectionPage
+// と同 shape。orderedItems は常に出力し (空でも []), prev/next は cursor がある時のみ (#1877)。
+type OrderedCollectionPage struct {
+	Context      any    `json:"@context,omitempty"`
+	ID           string `json:"id"`
+	Type         string `json:"type"`
+	PartOf       string `json:"partOf"`
+	TotalItems   int    `json:"totalItems"`
+	OrderedItems []any  `json:"orderedItems"`
+	Prev         string `json:"prev,omitempty"`
+	Next         string `json:"next,omitempty"`
+}
+
 // PublicKey is the embedded JSON-LD object describing a user's signing key.
 type PublicKey struct {
 	ID           string `json:"id"`
@@ -614,6 +628,8 @@ func AddContext(o any) {
 	case *Move:
 		v.Context = ctx
 	case *OrderedCollection:
+		v.Context = ctx
+	case *OrderedCollectionPage:
 		v.Context = ctx
 	}
 }

--- a/internal/api/ap/handler.go
+++ b/internal/api/ap/handler.go
@@ -70,6 +70,15 @@ type Handler struct {
 	// block (isFollowing 等) を埋めるための repo 束 (#1778)。未配線なら relation は
 	// omit (= legacy 挙動)。
 	relation userrelation.Repos
+	// followingRepo は followers/following collection endpoint (#1877) の page
+	// 取得用。未配線なら両 endpoint は 404 (= legacy 挙動)。
+	followingRepo repository.FollowingRepository
+}
+
+// SetFollowingRepo wires the repository used by the followers/following AP
+// collection endpoints (#1877)。
+func (h *Handler) SetFollowingRepo(r repository.FollowingRepository) {
+	h.followingRepo = r
 }
 
 // SetRelationRepos wires the repositories used to populate the viewer relation
@@ -644,4 +653,148 @@ func (h *Handler) Featured(c echo.Context) error {
 	col := h.renderer.RenderOrderedCollection(h.renderer.URLs().UserFeatured(id), len(items), "", "", items)
 	activitypub.AddContext(col)
 	return writeActivityJSON(c, col)
+}
+
+// Followers handles GET /users/:id/followers (#1877)。
+func (h *Handler) Followers(c echo.Context) error {
+	return h.serveFollowCollection(c, true)
+}
+
+// Following handles GET /users/:id/following (#1877)。
+func (h *Handler) Following(c echo.Context) error {
+	return h.serveFollowCollection(c, false)
+}
+
+// serveFollowCollection serves the followers / following OrderedCollection
+// for a local user (upstream ActivityPubServerService.followers/following, #1877)。
+// followers=true なら followers、false なら following。
+//
+// privacy: profile の followers/followingVisibility が public 以外なら 403
+// (unauthenticated AP request では公開リストのみ serve、upstream と同じ)。
+// base (page!=true) は totalItems + first link、?page=true は cursor ページングで
+// 相手側の actor URI を返す。
+func (h *Handler) serveFollowCollection(c echo.Context, followers bool) error {
+	c.Response().Header().Set("Vary", "Accept")
+	if h.followingRepo == nil {
+		return c.NoContent(http.StatusNotFound)
+	}
+	id := c.Param("id")
+	bundle, err := h.userService.ShowByID(id)
+	if err != nil {
+		return c.NoContent(http.StatusNotFound)
+	}
+	if !bundle.User.IsLocal() {
+		return c.NoContent(http.StatusNotFound)
+	}
+
+	// privacy gate: public 以外 (followers / private) は unauthenticated には出さない。
+	// profile を引けない (transient DB error 等で ShowByID が Profile=nil を返す) 場合は
+	// fail-closed で 403 にする。public default にすると private 設定の follower list を
+	// 一時的に leak し、しかも max-age=180 で 3 分 cache されてしまう (#1877 review、
+	// upstream は findOneByOrFail で 500 = fail-closed)。
+	if bundle.Profile == nil {
+		c.Response().Header().Set("Cache-Control", "public, max-age=30")
+		return c.NoContent(http.StatusForbidden)
+	}
+	vis := bundle.Profile.FollowersVisibility
+	if !followers {
+		vis = bundle.Profile.FollowingVisibility
+	}
+	if vis != model.FollowingVisibilityPublic {
+		c.Response().Header().Set("Cache-Control", "public, max-age=30")
+		return c.NoContent(http.StatusForbidden)
+	}
+
+	urls := h.renderer.URLs()
+	partOf := urls.UserFollowers(id)
+	totalItems := bundle.User.FollowersCount
+	if !followers {
+		partOf = urls.UserFollowing(id)
+		totalItems = bundle.User.FollowingCount
+	}
+
+	// index page: totalItems + first link (upstream renderOrderedCollection)。
+	if c.QueryParam("page") != "true" {
+		col := h.renderer.RenderOrderedCollection(partOf, totalItems, partOf+"?page=true", "", nil)
+		activitypub.AddContext(col)
+		c.Response().Header().Set("Cache-Control", "public, max-age=180")
+		return writeActivityJSON(c, col)
+	}
+
+	// paginated page: cursor (= Following row id) で id DESC ページング。
+	const limit = 10
+	cursor := c.QueryParam("cursor")
+	var rows []*model.Following
+	if followers {
+		rows, err = h.followingRepo.ListFollowersBefore(id, cursor, limit+1)
+	} else {
+		rows, err = h.followingRepo.ListFollowingBefore(id, cursor, limit+1)
+	}
+	if err != nil {
+		return c.NoContent(http.StatusInternalServerError)
+	}
+	inStock := len(rows) == limit+1
+	if inStock {
+		rows = rows[:limit]
+	}
+
+	counterpartIDs := make([]string, 0, len(rows))
+	for _, f := range rows {
+		if followers {
+			counterpartIDs = append(counterpartIDs, f.FollowerID)
+		} else {
+			counterpartIDs = append(counterpartIDs, f.FolloweeID)
+		}
+	}
+	items := h.resolveActorURIs(counterpartIDs)
+
+	// cursor は client 由来なので URL-encode して reflect する (upstream encodeURIComponent
+	// 相当)。aidx id は URL-safe だが、不正な cursor で id field が壊れないようにする。
+	pageID := partOf + "?page=true"
+	if cursor != "" {
+		pageID += "&cursor=" + url.QueryEscape(cursor)
+	}
+	next := ""
+	if inStock && len(rows) > 0 {
+		next = partOf + "?page=true&cursor=" + url.QueryEscape(rows[len(rows)-1].ID)
+	}
+	page := h.renderer.RenderOrderedCollectionPage(pageID, totalItems, items, partOf, "", next)
+	activitypub.AddContext(page)
+	return writeActivityJSON(c, page)
+}
+
+// resolveActorURIs maps a list of user IDs to their actor URIs (local:
+// /users/<id>, remote: user.uri), preserving order and dropping unresolved /
+// URI-less users. upstream renderFollowUser → getUserUri 相当 (#1877)。
+func (h *Handler) resolveActorURIs(ids []string) []any {
+	if len(ids) == 0 {
+		return []any{}
+	}
+	bundles, err := h.userService.ShowManyByIDs(ids)
+	if err != nil {
+		return []any{}
+	}
+	uriByID := make(map[string]string, len(bundles))
+	for _, b := range bundles {
+		uriByID[b.User.ID] = h.actorURI(b.User)
+	}
+	out := make([]any, 0, len(ids))
+	for _, uid := range ids {
+		if uri := uriByID[uid]; uri != "" {
+			out = append(out, uri)
+		}
+	}
+	return out
+}
+
+// actorURI returns the canonical actor URI for a user: local → /users/<id>,
+// remote → stored uri. Empty for a remote user with no uri (skipped by caller)。
+func (h *Handler) actorURI(u *model.User) string {
+	if u.IsLocal() {
+		return h.renderer.URLs().UserURI(u.ID)
+	}
+	if u.URI != nil {
+		return *u.URI
+	}
+	return ""
 }

--- a/internal/api/ap/handler_test.go
+++ b/internal/api/ap/handler_test.go
@@ -3,6 +3,7 @@ package ap
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -1082,6 +1083,220 @@ func TestFeatured_NotFound(t *testing.T) {
 	c, rec := newReq(t, "id", "ghost")
 	require.NoError(t, h.Featured(c))
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// --- followers / following collection (#1877) ---
+
+func newHandlerWithFollowing(t *testing.T) (*Handler, *testutil.MockUserRepository, *testutil.MockFollowingRepository) {
+	t.Helper()
+	userRepo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	piningRepo := testutil.NewMockUserNotePiningRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	userSvc := coreuser.NewService(userRepo, noteRepo, piningRepo, idGen)
+	querySvc := corenote.NewQueryService(noteRepo, nil)
+	keypairRepo := &memoryKeypairRepo{items: map[string]*model.UserKeypair{}}
+	h := NewHandler(activitypub.NewRenderer(activitypub.NewURLBuilder("https://example.com")), userSvc, querySvc, keypairRepo, idGen)
+	h.SetFollowingRepo(followingRepo)
+	return h, userRepo, followingRepo
+}
+
+// newReqQuery is newReq with a raw query string (page/cursor params)。
+func newReqQuery(t *testing.T, paramName, paramValue, rawQuery string) (echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/?"+rawQuery, nil)
+	req.Header.Set(echo.HeaderAccept, "application/activity+json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames(paramName)
+	c.SetParamValues(paramValue)
+	return c, rec
+}
+
+func TestFollowers_IndexCollection(t *testing.T) {
+	h, userRepo, _ := newHandlerWithFollowing(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", FollowersCount: 42}
+	userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1", FollowersVisibility: model.FollowingVisibilityPublic}
+
+	c, rec := newReq(t, "id", "u1")
+	require.NoError(t, h.Followers(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var col map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &col))
+	assert.Equal(t, "OrderedCollection", col["type"])
+	assert.Equal(t, "https://example.com/users/u1/followers", col["id"])
+	assert.Equal(t, float64(42), col["totalItems"])
+	assert.Equal(t, "https://example.com/users/u1/followers?page=true", col["first"])
+}
+
+func TestFollowers_Page_RendersActorURIs(t *testing.T) {
+	h, userRepo, followingRepo := newHandlerWithFollowing(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", FollowersCount: 2}
+	userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1", FollowersVisibility: model.FollowingVisibilityPublic}
+	// local follower + remote follower
+	userRepo.Users["loc"] = &model.User{ID: "loc", Username: "bob"}
+	remoteURI := "https://remote.example/users/carol"
+	host := "remote.example"
+	userRepo.Users["rem"] = &model.User{ID: "rem", Username: "carol", Host: &host, URI: &remoteURI}
+	require.NoError(t, followingRepo.Create(&model.Following{ID: "f1", FolloweeID: "u1", FollowerID: "loc"}))
+	require.NoError(t, followingRepo.Create(&model.Following{ID: "f2", FolloweeID: "u1", FollowerID: "rem"}))
+
+	c, rec := newReqQuery(t, "id", "u1", "page=true")
+	require.NoError(t, h.Followers(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var page map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &page))
+	assert.Equal(t, "OrderedCollectionPage", page["type"])
+	assert.Equal(t, "https://example.com/users/u1/followers", page["partOf"])
+	items, _ := page["orderedItems"].([]any)
+	require.Len(t, items, 2)
+	assert.Contains(t, items, "https://example.com/users/loc", "local follower → /users/<id>")
+	assert.Contains(t, items, remoteURI, "remote follower → stored uri")
+}
+
+func TestFollowers_PrivateVisibility_Forbidden(t *testing.T) {
+	for _, vis := range []model.FollowingVisibility{model.FollowingVisibilityPrivate, model.FollowingVisibilityFollowers} {
+		h, userRepo, _ := newHandlerWithFollowing(t)
+		userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+		userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1", FollowersVisibility: vis}
+		c, rec := newReq(t, "id", "u1")
+		require.NoError(t, h.Followers(c))
+		assert.Equal(t, http.StatusForbidden, rec.Code, "visibility=%s must 403", vis)
+		assert.Equal(t, "public, max-age=30", rec.Header().Get("Cache-Control"))
+	}
+}
+
+func TestFollowing_IndexCollection(t *testing.T) {
+	h, userRepo, _ := newHandlerWithFollowing(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", FollowingCount: 7}
+	userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1", FollowingVisibility: model.FollowingVisibilityPublic}
+
+	c, rec := newReq(t, "id", "u1")
+	require.NoError(t, h.Following(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var col map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &col))
+	assert.Equal(t, "https://example.com/users/u1/following", col["id"])
+	assert.Equal(t, float64(7), col["totalItems"])
+}
+
+func TestFollowers_Remote_NotFound(t *testing.T) {
+	h, userRepo, _ := newHandlerWithFollowing(t)
+	host := "remote.example"
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", Host: &host}
+	c, rec := newReq(t, "id", "u1")
+	require.NoError(t, h.Followers(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestFollowers_UnknownUser_NotFound(t *testing.T) {
+	h, _, _ := newHandlerWithFollowing(t)
+	c, rec := newReq(t, "id", "ghost")
+	require.NoError(t, h.Followers(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestFollowers_RepoUnwired_NotFound(t *testing.T) {
+	h, userRepo, _, _ := newHandlerWithPining(t) // followingRepo 未配線
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	c, rec := newReq(t, "id", "u1")
+	require.NoError(t, h.Followers(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// profile が引けない (transient DB error 等で Profile=nil) 場合は fail-closed で 403
+// にし、private 設定の follower list を public default で leak させない (#1877 review)。
+func TestFollowers_NilProfile_Forbidden(t *testing.T) {
+	h, userRepo, _ := newHandlerWithFollowing(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	// Profiles["u1"] を設定しない → ShowByID は Profile=nil を返す。
+	c, rec := newReq(t, "id", "u1")
+	require.NoError(t, h.Followers(c))
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, "public, max-age=30", rec.Header().Get("Cache-Control"))
+}
+
+func TestFollowers_Page_NextCursorWhenMore(t *testing.T) {
+	h, userRepo, followingRepo := newHandlerWithFollowing(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", FollowersCount: 11}
+	userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1", FollowersVisibility: model.FollowingVisibilityPublic}
+	// 11 followers (limit=10 + 1) → next link が出る。
+	for i := 0; i < 11; i++ {
+		uid := fmt.Sprintf("fu%02d", i)
+		userRepo.Users[uid] = &model.User{ID: uid, Username: uid}
+		require.NoError(t, followingRepo.Create(&model.Following{
+			ID: fmt.Sprintf("ff%02d", i), FolloweeID: "u1", FollowerID: uid,
+		}))
+	}
+
+	c, rec := newReqQuery(t, "id", "u1", "page=true")
+	require.NoError(t, h.Followers(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var page map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &page))
+	items, _ := page["orderedItems"].([]any)
+	assert.Len(t, items, 10, "page is capped at limit=10")
+	next, _ := page["next"].(string)
+	assert.Contains(t, next, "page=true&cursor=", "more rows → next link present")
+}
+
+func TestFollowing_Page_RendersActorURIs(t *testing.T) {
+	h, userRepo, followingRepo := newHandlerWithFollowing(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", FollowingCount: 1}
+	userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1", FollowingVisibility: model.FollowingVisibilityPublic}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob"}
+	require.NoError(t, followingRepo.Create(&model.Following{ID: "g1", FolloweeID: "bob", FollowerID: "u1"}))
+
+	c, rec := newReqQuery(t, "id", "u1", "page=true")
+	require.NoError(t, h.Following(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var page map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &page))
+	items, _ := page["orderedItems"].([]any)
+	require.Len(t, items, 1)
+	assert.Equal(t, "https://example.com/users/bob", items[0])
+}
+
+// remote follower で URI が無いものは skip する (suspend/delete 等で 500 にしない)。
+func TestFollowers_Page_SkipsURILessRemote(t *testing.T) {
+	h, userRepo, followingRepo := newHandlerWithFollowing(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", FollowersCount: 1}
+	userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1", FollowersVisibility: model.FollowingVisibilityPublic}
+	host := "remote.example"
+	userRepo.Users["rem"] = &model.User{ID: "rem", Username: "x", Host: &host} // URI=nil
+	require.NoError(t, followingRepo.Create(&model.Following{ID: "f1", FolloweeID: "u1", FollowerID: "rem"}))
+
+	c, rec := newReqQuery(t, "id", "u1", "page=true")
+	require.NoError(t, h.Followers(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var page map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &page))
+	items, _ := page["orderedItems"].([]any)
+	assert.Empty(t, items, "URI-less remote follower is skipped, no 500")
+}
+
+type errFollowingRepo struct {
+	*testutil.MockFollowingRepository
+}
+
+func (errFollowingRepo) ListFollowersBefore(string, string, int) ([]*model.Following, error) {
+	return nil, errors.New("db down")
+}
+
+func TestFollowers_Page_RepoError_500(t *testing.T) {
+	h, userRepo, _ := newHandlerWithFollowing(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", FollowersCount: 3}
+	userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1", FollowersVisibility: model.FollowingVisibilityPublic}
+	h.SetFollowingRepo(errFollowingRepo{testutil.NewMockFollowingRepository()})
+
+	c, rec := newReqQuery(t, "id", "u1", "page=true")
+	require.NoError(t, h.Followers(c))
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
 func TestFeatured_Remote(t *testing.T) {

--- a/internal/repository/following.go
+++ b/internal/repository/following.go
@@ -54,6 +54,13 @@ type FollowingRepository interface {
 	// ListFollowingByHostCursor is ListFollowingByHost with id cursor pagination.
 	// Used by federation/following (#1732)。
 	ListFollowingByHostCursor(host, sinceID, untilID string, limit int) ([]*model.Following, error)
+	// ListFollowersBefore returns Following rows (followeeId = userID) with
+	// id < cursor (cursor 空なら最新から), ordered id DESC, up to limit. AP
+	// followers collection の cursor pagination 用 (#1877)。
+	ListFollowersBefore(userID, cursor string, limit int) ([]*model.Following, error)
+	// ListFollowingBefore returns Following rows (followerId = userID) with
+	// id < cursor, ordered id DESC, up to limit. AP following collection 用 (#1877)。
+	ListFollowingBefore(userID, cursor string, limit int) ([]*model.Following, error)
 	// CountRemoteFollowees returns the number of Following rows whose
 	// followeeHost is non-NULL (= remote users being followed by anyone).
 	// federation/stats の allSubCount (upstream count where followeeHost is
@@ -291,6 +298,30 @@ func (r *followingRepository) ListFollowingByHostCursor(host, sinceID, untilID s
 	}
 	var rows []*model.Following
 	if err := q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *followingRepository) ListFollowersBefore(userID, cursor string, limit int) ([]*model.Following, error) {
+	q := r.db.Where(`"followeeId" = ?`, userID)
+	if cursor != "" {
+		q = q.Where("id < ?", cursor)
+	}
+	var rows []*model.Following
+	if err := q.Order("id DESC").Limit(limit).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *followingRepository) ListFollowingBefore(userID, cursor string, limit int) ([]*model.Following, error) {
+	q := r.db.Where(`"followerId" = ?`, userID)
+	if cursor != "" {
+		q = q.Where("id < ?", cursor)
+	}
+	var rows []*model.Following
+	if err := q.Order("id DESC").Limit(limit).Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil

--- a/internal/repository/following_test.go
+++ b/internal/repository/following_test.go
@@ -283,6 +283,55 @@ func TestFollowingRepository_ListFollowers_ListFollowing(t *testing.T) {
 	assert.Len(t, followingsOfA, 2)
 }
 
+// ListFollowersBefore / ListFollowingBefore は id DESC で cursor (id <) ページング
+// する (AP followers/following collection の page 用, #1877)。
+func TestFollowingRepository_ListFollowersBefore_ListFollowingBefore(t *testing.T) {
+	repo := NewFollowingRepository(testDB)
+	target := insertTestUser(t, "u_fb_t", "fbtarget")
+	defer cleanupUser(t, target.ID)
+	f1 := insertTestUser(t, "u_fb_1", "fb1")
+	defer cleanupUser(t, f1.ID)
+	f2 := insertTestUser(t, "u_fb_2", "fb2")
+	defer cleanupUser(t, f2.ID)
+	f3 := insertTestUser(t, "u_fb_3", "fb3")
+	defer cleanupUser(t, f3.ID)
+	// f1,f2,f3 follow target → target の followers。row id 昇順 fb_a < fb_b < fb_c。
+	insertFollowing(t, "fb_a", f1.ID, target.ID)
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, "fb_a")
+	insertFollowing(t, "fb_b", f2.ID, target.ID)
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, "fb_b")
+	insertFollowing(t, "fb_c", f3.ID, target.ID)
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, "fb_c")
+
+	// cursor 無し → 全件 id DESC。
+	all, err := repo.ListFollowersBefore(target.ID, "", 10)
+	require.NoError(t, err)
+	require.Len(t, all, 3)
+	assert.Equal(t, "fb_c", all[0].ID)
+	assert.Equal(t, "fb_a", all[2].ID)
+
+	// limit。
+	lim, err := repo.ListFollowersBefore(target.ID, "", 2)
+	require.NoError(t, err)
+	assert.Len(t, lim, 2)
+
+	// cursor: id < "fb_c" → fb_b, fb_a。
+	page, err := repo.ListFollowersBefore(target.ID, "fb_c", 10)
+	require.NoError(t, err)
+	require.Len(t, page, 2)
+	assert.Equal(t, "fb_b", page[0].ID)
+
+	// following 側: target が g1 を follow。
+	g1 := insertTestUser(t, "u_fb_g", "fbg")
+	defer cleanupUser(t, g1.ID)
+	insertFollowing(t, "fb_g", target.ID, g1.ID)
+	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, "fb_g")
+	flw, err := repo.ListFollowingBefore(target.ID, "", 10)
+	require.NoError(t, err)
+	require.Len(t, flw, 1)
+	assert.Equal(t, "fb_g", flw[0].ID)
+}
+
 // ListFollowersToNotify は notify='normal' の follower row だけを返す (#1559)。
 func TestFollowingRepository_ListFollowersToNotify(t *testing.T) {
 	repo := NewFollowingRepository(testDB)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1777,6 +1777,7 @@ func (s *Server) setupRoutes() {
 	// FEP-521a Multikey 対応で actor JSON に assertionMethod[] を expose する
 	// ため Ed25519 keypair repo を wire (#1067 / #1069)。
 	apHandler.SetKeypairExtraRepo(keypairExtraRepo)
+	apHandler.SetFollowingRepo(followingRepo) // #1877 followers/following collection
 	// ap/show が返す UserDetailedNotMe に viewer relation block を埋める (#1778)。
 	apHandler.SetRelationRepos(userrelation.Repos{
 		Following:     followingRepo,
@@ -1792,6 +1793,8 @@ func (s *Server) setupRoutes() {
 	apHandler.SetNonAPFallback(frontend)
 	s.echo.GET("/users/:id", apHandler.User)
 	s.echo.GET("/users/:id/collections/featured", apHandler.Featured) // #1876 pinned notes
+	s.echo.GET("/users/:id/followers", apHandler.Followers)           // #1877
+	s.echo.GET("/users/:id/following", apHandler.Following)           // #1877
 	s.echo.GET("/notes/:id", apHandler.Note)
 	s.echo.GET("/@:acct", apHandler.UserByAcct)
 

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -5356,6 +5356,18 @@ func (m *MockFollowingRepository) ListFollowingByHostCursor(host, sinceID, until
 	}, sinceID, untilID, limit), nil
 }
 
+func (m *MockFollowingRepository) ListFollowersBefore(userID, cursor string, limit int) ([]*model.Following, error) {
+	return m.hostCursorPage(func(f *model.Following) bool {
+		return f.FolloweeID == userID
+	}, "", cursor, limit), nil
+}
+
+func (m *MockFollowingRepository) ListFollowingBefore(userID, cursor string, limit int) ([]*model.Following, error) {
+	return m.hostCursorPage(func(f *model.Following) bool {
+		return f.FollowerID == userID
+	}, "", cursor, limit), nil
+}
+
 func (m *MockFollowingRepository) CountRemoteFollowees() (int64, error) {
 	var n int64
 	for _, f := range m.Followings {


### PR DESCRIPTION
## Summary

#1827 → #1871 (AP collection endpoints) 再分割の 2 件目。actor が advertise する `followers`/`following` URI に対応する GET endpoint が無く全て 404 だった。upstream `ActivityPubServerService.followers`/`following` 同等に OrderedCollection として serve する。

## 主な変更点

- **types/renderer**: `OrderedCollectionPage` 型 + `RenderOrderedCollectionPage` (orderedItems は空でも `[]` を出力、prev/next omitempty)。
- **repository**: `ListFollowersBefore` / `ListFollowingBefore` (`followeeId`/`followerId`, `id < cursor`, `id DESC`) を interface + 実装 + mock + testcontainer test で追加。
- **ap/handler.go**: `GET /users/:id/followers` と `/following` → `serveFollowCollection`。
  - **privacy gate**: `followersVisibility`/`followingVisibility` が public 以外 (followers/private) なら 403 + `Cache-Control: public, max-age=30`。**profile を引けない場合も fail-closed で 403** (transient DB error で private list を public default + 180s cache で漏らさない)。
  - index (no `?page`) は `{totalItems: FollowersCount, first: ...?page=true}` + `max-age=180`。
  - `?page=true` は cursor (Following row id) ページング (limit 10) で相手側の actor URI (local→`/users/id`、remote→`uri`、URI 無しは skip) を OrderedCollectionPage で返す。cursor は URL-encode。
- **router.go**: route + `SetFollowingRepo` 配線。

## レビュー指摘の対応

敵対的レビュー round-1 で **MAJOR (nil profile 時の fail-open privacy leak)** を検出し fail-closed 403 に修正 (round-2 RESOLVED 確認)。cursor の URL-encode・pagination/next/skip/500 経路のテストも追加。

## テスト

- ap handler: index / page (local+remote URI) / privacy 403 (private+followers、Cache-Control 検証) / nil profile 403 / remote 404 / unknown 404 / unwired 404 / next cursor (>limit) / following page / URI-less skip / repo error 500。
- repository: `ListFollowersBefore`/`ListFollowingBefore` の cursor pagination。
- renderer: `RenderOrderedCollectionPage` shape。
- `make fmt && make lint` green。`go test ./internal/api/ap/ ./internal/activitypub/ ./internal/repository/` green (ap 96.3% / activitypub 90.7% / repository 90.1%)。

Closes #1877

🤖 Generated with [Claude Code](https://claude.com/claude-code)