### PR TITLE
AP outbox collection endpoint (#1878)

### DIFF
--- a/internal/api/ap/handler.go
+++ b/internal/api/ap/handler.go
@@ -73,12 +73,21 @@ type Handler struct {
 	// followingRepo は followers/following collection endpoint (#1877) の page
 	// 取得用。未配線なら両 endpoint は 404 (= legacy 挙動)。
 	followingRepo repository.FollowingRepository
+	// noteRepo は outbox collection endpoint (#1878) の public note 取得 +
+	// pure renote の target URI 解決用。未配線なら outbox は 404。
+	noteRepo repository.NoteRepository
 }
 
 // SetFollowingRepo wires the repository used by the followers/following AP
 // collection endpoints (#1877)。
 func (h *Handler) SetFollowingRepo(r repository.FollowingRepository) {
 	h.followingRepo = r
+}
+
+// SetNoteRepo wires the repository used by the outbox AP collection endpoint
+// (#1878)。
+func (h *Handler) SetNoteRepo(r repository.NoteRepository) {
+	h.noteRepo = r
 }
 
 // SetRelationRepos wires the repositories used to populate the viewer relation
@@ -795,6 +804,109 @@ func (h *Handler) actorURI(u *model.User) string {
 	}
 	if u.URI != nil {
 		return *u.URI
+	}
+	return ""
+}
+
+// Outbox handles GET /users/:id/outbox, serving the local user's public/home
+// (non-localOnly) notes as Create/Announce activities in an OrderedCollection
+// (upstream ActivityPubServerService.outbox, #1878)。
+func (h *Handler) Outbox(c echo.Context) error {
+	c.Response().Header().Set("Vary", "Accept")
+	if h.noteRepo == nil {
+		return c.NoContent(http.StatusNotFound)
+	}
+	id := c.Param("id")
+	bundle, err := h.userService.ShowByID(id)
+	if err != nil {
+		return c.NoContent(http.StatusNotFound)
+	}
+	if !bundle.User.IsLocal() {
+		return c.NoContent(http.StatusNotFound)
+	}
+
+	partOf := h.renderer.URLs().UserOutbox(id)
+	totalItems := bundle.User.NotesCount
+
+	// index page: totalItems + first link (upstream renderOrderedCollection)。
+	// upstream は last link (since_id=<min>) も出すが ObjectId 前提の sentinel な
+	// ので、aidx の mk-go では first + next 走査のみで完結させ last は省略する。
+	if c.QueryParam("page") != "true" {
+		col := h.renderer.RenderOrderedCollection(partOf, totalItems, partOf+"?page=true", "", nil)
+		activitypub.AddContext(col)
+		c.Response().Header().Set("Cache-Control", "public, max-age=180")
+		return writeActivityJSON(c, col)
+	}
+
+	sinceID := c.QueryParam("since_id")
+	untilID := c.QueryParam("until_id")
+	// upstream: since_id と until_id を同時指定したら 400。
+	if sinceID != "" && untilID != "" {
+		return c.NoContent(http.StatusBadRequest)
+	}
+	const limit = 20
+	notes, err := h.noteRepo.ListPublicByUserID(id, untilID, sinceID, limit)
+	if err != nil {
+		return c.NoContent(http.StatusInternalServerError)
+	}
+	// since_id 指定時は ASC で返るので、collection の新しい順 (DESC) に揃えるため反転。
+	if sinceID != "" {
+		for i, j := 0, len(notes)-1; i < j; i, j = i+1, j-1 {
+			notes[i], notes[j] = notes[j], notes[i]
+		}
+	}
+
+	items := make([]any, 0, len(notes))
+	for _, n := range notes {
+		items = append(items, h.packOutboxActivity(bundle.User, n))
+	}
+
+	pageID := partOf + "?page=true"
+	if sinceID != "" {
+		pageID += "&since_id=" + url.QueryEscape(sinceID)
+	}
+	if untilID != "" {
+		pageID += "&until_id=" + url.QueryEscape(untilID)
+	}
+	prev, next := "", ""
+	if len(notes) > 0 {
+		prev = partOf + "?page=true&since_id=" + url.QueryEscape(notes[0].ID)
+		next = partOf + "?page=true&until_id=" + url.QueryEscape(notes[len(notes)-1].ID)
+	}
+	page := h.renderer.RenderOrderedCollectionPage(pageID, totalItems, items, partOf, prev, next)
+	activitypub.AddContext(page)
+	return writeActivityJSON(c, page)
+}
+
+// packOutboxActivity renders an outbox item: a pure renote becomes an Announce,
+// everything else a Create (upstream packActivity, #1878)。embed するので
+// per-activity @context は外す (collection 側が持つ)。
+func (h *Handler) packOutboxActivity(author *model.User, n *model.Note) any {
+	if corenote.IsPureRenote(n) && n.RenoteID != nil && *n.RenoteID != "" {
+		if targetURI := h.renoteTargetURI(*n.RenoteID); targetURI != "" {
+			ann := h.renderer.RenderAnnounce(author, n.ID, targetURI)
+			ann.Context = nil
+			return ann
+		}
+		// target を解決できないときは Create にフォールバック (shape は valid のまま)。
+	}
+	create := h.renderer.RenderCreate(n, h.idGen)
+	create.Context = nil
+	return create
+}
+
+// renoteTargetURI resolves a renote target note id to its AP URI
+// (local → /notes/<id>, remote → stored uri)。
+func (h *Handler) renoteTargetURI(targetID string) string {
+	t, err := h.noteRepo.FindByID(targetID)
+	if err != nil || t == nil {
+		return ""
+	}
+	if t.UserHost == nil || *t.UserHost == "" {
+		return h.renderer.URLs().NoteURI(t.ID)
+	}
+	if t.URI != nil {
+		return *t.URI
 	}
 	return ""
 }

--- a/internal/api/ap/handler_test.go
+++ b/internal/api/ap/handler_test.go
@@ -1307,3 +1307,196 @@ func TestFeatured_Remote(t *testing.T) {
 	require.NoError(t, h.Featured(c))
 	assert.Equal(t, http.StatusNotFound, rec.Code, "remote actor featured must 404")
 }
+
+// --- outbox collection (#1878) ---
+
+func newHandlerWithOutbox(t *testing.T) (*Handler, *testutil.MockUserRepository, *testutil.MockNoteRepository) {
+	t.Helper()
+	userRepo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	piningRepo := testutil.NewMockUserNotePiningRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	userSvc := coreuser.NewService(userRepo, noteRepo, piningRepo, idGen)
+	querySvc := corenote.NewQueryService(noteRepo, nil)
+	keypairRepo := &memoryKeypairRepo{items: map[string]*model.UserKeypair{}}
+	h := NewHandler(activitypub.NewRenderer(activitypub.NewURLBuilder("https://example.com")), userSvc, querySvc, keypairRepo, idGen)
+	h.SetNoteRepo(noteRepo)
+	return h, userRepo, noteRepo
+}
+
+func TestOutbox_IndexCollection(t *testing.T) {
+	h, userRepo, _ := newHandlerWithOutbox(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", NotesCount: 10}
+
+	c, rec := newReq(t, "id", "u1")
+	require.NoError(t, h.Outbox(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "public, max-age=180", rec.Header().Get("Cache-Control"))
+
+	var col map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &col))
+	assert.Equal(t, "OrderedCollection", col["type"])
+	assert.Equal(t, "https://example.com/users/u1/outbox", col["id"])
+	assert.Equal(t, float64(10), col["totalItems"])
+	assert.Equal(t, "https://example.com/users/u1/outbox?page=true", col["first"])
+}
+
+func TestOutbox_Page_CreateActivities(t *testing.T) {
+	h, userRepo, noteRepo := newHandlerWithOutbox(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", NotesCount: 2}
+	text := "hi"
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic, Text: &text}
+	noteRepo.Notes["n2"] = &model.Note{ID: "n2", UserID: "u1", Visibility: model.NoteVisibilityHome, Text: &text}
+
+	c, rec := newReqQuery(t, "id", "u1", "page=true")
+	require.NoError(t, h.Outbox(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var page map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &page))
+	assert.Equal(t, "OrderedCollectionPage", page["type"])
+	assert.Equal(t, "https://example.com/users/u1/outbox", page["partOf"])
+	items, _ := page["orderedItems"].([]any)
+	require.Len(t, items, 2)
+	first, _ := items[0].(map[string]any)
+	assert.Equal(t, "Create", first["type"])
+	next, _ := page["next"].(string)
+	assert.Contains(t, next, "page=true&until_id=")
+}
+
+func TestOutbox_Page_PureRenoteAsAnnounce(t *testing.T) {
+	h, userRepo, noteRepo := newHandlerWithOutbox(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", NotesCount: 1}
+	noteRepo.Notes["tgt"] = &model.Note{ID: "tgt", UserID: "bob", Visibility: model.NoteVisibilityPublic}
+	renoteID := "tgt"
+	noteRepo.Notes["re"] = &model.Note{ID: "re", UserID: "u1", Visibility: model.NoteVisibilityPublic, RenoteID: &renoteID}
+
+	c, rec := newReqQuery(t, "id", "u1", "page=true")
+	require.NoError(t, h.Outbox(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var page map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &page))
+	items, _ := page["orderedItems"].([]any)
+	require.Len(t, items, 1)
+	item, _ := items[0].(map[string]any)
+	assert.Equal(t, "Announce", item["type"])
+	assert.Equal(t, "https://example.com/notes/tgt", item["object"], "Announce object = target note URI")
+}
+
+func TestOutbox_Page_ExcludesNonPublic(t *testing.T) {
+	h, userRepo, noteRepo := newHandlerWithOutbox(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", NotesCount: 4}
+	text := "x"
+	noteRepo.Notes["pub"] = &model.Note{ID: "pub", UserID: "u1", Visibility: model.NoteVisibilityPublic, Text: &text}
+	noteRepo.Notes["fol"] = &model.Note{ID: "fol", UserID: "u1", Visibility: model.NoteVisibilityFollowers, Text: &text}
+	noteRepo.Notes["spec"] = &model.Note{ID: "spec", UserID: "u1", Visibility: model.NoteVisibilitySpecified, Text: &text}
+	noteRepo.Notes["lo"] = &model.Note{ID: "lo", UserID: "u1", Visibility: model.NoteVisibilityPublic, LocalOnly: true, Text: &text}
+
+	c, rec := newReqQuery(t, "id", "u1", "page=true")
+	require.NoError(t, h.Outbox(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var page map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &page))
+	items, _ := page["orderedItems"].([]any)
+	assert.Len(t, items, 1, "followers/specified/localOnly notes excluded from outbox")
+}
+
+// since_id 指定時は repo が ASC で返すのを handler が DESC に反転し、prev/next を
+// 正しい向き (prev=最新, next=最古) で出すこと (#1878 review M1)。
+func TestOutbox_Page_SinceReverse(t *testing.T) {
+	h, userRepo, noteRepo := newHandlerWithOutbox(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", NotesCount: 3}
+	text := "x"
+	for _, nid := range []string{"o1", "o2", "o3"} { // o1 < o2 < o3
+		noteRepo.Notes[nid] = &model.Note{ID: nid, UserID: "u1", Visibility: model.NoteVisibilityPublic, Text: &text}
+	}
+
+	// since_id=o1 → id > o1 = {o2,o3}、ASC で取得 → DESC に反転 → [o3, o2]。
+	c, rec := newReqQuery(t, "id", "u1", "page=true&since_id=o1")
+	require.NoError(t, h.Outbox(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var page map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &page))
+	items, _ := page["orderedItems"].([]any)
+	require.Len(t, items, 2)
+	// 反転後の先頭は最新 (o3)。Create.object.id = .../notes/o3。
+	first, _ := items[0].(map[string]any)
+	obj, _ := first["object"].(map[string]any)
+	assert.Equal(t, "https://example.com/notes/o3", obj["id"], "reversed → newest first")
+	// prev=最新 (o3), next=最古 (o2)。
+	assert.Contains(t, page["prev"], "since_id=o3")
+	assert.Contains(t, page["next"], "until_id=o2")
+}
+
+// remote renote target は Announce.object に remote URI を出す (#1878 review m1)。
+func TestOutbox_Page_RemoteRenoteTarget_Announce(t *testing.T) {
+	h, userRepo, noteRepo := newHandlerWithOutbox(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", NotesCount: 1}
+	host := "remote.example"
+	turi := "https://remote.example/notes/x"
+	noteRepo.Notes["tgt"] = &model.Note{ID: "tgt", UserID: "rem", Visibility: model.NoteVisibilityPublic, UserHost: &host, URI: &turi}
+	rid := "tgt"
+	noteRepo.Notes["re"] = &model.Note{ID: "re", UserID: "u1", Visibility: model.NoteVisibilityPublic, RenoteID: &rid}
+
+	c, rec := newReqQuery(t, "id", "u1", "page=true")
+	require.NoError(t, h.Outbox(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var page map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &page))
+	items, _ := page["orderedItems"].([]any)
+	require.Len(t, items, 1)
+	item, _ := items[0].(map[string]any)
+	assert.Equal(t, "Announce", item["type"])
+	assert.Equal(t, turi, item["object"], "Announce object = remote target uri")
+}
+
+// target を解決できない pure renote は Create にフォールバックする (#1878 review m1)。
+func TestOutbox_Page_RenoteTargetMissing_CreateFallback(t *testing.T) {
+	h, userRepo, noteRepo := newHandlerWithOutbox(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", NotesCount: 1}
+	rid := "ghost" // target を seed しない
+	noteRepo.Notes["re"] = &model.Note{ID: "re", UserID: "u1", Visibility: model.NoteVisibilityPublic, RenoteID: &rid}
+
+	c, rec := newReqQuery(t, "id", "u1", "page=true")
+	require.NoError(t, h.Outbox(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var page map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &page))
+	items, _ := page["orderedItems"].([]any)
+	require.Len(t, items, 1)
+	item, _ := items[0].(map[string]any)
+	assert.Equal(t, "Create", item["type"], "unresolvable target → Create fallback")
+}
+
+func TestOutbox_SinceAndUntil_400(t *testing.T) {
+	h, userRepo, _ := newHandlerWithOutbox(t)
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	c, rec := newReqQuery(t, "id", "u1", "page=true&since_id=a&until_id=b")
+	require.NoError(t, h.Outbox(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestOutbox_Remote_NotFound(t *testing.T) {
+	h, userRepo, _ := newHandlerWithOutbox(t)
+	host := "remote.example"
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice", Host: &host}
+	c, rec := newReq(t, "id", "u1")
+	require.NoError(t, h.Outbox(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestOutbox_UnknownUser_NotFound(t *testing.T) {
+	h, _, _ := newHandlerWithOutbox(t)
+	c, rec := newReq(t, "id", "ghost")
+	require.NoError(t, h.Outbox(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestOutbox_RepoUnwired_NotFound(t *testing.T) {
+	h, userRepo, _, _ := newHandlerWithPining(t) // noteRepo (outbox) 未配線
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	c, rec := newReq(t, "id", "u1")
+	require.NoError(t, h.Outbox(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -836,6 +836,9 @@ func (f *failingNoteRepo) IncrementReaction(_ string, _ string, _ int) error { r
 func (f *failingNoteRepo) ListByUserID(_ string, _, _ string, _ int) ([]*model.Note, error) {
 	return nil, nil
 }
+func (f *failingNoteRepo) ListPublicByUserID(_ string, _, _ string, _ int) ([]*model.Note, error) {
+	return nil, nil
+}
 func (f *failingNoteRepo) ListByUserIDFiltered(_, _, _, _ string, _ int, _, _, _, _ bool) ([]*model.Note, error) {
 	return nil, nil
 }

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -66,6 +66,9 @@ type NoteRepository interface {
 	IncrementCount(noteID, column string, delta int) error
 	IncrementReaction(noteID, reaction string, delta int) error
 	ListByUserID(userID string, untilID, sinceID string, limit int) ([]*model.Note, error)
+	// ListPublicByUserID is ListByUserID restricted to AP-servable notes
+	// (visibility IN (public, home) AND NOT localOnly), for the actor outbox (#1878)。
+	ListPublicByUserID(userID string, untilID, sinceID string, limit int) ([]*model.Note, error)
 	// ListByUserIDFiltered returns notes owned by userID with upstream
 	// `users/notes` filter parameters applied. 4 つの bool は upstream paramDef
 	// と同じ semantics で各々:
@@ -334,6 +337,24 @@ func (r *noteRepository) IncrementReaction(noteID, reaction string, delta int) e
 func (r *noteRepository) ListByUserID(userID string, untilID, sinceID string, limit int) ([]*model.Note, error) {
 	var notes []*model.Note
 	q := preloadNoteRelations(r.db).Where("\"userId\" = ?", userID)
+	if untilID != "" {
+		q = q.Where("id < ?", untilID)
+	}
+	if sinceID != "" {
+		q = q.Where("id > ?", sinceID)
+	}
+	if err := q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit).Find(&notes).Error; err != nil {
+		return nil, err
+	}
+	return notes, nil
+}
+
+func (r *noteRepository) ListPublicByUserID(userID string, untilID, sinceID string, limit int) ([]*model.Note, error) {
+	var notes []*model.Note
+	q := preloadNoteRelations(r.db).
+		Where("\"userId\" = ?", userID).
+		Where("visibility IN ?", []string{"public", "home"}).
+		Where("\"localOnly\" = ?", false)
 	if untilID != "" {
 		q = q.Where("id < ?", untilID)
 	}

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -3239,3 +3239,50 @@ func TestNoteRepository_CountLocal_Error(t *testing.T) {
 	_, err = repo.CountLocalComments()
 	assert.Error(t, err)
 }
+
+// ListPublicByUserID は visibility ∈ {public, home} かつ !localOnly の note のみを
+// id DESC / cursor で返す (AP outbox 用, #1878)。
+func TestNoteRepository_ListPublicByUserID(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	u := insertTestUser(t, "u_obx", "obxuser")
+	defer cleanupUser(t, u.ID)
+	defer testDB.Exec(`DELETE FROM "note" WHERE "userId" = ?`, u.ID)
+
+	mk := func(id string, vis model.NoteVisibility, localOnly bool) {
+		require.NoError(t, repo.Create(&model.Note{ID: id, UserID: u.ID, Visibility: vis, LocalOnly: localOnly}))
+	}
+	mk("obx_pub1", model.NoteVisibilityPublic, false)
+	mk("obx_pub2", model.NoteVisibilityPublic, false)
+	mk("obx_home", model.NoteVisibilityHome, false)
+	mk("obx_fol", model.NoteVisibilityFollowers, false)
+	mk("obx_spec", model.NoteVisibilitySpecified, false)
+	mk("obx_lo", model.NoteVisibilityPublic, true)
+
+	all, err := repo.ListPublicByUserID(u.ID, "", "", 50)
+	require.NoError(t, err)
+	got := map[string]bool{}
+	for _, n := range all {
+		got[n.ID] = true
+	}
+	assert.Len(t, all, 3, "public x2 + home only")
+	assert.True(t, got["obx_pub1"])
+	assert.True(t, got["obx_home"])
+	assert.False(t, got["obx_fol"], "followers excluded")
+	assert.False(t, got["obx_spec"], "specified excluded")
+	assert.False(t, got["obx_lo"], "localOnly excluded")
+
+	// untilID cursor: id < "obx_pub2"。
+	page, err := repo.ListPublicByUserID(u.ID, "obx_pub2", "", 50)
+	require.NoError(t, err)
+	for _, n := range page {
+		assert.Less(t, n.ID, "obx_pub2", "cursor excludes id >= until")
+	}
+
+	// sinceID cursor: id > "obx_home" → obx_pub1, obx_pub2 を ASC で返す
+	// (paginationOrder が since-only で ASC に倒す。handler 側で reverse される)。
+	sinceRows, err := repo.ListPublicByUserID(u.ID, "", "obx_home", 50)
+	require.NoError(t, err)
+	require.Len(t, sinceRows, 2)
+	assert.Equal(t, "obx_pub1", sinceRows[0].ID, "since-only is ASC")
+	assert.Equal(t, "obx_pub2", sinceRows[1].ID)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1778,6 +1778,7 @@ func (s *Server) setupRoutes() {
 	// ため Ed25519 keypair repo を wire (#1067 / #1069)。
 	apHandler.SetKeypairExtraRepo(keypairExtraRepo)
 	apHandler.SetFollowingRepo(followingRepo) // #1877 followers/following collection
+	apHandler.SetNoteRepo(noteRepo)           // #1878 outbox collection
 	// ap/show が返す UserDetailedNotMe に viewer relation block を埋める (#1778)。
 	apHandler.SetRelationRepos(userrelation.Repos{
 		Following:     followingRepo,
@@ -1795,6 +1796,7 @@ func (s *Server) setupRoutes() {
 	s.echo.GET("/users/:id/collections/featured", apHandler.Featured) // #1876 pinned notes
 	s.echo.GET("/users/:id/followers", apHandler.Followers)           // #1877
 	s.echo.GET("/users/:id/following", apHandler.Following)           // #1877
+	s.echo.GET("/users/:id/outbox", apHandler.Outbox)                 // #1878
 	s.echo.GET("/notes/:id", apHandler.Note)
 	s.echo.GET("/@:acct", apHandler.UserByAcct)
 

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1131,6 +1131,13 @@ func (m *MockNoteRepository) ListByUserID(userID string, untilID, sinceID string
 	}, untilID, sinceID, limit), nil
 }
 
+func (m *MockNoteRepository) ListPublicByUserID(userID string, untilID, sinceID string, limit int) ([]*model.Note, error) {
+	return m.listFiltered(func(n *model.Note) bool {
+		return n.UserID == userID && !n.LocalOnly &&
+			(n.Visibility == model.NoteVisibilityPublic || n.Visibility == model.NoteVisibilityHome)
+	}, untilID, sinceID, limit), nil
+}
+
 // ListByUserIDFiltered は ListByUserID に upstream `users/notes` 互換の
 // filter 引数を適用した版。production GORM impl と同 logic で predicate に
 // 詰めて listFiltered に委譲する (#1021)。bool 4 引数は repository interface


### PR DESCRIPTION
## Summary

#1827 → #1871 (AP collection endpoints) 再分割の 3 件目 (最後)。actor が advertise する `outbox` URI に対応する GET endpoint が無く 404 だった。upstream `ActivityPubServerService.outbox` 同等に、user の public/home (非 localOnly) note を Create/Announce activity の OrderedCollection として serve する。

## 主な変更点

- **repository/note.go**: `ListPublicByUserID` (`visibility IN (public, home) AND NOT localOnly`, since/until cursor) を interface + 実装 + mock + testcontainer test で追加。
- **api/ap/handler.go**: `GET /users/:id/outbox`。
  - index (no `?page`) は `{totalItems: NotesCount, first: ...?page=true}` + `Cache-Control: public, max-age=180`。
  - `?page=true` (`since_id`/`until_id`、両指定は 400) は public note を limit=20 でページングし、`packActivity` (pure renote → `Announce`、それ以外 → `Create`) で返す。`since_id` 指定時は repo が ASC で返すのを DESC に反転、`prev=since_id`/`next=until_id`。embed activity の `@context` は外す (collection 側が持つ、#1876 と同方針)。aidx では ObjectId sentinel 依存の `last` link は省略。
- **router.go**: route + `SetNoteRepo` 配線。

## レビュー指摘の対応

敵対的レビューで since/until reverse 経路と renote target URI 解決 (remote/欠落) 経路のテストを追加。pre-existing divergence (`RenderAnnounce` の renote-visibility 無視 / `IsPureRenote` の quote=replyId 未考慮) は **#1882** に分離。

## テスト

- ap handler: index / page (Create) / pure renote→Announce / remote target→Announce / target 欠落→Create fallback / since reverse (prev/next 向き) / 非public 除外 / since+until 400 / remote 404 / unknown 404 / unwired 404。
- repository: `ListPublicByUserID` の visibility filter + until/since cursor。
- `make fmt && make lint` green。`go test ./internal/api/ap/ ./internal/repository/` green (ap 96.0% / repository 90.1%)。

Closes #1878

🤖 Generated with [Claude Code](https://claude.com/claude-code)