### PR TITLE
ap/get の resolveLocal に host guard を追加し remote object を local 化しない (#1873)

### DIFF
--- a/internal/api/ap/handler.go
+++ b/internal/api/ap/handler.go
@@ -526,12 +526,25 @@ func (h *Handler) resolveLocal(uri string) (any, error) {
 		if err != nil {
 			return nil, err
 		}
+		// remote note は local-domain の id/uri で render すると別オブジェクトに
+		// なってしまうので local 専用 (#1873)。error 返しで caller は remote fetch
+		// → NO_SUCH_OBJECT へフォールバックする。
+		if n.UserHost != nil && *n.UserHost != "" {
+			return nil, http.ErrNotSupported
+		}
 		return h.renderer.RenderNote(n, h.idGen), nil
 	}
 	if userID := extractLocalID(uri, "/users/"); userID != "" {
 		bundle, err := h.userService.ShowByID(userID)
 		if err != nil {
 			return nil, err
+		}
+		// remote user (local aidx id を持つ) を local-domain actor として render
+		// すると id/url/featured が誤った自ドメイン URI になるので local 専用
+		// (#1873。連合向けの User/Followers/Following/Outbox/Featured handler は
+		// 既に Host guard 済みだが、この admin ap/get 経路だけ漏れていた)。
+		if !bundle.User.IsLocal() {
+			return nil, http.ErrNotSupported
 		}
 		keypair, err := h.keypairRepo.FindByUserID(bundle.User.ID)
 		if err != nil {

--- a/internal/api/ap/handler_test.go
+++ b/internal/api/ap/handler_test.go
@@ -463,6 +463,28 @@ func TestAPIGet_UserNotFound(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "NO_SUCH_OBJECT")
 }
 
+// remote user (local aidx id を持つ) を local-domain URI で ap/get しても、自ドメインの
+// 誤った Person を返さず NO_SUCH_OBJECT になる (#1873)。
+func TestAPIGet_RemoteUserViaLocalURI_NotFound(t *testing.T) {
+	h, userRepo, _, _ := newHandler(t)
+	host := "remote.example"
+	userRepo.Users["rem1"] = &model.User{ID: "rem1", Username: "carol", Host: &host}
+	rec := postJSON(h.APIGet, `{"uri":"https://example.com/users/rem1"}`)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_OBJECT")
+	assert.NotContains(t, rec.Body.String(), "Person", "remote user must not be rendered as a local Person")
+}
+
+// remote note も local-domain URI 経由では render せず NO_SUCH_OBJECT (#1873)。
+func TestAPIGet_RemoteNoteViaLocalURI_NotFound(t *testing.T) {
+	h, _, noteRepo, _ := newHandler(t)
+	host := "remote.example"
+	noteRepo.Notes["rn1"] = &model.Note{ID: "rn1", UserID: "bob", Visibility: model.NoteVisibilityPublic, UserHost: &host}
+	rec := postJSON(h.APIGet, `{"uri":"https://example.com/notes/rn1"}`)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_OBJECT")
+}
+
 func TestAPIGet_UserKeypairError(t *testing.T) {
 	h, userRepo, _, keypairRepo := newHandler(t)
 	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}


### PR DESCRIPTION
## Summary

#1869 の敵対的レビューで surface した pre-existing gap (#1873)。admin-only `POST /api/ap/get` → `resolveLocal(uri)` は `/users/<id>` / `/notes/<id>` を host 無視で抽出し、remote object (local aidx id + 非 nil Host で永続化) を `RenderPerson`/`RenderNote` に渡していた。結果 `id`/`url`/`featured` (user) や `id`/`uri` (note) が誤った自ドメイン URI になっていた。

連合向けの `User`/`Followers`/`Following`/`Outbox`/`Featured` handler は既に Host guard 済みだが、この admin debug 経路だけ漏れていた。

## 主な変更点

- `resolveLocal` の note branch: `n.UserHost` が非 nil/空なら `ErrNotSupported`。
- user branch: `!bundle.User.IsLocal()` なら `ErrNotSupported` (keypair fetch / RenderPerson の前)。
- caller (`APIGet`) は error を remote fetch へフォールバックさせ、local-domain URI の self-fetch は local handler が remote を 404 するため最終的に `NO_SUCH_OBJECT` になる (loop / SSRF / leak 無し)。

## テスト

- `TestAPIGet_RemoteUserViaLocalURI_NotFound`: remote user を `/users/<id>` で ap/get → `NO_SUCH_OBJECT` (body に "Person" を含まない)。
- `TestAPIGet_RemoteNoteViaLocalURI_NotFound`: remote note → `NO_SUCH_OBJECT`。
- 既存の local user/note 解決 (`TestAPIGet_Success_User`/`_Note`) は不変で pass。
- `make fmt && make lint` green。`go test ./internal/api/ap/` green (coverage 96.1%、`resolveLocal` 100%)。

Closes #1873

🤖 Generated with [Claude Code](https://claude.com/claude-code)