### PR TITLE
federation 無効 (mode=none) 時に AP serve handler を 403 にする (#1879)

### DIFF
--- a/internal/api/ap/handler.go
+++ b/internal/api/ap/handler.go
@@ -44,6 +44,10 @@ type RemoteResolver interface {
 type HostBlockChecker interface {
 	IsBlocked(host string) bool
 	IsAllowed(host string) bool
+	// FederationDisabled reports whether the instance federation mode is
+	// "none" (fully isolated)。true のとき AP serve handler は 403 を返す
+	// (upstream ActivityPubServerService の federation==='none' gate、#1879)。
+	FederationDisabled() bool
 }
 
 // Handler handles ActivityPub resource endpoints.
@@ -107,6 +111,13 @@ func (h *Handler) SetRemote(fetcher RemoteFetcher, resolver RemoteResolver) {
 func (h *Handler) SetFederationGate(c HostBlockChecker, localHost string) {
 	h.hostBlocker = c
 	h.localHost = localHost
+}
+
+// federationDisabled reports whether the instance is fully isolated
+// (federation mode "none")。AP serve handler はこのとき 403 を返す
+// (#1879)。hostBlocker 未配線時は false (= serve、legacy 挙動)。
+func (h *Handler) federationDisabled() bool {
+	return h.hostBlocker != nil && h.hostBlocker.FederationDisabled()
 }
 
 // SetNonAPFallback registers a handler to serve when the incoming Accept
@@ -297,6 +308,12 @@ func (h *Handler) User(c echo.Context) error {
 		return c.Redirect(http.StatusFound, acct)
 	}
 
+	// federation 無効 (mode=none) なら actor を AP serve しない (#1879)。上の
+	// browser (非AP Accept) 経路は redirect 済みなので、ローカル web UI は影響しない。
+	if h.federationDisabled() {
+		return c.NoContent(http.StatusForbidden)
+	}
+
 	// リモートユーザーへのリダイレクト相当は将来対応
 	if bundle.User.Host != nil {
 		return c.NoContent(http.StatusNotFound)
@@ -318,6 +335,12 @@ func (h *Handler) User(c echo.Context) error {
 func (h *Handler) UserByAcct(c echo.Context) error {
 	if !wantsActivityJSON(c.Request().Header.Get("Accept")) {
 		return h.serveNonAP(c)
+	}
+	// federation 無効 (mode=none) なら actor を AP serve しない (#1879)。/@acct も
+	// /users/:id と同じく upstream で gate されるため、こちらにも入れる。browser 経路は
+	// 上で serveNonAP に流れるので影響しない。
+	if h.federationDisabled() {
+		return c.NoContent(http.StatusForbidden)
 	}
 	acct := c.Param("acct")
 	// /@alice or /@alice@host 形式。ローカルのみ扱う。
@@ -623,6 +646,11 @@ func (h *Handler) Note(c echo.Context) error {
 	if !wantsActivityJSON(c.Request().Header.Get("Accept")) {
 		return h.serveNonAP(c)
 	}
+	// federation 無効 (mode=none) なら AP serve しない (#1879)。browser (非AP) 経路は
+	// 上で serveNonAP に流れるので、ローカル web UI は影響しない。
+	if h.federationDisabled() {
+		return c.NoContent(http.StatusForbidden)
+	}
 	noteID := c.Param("id")
 	// 公開ノートのみAPでフェッチ可能 (非ログインから取得されるため viewer=nil)
 	n, err := h.queryService.Show(nil, noteID)
@@ -646,6 +674,9 @@ func (h *Handler) Note(c echo.Context) error {
 // followers/specified/localOnly な pinned note を unauthenticated AP へ leak させない。
 func (h *Handler) Featured(c echo.Context) error {
 	c.Response().Header().Set("Vary", "Accept")
+	if h.federationDisabled() {
+		return c.NoContent(http.StatusForbidden)
+	}
 	id := c.Param("id")
 	bundle, err := h.userService.ShowByID(id)
 	if err != nil {
@@ -697,6 +728,9 @@ func (h *Handler) Following(c echo.Context) error {
 // 相手側の actor URI を返す。
 func (h *Handler) serveFollowCollection(c echo.Context, followers bool) error {
 	c.Response().Header().Set("Vary", "Accept")
+	if h.federationDisabled() {
+		return c.NoContent(http.StatusForbidden)
+	}
 	if h.followingRepo == nil {
 		return c.NoContent(http.StatusNotFound)
 	}
@@ -826,6 +860,9 @@ func (h *Handler) actorURI(u *model.User) string {
 // (upstream ActivityPubServerService.outbox, #1878)。
 func (h *Handler) Outbox(c echo.Context) error {
 	c.Response().Header().Set("Vary", "Accept")
+	if h.federationDisabled() {
+		return c.NoContent(http.StatusForbidden)
+	}
 	if h.noteRepo == nil {
 		return c.NoContent(http.StatusNotFound)
 	}

--- a/internal/api/ap/handler_test.go
+++ b/internal/api/ap/handler_test.go
@@ -789,8 +789,9 @@ func TestAPIShow_RemoteFetchServiceType(t *testing.T) {
 
 // apShowHostBlocker は federation gate test 用 stub。
 type apShowHostBlocker struct {
-	blocked map[string]bool
-	allowed map[string]bool // nil = 全 allow
+	blocked     map[string]bool
+	allowed     map[string]bool // nil = 全 allow
+	fedDisabled bool
 }
 
 func (b apShowHostBlocker) IsBlocked(host string) bool { return b.blocked[host] }
@@ -800,6 +801,7 @@ func (b apShowHostBlocker) IsAllowed(host string) bool {
 	}
 	return b.allowed[host]
 }
+func (b apShowHostBlocker) FederationDisabled() bool { return b.fedDisabled }
 
 // #1557 不正な URI (http(s) でない / host 無し) → URI_INVALID。
 func TestAPIShow_URIInvalid(t *testing.T) {
@@ -1521,4 +1523,54 @@ func TestOutbox_RepoUnwired_NotFound(t *testing.T) {
 	c, rec := newReq(t, "id", "u1")
 	require.NoError(t, h.Outbox(c))
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// federation 無効 (mode=none) の instance は AP serve handler が一律 403 を返す
+// (#1879、upstream ActivityPubServerService の federation==='none' gate)。
+func TestAPServe_FederationDisabled_403(t *testing.T) {
+	cases := []struct {
+		name string
+		call func(*Handler, echo.Context) error
+	}{
+		{"User", (*Handler).User},
+		{"UserByAcct", (*Handler).UserByAcct},
+		{"Note", (*Handler).Note},
+		{"Featured", (*Handler).Featured},
+		{"Followers", (*Handler).Followers},
+		{"Following", (*Handler).Following},
+		{"Outbox", (*Handler).Outbox},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, userRepo, _, _ := newHandler(t)
+			h.SetFederationGate(apShowHostBlocker{fedDisabled: true}, "local.example")
+			userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+			c, rec := newReq(t, "id", "u1") // AP Accept
+			require.NoError(t, tc.call(h, c))
+			assert.Equal(t, http.StatusForbidden, rec.Code, "%s must 403 when federation=none", tc.name)
+		})
+	}
+}
+
+// federation 有効時は従来どおり serve する (gate が false を返す regression guard)。
+func TestAPServe_FederationEnabled_Serves(t *testing.T) {
+	h, userRepo, _, keypairRepo := newHandler(t)
+	h.SetFederationGate(apShowHostBlocker{fedDisabled: false}, "local.example")
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	keypairRepo.items["u1"] = &model.UserKeypair{UserID: "u1", PublicKey: "PUB"}
+	c, rec := newReq(t, "id", "u1")
+	require.NoError(t, h.User(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "Person")
+}
+
+// browser (非AP Accept) 経路は federation 無効でも redirect される (ローカル web UI は
+// federation gate の影響を受けない)。
+func TestUser_FederationDisabled_BrowserStillRedirects(t *testing.T) {
+	h, userRepo, _, _ := newHandler(t)
+	h.SetFederationGate(apShowHostBlocker{fedDisabled: true}, "local.example")
+	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
+	c, rec := newBrowserReq(t, "id", "u1")
+	require.NoError(t, h.User(c))
+	assert.Equal(t, http.StatusFound, rec.Code, "browser path must redirect even when federation disabled")
 }

--- a/internal/core/instance/instance_service.go
+++ b/internal/core/instance/instance_service.go
@@ -496,6 +496,20 @@ func (s *Service) IsAllowed(host string) bool {
 	return !HostMatchesAny(meta.BlockedHosts, host)
 }
 
+// FederationDisabled reports whether the instance federation mode is "none"
+// (fully isolated)。AP serve handler (actor / note / collections) はこのとき
+// 403 を返す (upstream ActivityPubServerService の federation==='none' gate、#1879)。
+// inbound は既に IsAllowed で全 host deny されるので、serve も止めるのが整合的。
+// meta が読めない場合は inbound の IsAllowed と同じくベストエフォートで false
+// (= serve) に倒し、起動時 transient error で連合露出が落ちないようにする。
+func (s *Service) FederationDisabled() bool {
+	meta, err := s.metaRepo.Fetch()
+	if err != nil {
+		return false
+	}
+	return meta.Federation == "none"
+}
+
 // ShouldSkipDelivery reports whether ActivityPub delivery to host must be
 // skipped because the remote instance is blocked, excluded by the federation
 // mode, or administratively suspended (suspensionState != none). 配送の

--- a/internal/core/instance/instance_service_test.go
+++ b/internal/core/instance/instance_service_test.go
@@ -433,6 +433,26 @@ func TestService_IsAllowed_AllMode(t *testing.T) {
 	assert.True(t, svc.IsAllowed(""), "empty host (= local) is always allowed")
 }
 
+// FederationDisabled は federation mode が "none" のときだけ true (#1879)。
+func TestService_FederationDisabled(t *testing.T) {
+	svc, _, metaRepo := newService(t)
+	metaRepo.Meta.Federation = "none"
+	assert.True(t, svc.FederationDisabled())
+	metaRepo.Meta.Federation = "all"
+	assert.False(t, svc.FederationDisabled())
+	metaRepo.Meta.Federation = "specified"
+	assert.False(t, svc.FederationDisabled())
+	metaRepo.Meta.Federation = ""
+	assert.False(t, svc.FederationDisabled(), "empty federation mode is not 'none'")
+}
+
+// meta が読めない場合は fail-open (= false, serve) でベストエフォート (#1879)。
+func TestService_FederationDisabled_MetaError(t *testing.T) {
+	svc, _, metaRepo := newService(t)
+	metaRepo.Meta = nil
+	assert.False(t, svc.FederationDisabled())
+}
+
 // federation == "specified" は federationHosts に列挙された host だけ allow。
 func TestService_IsAllowed_SpecifiedMode(t *testing.T) {
 	svc, _, metaRepo := newService(t)


### PR DESCRIPTION
## Summary

#1876 の敵対的レビューで surface した project-wide gap (#1879)。upstream `ActivityPubServerService` は各 AP serve handler 冒頭で `if (meta.federation === 'none') 403` を返すが、mk-go の serve handler (User/UserByAcct/Note/Featured/Followers/Following/Outbox) はこの gate を欠いていた。

mk-go は federation mode を **inbound** (`instance.Service.IsAllowed`: none→全 host deny) では既に enforce しているのに、**serve 側だけ素通し**で、連合無効 instance でも actor / note / collection を AP として配信していた。

## 主な変更点

- `instance.Service.FederationDisabled()` を追加 (`meta.Federation == "none"`。meta 取得失敗時は `IsAllowed` と同じく fail-open で false → serve、起動時 transient error で連合露出を落とさない)。
- `ap.HostBlockChecker` interface に `FederationDisabled()` を追加し、`Handler.federationDisabled()` helper (hostBlocker 未配線時は false = serve / legacy) 経由で **6 serve handler を gate** (`403 NoContent`)。
- browser/非AP 経路 (User/UserByAcct/Note の `serveNonAP` / redirect 分岐) は gate の前段なので**ローカル web UI は影響しない**。
- `'specified'`/`'all'` は従来どおり serve (public actor pages は許可。upstream と同じく gate は `'none'` のみ)。

## 整合性 / 影響範囲

連合する instance は `'all'`/`'specified'` (でないと inbound も受けられない) なので**影響なし**。fresh な `'none'` instance は inbound 同様 serve も isolate される (整合的、upstream の default `'none'` と同じ posture)。403 は空 body・Cache-Control 無し (upstream と一致)。

敵対的レビュー round-1 で **`UserByAcct` (/@:acct) の gate 漏れ (MAJOR、actor leak)** を検出し追加。

## テスト

- ap handler: 6 handler が `none` で 403 / enabled で serve / User browser redirect は維持。
- instance: `FederationDisabled` の none→true / all・specified・空→false / meta-error→false。
- `make fmt && make lint` green。`go test ./internal/api/ap/ ./internal/core/instance/` green (ap 96.2% / instance 92.4%)。

Closes #1879

🤖 Generated with [Claude Code](https://claude.com/claude-code)