### PR TITLE
RenderAnnounce を renote visibility 由来の to/cc に + IsPureRenote の quote(replyId)考慮 (#1882)

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -1091,9 +1091,25 @@ func (r *Renderer) RenderUndoLike(reactor *model.User, like *Like) *Undo {
 	return u
 }
 
-// RenderAnnounce returns an Announce activity for a pure renote.
-// targetURI は元ノートの URI (リモート / ローカル)。renoteID は renote 自身の ID。
-func (r *Renderer) RenderAnnounce(renoter *model.User, renoteID string, targetURI string) *Announce {
+// RenderAnnounce builds an Announce (boost) activity for a pure renote.
+// targetURI は元ノートの URI (リモート / ローカル)、renoteID は renote 自身の ID。
+// to/cc は renote 自身の visibility 由来で決める (upstream renderAnnounce、#1882):
+//   - public:    to=[Public],    cc=[followers]
+//   - home:      to=[followers], cc=[Public]
+//   - followers: to=[followers], cc=[]
+//
+// それ以外 (specified 等) は public 扱いにフォールバックする。なお specified な
+// pure renote を federate しない upstream の throw 相当の suppression は別スコープ
+// (#1886 参照)。
+func (r *Renderer) RenderAnnounce(renoter *model.User, renoteID, targetURI string, visibility model.NoteVisibility) *Announce {
+	followers := r.urls.UserFollowers(renoter.ID)
+	to, cc := []string{Public}, []string{followers}
+	switch visibility {
+	case model.NoteVisibilityHome:
+		to, cc = []string{followers}, []string{Public}
+	case model.NoteVisibilityFollowers:
+		to, cc = []string{followers}, nil
+	}
 	a := &Announce{
 		Activity: Activity{
 			Object: Object{
@@ -1101,8 +1117,8 @@ func (r *Renderer) RenderAnnounce(renoter *model.User, renoteID string, targetUR
 				Type: "Announce",
 			},
 			Actor: r.urls.UserURI(renoter.ID),
-			To:    []string{Public},
-			CC:    []string{r.urls.UserFollowers(renoter.ID)},
+			To:    to,
+			CC:    cc,
 		},
 		Object: targetURI,
 	}

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -671,7 +671,7 @@ func TestRenderer_RenderUndoLike(t *testing.T) {
 func TestRenderer_RenderAnnounce(t *testing.T) {
 	r := newRenderer()
 	renoter := &model.User{ID: "alice"}
-	a := r.RenderAnnounce(renoter, "renote1", "https://remote.example/notes/orig")
+	a := r.RenderAnnounce(renoter, "renote1", "https://remote.example/notes/orig", model.NoteVisibilityPublic)
 	assert.Equal(t, "Announce", a.Type)
 	assert.Equal(t, "https://example.com/users/alice", a.Actor)
 	assert.Equal(t, "https://remote.example/notes/orig", a.Object)
@@ -680,10 +680,25 @@ func TestRenderer_RenderAnnounce(t *testing.T) {
 	assert.Contains(t, a.CC, "https://example.com/users/alice/followers")
 }
 
+// renote 自身の visibility で to/cc を入れ替える (#1882、upstream renderAnnounce)。
+func TestRenderer_RenderAnnounce_Visibility(t *testing.T) {
+	r := newRenderer()
+	renoter := &model.User{ID: "alice"}
+	followers := "https://example.com/users/alice/followers"
+
+	home := r.RenderAnnounce(renoter, "r", "https://x/orig", model.NoteVisibilityHome)
+	assert.Equal(t, []string{followers}, home.To, "home: to=[followers]")
+	assert.Equal(t, []string{Public}, home.CC, "home: cc=[Public]")
+
+	fol := r.RenderAnnounce(renoter, "r", "https://x/orig", model.NoteVisibilityFollowers)
+	assert.Equal(t, []string{followers}, fol.To, "followers: to=[followers]")
+	assert.Empty(t, fol.CC, "followers: cc empty")
+}
+
 func TestRenderer_RenderUndoAnnounce(t *testing.T) {
 	r := newRenderer()
 	renoter := &model.User{ID: "alice"}
-	announce := r.RenderAnnounce(renoter, "renote1", "https://remote.example/notes/orig")
+	announce := r.RenderAnnounce(renoter, "renote1", "https://remote.example/notes/orig", model.NoteVisibilityPublic)
 	u := r.RenderUndoAnnounce(renoter, announce)
 	assert.Equal(t, "Undo", u.Type)
 	assert.Equal(t, "https://example.com/users/alice", u.Actor)

--- a/internal/api/ap/handler.go
+++ b/internal/api/ap/handler.go
@@ -934,7 +934,7 @@ func (h *Handler) Outbox(c echo.Context) error {
 func (h *Handler) packOutboxActivity(author *model.User, n *model.Note) any {
 	if corenote.IsPureRenote(n) && n.RenoteID != nil && *n.RenoteID != "" {
 		if targetURI := h.renoteTargetURI(*n.RenoteID); targetURI != "" {
-			ann := h.renderer.RenderAnnounce(author, n.ID, targetURI)
+			ann := h.renderer.RenderAnnounce(author, n.ID, targetURI, n.Visibility)
 			ann.Context = nil
 			return ann
 		}

--- a/internal/core/federation/note_delivery_hook.go
+++ b/internal/core/federation/note_delivery_hook.go
@@ -214,7 +214,7 @@ func (h *NoteDeliveryHook) deliverAnnounce(note *model.Note, author *model.User)
 	if target.URI != nil && *target.URI != "" {
 		targetURI = *target.URI
 	}
-	announce := h.renderer.RenderAnnounce(author, note.ID, targetURI)
+	announce := h.renderer.RenderAnnounce(author, note.ID, targetURI, note.Visibility)
 	body, _ := json.Marshal(announce)
 	if err := h.deliver.DeliverToFollowers(author.ID, body); err != nil {
 		slog.Warn("note delivery: announce failed",

--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -1049,6 +1049,11 @@ func IsPureRenote(n *model.Note) bool {
 	if n.HasPoll {
 		return false
 	}
+	// renote + reply は quote 扱い (upstream isQuote は replyId != null も quote)
+	// なので pure renote ではない。Announce ではなく Create で配信される (#1882)。
+	if n.ReplyID != nil && *n.ReplyID != "" {
+		return false
+	}
 	return true
 }
 

--- a/internal/core/note/note_create_service_test.go
+++ b/internal/core/note/note_create_service_test.go
@@ -1211,6 +1211,7 @@ func TestIsPureRenote_ModelNote(t *testing.T) {
 		{"with cw", &model.Note{RenoteID: &renoteID, CW: &cw}, false},
 		{"with files", &model.Note{RenoteID: &renoteID, FileIDs: []string{"f"}}, false},
 		{"with poll", &model.Note{RenoteID: &renoteID, HasPoll: true}, false},
+		{"with reply (quote)", &model.Note{RenoteID: &renoteID, ReplyID: &renoteID}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

#1878 (outbox) の敵対的レビューで surface した pre-existing divergence 2件 (#1882)。

## 主な変更点

### 1. RenderAnnounce が renote visibility を無視して to/cc を hardcode

`RenderAnnounce` は常に `to=[Public], cc=[followers]` を出していたが、upstream `renderAnnounce` は renote 自身の visibility 由来で to/cc を決める:

- public: `to=[Public], cc=[followers]`
- home: `to=[followers], cc=[Public]`
- followers: `to=[followers], cc=[]`

signature に `visibility model.NoteVisibility` を追加し、caller (`deliverAnnounce` / outbox `packOutboxActivity`) は **renote 自身の visibility** を渡す。home pure-renote の Announce が public 化されていたのを修正。

### 2. IsPureRenote が replyId(quote) を考慮しない

`IsPureRenote` は text/cw/file/poll のみ見ていたが、upstream `isQuote` は `replyId != null` も quote 扱い。renote+reply (本文空) が Announce 配信されていたのを、replyId 判定追加で Create (quote) に統一。

## スコープ / follow-up

- specified pure-renote の federation suppression (upstream の throw 相当) と、sibling な `isQuote`/`isPureRenote` 重複実装 (notification/reaction/timeline) の replyId 統一は pre-existing として **#1886** に分離。

## テスト

- `TestRenderer_RenderAnnounce_Visibility`: home→to[followers]/cc[Public]、followers→to[followers]/cc 空。
- `TestIsPureRenote_ModelNote` に renote+reply→false ケースを追加。
- 既存の RenderAnnounce / deliver-hook Announce / federation / notification テストは全 pass (public arm 不変)。
- `make fmt && make lint` green。`go test ./internal/activitypub/ ./internal/core/note/ ./internal/core/federation/ ./internal/core/notification/ ./internal/api/ap/` green (activitypub 90.8% / note 94.9% / ap 96.2%)。

Closes #1882

🤖 Generated with [Claude Code](https://claude.com/claude-code)