### PR TITLE
specified pure-renote を federate しない + sibling pure-renote/quote predicate を replyId 込みに統一 (#1886)

### DIFF
--- a/internal/core/federation/note_delivery_hook.go
+++ b/internal/core/federation/note_delivery_hook.go
@@ -204,6 +204,14 @@ func (h *NoteDeliveryHook) findNoteAuthor(noteID string, origin *model.Note, kin
 // deliverAnnounce renders an Announce activity for a pure renote and ships it
 // to the renoter's followers.
 func (h *NoteDeliveryHook) deliverAnnounce(note *model.Note, author *model.User) {
+	// upstream renderAnnounce は specified visibility で throw し、federation 自体が
+	// 中止される (= specified pure renote は連合しない)。mk-go も specified renote を
+	// public-addressed Announce で follower へ漏らさないよう、ここで連合を skip する
+	// (#1886)。specified の宛先は visibleUsers 限定であり、renote の Announce を
+	// 配送する経路は upstream に存在しない。
+	if note.Visibility == model.NoteVisibilitySpecified {
+		return
+	}
 	target, err := h.noteRepo.FindByID(*note.RenoteID)
 	if err != nil {
 		slog.Warn("note delivery: renote target not found",

--- a/internal/core/federation/note_delivery_hook_test.go
+++ b/internal/core/federation/note_delivery_hook_test.go
@@ -469,6 +469,23 @@ func TestNoteDeliveryHook_PureRenote_RemoteTarget_UsesURI(t *testing.T) {
 	assert.Equal(t, uri, got["object"])
 }
 
+// specified visibility の pure renote は federate しない (#1886、upstream は
+// renderAnnounce が specified で throw して federation を中止する)。public-addressed
+// Announce を follower に漏らさない。
+func TestNoteDeliveryHook_SpecifiedPureRenote_NoAnnounce(t *testing.T) {
+	hook, enq, userRepo, followingRepo, keypairRepo, noteRepo := newNoteDeliveryHook(t)
+	author := makeLocalAuthor(t, userRepo, keypairRepo)
+	followingRepo.RemoteInboxes[author.ID] = []string{"https://r.example/inbox"}
+	noteRepo.Notes["tgt1"] = &model.Note{ID: "tgt1", UserID: "other", Visibility: model.NoteVisibilityPublic}
+
+	renoteID := "tgt1"
+	renote := makeNote(author.ID, model.NoteVisibilitySpecified)
+	renote.RenoteID = &renoteID
+
+	hook.OnNoteCreated(renote, author)
+	assert.Empty(t, enq.calls, "specified pure renote must not federate")
+}
+
 func TestNoteDeliveryHook_PureRenote_TargetNotFound(t *testing.T) {
 	hook, enq, userRepo, _, keypairRepo, _ := newNoteDeliveryHook(t)
 	author := makeLocalAuthor(t, userRepo, keypairRepo)

--- a/internal/core/notification/hooks.go
+++ b/internal/core/notification/hooks.go
@@ -642,7 +642,8 @@ func (h *Hook) buildPushBody(n *Notification, notifieeID string) map[string]any 
 	return body
 }
 
-// isQuote reports whether the note is a quote renote (renote with text/cw/files/poll).
+// isQuote reports whether the note is a quote renote (renote with
+// text/cw/files/poll/reply)。upstream isQuote は replyId != null も quote 扱い (#1886)。
 func isQuote(n *model.Note) bool {
 	if n.RenoteID == nil {
 		return false
@@ -657,6 +658,9 @@ func isQuote(n *model.Note) bool {
 		return true
 	}
 	if n.HasPoll {
+		return true
+	}
+	if n.ReplyID != nil && *n.ReplyID != "" {
 		return true
 	}
 	return false

--- a/internal/core/notification/hooks_test.go
+++ b/internal/core/notification/hooks_test.go
@@ -618,6 +618,7 @@ func TestIsQuote_Variants(t *testing.T) {
 		{"with cw", &model.Note{RenoteID: &target, CW: ptrString("warn")}, true},
 		{"with file", &model.Note{RenoteID: &target, FileIDs: pq.StringArray{"f1"}}, true},
 		{"with poll", &model.Note{RenoteID: &target, HasPoll: true}, true},
+		{"with reply", &model.Note{RenoteID: &target, ReplyID: ptrString("r1")}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/core/reaction/reaction_service.go
+++ b/internal/core/reaction/reaction_service.go
@@ -662,5 +662,9 @@ func isPureRenote(n *model.Note) bool {
 	if n.HasPoll {
 		return false
 	}
+	// renote + reply は quote 扱いなので pure renote ではない (#1886、upstream isQuote)。
+	if n.ReplyID != nil && *n.ReplyID != "" {
+		return false
+	}
 	return true
 }

--- a/internal/core/timeline/timeline_filter.go
+++ b/internal/core/timeline/timeline_filter.go
@@ -76,9 +76,16 @@ func boolDefault(b *bool, def bool) bool {
 	return def
 }
 
-// isPureRenote returns true if the note is a pure renote (no text, no files).
+// isPureRenote returns true if the note is a pure renote (renote with no
+// text/cw/files/poll/reply)。upstream isPureRenote (= !isQuote) と揃える。quote
+// (text/cw/files/poll/replyId のいずれかを伴う renote) は pure renote ではない (#1886)。
 func isPureRenote(n *model.Note) bool {
-	return n.RenoteID != nil && n.Text == nil && len(n.FileIDs) == 0
+	return n.RenoteID != nil &&
+		(n.Text == nil || *n.Text == "") &&
+		(n.CW == nil || *n.CW == "") &&
+		!n.HasPoll &&
+		len(n.FileIDs) == 0 &&
+		(n.ReplyID == nil || *n.ReplyID == "")
 }
 
 // userSuspended reports whether the (nilable) preloaded user is suspended.

--- a/internal/core/timeline/timeline_filter_test.go
+++ b/internal/core/timeline/timeline_filter_test.go
@@ -45,6 +45,10 @@ func TestIsPureRenote(t *testing.T) {
 	assert.False(t, isPureRenote(makeNote("2")))
 	assert.False(t, isPureRenote(makeNote("3", withRenote, withText)))
 	assert.False(t, isPureRenote(makeNote("4", withRenote, withFiles)))
+	// quote 判定は cw / poll / reply も含む (#1886、upstream isPureRenote = !isQuote)。
+	assert.False(t, isPureRenote(makeNote("5", withRenote, func(n *model.Note) { n.CW = strPtr("cw") })))
+	assert.False(t, isPureRenote(makeNote("6", withRenote, func(n *model.Note) { n.HasPoll = true })))
+	assert.False(t, isPureRenote(makeNote("7", withRenote, withReply)), "renote + reply = quote")
 }
 
 func withReplyUser(uid string) func(*model.Note) {


### PR DESCRIPTION
## Summary

#1882 の敵対的レビューで分離した pre-existing divergence 2件 (#1886)。

## 主な変更点

### 1. specified pure-renote の federation suppression (leak fix)

upstream `renderAnnounce` は `specified` visibility で throw し、federation IIFE 全体が中止される (specified pure renote は連合しない)。mk-go の `deliverAnnounce` は specified renote を **public-addressed Announce で follower へ配送**しており、specified の宛先意図に反する leak だった。`deliverAnnounce` 冒頭で `visibility == specified` を skip して連合を止める (outbox は `ListPublicByUserID` で public/home 限定なので影響なし。OnNoteCreated の pure-renote 経路は deliverAnnounce のみなので、specified pure renote は一切 federate されない = upstream throw と同等)。

### 2. sibling pure-renote/quote predicate の replyId 統一

#1882 で canonical な `core/note.IsPureRenote` に replyId を入れたが、同等判定の重複コピーが未追従だった。upstream `isQuote` (= text||cw||replyId||poll||files) に揃える:
- `notification.isQuote`: replyId 追加 (renote+reply を `quote` 通知に)。
- `reaction.isPureRenote`: replyId 追加。
- `timeline.isPureRenote`: cw/poll/replyId 追加 (旧実装は text/files のみ)。

## スコープ / follow-up

- SQL層の pure-renote predicate (`repository/note.go` 5箇所) と mock predicate の追従は別スコープとして **#1888** に分離 (timeline DB 経路の parity 完成は #1888 で)。

## テスト

- federation: `TestNoteDeliveryHook_SpecifiedPureRenote_NoAnnounce` (specified→no enqueue)。
- notification: `TestIsQuote_Variants` に reply→true。
- timeline: `TestIsPureRenote` に cw/poll/reply→false。
- `make fmt && make lint` green。`go test ./internal/core/federation/ ./internal/core/notification/ ./internal/core/reaction/ ./internal/core/timeline/` green (federation 90.2% / notification 91.6% / reaction 93.9% / timeline 96.0%)。

Closes #1886

🤖 Generated with [Claude Code](https://claude.com/claude-code)