### PR TITLE
SQL / stream / mock の pure-renote predicate を cw/poll/replyId 込みに統一 (#1888)

### DIFF
--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -26,6 +26,22 @@ const aidxTime2000Ms int64 = 946684800000
 // ことを保証する (#1491 review B 指摘の二重定義解消)。
 const FeaturedNotesPerUserPoolSize = 50
 
+// pureRenoteCondSQL は pure renote (= text/cw/files/poll/reply を伴わない renote)
+// を表す SQL 断片。upstream isPureRenote (= !isQuote) と揃える (#1888)。timeline
+// (withRenotes) / home TL / renote-mute の各 filter で共有し、列定義の drift を防ぐ。
+// 列は全 caller で曖昧にならないよう非修飾 (JOIN 先に同名列は無い)。
+//
+// text/cw/replyId は IS NULL のみ判定する (空文字は判定しない)。upstream isQuote は
+// `text != null` 等の null 判定なので、空文字 text="" の renote は upstream でも quote
+// 扱いになり、この SQL と一致する (= NULL のみが pure)。空文字を pure とみなす方向に
+// 変えない (それは upstream から乖離する)。
+const pureRenoteCondSQL = `"renoteId" IS NOT NULL AND "text" IS NULL AND "cw" IS NULL AND "fileIds" = '{}' AND "hasPoll" = false AND "replyId" IS NULL`
+
+// renoteHasContentSQL は pureRenoteCondSQL の content 部の否定 (= quote renote:
+// text/cw/files/poll/reply のいずれかを伴う renote)。children listing で quote を
+// 含めるのに使う (#1888)。
+const renoteHasContentSQL = `("text" IS NOT NULL OR "cw" IS NOT NULL OR "fileIds" != '{}' OR "hasPoll" = TRUE OR "replyId" IS NOT NULL)`
+
 // aidxCutoffID は与えられた time に対応する最小のaidx ID文字列を返す。
 // aidxは「時刻base36(8) + nodeID(4) + counter(4)」の 16 文字で、先頭 8 文字が
 // ms-since-2000 を base36 で表したもの。そのため lexicographic 比較で時刻順に
@@ -397,9 +413,9 @@ func (r *noteRepository) ListByUserIDFiltered(userID, viewerID, untilID, sinceID
 		q = q.Where(`"replyId" IS NULL`)
 	}
 	if !withRenotes {
-		// pure renote (= text / fileIds / poll 全て空 + renoteId あり) を除外する。
-		// quote (= text あり + renoteId) は通常の投稿として残す。
-		q = q.Where(`NOT ("renoteId" IS NOT NULL AND "text" IS NULL AND "fileIds" = '{}' AND "hasPoll" = false)`)
+		// pure renote (= text/cw/files/poll/reply 全て空 + renoteId あり) を除外する。
+		// quote (= 本文等を伴う renote) は通常の投稿として残す (#1888)。
+		q = q.Where(`NOT (` + pureRenoteCondSQL + `)`)
 	}
 	if !withChannelNotes {
 		q = q.Where(`"channelId" IS NULL`)
@@ -485,11 +501,11 @@ func (r *noteRepository) ListChildrenOf(noteID, viewerID, untilID, sinceID strin
 	// (#1500)。実際のリーク防止は ListChildrenOf_VisibilityPushDown の回帰テストで担保。
 	//
 	// renoteId 側は upstream notes/children (children.ts:53-67) に合わせ、本文・
-	// ファイル・投票のいずれかを持つ引用 renote のみ含める。pure renote (text NULL
-	// かつ fileIds = '{}' かつ hasPoll = false) は children に出さない (#1554)。
+	// text/cw/file/poll/reply のいずれかを持つ引用 renote のみ含める。pure renote は
+	// children に出さない (#1554、quote 判定は #1888 で cw/reply 込みに統一)。
 	// reply 側にはこの content ガードを掛けない (返信は本文が空でも子として返す)。
 	q := preloadNoteRelations(r.db).
-		Where(`("replyId" = ? OR ("renoteId" = ? AND ("text" IS NOT NULL OR "fileIds" != '{}' OR "hasPoll" = TRUE)))`, noteID, noteID)
+		Where(`("replyId" = ? OR ("renoteId" = ? AND `+renoteHasContentSQL+`))`, noteID, noteID)
 	// visibility push-down (#1500): viewer が見られる child のみ LIMIT 前に絞る。
 	q = applyViewerVisibility(q, viewerID)
 	if untilID != "" {
@@ -919,8 +935,8 @@ func applyTimelineFilter(q *gorm.DB, f model.TimelineDBFilter) *gorm.DB {
 		q = q.Where(`"fileIds" != '{}'`)
 	}
 	if f.WithRenotes != nil && !*f.WithRenotes {
-		// pure renote (テキストもファイルもない renote) を除外
-		q = q.Where(`NOT ("renoteId" IS NOT NULL AND text IS NULL AND "fileIds" = '{}')`)
+		// pure renote (text/cw/files/poll/reply 全て空の renote) を除外 (#1888)。
+		q = q.Where(`NOT (` + pureRenoteCondSQL + `)`)
 	}
 	if f.WithReplies != nil && !*f.WithReplies {
 		// upstream Misskey TS Home TL と完全一致: `replyId IS NULL` か、
@@ -941,13 +957,13 @@ func applyTimelineFilter(q *gorm.DB, f model.TimelineDBFilter) *gorm.DB {
 	if f.IncludeMyRenotes != nil && !*f.IncludeMyRenotes && f.ViewerID != "" {
 		// "userId" は JOIN を持つ呼び出し元 (ListByUserList の user_list_membership)
 		// で membership.userId と衝突するため "note". で修飾する (#1498)。
-		q = q.Where(`NOT ("renoteId" IS NOT NULL AND text IS NULL AND "fileIds" = '{}' AND "note"."userId" = ?)`, f.ViewerID)
+		q = q.Where(`NOT (`+pureRenoteCondSQL+` AND "note"."userId" = ?)`, f.ViewerID)
 	}
 	if f.IncludeRenotedMyNotes != nil && !*f.IncludeRenotedMyNotes && f.ViewerID != "" {
-		q = q.Where(`NOT ("renoteId" IS NOT NULL AND text IS NULL AND "fileIds" = '{}' AND "renoteUserId" = ?)`, f.ViewerID)
+		q = q.Where(`NOT (`+pureRenoteCondSQL+` AND "renoteUserId" = ?)`, f.ViewerID)
 	}
 	if f.IncludeLocalRenotes != nil && !*f.IncludeLocalRenotes {
-		q = q.Where(`NOT ("renoteId" IS NOT NULL AND text IS NULL AND "fileIds" = '{}' AND "renoteUserHost" IS NULL)`)
+		q = q.Where(`NOT (` + pureRenoteCondSQL + ` AND "renoteUserHost" IS NULL)`)
 	}
 	if len(f.MutedChannelIDs) > 0 {
 		// channel_mutingに登録されたチャンネルのノートはタイムラインから除外する。
@@ -1029,10 +1045,10 @@ func applyTimelineFilter(q *gorm.DB, f model.TimelineDBFilter) *gorm.DB {
 	// path (RenoteMutedUserIDs を直接 IN) は現状 test/production とも未使用
 	// なので未実装。必要になったら同 file の MutedUserIDs literal 分岐と
 	// 同 pattern で追加可能。
-	// pure renote condition: text IS NULL AND fileIds = '{}' AND renoteId IS NOT NULL
+	// pure renote condition は pureRenoteCondSQL (text/cw/files/poll/reply 全空) を共有 (#1888)。
 	if f.UseRenoteMutingSubquery && f.ViewerID != "" {
 		q = q.Where(
-			`NOT (EXISTS (SELECT 1 FROM "renote_muting" rm WHERE rm."muterId" = ? AND rm."muteeId" = "note"."userId") AND text IS NULL AND "fileIds" = '{}' AND "renoteId" IS NOT NULL)`,
+			`NOT (EXISTS (SELECT 1 FROM "renote_muting" rm WHERE rm."muterId" = ? AND rm."muteeId" = "note"."userId") AND `+pureRenoteCondSQL+`)`,
 			f.ViewerID,
 		)
 	}

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -725,6 +725,37 @@ func TestNoteRepository_ListByUserIDFiltered(t *testing.T) {
 	assert.Equal(t, "n_lf_file", out[0].ID)
 }
 
+// withRenotes=false は pure renote のみ除外し、cw/poll/reply を伴う quote renote は
+// 残す (#1888、pureRenoteCondSQL が cw/poll/reply を考慮)。
+func TestNoteRepository_ListByUserIDFiltered_WithRenotesFalseKeepsQuotes(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	user := insertTestUser(t, "u_wrq", "wrquser")
+	defer cleanupUser(t, user.ID)
+
+	mk := func(id string, mutate func(n *model.Note)) {
+		n := &model.Note{ID: id, UserID: user.ID, Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}"))}
+		mutate(n)
+		require.NoError(t, repo.Create(n))
+		t.Cleanup(func() { cleanupNote(t, id) })
+	}
+	mk("n_wrq_target", func(n *model.Note) {})
+	tid := "n_wrq_target"
+	mk("n_wrq_pure", func(n *model.Note) { n.RenoteID = &tid })
+	mk("n_wrq_cw", func(n *model.Note) { n.RenoteID = &tid; cw := "w"; n.CW = &cw })
+	mk("n_wrq_poll", func(n *model.Note) { n.RenoteID = &tid; n.HasPoll = true })
+	mk("n_wrq_reply", func(n *model.Note) { n.RenoteID = &tid; n.ReplyID = &tid })
+
+	// withRenotes=false (3rd bool)。pure renote のみ除外される。
+	out, err := repo.ListByUserIDFiltered(user.ID, "", "", "", 20, false, true, false, false)
+	require.NoError(t, err)
+	got := idSet(out)
+	assert.True(t, got["n_wrq_target"])
+	assert.True(t, got["n_wrq_cw"], "cw renote は quote なので残る")
+	assert.True(t, got["n_wrq_poll"], "poll renote は quote なので残る")
+	assert.True(t, got["n_wrq_reply"], "reply renote は quote なので残る")
+	assert.NotContains(t, got, "n_wrq_pure", "pure renote は除外される")
+}
+
 // TestNoteRepository_ListByUserIDFiltered_VisibilityPushDown は users/notes の
 // visibility push-down (#1418 review) を検証する。author が public / followers /
 // specified の 3 note を持ち、viewer ごとに SQL 段階で見える note が変わること
@@ -1162,14 +1193,30 @@ func TestNoteRepository_ListChildrenOf_PureRenoteExcluded(t *testing.T) {
 		n.RenoteID = &parentID
 		n.HasPoll = true
 	})
+	// renote + cw → 含める (#1888: cw も quote 判定に含む)
+	mk("n_lcpr_c6_cw", func(n *model.Note) {
+		n.RenoteID = &parentID
+		cw := "warn"
+		n.CW = &cw
+	})
+	// 別 note への reply を伴う renote-of-parent → quote として含める (#1888: replyId も
+	// quote 判定に含む)。reply target は parent ではないので reply branch では拾われない。
+	mk("n_lcpr_other", func(n *model.Note) {})
+	otherID := "n_lcpr_other"
+	mk("n_lcpr_c7_replyquote", func(n *model.Note) {
+		n.RenoteID = &parentID
+		n.ReplyID = &otherID
+	})
 
 	out, err := repo.ListChildrenOf(parentID, "", "", "", 10)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]bool{
-		"n_lcpr_c1_reply": true,
-		"n_lcpr_c3_quote": true,
-		"n_lcpr_c4_file":  true,
-		"n_lcpr_c5_poll":  true,
+		"n_lcpr_c1_reply":      true,
+		"n_lcpr_c3_quote":      true,
+		"n_lcpr_c4_file":       true,
+		"n_lcpr_c5_poll":       true,
+		"n_lcpr_c6_cw":         true,
+		"n_lcpr_c7_replyquote": true,
 	}, idSet(out))
 	// pure renote が含まれていないことを明示
 	assert.NotContains(t, idSet(out), "n_lcpr_c2_pure")

--- a/internal/stream/channels/note_filter.go
+++ b/internal/stream/channels/note_filter.go
@@ -390,14 +390,28 @@ type replyMeta struct {
 // 判定するのに使う。NoteEntityService.pack は packed note に `mentions:
 // string[]` を出力するので JSON tag で拾える。
 type notePayload struct {
-	UserID   string     `json:"userId"`
-	Text     *string    `json:"text"`
-	CW       *string    `json:"cw"`
-	RenoteID *string    `json:"renoteId"`
-	ReplyID  *string    `json:"replyId"`
-	FileIDs  []string   `json:"fileIds"`
-	Mentions []string   `json:"mentions"`
-	Reply    *replyMeta `json:"reply,omitempty"`
+	UserID   string          `json:"userId"`
+	Text     *string         `json:"text"`
+	CW       *string         `json:"cw"`
+	RenoteID *string         `json:"renoteId"`
+	ReplyID  *string         `json:"replyId"`
+	FileIDs  []string        `json:"fileIds"`
+	Mentions []string        `json:"mentions"`
+	Poll     json.RawMessage `json:"poll"`
+	Reply    *replyMeta      `json:"reply,omitempty"`
+}
+
+// isPureRenote reports whether the payload is a pure renote (renote with no
+// text/cw/files/poll/reply)。SQL pureRenoteCondSQL / core/note.IsPureRenote /
+// timeline.isPureRenote と揃える (#1888)。これが揺れると cache-hit (stream) と
+// DB fallback で withRenotes フィルタの挙動が割れる。
+func (n *notePayload) isPureRenote() bool {
+	return n.RenoteID != nil &&
+		n.Text == nil &&
+		n.CW == nil &&
+		n.ReplyID == nil &&
+		len(n.FileIDs) == 0 &&
+		(len(n.Poll) == 0 || string(n.Poll) == "null")
 }
 
 // shouldEmit returns true if the note passes non-reply filter conditions
@@ -414,9 +428,9 @@ func (f *noteFilter) shouldEmit(payload []byte, hardMuteRules []byte, viewerID s
 		return true
 	}
 
-	// 純リノート（テキストなし + renoteIdあり + ファイルなし）をフィルタ
-	// timeline_filter.goのisPureRenoteと一致させる
-	if !f.WithRenotes && note.Text == nil && note.RenoteID != nil && len(note.FileIDs) == 0 {
+	// 純リノート (text/cw/files/poll/reply 全て空 + renoteId あり) をフィルタ。
+	// SQL pureRenoteCondSQL / timeline_filter.go の isPureRenote と一致させる (#1888)。
+	if !f.WithRenotes && note.isPureRenote() {
 		return false
 	}
 

--- a/internal/stream/channels/note_filter_test.go
+++ b/internal/stream/channels/note_filter_test.go
@@ -47,6 +47,23 @@ func TestShouldEmit_RenoteWithFilesAllowed(t *testing.T) {
 	assert.True(t, f.shouldEmit(payload, nil, ""))
 }
 
+// #1888: cw / poll / reply を伴う renote は quote なので withRenotes=false でも通過する
+// (SQL pureRenoteCondSQL と cache 経路の挙動を一致させる)。
+func TestShouldEmit_RenoteWithCWAllowed(t *testing.T) {
+	f := noteFilter{WithRenotes: false, WithReplies: false, WithFiles: false}
+	assert.True(t, f.shouldEmit([]byte(`{"renoteId":"r1","cw":"warn"}`), nil, ""))
+}
+
+func TestShouldEmit_RenoteWithPollAllowed(t *testing.T) {
+	f := noteFilter{WithRenotes: false, WithReplies: false, WithFiles: false}
+	assert.True(t, f.shouldEmit([]byte(`{"renoteId":"r1","poll":{"choices":[]}}`), nil, ""))
+}
+
+func TestShouldEmit_RenoteWithReplyAllowed(t *testing.T) {
+	f := noteFilter{WithRenotes: false, WithReplies: false, WithFiles: false}
+	assert.True(t, f.shouldEmit([]byte(`{"renoteId":"r1","replyId":"p1"}`), nil, ""))
+}
+
 // #1063: shouldEmit は reply blanket-drop を持たない (upstream Misskey TS の
 // home/hybrid/local channel に揃った semantics で、reply 表示可否は
 // replyShouldEmit が channel ごとに判定する)。WithReplies フィールドは

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1024,9 +1024,9 @@ func (m *MockNoteRepository) ListChildrenOf(noteID, viewerID, untilID, sinceID s
 			return true
 		}
 		if n.RenoteID != nil && *n.RenoteID == noteID {
-			// pure renote 判定は repository note.go の SQL (text IS NULL AND
-			// fileIds = '{}' AND hasPoll = false) と一致させる。
-			isPureRenote := n.Text == nil && len(n.FileIDs) == 0 && !n.HasPoll
+			// pure renote 判定は repository note.go の pureRenoteCondSQL
+			// (text/cw/fileIds/poll/replyId 全空) と一致させる (#1888)。
+			isPureRenote := n.Text == nil && n.CW == nil && len(n.FileIDs) == 0 && !n.HasPoll && n.ReplyID == nil
 			return !isPureRenote
 		}
 		return false
@@ -1159,12 +1159,9 @@ func (m *MockNoteRepository) ListByUserIDFiltered(userID, viewerID, untilID, sin
 			return false
 		}
 		if !withRenotes {
-			// pure renote (text / fileIds / poll 全て空 + renoteId あり) を除外
-			text := ""
-			if n.Text != nil {
-				text = *n.Text
-			}
-			if n.RenoteID != nil && text == "" && len(n.FileIDs) == 0 && !n.HasPoll {
+			// pure renote (text/cw/fileIds/poll/replyId 全空 + renoteId あり) を除外。
+			// real SQL pureRenoteCondSQL と一致させる (#1888)。
+			if n.RenoteID != nil && n.Text == nil && n.CW == nil && len(n.FileIDs) == 0 && !n.HasPoll && n.ReplyID == nil {
 				return false
 			}
 		}
@@ -1560,10 +1557,9 @@ func (m *MockNoteRepository) ListByUserList(listID string, limit int, sinceID, u
 		if filter.WithFiles && len(n.FileIDs) == 0 {
 			continue
 		}
-		// pure renote 判定: applyTimelineFilter と同じく
-		// `RenoteID != nil && Text == nil && len(FileIDs) == 0` で一致させる
-		// (real SQL: renoteId IS NOT NULL AND text IS NULL AND fileIds = '{}')。
-		isPureRenote := n.RenoteID != nil && n.Text == nil && len(n.FileIDs) == 0
+		// pure renote 判定: real SQL pureRenoteCondSQL (renoteId IS NOT NULL AND
+		// text/cw/fileIds/poll/replyId 全空) と一致させる (#1888)。
+		isPureRenote := n.RenoteID != nil && n.Text == nil && n.CW == nil && len(n.FileIDs) == 0 && !n.HasPoll && n.ReplyID == nil
 		if !withRenotes && isPureRenote {
 			// pure renote (= boost) excluded; quote renote (text or files あり) は通る。
 			continue


### PR DESCRIPTION
## Summary

#1882/#1886 で Go の pure-renote/quote 判定 (`core/note.IsPureRenote` / notification / reaction / timeline) を upstream `isQuote` (= text||cw||replyId||poll||files) に揃えたが、**SQL 層と stream 層のコピーが旧定義** (`renoteId IS NOT NULL AND text IS NULL AND fileIds='{}'`、一部のみ hasPoll、cw/replyId 未考慮) のままだった。timeline は SQL/cache が先に効くため、cw・poll・reply を伴う quote renote が誤って pure renote 扱い (withRenotes=false で除外 / renote-mute) されていた。

## 主な変更点

- **repository/note.go**: `pureRenoteCondSQL` / `renoteHasContentSQL` の 2 つの共有 const を導入し、7 箇所 (ListByUserIDFiltered withRenotes / home TL withRenotes / children quote 判定 / IncludeMyRenotes / IncludeRenotedMyNotes / IncludeLocalRenotes / renote-mute subquery) を統一。列定義の drift を根本解消。
  - NULL 判定は upstream `isQuote` の `!= null` と一致 (空文字 `text=""` の renote は upstream でも quote 扱いなので `IS NULL` のまま据え置く旨をコメント明記)。
- **stream/channels/note_filter.go**: `notePayload` に `poll` を追加し `notePayload.isPureRenote()` を full 判定にして withRenotes フィルタを SQL と一致させる (cache-hit (stream) と DB fallback で挙動が割れていたのを解消)。
- **testutil mock 3 箇所** (children / timeline applyFilter / ListByUserIDFiltered) を SQL と一致させる。

## レビュー指摘の対応

敵対的レビュー round-1 で **stream 層の twin (`note_filter.go`) が旧定義のまま cache-vs-DB divergence を再生する MAJOR** を検出し修正。round-2 self-scan で 3 つ目の mock drift (`ListByUserIDFiltered` mock) も検出・修正。`FindRenoteByUser` (mock 1293) は real query (`text IS NULL` の un-renote 用、別 predicate) と一致しているため対象外。

## テスト

- repository: children に cw / 別 note への reply を伴う quote renote 包含、withRenotes=false で cw/poll/reply quote 保持 + pure 除外。
- stream: `shouldEmit` で cw/poll/reply renote 通過。
- `make fmt && make lint` green。`go test ./internal/repository/ ./internal/stream/channels/ ./internal/testutil/ ./internal/core/timeline/` green (repository 90.1% / stream 91.9%)。

Closes #1888

🤖 Generated with [Claude Code](https://claude.com/claude-code)