### PR TITLE
Fix ap-resolver parity (#1892): Resolver の fragment 拒否 + quote chain recursion limit(256)

### DIFF
--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -89,7 +89,19 @@ var (
 	// (なりすまし) を防ぐ (#1839)。malformed note (ErrInvalidNote) と違い、これは
 	// retry しても解消しないため caller は ack して drop する。
 	ErrNoteAttributionMismatch = errors.New("note attribution does not match delivering actor or id host")
+	// ErrResolveFragment is returned when a resolve target URL carries a `#`
+	// fragment. Fragments are not transmitted over HTTP(S) so such URLs cannot
+	// be dereferenced; mirrors upstream Resolver の b94fd5b1 guard (#1828)。
+	ErrResolveFragment = errors.New("cannot resolve URL with fragment")
+	// ErrRecursionLimit is returned when a single resolve operation's note/quote
+	// chain exceeds resolveRecursionLimit, mirroring upstream Resolver の
+	// d592da9f guard。悪意ある quote チェーンによる無限再帰・amplification を防ぐ。
+	ErrRecursionLimit = errors.New("hit recursion limit")
 )
+
+// resolveRecursionLimit bounds how deep a single resolve operation may recurse
+// through note quote chains, matching upstream Resolver.recursionLimit (256)。
+const resolveRecursionLimit = 256
 
 // DefaultActorTTL is the default duration after which a cached actor (and its
 // public key) is considered stale and refetched on next access.
@@ -377,6 +389,12 @@ func (r *Resolver) ResolveActor(uri string) (*model.User, error) {
 // resolveActorOnce is the body of ResolveActor, invoked once per URI by
 // singleflight.Do.
 func (r *Resolver) resolveActorOnce(uri string) (*model.User, error) {
+	// fragment 付き URL は HTTP(S) で fragment が送られず正しく解決できないため
+	// 拒否する (本家 Resolver の b94fd5b1 guard、#1828)。keyId fragment は
+	// ResolveActorByKeyID -> ResolveKeyURL で除去済みなのでここには来ない。
+	if strings.Contains(uri, "#") {
+		return nil, ErrResolveFragment
+	}
 	if existing, err := r.userRepo.FindByURI(uri); err == nil {
 		if r.shouldRefreshActor(existing) {
 			r.refreshActor(existing, uri)
@@ -859,11 +877,18 @@ func (r *Resolver) ResolveActorByKeyID(keyID string) (*model.User, error) {
 //   - リモート URI で既に取り込み済みなら noteRepo.FindByURI で返す
 //   - 未知のリモート URI なら fetcher で取得して IngestNote で永続化
 func (r *Resolver) ResolveNote(uri string) (*model.Note, error) {
+	return r.resolveNoteDepth(uri, 0)
+}
+
+// resolveNoteDepth is ResolveNote carrying the current recursion depth so the
+// note/quote chain can be bounded (#1828)。quote 解決経路 (resolveQuoteURI) が
+// depth+1 で再入する。
+func (r *Resolver) resolveNoteDepth(uri string, depth int) (*model.Note, error) {
 	// 同一 URI への並行呼び出しは singleflight で collapse (#300 3-7)。
 	// ResolveActor と同じく cold path の HTTP fetch + IngestNote を重複
 	// 実行しないことが目的。
 	v, err, _ := r.resolveNoteGroup.Do(uri, func() (any, error) {
-		return r.resolveNoteOnce(uri)
+		return r.resolveNoteOnce(uri, depth)
 	})
 	if err != nil {
 		return nil, err
@@ -874,11 +899,20 @@ func (r *Resolver) ResolveNote(uri string) (*model.Note, error) {
 	return v.(*model.Note), nil
 }
 
-// resolveNoteOnce is the body of ResolveNote, invoked once per URI by
-// singleflight.Do.
-func (r *Resolver) resolveNoteOnce(uri string) (*model.Note, error) {
+// resolveNoteOnce is the body of resolveNoteDepth, invoked once per URI by
+// singleflight.Do. depth は quote chain の現在の深さ。
+func (r *Resolver) resolveNoteOnce(uri string, depth int) (*model.Note, error) {
 	if r.noteRepo == nil {
 		return nil, ErrInvalidNote
+	}
+	// fragment 付き URL は解決不能なため拒否 (本家 b94fd5b1 guard、#1828)。
+	if strings.Contains(uri, "#") {
+		return nil, ErrResolveFragment
+	}
+	// quote chain の再帰上限 (本家 d592da9f guard、#1828)。悪意ある深い
+	// quote チェーンによる無限再帰・amplification を防ぐ。
+	if depth > resolveRecursionLimit {
+		return nil, ErrRecursionLimit
 	}
 	if id := r.extractLocalNoteID(uri); id != "" {
 		if existing, err := r.noteRepo.FindByID(id); err == nil {
@@ -922,7 +956,10 @@ func (r *Resolver) resolveNoteOnce(uri string) (*model.Note, error) {
 		slog.Warn("federation: note id host mismatch", "uri", uri, "finalURL", finalURL, "id", idProbe.ID)
 		return nil, err
 	}
-	return r.IngestNote(body)
+	// fetch 経由は配送 actor が無いので attribution==actor 検証は skip ("")。
+	// quote chain の depth を引き継いで再帰上限を効かせる。
+	note, _, err := r.ingestNoteWithCreated(body, "", depth)
+	return note, err
 }
 
 // resolveQuoteTarget resolves the quote target of an inbound note from its
@@ -934,18 +971,18 @@ func (r *Resolver) resolveNoteOnce(uri string) (*model.Note, error) {
 // 既知 note (local ID / 取り込み済み URI) を fetch 無しで優先的に引く。未知 URI は
 // ResolveNote で fetch するが、その URI が現在 ingest 中 (quote cycle) の場合は
 // fetch を skip して無限再帰を防ぐ (#1527)。
-func (r *Resolver) resolveQuoteTarget(misskeyQuote, quoteURL string) *model.Note {
+func (r *Resolver) resolveQuoteTarget(misskeyQuote, quoteURL string, depth int) *model.Note {
 	if r.noteRepo == nil {
 		return nil
 	}
 	// upstream ApNoteService は `[_misskey_quote, quoteUrl]` を順に解決し、最初に
 	// 成功した note を採用する (`.at(0)`)。通常は両者同値だが、片方しか解決できない
 	// ケースで取りこぼさないよう順に試す。
-	if n := r.resolveQuoteURI(misskeyQuote); n != nil {
+	if n := r.resolveQuoteURI(misskeyQuote, depth); n != nil {
 		return n
 	}
 	if quoteURL != misskeyQuote {
-		if n := r.resolveQuoteURI(quoteURL); n != nil {
+		if n := r.resolveQuoteURI(quoteURL, depth); n != nil {
 			return n
 		}
 	}
@@ -955,7 +992,7 @@ func (r *Resolver) resolveQuoteTarget(misskeyQuote, quoteURL string) *model.Note
 // resolveQuoteURI resolves a single quote URI to a local note row. 既知 note
 // (local ID / 取り込み済み URI) は fetch 無しで引き、未知 URI は cycle でなければ
 // ResolveNote で fetch する。空 URI / 解決不能は nil。
-func (r *Resolver) resolveQuoteURI(uri string) *model.Note {
+func (r *Resolver) resolveQuoteURI(uri string, depth int) *model.Note {
 	if uri == "" {
 		return nil
 	}
@@ -970,11 +1007,13 @@ func (r *Resolver) resolveQuoteURI(uri string) *model.Note {
 	if n, err := r.noteRepo.FindByURI(uri); err == nil {
 		return n
 	}
-	// 3. 未知 URI: cycle でなければ fetch して取り込む (本家同様)。
+	// 3. 未知 URI: cycle でなければ fetch して取り込む (本家同様)。in-flight URI
+	// (ancestor chain) は already-resolved として skip し quote cycle を防ぐ
+	// (#1527、本家 0dc86cf6 guard 相当)。depth+1 で再帰上限も効かせる。
 	if _, inflight := r.ingesting.Load(uri); inflight {
 		return nil
 	}
-	if n, err := r.ResolveNote(uri); err == nil {
+	if n, err := r.resolveNoteDepth(uri, depth+1); err == nil {
 		return n
 	}
 	return nil
@@ -989,7 +1028,7 @@ func (r *Resolver) resolveQuoteURI(uri string) *model.Note {
 func (r *Resolver) IngestNote(body []byte) (*model.Note, error) {
 	// fetch 経由は配送 actor が無いので attribution==actor 検証は skip ("")。
 	// id host == attributedTo host 検証は IngestNoteWithCreated 側で常に行う。
-	note, _, err := r.IngestNoteWithCreated(body, "")
+	note, _, err := r.ingestNoteWithCreated(body, "", 0)
 	return note, err
 }
 
@@ -1016,6 +1055,13 @@ func (r *Resolver) IngestNote(body []byte) (*model.Note, error) {
 // fetch 経由 (IngestNote) では空文字を渡し、この検証を skip する (upstream
 // validateNote が actor 未指定時に attribution==actor を skip するのと同じ)。
 func (r *Resolver) IngestNoteWithCreated(body []byte, deliveringActorURI string) (*model.Note, bool, error) {
+	// inbound delivery 起点は quote chain depth 0。
+	return r.ingestNoteWithCreated(body, deliveringActorURI, 0)
+}
+
+// ingestNoteWithCreated is the body of IngestNoteWithCreated carrying the
+// current note/quote-chain recursion depth (#1828)。
+func (r *Resolver) ingestNoteWithCreated(body []byte, deliveringActorURI string, depth int) (*model.Note, bool, error) {
 	if r.noteRepo == nil {
 		return nil, false, ErrInvalidNote
 	}
@@ -1203,7 +1249,7 @@ func (r *Resolver) IngestNoteWithCreated(body []byte, deliveringActorURI string)
 	// 「本文だけ」で引用元が表示されない。解決失敗は best-effort で quote 無し扱い。
 	// AP vote の早期 return より後 (= 実際に note を作る経路) で解決し、vote object に
 	// quote field が乗っていても無駄な fetch をしない。renoteCount の増分は Create 後。
-	quoted := r.resolveQuoteTarget(apNote.MisskeyQuote, apNote.QuoteURL)
+	quoted := r.resolveQuoteTarget(apNote.MisskeyQuote, apNote.QuoteURL, depth)
 	// 引用先が followers / specified(DM) の場合は紐付けない。本家
 	// NoteCreateService.ts:346-352 は他人の followers note と全 specified note を
 	// renote 対象から reject するため、連合の正規 quote がこれらを指すことはない。

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -480,6 +480,83 @@ func TestIngestNote_NoContextStillIngested(t *testing.T) {
 	require.NotNil(t, note)
 }
 
+// TestResolveActor_RejectsFragmentURL pins the upstream b94fd5b1 guard (#1828):
+// an actor URL with a `#` fragment cannot be dereferenced and is rejected
+// before any fetch. (keyId fragments are stripped by ResolveActorByKeyID and
+// therefore still resolve — see TestResolveActorByKeyID.)
+func TestResolveActor_RejectsFragmentURL(t *testing.T) {
+	r, repo := newResolver(t, sampleActor, nil)
+	_, err := r.ResolveActor("https://remote.example/users/alice#frag")
+	require.ErrorIs(t, err, federation.ErrResolveFragment)
+	assert.Empty(t, repo.Users)
+}
+
+// TestResolveNote_RejectsFragmentURL pins the same guard for note resolution.
+func TestResolveNote_RejectsFragmentURL(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleRemoteNote)}, idGen)
+	_, err := r.ResolveNote("https://remote.example/notes/n1#frag")
+	require.ErrorIs(t, err, federation.ErrResolveFragment)
+}
+
+// quoteChainFetcher serves an unbounded chain of notes where note N quotes
+// note N+1, plus the shared author actor. Used to exercise the resolve
+// recursion limit (#1828) — without the limit the chain would never terminate.
+type quoteChainFetcher struct {
+	actorBody string
+	calls     atomic.Int64
+}
+
+func (f *quoteChainFetcher) FetchObject(uri string) ([]byte, error) {
+	f.calls.Add(1)
+	if strings.Contains(uri, "/users/") {
+		return []byte(f.actorBody), nil
+	}
+	n := 0
+	if i := strings.LastIndex(uri, "/"); i >= 0 {
+		n, _ = strconv.Atoi(uri[i+1:])
+	}
+	body := fmt.Sprintf(`{
+		"@context": "https://www.w3.org/ns/activitystreams",
+		"id": %q,
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "n%d",
+		"_misskey_quote": "https://remote.example/notes/%d"
+	}`, uri, n, n+1)
+	return []byte(body), nil
+}
+
+// TestResolveNote_RecursionLimit pins the upstream d592da9f guard (#1828): a
+// note whose quote chain is unbounded is resolved up to resolveRecursionLimit
+// (256) deep and then stops, rather than recursing forever. The top note is
+// still created; the chain just truncates. We observe the bound via the fetch
+// count (without the limit this test would not terminate).
+func TestResolveNote_RecursionLimit(t *testing.T) {
+	f := &quoteChainFetcher{actorBody: sampleActor}
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, f, idGen)
+
+	note, err := r.ResolveNote("https://remote.example/notes/0")
+	require.NoError(t, err)
+	require.NotNil(t, note)
+	// 上限 (256) + 著者 actor 1 回程度で頭打ちになり、際限なく fetch しないこと
+	// (上限が無ければ chain は終わらない)。note/0..256 の 257 + actor 1 = 258 想定。
+	assert.LessOrEqual(t, f.calls.Load(), int64(260))
+	// 深く再帰したこと自体の確認: 上限近くの note は取り込まれている。
+	_, err = noteRepo.FindByURI("https://remote.example/notes/200")
+	require.NoError(t, err)
+	// 上限を超えた先の note は ErrRecursionLimit で truncate され取り込まれない。
+	_, err = noteRepo.FindByURI("https://remote.example/notes/300")
+	require.Error(t, err)
+}
+
 // failingUserRepo returns Create errors for the resolver.
 type failingUserRepo struct {
 	*testutil.MockUserRepository


### PR DESCRIPTION
## Summary

`#1828` (ap-resolver 再監査(2)) の sub-issue。upstream `Resolver.resolve` が持つ guard のうち mk-go に欠けていた **fragment 拒否** と **recursion limit** を移植し、悪意ある参照チェーンによる解決不能 URL / 無限再帰・amplification を防ぐ。

## 主な変更点 (`internal/core/federation/resolver.go`)

### fragment 拒否 (本家 b94fd5b1)
- `resolveActorOnce` / `resolveNoteOnce` の冒頭で URI に `#` を含む場合は `ErrResolveFragment` で拒否。fragment は HTTP(S) で送られず dereference 不能なため。
- keyId fragment (`...#main-key`) は `ResolveActorByKeyID` → `ResolveKeyURL` で除去済みのためこの経路には来ず、HTTP 署名検証の keyId 解決は従来どおり動く (`TestResolveActorByKeyID` で担保)。

### recursion limit (本家 d592da9f, 256)
- note→quote→note の**唯一の再帰 fetch 経路**に `depth` を通し、`resolveNoteOnce` で `depth > resolveRecursionLimit(256)` を `ErrRecursionLimit` で拒否。
- public `ResolveNote` / `IngestNote` / `IngestNoteWithCreated` は signature 据え置きで depth 0 から開始。quote 解決 (`resolveQuoteURI`) のみ `resolveNoteDepth(uri, depth+1)` で再入する (public `ResolveNote` を経由しないので depth がリセットされない)。

### already-resolved (本家 0dc86cf6)
- 既存の `ingesting` sync.Map (in-flight note URI を mark し ancestor への再 fetch を skip) が note-quote cycle を塞いでおり、recursion limit はそれを補完する**非循環チェーンの backstop**として機能する。新規追加なし。

## 本家との対応関係 (注意)
upstream の `recursionLimit` / `history` は **inReplyTo** chain を bound する (quote は fresh resolver で history 空)。mk-go は reply (inReplyTo) を**ローカル lookup のみ**で解決し再帰 fetch しないため、唯一の再帰 fetch 経路である **quote chain** を bound するのが mk-go architecture での正しい対応。1:1 mirror ではなく、より安全側の適応。

## テスト
- fragment 拒否 (actor / note) → `ErrResolveFragment`。
- recursion limit: 無限の quote chain (note N が note N+1 を quote) を解決させ、(1) 終了すること (上限が無ければ終わらない)、(2) fetch 回数が bounded (≤260)、(3) 上限手前の note は取り込まれ上限超の note は truncate されることを pin。
- `make fmt && make lint` clean、`go test ./...` 全 package green (0 failures)。
- 敵対的レビュー実施: BLOCKER/MAJOR/MINOR(blocking) なし。

Closes #1892

🤖 Generated with [Claude Code](https://claude.com/claude-code)