### PR TITLE
Fix ap-resolver parity (#1893): federation-loop fetch で request-URL host == id host を要求 (#1820 派生)

### DIFF
--- a/internal/api/ap/handler.go
+++ b/internal/api/ap/handler.go
@@ -35,6 +35,11 @@ type RemoteFetcher interface {
 type RemoteResolver interface {
 	ResolveActor(uri string) (*model.User, error)
 	ResolveNote(uri string) (*model.Note, error)
+	// *AllowCrossHost variants relax the request-url ↔ id host binding for
+	// user-initiated /api/ap/show lookups (upstream CrossOrigin softfail、#1828)。
+	// federation-loop の解決は Strict な ResolveActor / ResolveNote を使う。
+	ResolveActorAllowCrossHost(uri string) (*model.User, error)
+	ResolveNoteAllowCrossHost(uri string) (*model.Note, error)
 }
 
 // HostBlockChecker reports whether a remote host is blocked / federation-allowed
@@ -487,7 +492,7 @@ func (h *Handler) APIShow(c echo.Context) error {
 			switch t {
 			case "Note", "Article", "Question":
 				if h.remoteResolver != nil {
-					if remoteNote, err := h.remoteResolver.ResolveNote(req.URI); err == nil {
+					if remoteNote, err := h.remoteResolver.ResolveNoteAllowCrossHost(req.URI); err == nil {
 						return c.JSON(http.StatusOK, map[string]any{
 							"type":   "Note",
 							"object": h.packNoteForAPI(middleware.GetUser(c), remoteNote),
@@ -501,7 +506,7 @@ func (h *Handler) APIShow(c echo.Context) error {
 				})
 			case "Person", "Service", "Application", "Organization", "Group":
 				if h.remoteResolver != nil {
-					if remoteUser, err := h.remoteResolver.ResolveActor(req.URI); err == nil {
+					if remoteUser, err := h.remoteResolver.ResolveActorAllowCrossHost(req.URI); err == nil {
 						return c.JSON(http.StatusOK, map[string]any{
 							"type":   "User",
 							"object": h.packUserForAPI(middleware.GetUser(c), remoteUser, h.userService.GetProfile(remoteUser.ID)),
@@ -515,7 +520,7 @@ func (h *Handler) APIShow(c echo.Context) error {
 	// フェッチ失敗 or Type 不明の場合は ResolveActor を試す (webfinger 経由の
 	// /@user URL に対する fetch が失敗するケースがあるため)。
 	if h.remoteResolver != nil {
-		if remoteUser, err := h.remoteResolver.ResolveActor(req.URI); err == nil {
+		if remoteUser, err := h.remoteResolver.ResolveActorAllowCrossHost(req.URI); err == nil {
 			return c.JSON(http.StatusOK, map[string]any{
 				"type":   "User",
 				"object": h.packUserForAPI(middleware.GetUser(c), remoteUser, h.userService.GetProfile(remoteUser.ID)),

--- a/internal/api/ap/handler_test.go
+++ b/internal/api/ap/handler_test.go
@@ -686,6 +686,16 @@ func (m *mockResolver) ResolveNote(_ string) (*model.Note, error) {
 	return m.note, m.noteErr
 }
 
+// AllowCrossHost variants delegate to the same fields: the relaxed binding is
+// exercised by the resolver's own tests, here we only need shape compatibility.
+func (m *mockResolver) ResolveActorAllowCrossHost(_ string) (*model.User, error) {
+	return m.user, m.err
+}
+
+func (m *mockResolver) ResolveNoteAllowCrossHost(_ string) (*model.Note, error) {
+	return m.note, m.noteErr
+}
+
 func TestSetRemote(t *testing.T) {
 	h, _, _, _ := newHandler(t)
 	h.SetRemote(&mockFetcher{}, &mockResolver{})

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -370,12 +370,26 @@ func (r *Resolver) PublicKeyForActor(actorID string) (string, error) {
 // が actorTTL を超えていたら fetch しなおして name / inbox / sharedInbox /
 // publicKey を更新する。fetch 失敗時はベストエフォートで既存値を返す。
 func (r *Resolver) ResolveActor(uri string) (*model.User, error) {
+	return r.resolveActor(uri, false)
+}
+
+// ResolveActorAllowCrossHost is ResolveActor for user-initiated lookups
+// (/api/ap/show) where upstream relaxes the request-url ↔ id binding to
+// CrossOrigin softfail (ap/show.ts:153、#1828)。entry URI が admin の手入力で
+// attacker 制御でないため cross-host redirect を許容する。finalURL ↔ id binding は
+// 引き続き適用される。
+func (r *Resolver) ResolveActorAllowCrossHost(uri string) (*model.User, error) {
+	return r.resolveActor(uri, true)
+}
+
+// resolveActor is ResolveActor carrying the cross-host-allowed flag (#1828)。
+func (r *Resolver) resolveActor(uri string, allowCrossHost bool) (*model.User, error) {
 	// 同一 URI への並行呼び出しは singleflight で 1 つに collapse する
 	// (#300 3-7)。cache hit 経路は微秒なので serialize の影響は無視でき、
 	// cold な fetch + Create で発生する HTTP fan-out + UNIQUE 衝突を抑える
 	// 効果が大きい。
-	v, err, _ := r.resolveActorGroup.Do(uri, func() (any, error) {
-		return r.resolveActorOnce(uri)
+	v, err, _ := r.resolveActorGroup.Do(crossHostKey(uri, allowCrossHost), func() (any, error) {
+		return r.resolveActorOnce(uri, allowCrossHost)
 	})
 	if err != nil {
 		return nil, err
@@ -386,9 +400,9 @@ func (r *Resolver) ResolveActor(uri string) (*model.User, error) {
 	return v.(*model.User), nil
 }
 
-// resolveActorOnce is the body of ResolveActor, invoked once per URI by
+// resolveActorOnce is the body of resolveActor, invoked once per URI by
 // singleflight.Do.
-func (r *Resolver) resolveActorOnce(uri string) (*model.User, error) {
+func (r *Resolver) resolveActorOnce(uri string, allowCrossHost bool) (*model.User, error) {
 	// fragment 付き URL は HTTP(S) で fragment が送られず正しく解決できないため
 	// 拒否する (本家 Resolver の b94fd5b1 guard、#1828)。keyId fragment は
 	// ResolveActorByKeyID -> ResolveKeyURL で除去済みなのでここには来ない。
@@ -411,7 +425,7 @@ func (r *Resolver) resolveActorOnce(uri string) (*model.User, error) {
 		return existing, nil
 	}
 
-	actor, err := r.fetchActor(uri)
+	actor, err := r.fetchActor(uri, allowCrossHost)
 	if err != nil {
 		return nil, err
 	}
@@ -584,7 +598,8 @@ func (r *Resolver) shouldRefreshActor(u *model.User) bool {
 // on the local user row. 失敗してもエラーは返さず (呼び出し側はベストエフォート
 // で既存値を使う)、ログは呼び出し元側で残す。
 func (r *Resolver) refreshActor(existing *model.User, uri string) {
-	actor, err := r.fetchActor(uri)
+	// background refresh は federation-loop 扱いで Strict (request host binding 有効)。
+	actor, err := r.fetchActor(uri, false)
 	if err != nil {
 		return
 	}
@@ -707,7 +722,7 @@ func (r *Resolver) refreshActor(existing *model.User, uri string) {
 // fetchActor fetches and decodes a remote actor document. Reject any
 // document whose `type` is not in activitypub.ValidActorTypes — this guards
 // against a non-Actor object (e.g. a Note) being interpreted as a Person.
-func (r *Resolver) fetchActor(uri string) (*activitypub.Person, error) {
+func (r *Resolver) fetchActor(uri string, allowCrossHost bool) (*activitypub.Person, error) {
 	// federation policy gate: ホワイトリスト連合 (federation: specified) や
 	// blockedHosts 設定下では、対象 URI の host が許可されていなければ HTTP
 	// fetch 自体を抑止する。refreshActor / refreshPublicKey / resolveActorOnce
@@ -740,6 +755,15 @@ func (r *Resolver) fetchActor(uri string) (*activitypub.Person, error) {
 		slog.Warn("federation: actor id host mismatch", "uri", uri, "finalURL", finalURL, "id", actor.ID)
 		return nil, err
 	}
+	// request URI host == id host も要求する (Strict、#1828)。attacker.example の
+	// entry URI から 302 で victim.example の actor 解決を誘発するのを防ぐ。
+	// user-initiated ap/show (allowCrossHost) は upstream 同様 cross-host を許容。
+	if !allowCrossHost {
+		if err := assertRequestHostMatches(uri, actor.ID); err != nil {
+			slog.Warn("federation: actor request host mismatch", "uri", uri, "id", actor.ID)
+			return nil, err
+		}
+	}
 	if !activitypub.IsValidActorType(actor.Type) {
 		// Note/Activity 等 Actor でない object が actor として参照された場合の
 		// 防衛策。デバッグのため URI と type を残してから拒否する。
@@ -752,7 +776,8 @@ func (r *Resolver) fetchActor(uri string) (*activitypub.Person, error) {
 // refreshPublicKey fetches the actor again and caches its public key. エラー
 // は呼び出し側でログするだけで上には伝搬しない。
 func (r *Resolver) refreshPublicKey(userID, uri string) {
-	actor, err := r.fetchActor(uri)
+	// background refresh は federation-loop 扱いで Strict。
+	actor, err := r.fetchActor(uri, false)
 	if err != nil {
 		return
 	}
@@ -877,18 +902,26 @@ func (r *Resolver) ResolveActorByKeyID(keyID string) (*model.User, error) {
 //   - リモート URI で既に取り込み済みなら noteRepo.FindByURI で返す
 //   - 未知のリモート URI なら fetcher で取得して IngestNote で永続化
 func (r *Resolver) ResolveNote(uri string) (*model.Note, error) {
-	return r.resolveNoteDepth(uri, 0)
+	return r.resolveNoteDepth(uri, 0, false)
+}
+
+// ResolveNoteAllowCrossHost is ResolveNote for user-initiated lookups
+// (/api/ap/show) where upstream relaxes the request-url ↔ id binding to
+// CrossOrigin softfail (#1828)。entry URI が attacker 制御でないため cross-host
+// redirect を許容する。finalURL ↔ id binding は引き続き適用される。
+func (r *Resolver) ResolveNoteAllowCrossHost(uri string) (*model.Note, error) {
+	return r.resolveNoteDepth(uri, 0, true)
 }
 
 // resolveNoteDepth is ResolveNote carrying the current recursion depth so the
 // note/quote chain can be bounded (#1828)。quote 解決経路 (resolveQuoteURI) が
-// depth+1 で再入する。
-func (r *Resolver) resolveNoteDepth(uri string, depth int) (*model.Note, error) {
+// depth+1 で再入する。allowCrossHost は user-initiated ap/show 経路でのみ true。
+func (r *Resolver) resolveNoteDepth(uri string, depth int, allowCrossHost bool) (*model.Note, error) {
 	// 同一 URI への並行呼び出しは singleflight で collapse (#300 3-7)。
 	// ResolveActor と同じく cold path の HTTP fetch + IngestNote を重複
 	// 実行しないことが目的。
-	v, err, _ := r.resolveNoteGroup.Do(uri, func() (any, error) {
-		return r.resolveNoteOnce(uri, depth)
+	v, err, _ := r.resolveNoteGroup.Do(crossHostKey(uri, allowCrossHost), func() (any, error) {
+		return r.resolveNoteOnce(uri, depth, allowCrossHost)
 	})
 	if err != nil {
 		return nil, err
@@ -900,8 +933,9 @@ func (r *Resolver) resolveNoteDepth(uri string, depth int) (*model.Note, error) 
 }
 
 // resolveNoteOnce is the body of resolveNoteDepth, invoked once per URI by
-// singleflight.Do. depth は quote chain の現在の深さ。
-func (r *Resolver) resolveNoteOnce(uri string, depth int) (*model.Note, error) {
+// singleflight.Do. depth は quote chain の現在の深さ。allowCrossHost は
+// user-initiated ap/show 経路でのみ true。
+func (r *Resolver) resolveNoteOnce(uri string, depth int, allowCrossHost bool) (*model.Note, error) {
 	if r.noteRepo == nil {
 		return nil, ErrInvalidNote
 	}
@@ -955,6 +989,15 @@ func (r *Resolver) resolveNoteOnce(uri string, depth int) (*model.Note, error) {
 	if err := assertResponseHostMatches(finalURL, idProbe.ID); err != nil {
 		slog.Warn("federation: note id host mismatch", "uri", uri, "finalURL", finalURL, "id", idProbe.ID)
 		return nil, err
+	}
+	// request URI host == id host も要求する (Strict、#1828)。Announce / quote 等
+	// attacker 制御の entry URI から cross-host redirect で第三者 note を解決させる
+	// のを防ぐ。user-initiated ap/show (allowCrossHost) は cross-host を許容。
+	if !allowCrossHost {
+		if err := assertRequestHostMatches(uri, idProbe.ID); err != nil {
+			slog.Warn("federation: note request host mismatch", "uri", uri, "id", idProbe.ID)
+			return nil, err
+		}
 	}
 	// fetch 経由は配送 actor が無いので attribution==actor 検証は skip ("")。
 	// quote chain の depth を引き継いで再帰上限を効かせる。
@@ -1013,7 +1056,8 @@ func (r *Resolver) resolveQuoteURI(uri string, depth int) *model.Note {
 	if _, inflight := r.ingesting.Load(uri); inflight {
 		return nil
 	}
-	if n, err := r.resolveNoteDepth(uri, depth+1); err == nil {
+	// quote 解決は federation-loop 扱いで Strict (request host binding 有効)。
+	if n, err := r.resolveNoteDepth(uri, depth+1, false); err == nil {
 		return n
 	}
 	return nil
@@ -2077,6 +2121,40 @@ func assertResponseHostMatches(finalURL, objectID string) error {
 		return ErrObjectHostMismatch
 	}
 	return nil
+}
+
+// assertRequestHostMatches enforces that the original request URI host equals
+// the fetched object's id host, mirroring upstream assertActivityMatchesUrl の
+// request-url ↔ id Strict 検証 (#1828)。federation-loop fetch (fetchActor /
+// resolveNoteOnce) で attacker 制御の entry URI から cross-host redirect を辿って
+// 第三者 object の解決/refresh を誘発される SSRF/amplification を防ぐ。finalURL ↔
+// id の binding は assertResponseHostMatches が別途担保するので、ここは request ↔
+// id の host 一致のみを見る (downgrade は final ↔ id 側で検出済み)。user-initiated
+// な ap/show 経路は upstream 同様 cross-host を許容するため、この検証を skip する。
+func assertRequestHostMatches(requestURI, objectID string) error {
+	if objectID == "" {
+		return ErrObjectHostMismatch
+	}
+	ru, rerr := url.Parse(requestURI)
+	iu, ierr := url.Parse(objectID)
+	if rerr != nil || ierr != nil || ru.Hostname() == "" || iu.Hostname() == "" {
+		return ErrObjectHostMismatch
+	}
+	if normalizeMatchHost(ru) != normalizeMatchHost(iu) {
+		return ErrObjectHostMismatch
+	}
+	return nil
+}
+
+// crossHostKey namespaces a singleflight key for cross-host-allowed (ap/show)
+// resolves so a Strict federation-loop resolve never collapses onto a relaxed
+// in-flight one (and thereby skip its request-host binding)。Strict 経路の key は
+// uri そのままなので通常の dedup 挙動は不変。
+func crossHostKey(uri string, allowCrossHost bool) string {
+	if allowCrossHost {
+		return "xhost\x00" + uri
+	}
+	return uri
 }
 
 // normalizeMatchHost canonicalizes a URL host for object-host comparison,

--- a/internal/core/federation/resolver_allowlist_test.go
+++ b/internal/core/federation/resolver_allowlist_test.go
@@ -162,7 +162,21 @@ func TestProcessCreate_AllowedSenderNonFederatedAttributedToIsDropped(t *testing
 	followingRepo := testutil.NewMockFollowingRepository()
 	urls := activitypub.NewURLBuilder("https://example.com")
 	idGen, _ := id.NewGenerator("aidx")
-	resolver := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+	// 送信者 (relay.allowed) の actor を返す。id host が request host と一致する
+	// (Strict request-host binding #1828 を通す)。
+	relayActor := `{
+		"@context": "https://www.w3.org/ns/activitystreams",
+		"id": "https://relay.allowed/users/relay",
+		"type": "Application",
+		"preferredUsername": "relay",
+		"inbox": "https://relay.allowed/users/relay/inbox",
+		"publicKey": {
+			"id": "https://relay.allowed/users/relay#main-key",
+			"owner": "https://relay.allowed/users/relay",
+			"publicKeyPem": "-----BEGIN PUBLIC KEY-----\nFAKE\n-----END PUBLIC KEY-----"
+		}
+	}`
+	resolver := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(relayActor)}, idGen)
 	// note の attributedTo (remote.example) のみ非連合。送信者 host は許可。
 	resolver.SetHostBlockChecker(&stubHostBlocker{disallowed: map[string]bool{"remote.example": true}})
 	followingSvc := corefollowing.NewService(repo, followingRepo, testutil.NewMockFollowRequestRepository(), idGen)

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -362,7 +362,8 @@ func TestResolveActor_MissingFields(t *testing.T) {
 }
 
 func TestResolveActor_BadHost(t *testing.T) {
-	// invalid URL with control char
+	// invalid URL with control char。request host (x.example) と id host が
+	// 一致しないため Strict request-host binding (#1828) が先に弾く。
 	body := `{
 		"@context": "https://www.w3.org/ns/activitystreams",
 		"id": "://invalid",
@@ -371,11 +372,30 @@ func TestResolveActor_BadHost(t *testing.T) {
 	}`
 	r, _ := newResolver(t, body, nil)
 	_, err := r.ResolveActor("https://x.example/")
+	require.ErrorIs(t, err, federation.ErrObjectHostMismatch)
+}
+
+// TestResolveActorAllowCrossHost_BadIDHostRejected exercises the relaxed
+// (ap/show) path where the request-host binding is skipped: an actor with a
+// valid type but an unparseable / hostless id is still rejected by the
+// downstream hostFromURI check (#1828)。
+func TestResolveActorAllowCrossHost_BadIDHostRejected(t *testing.T) {
+	// type は valid なので fetchActor は通り、resolveActorOnce の hostFromURI で
+	// ErrInvalidActor になる経路 (relaxed path) を踏む。
+	body := `{
+		"@context": "https://www.w3.org/ns/activitystreams",
+		"id": "mailto:alice@example.com",
+		"type": "Person",
+		"preferredUsername": "alice",
+		"inbox": "x"
+	}`
+	r, _ := newResolver(t, body, nil)
+	_, err := r.ResolveActorAllowCrossHost("https://x.example/")
 	require.ErrorIs(t, err, federation.ErrInvalidActor)
 }
 
 func TestResolveActor_EmptyHost(t *testing.T) {
-	// mailto: parses but has no host
+	// mailto: parses but has no host。request host 不一致で Strict binding が弾く。
 	body := `{
 		"@context": "https://www.w3.org/ns/activitystreams",
 		"id": "mailto:alice@example.com",
@@ -384,7 +404,7 @@ func TestResolveActor_EmptyHost(t *testing.T) {
 	}`
 	r, _ := newResolver(t, body, nil)
 	_, err := r.ResolveActor("https://x.example/")
-	require.ErrorIs(t, err, federation.ErrInvalidActor)
+	require.ErrorIs(t, err, federation.ErrObjectHostMismatch)
 }
 
 // TestResolveActor_RejectsMissingContext pins the upstream invalid-response
@@ -555,6 +575,90 @@ func TestResolveNote_RecursionLimit(t *testing.T) {
 	// 上限を超えた先の note は ErrRecursionLimit で truncate され取り込まれない。
 	_, err = noteRepo.FindByURI("https://remote.example/notes/300")
 	require.Error(t, err)
+}
+
+// TestResolveActor_StrictRejectsCrossHostRedirect pins the upstream Strict
+// request-url ↔ id binding (#1828): a federation-loop fetch whose original
+// request host differs from the fetched actor's id host is rejected even when
+// the final (post-redirect) host matches the id host. This blocks an
+// attacker-controlled entry URI from redirecting to a victim actor.
+func TestResolveActor_StrictRejectsCrossHostRedirect(t *testing.T) {
+	f := &finalURLStubFetcher{body: []byte(sampleActor), finalURL: "https://remote.example/users/alice"}
+	r, repo := newResolverWithFetcher(t, f)
+	_, err := r.ResolveActor("https://attacker.example/users/alice")
+	require.ErrorIs(t, err, federation.ErrObjectHostMismatch)
+	assert.Empty(t, repo.Users)
+}
+
+// TestResolveActorAllowCrossHost_AllowsCrossHostRedirect: the user-initiated
+// ap/show path relaxes the request-host binding (upstream CrossOrigin softfail),
+// so a cross-host redirect resolves successfully (#1828)。
+func TestResolveActorAllowCrossHost_AllowsCrossHostRedirect(t *testing.T) {
+	f := &finalURLStubFetcher{body: []byte(sampleActor), finalURL: "https://remote.example/users/alice"}
+	r, repo := newResolverWithFetcher(t, f)
+	user, err := r.ResolveActorAllowCrossHost("https://attacker.example/users/alice")
+	require.NoError(t, err)
+	assert.Equal(t, "alice", user.Username)
+	assert.Len(t, repo.Users, 1)
+}
+
+// crossHostDispatchFetcher serves the note for /notes/ URIs and the author actor
+// for /users/ URIs, each with a controllable final URL, so note resolution
+// (which resolves attributedTo) can be exercised end-to-end (#1828)。
+type crossHostDispatchFetcher struct {
+	noteBody, actorBody   string
+	noteFinal, actorFinal string
+}
+
+func (f *crossHostDispatchFetcher) FetchObject(uri string) ([]byte, error) {
+	b, _, err := f.FetchObjectWithFinalURL(uri)
+	return b, err
+}
+
+func (f *crossHostDispatchFetcher) FetchObjectWithFinalURL(uri string) ([]byte, string, error) {
+	if strings.Contains(uri, "/users/") {
+		return []byte(f.actorBody), f.actorFinal, nil
+	}
+	return []byte(f.noteBody), f.noteFinal, nil
+}
+
+// TestResolveNote_StrictRejectsCrossHostRedirect mirrors the actor test for
+// note resolution (#1828)。
+func TestResolveNote_StrictRejectsCrossHostRedirect(t *testing.T) {
+	f := &crossHostDispatchFetcher{
+		noteBody:   sampleRemoteNote,
+		noteFinal:  "https://remote.example/notes/n1",
+		actorBody:  sampleActor,
+		actorFinal: "https://remote.example/users/alice",
+	}
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, f, idGen)
+	_, err := r.ResolveNote("https://attacker.example/notes/x")
+	require.ErrorIs(t, err, federation.ErrObjectHostMismatch)
+	assert.Empty(t, noteRepo.Notes)
+}
+
+// TestResolveNoteAllowCrossHost_AllowsCrossHostRedirect: ap/show note lookup
+// relaxes the request-host binding and resolves the note (and its author)
+// across a cross-host redirect (#1828)。
+func TestResolveNoteAllowCrossHost_AllowsCrossHostRedirect(t *testing.T) {
+	f := &crossHostDispatchFetcher{
+		noteBody:   sampleRemoteNote,
+		noteFinal:  "https://remote.example/notes/n1",
+		actorBody:  sampleActor,
+		actorFinal: "https://remote.example/users/alice",
+	}
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, f, idGen)
+	note, err := r.ResolveNoteAllowCrossHost("https://attacker.example/notes/x")
+	require.NoError(t, err)
+	require.NotNil(t, note)
 }
 
 // failingUserRepo returns Create errors for the resolver.


### PR DESCRIPTION
## Summary

`#1828` (ap-resolver 再監査(2)) の最後の sub-issue (#1820 派生 MAJOR)。upstream `assertActivityMatchesUrl` の **Strict request-url ↔ id host binding** を移植する。`#1820` は finalURL host == id host を bind したが、本家 federation loop はさらに **request-URL host == id host (== finalURL host)** まで Strict に要求する。これにより `attacker.example → 302 → victim.example` のように attacker 制御の entry URI から victim actor/note の解決/refresh を誘発する cross-host redirect SSRF/amplification を防ぐ (取得データ自体は victim 本物なので impersonation でなく canonical-id / defense-in-depth 上の差)。

## 主な変更点

### resolver.go
- `assertRequestHostMatches(requestURI, objectID)`: `normalizeMatchHost` 正規化で request host == id host を検証 (downgrade は final↔id 側で検出済みのため host 一致のみ)。
- `allowCrossHost` を `ResolveActor`/`ResolveNote` → `resolveActorOnce`/`resolveNoteOnce` → `fetchActor` に通し、**`!allowCrossHost` のときのみ** request-host binding を適用。
- public `ResolveActorAllowCrossHost` / `ResolveNoteAllowCrossHost` を追加。
- `crossHostKey` で relaxed resolve の singleflight key を namespace し、Strict caller が relaxed in-flight resolve に collapse して binding を skip するのを防ぐ。Strict 経路の key は `uri` のままで dedup 挙動不変。
- relaxed note 解決でも attributedTo actor / quote の**内部解決は Strict**な public `ResolveActor` / `resolveNoteDepth(...,false)` を使う (flag は nested resolve に漏れない)。
- federation-loop (Announce / quote 再帰 / attributedTo / HTTP-sig keyId / background refresh) はすべて Strict。

### api/ap/handler.go
- `RemoteResolver` interface に `*AllowCrossHost` 2 メソッドを追加。
- APIShow (`/api/ap/show`、`RequireAuth + read:account`) の 3 resolve call site を relaxed 変種に変更。upstream が ap/show を `CrossOrigin softfail` で緩和する (ap/show.ts:153) のと同じ。entry URI が user/admin 手入力で attacker 制御でないため cross-host redirect を許容。

## テスト
- actor/note それぞれで **Strict が cross-host redirect を reject**し (`ErrObjectHostMismatch` + 何も永続化しない)、**relaxed が許容**することを pin。
- relaxed path も `hostFromURI` で bad-id を弾くこと、`BadHost`/`EmptyHost`/非連合 attributedTo drop の既存テストを新 precedence に整合。
- `make fmt && make lint` clean、`go test ./...` 全 package green (0 failures)。
- 敵対的レビュー実施 (gate 完全性 / flag leak / singleflight bypass / parity): BLOCKER/MAJOR/MINOR なし。

## 親 issue 完了
本 PR で `#1828` (ap-resolver) の 3 sub-issue (#1891 / #1892 / #1893) がすべて完了。

Closes #1893
Closes #1828

🤖 Generated with [Claude Code](https://claude.com/claude-code)