### PR TITLE
Fix auth-oauth parity (#1897): app/show が app access token owner に secret を返さないよう gate

### DIFF
--- a/internal/api/app/handler.go
+++ b/internal/api/app/handler.go
@@ -119,10 +119,16 @@ func (h *Handler) Show(c echo.Context) error {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_APP", "No such app.", "dce83913-2dc6-4093-8a7b-71dbb11718a3"))
 	}
 
-	// 認証済み && 自分のアプリならsecretも返す
+	// upstream app/show は isSecure = (user != null && token == null) を計算し、
+	// native session (= users.token) かつ自分の app のときだけ secret を返す。
+	// OAuth/MiAuth の app access token (token != null) では owner でも secret を
+	// 返さない: secret は access token hash 生成に使う app credential であり、
+	// app token に渡すと privilege escalation になる (#1829)。RequireSecure と
+	// 同じ native-session 判定 (raw token == users.token) を inline で行う。
 	me := middleware.GetUser(c)
 	includeSecret := false
-	if me != nil && a.UserID != nil && *a.UserID == me.ID {
+	if me != nil && a.UserID != nil && *a.UserID == me.ID &&
+		me.Token != nil && *me.Token == middleware.GetToken(c) {
 		includeSecret = true
 	}
 

--- a/internal/api/app/handler_test.go
+++ b/internal/api/app/handler_test.go
@@ -137,6 +137,23 @@ func post(handler func(echo.Context) error, body string, user *model.User) *http
 	return rec
 }
 
+// postWithToken is post but also wires the raw auth token onto the context so
+// handlers that distinguish native session vs app access token (app/show
+// secret gate, #1829) can be exercised.
+func postWithToken(handler func(echo.Context) error, body string, user *model.User, token string) *httptest.ResponseRecorder {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if user != nil {
+		c.Set(string(middleware.UserContextKey), user)
+	}
+	c.Set(string(middleware.TokenContextKey), token)
+	_ = handler(c)
+	return rec
+}
+
 // --- Create ---
 
 func TestCreate_Success(t *testing.T) {
@@ -234,17 +251,41 @@ func TestShow_IsAuthorized(t *testing.T) {
 	assert.Equal(t, true, resp["isAuthorized"])
 }
 
+// TestShow_WithOwner: owner が native session (raw token == users.token) で
+// 叩くと secret を返す (upstream isSecure = token==null)。
 func TestShow_WithOwner(t *testing.T) {
 	h, repo := newTestHandler()
 	uid := "u1"
 	repo.apps["app1"] = &model.App{ID: "app1", Name: "MyApp", Secret: "s1", UserID: &uid, Permission: pq.StringArray{"read:account"}}
 
-	rec := post(h.Show, `{"appId":"app1"}`, &model.User{ID: "u1"})
+	nativeTok := "native-session-token"
+	rec := postWithToken(h.Show, `{"appId":"app1"}`, &model.User{ID: "u1", Token: &nativeTok}, nativeTok)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Equal(t, "s1", resp["secret"])
+}
+
+// TestShow_OwnerViaAppTokenNoSecret: owner であっても app access token
+// (raw token != users.token) で叩くと secret を返さない。secret を app token に
+// 渡す privilege escalation の防止 (#1829, upstream isSecure = token==null)。
+func TestShow_OwnerViaAppTokenNoSecret(t *testing.T) {
+	h, repo := newTestHandler()
+	uid := "u1"
+	repo.apps["app1"] = &model.App{ID: "app1", Name: "MyApp", Secret: "s1", UserID: &uid, Permission: pq.StringArray{"read:account"}}
+
+	nativeTok := "native-session-token"
+	// raw token は app access token (native token とは別) を渡す。
+	rec := postWithToken(h.Show, `{"appId":"app1"}`, &model.User{ID: "u1", Token: &nativeTok}, "app-access-token")
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	_, hasSecret := resp["secret"]
+	assert.False(t, hasSecret, "app access token (owner) には secret を返さない")
+	// name 等の public field は返る。
+	assert.Equal(t, "MyApp", resp["name"])
 }
 
 func TestShow_NotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

`#1829` (auth-oauth 再監査(2)) の sub-issue (F2、MEDIUM/security)。`app/show` が app access token の owner にも `secret` を返していた privilege escalation を修正する。

## 問題
upstream `app/show` は `isSecure = (user != null && token == null)` を計算し、**native session** (= `users.token`) かつ自分の app のときだけ `secret` を含める。OAuth/MiAuth の **app access token (token != null) では owner でも `secret` を返さない**。`secret` は `auth/accept` で access token hash 生成に使う app credential であり、app token に渡すと privilege escalation。

mk-go は `middleware.GetUser` のみで判定し token 種別 (native vs app token) を区別しなかったため、`read:account` scope の app access token が owner の app に対し `app/show` を叩くと `secret` が漏れていた。

## 修正 (`internal/api/app/handler.go`)
`RequireSecure` と同じ native-session 判定を inline で追加:
```go
if me != nil && a.UserID != nil && *a.UserID == me.ID &&
    me.Token != nil && *me.Token == middleware.GetToken(c) {
    includeSecret = true
}
```
`app/show` は optionally-authed なので `RequireSecure` middleware (anonymous を 403) は使えず、upstream 同様 endpoint 内で `isSecure` 相当を inline する。auth middleware は native/app 双方で `TokenContextKey = raw token` を積み、native session のみ raw token == `users.token` になる invariant を利用 (`RequireSecure` と同一)。

## テスト
- native session owner → `secret` 返す。
- app access token owner (raw token != `users.token`) → `secret` 返さない (public field は返る)。
- `post` helper に token context を積む `postWithToken` を追加。

## その他
- 実装中に隣接 vuln (`my/apps` が secret を無条件で返す) を発見 → 別 issue **#1900** に分離 (本 PR 対象外)。
- `make fmt && make lint` clean、敵対的レビュー CLEAN (gate 正当性 / false-negative / bypass / test 品質)。

Closes #1897

🤖 Generated with [Claude Code](https://claude.com/claude-code)