### PR TITLE
Fix auth-oauth parity (#1898): signin 系 rate-limit を TOO_MANY_AUTHENTICATION_FAILURES + upstream しきい値に整合

### DIFF
--- a/internal/api/apierr/errors.go
+++ b/internal/api/apierr/errors.go
@@ -163,6 +163,10 @@ const (
 	// UUID for rate limiting (third_party/misskey/.../ApiCallService.ts).
 	UUIDRateLimitExceeded = "d5826d14-3982-4d2e-8011-b9e9f02499ef"
 
+	// UUID for signin / signin-flow / signin-with-passkey rate limiting
+	// (third_party/misskey/.../SigninApiService.ts、SigninWithPasskeyApiService.ts).
+	UUIDTooManyAuthenticationFailures = "22d05606-fbcf-421a-a2db-b32610dcfd1b"
+
 	// UUID for users/show (third_party/misskey/.../endpoints/users/show.ts).
 	UUIDFailedToResolveRemoteUser = "ef7b9be4-9cba-4e6f-ab41-90ed171c7d3c"
 
@@ -554,6 +558,15 @@ func FailedToResolveRemoteUser() map[string]any {
 // RateLimitExceeded returns a 429 RATE_LIMIT_EXCEEDED error response.
 func RateLimitExceeded() map[string]any {
 	return Error("RATE_LIMIT_EXCEEDED", "Rate limit exceeded. Please try again later.", UUIDRateLimitExceeded)
+}
+
+// TooManyAuthenticationFailures returns the 429 error used by signin /
+// signin-flow / signin-with-passkey when the per-IP attempt limit is hit,
+// matching upstream SigninApiService (code TOO_MANY_AUTHENTICATION_FAILURES、
+// #1829)。汎用 RATE_LIMIT_EXCEEDED と区別して、認証失敗の brute-force 抑止で
+// あることをクライアントに伝える。
+func TooManyAuthenticationFailures() map[string]any {
+	return Error("TOO_MANY_AUTHENTICATION_FAILURES", "Too many failed attempts to sign in. Try again later.", UUIDTooManyAuthenticationFailures)
 }
 
 // InvalidToken returns a 403 INVALID_TOKEN error response. Used by 2FA flows

--- a/internal/server/middleware/ratelimit.go
+++ b/internal/server/middleware/ratelimit.go
@@ -21,6 +21,10 @@ type EndpointLimit struct {
 	Duration    time.Duration // ウィンドウ幅（例: 1時間）
 	Max         int           // ウィンドウ内最大リクエスト数
 	MinInterval time.Duration // 連続リクエスト最小間隔（0なら無効）
+	// RejectResponse overrides the default RATE_LIMIT_EXCEEDED body returned on
+	// 429 for this endpoint. nil なら汎用 RateLimitExceeded。signin 系は
+	// TOO_MANY_AUTHENTICATION_FAILURES を返すために使う (#1829)。
+	RejectResponse func() map[string]any
 }
 
 // LimitInfo holds the result of a rate limit check.
@@ -177,7 +181,7 @@ func (rl *RateLimiter) Middleware() echo.MiddlewareFunc {
 						continue
 					}
 					if info.Remaining == 0 {
-						return rl.rejectRequest(c, info)
+						return rl.rejectRequest(c, info, limit)
 					}
 				}
 
@@ -189,7 +193,7 @@ func (rl *RateLimiter) Middleware() echo.MiddlewareFunc {
 						continue
 					}
 					if info.Remaining == 0 {
-						return rl.rejectRequest(c, info)
+						return rl.rejectRequest(c, info, limit)
 					}
 					if minRemaining < 0 || info.Remaining < minRemaining {
 						minRemaining = info.Remaining
@@ -281,13 +285,19 @@ func scaledMax(base int, factor float64) int {
 	return scaled
 }
 
-// rejectRequest returns a 429 response with appropriate headers.
-func (rl *RateLimiter) rejectRequest(c echo.Context, info LimitInfo) error {
+// rejectRequest returns a 429 response with appropriate headers. limit may
+// carry a per-endpoint RejectResponse override (e.g. signin returns
+// TOO_MANY_AUTHENTICATION_FAILURES instead of the generic RATE_LIMIT_EXCEEDED、
+// #1829)。
+func (rl *RateLimiter) rejectRequest(c echo.Context, info LimitInfo, limit *EndpointLimit) error {
 	retryAfterSec := (info.ResetMs - time.Now().UnixMilli() + 999) / 1000
 	if retryAfterSec < 0 {
 		retryAfterSec = 0
 	}
 	c.Response().Header().Set("Retry-After", fmt.Sprintf("%d", retryAfterSec))
+	if limit != nil && limit.RejectResponse != nil {
+		return c.JSON(http.StatusTooManyRequests, limit.RejectResponse())
+	}
 	return c.JSON(http.StatusTooManyRequests, apierr.RateLimitExceeded())
 }
 

--- a/internal/server/middleware/ratelimit_defs.go
+++ b/internal/server/middleware/ratelimit_defs.go
@@ -1,6 +1,10 @@
 package middleware
 
-import "time"
+import (
+	"time"
+
+	"github.com/shiroha-a/mk/internal/api/apierr"
+)
 
 // DefaultEndpointLimits defines per-endpoint rate limits matching
 // Misskey TS upstream. Endpoints not listed here have no rate limit.
@@ -114,11 +118,14 @@ var DefaultEndpointLimits = map[string]*EndpointLimit{
 	// (1 確認 code 試行を 30 回まで許容、TTL 内で総当たりされても 16 byte
 	// hex の探索空間 (2^128) には到底届かない)。
 	"signup-pending": {Duration: time.Hour, Max: 30},
-	// signin / signin-flow は credential brute force 対策。1h 60 回。
-	// 正当な打ち間違い (typo, password manager 不発等) をブロックしない
-	// 最低限のしきい値。
-	"signin":      {Duration: time.Hour, Max: 60},
-	"signin-flow": {Duration: time.Hour, Max: 60},
+	// signin / signin-flow は credential brute force 対策。upstream
+	// SigninApiService に合わせて 1h 10 回 + 1s minInterval、超過時は専用の
+	// TOO_MANY_AUTHENTICATION_FAILURES (22d05606-...) を返す (#1829)。
+	"signin":      {Duration: time.Hour, Max: 10, MinInterval: time.Second, RejectResponse: apierr.TooManyAuthenticationFailures},
+	"signin-flow": {Duration: time.Hour, Max: 10, MinInterval: time.Second, RejectResponse: apierr.TooManyAuthenticationFailures},
+	// signin-with-passkey は upstream SigninWithPasskeyApiService に合わせて
+	// 30min 200 回 + 250ms minInterval、同 code (#1829)。
+	"signin-with-passkey": {Duration: 30 * time.Minute, Max: 200, MinInterval: 250 * time.Millisecond, RejectResponse: apierr.TooManyAuthenticationFailures},
 
 	// ── Admin ──────────────────────────────────────────
 	"admin/system-webhook/test": {Duration: 15 * time.Minute, Max: 60},

--- a/internal/server/middleware/ratelimit_test.go
+++ b/internal/server/middleware/ratelimit_test.go
@@ -522,8 +522,9 @@ func TestDefaultEndpointLimits_KnownEndpoints(t *testing.T) {
 		// Auth / password reset (#600 item 3): signup spam / brute-force 対策。
 		{"signup", 5},
 		{"signup-pending", 30},
-		{"signin", 60},
-		{"signin-flow", 60},
+		{"signin", 10},
+		{"signin-flow", 10},
+		{"signin-with-passkey", 200},
 		{"request-reset-password", 3},
 		{"reset-password", 30},
 	}
@@ -545,6 +546,9 @@ func TestDefaultEndpointLimits_MinIntervalEndpoints(t *testing.T) {
 		{"notes/unrenote", time.Second},
 		{"notes/reactions/delete", 3 * time.Second},
 		{"bubble-game/register", 30 * time.Second},
+		{"signin", time.Second},
+		{"signin-flow", time.Second},
+		{"signin-with-passkey", 250 * time.Millisecond},
 	}
 	for _, tc := range cases {
 		t.Run(tc.endpoint, func(t *testing.T) {
@@ -573,6 +577,72 @@ func TestMiddleware_RetryAfterNegativeClampsToZero(t *testing.T) {
 
 	assert.Equal(t, http.StatusTooManyRequests, rec.Code)
 	assert.Equal(t, "0", rec.Header().Get("Retry-After"))
+}
+
+// TestMiddleware_SigninReturnsTooManyAuthFailures verifies the signin endpoint's
+// 429 carries the upstream TOO_MANY_AUTHENTICATION_FAILURES code/id rather than
+// the generic RATE_LIMIT_EXCEEDED (#1829)。signin は minInterval(1s) と
+// duration/max(10/1h) の 2 gate を持つので、両方の reject 経路で custom error が
+// 返ることを確認する (1 件目で minInterval gate、2 件目で minInterval pass →
+// duration gate)。
+func TestMiddleware_SigninReturnsTooManyAuthFailures(t *testing.T) {
+	cases := []struct {
+		name    string
+		results []mockResult
+	}{
+		{
+			name:    "minInterval gate",
+			results: []mockResult{{Info: LimitInfo{Remaining: 0, ResetMs: time.Now().Add(time.Hour).UnixMilli()}}},
+		},
+		{
+			name: "duration gate",
+			results: []mockResult{
+				{Info: LimitInfo{Remaining: 1, ResetMs: time.Now().Add(time.Second).UnixMilli()}}, // minInterval pass
+				{Info: LimitInfo{Remaining: 0, ResetMs: time.Now().Add(time.Hour).UnixMilli()}},   // duration reject
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &mockLimitStore{results: tc.results}
+			// 実際の wired def を使い、RejectResponse 配線まで含めて検証する。
+			limits := map[string]*EndpointLimit{"signin": DefaultEndpointLimits["signin"]}
+			rl := NewRateLimiter(store, true, limits)
+			e, h := setupEcho(rl)
+
+			rec := doRequest(e, rl.Middleware(), h, "/api/signin", &model.User{ID: "u1"})
+
+			assert.Equal(t, http.StatusTooManyRequests, rec.Code)
+			var body map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+			errObj, _ := body["error"].(map[string]any)
+			require.NotNil(t, errObj)
+			assert.Equal(t, "TOO_MANY_AUTHENTICATION_FAILURES", errObj["code"])
+			assert.Equal(t, "22d05606-fbcf-421a-a2db-b32610dcfd1b", errObj["id"])
+		})
+	}
+}
+
+// TestMiddleware_GenericEndpointReturnsRateLimitExceeded confirms endpoints
+// without a RejectResponse override still return the generic error.
+func TestMiddleware_GenericEndpointReturnsRateLimitExceeded(t *testing.T) {
+	store := &mockLimitStore{
+		results: []mockResult{
+			{Info: LimitInfo{Remaining: 0, ResetMs: time.Now().Add(time.Hour).UnixMilli()}},
+		},
+	}
+	limits := map[string]*EndpointLimit{"notes/create": {Duration: time.Hour, Max: 300}}
+	rl := NewRateLimiter(store, true, limits)
+	e, h := setupEcho(rl)
+
+	rec := doRequest(e, rl.Middleware(), h, "/api/notes/create", &model.User{ID: "u1"})
+
+	assert.Equal(t, http.StatusTooManyRequests, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	errObj, _ := body["error"].(map[string]any)
+	require.NotNil(t, errObj)
+	assert.Equal(t, "RATE_LIMIT_EXCEEDED", errObj["code"])
 }
 
 // --- Redis integration test ---


### PR DESCRIPTION
## Summary

`#1829` (auth-oauth 再監査(2)) の sub-issue (F3、MEDIUM/error_code)。signin 系の rate-limit 超過時のエラーコードとしきい値を upstream に合わせる。

## 問題
upstream `SigninApiService` / `SigninWithPasskeyApiService` は signin 系の 429 で専用エラー `code=TOO_MANY_AUTHENTICATION_FAILURES, id=22d05606-fbcf-421a-a2db-b32610dcfd1b` を返し、しきい値も signin=10/1h+1s minInterval、passkey=200/30min+250ms。

mk-go は signin/signin-flow を 60/1h で汎用 `RATE_LIMIT_EXCEEDED` (id d5826d14-...) を返し、signin-with-passkey は**無制限**だった。429 を識別して再試行制御するクライアントが本家と別挙動。

## 修正
- `apierr`: `UUIDTooManyAuthenticationFailures` + `TooManyAuthenticationFailures()` を追加 (code/id/message を upstream に一致)。
- `ratelimit.go`: `EndpointLimit` に optional `RejectResponse func() map[string]any` を追加。`rejectRequest` が set 時はそれを 429 body に使う (nil なら従来の `RateLimitExceeded`)。**minInterval gate / duration gate どちらの reject 経路でも**適用される (両 call site に `limit` を渡す)。
- `ratelimit_defs.go`: signin/signin-flow=10/1h+1s minInterval、signin-with-passkey=200/30min+250ms、いずれも `RejectResponse=TooManyAuthenticationFailures`。

## テスト
- signin の 429 が `TOO_MANY_AUTHENTICATION_FAILURES` を返すこと (**minInterval gate / duration gate 両方**を table で網羅)。
- `RejectResponse` 無しの endpoint は従来どおり `RATE_LIMIT_EXCEEDED` を返すこと。
- KnownEndpoints / MinInterval の def table も更新。
- `make fmt && make lint` clean、`go test ./...` 全 package green (0 failures)。
- 敵対的レビュー実施 (parity / routing / minInterval semantics / threshold tightening risk): BLOCKER/MAJOR なし。MINOR (duration-gate test 不足) は修正済み。

## 備考
- レビューで確認: signin/signin-flow を 10/1h に絞るのは upstream parity (upstream も単一 `signin` key を multi-step flow に適用、mk-go の `/signin` は vestigial)。閾値タイト化による正規ユーザー lockout の懸念は無し。

Closes #1898

🤖 Generated with [Claude Code](https://claude.com/claude-code)