### PR TITLE
Fix auth-oauth parity (#1900): my/apps が app secret を返さないよう修正

### DIFF
--- a/internal/api/app/handler.go
+++ b/internal/api/app/handler.go
@@ -166,9 +166,13 @@ func (h *Handler) MyApps(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
+	// upstream my/apps は appEntityService.pack(app, me, {detail:true}) を呼び
+	// includeSecret 未指定 (= false) なので secret を返さない。secret 取得は
+	// app/show (secure session) 経由のみ。app token でも叩ける my/apps で
+	// secret を返すと全 app の credential が漏れる (#1900)。
 	result := make([]map[string]any, len(apps))
 	for i, a := range apps {
-		result[i] = packApp(a, true, h.isAuthorizedFor(a.ID, u))
+		result[i] = packApp(a, false, h.isAuthorizedFor(a.ID, u))
 	}
 	return c.JSON(http.StatusOK, result)
 }

--- a/internal/api/app/handler_test.go
+++ b/internal/api/app/handler_test.go
@@ -316,9 +316,12 @@ func TestMyApps_Success(t *testing.T) {
 	var resp []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Len(t, resp, 2)
-	// secretが含まれている
+	// my/apps は secret を返さない (upstream parity、#1900)。secret 取得は
+	// app/show (secure session) 経由のみ。public field (name 等) は返る。
 	for _, a := range resp {
-		assert.NotEmpty(t, a["secret"])
+		_, hasSecret := a["secret"]
+		assert.False(t, hasSecret, "my/apps は secret を含めない")
+		assert.NotEmpty(t, a["name"])
 	}
 }
 


### PR DESCRIPTION
## Summary

`#1897` (app/show secret gate) 実装中に発見した隣接 vuln。`my/apps` が所有 app の `secret` を無条件で返していた secret leak を修正する。

## 問題
upstream `my/apps` は `appEntityService.pack(app, me, {detail:true})` を呼び `includeSecret` 未指定 (= default false) なので **secret を返さない**。secret 取得は `app/show` (secure session) 経由のみ。

mk-go の `MyApps` は `packApp(a, true, ...)` で secret を無条件に返しており、`/my/apps` は `RequireAuth + RequireScope("read:account")` のみ (`RequireSecure` 無し) のため、`read:account` scope の app access token で叩くと user の**全 app の secret** が漏れていた (#1897 の app/show 単体より blast radius が大きい)。

## 修正
`MyApps` の `packApp(a, true, ...)` → `packApp(a, false, ...)`。secret は app/show (secure session) 経由でのみ取得可能になり upstream と一致。app/create は引き続き作成時に secret を返す (upstream parity)。

## テスト
- `TestMyApps_Success` を「secret 非公開 + public field (name) は返る」に更新。
- `make fmt && make lint` clean、敵対的レビュー CLEAN (parity / breakage / completeness / test)。

Closes #1900

🤖 Generated with [Claude Code](https://claude.com/claude-code)