### PR TITLE
Fix auth-oauth parity (#1899): OAuth2 / IndieAuth provider (/oauth/authorize /decision /token) を実装

### DIFF
--- a/internal/api/oauth/client_discovery.go
+++ b/internal/api/oauth/client_discovery.go
@@ -1,0 +1,339 @@
+package oauth
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// maxClientDocBytes caps how much of the client_id document we read.
+const maxClientDocBytes = 1 << 20 // 1 MiB
+
+// errInvalidClient indicates the client_id or its discovered metadata is
+// invalid. Surfaced to the caller as an invalid_request authorization error.
+var errInvalidClient = errors.New("oauth: invalid client")
+
+// clientInfo is the discovered client metadata used to render the consent
+// prompt and validate the redirect_uri.
+type clientInfo struct {
+	ID           string
+	RedirectURIs []string
+	Name         string
+	Logo         string
+}
+
+var domainHostRe = regexp.MustCompile(`\.\w+$`)
+
+// validateClientID enforces the IndieAuth client-identifier rules
+// (https://indieauth.spec.indieweb.org/#client-identifier), mirroring upstream
+// validateClientId. allowHTTP permits http scheme (test only); production
+// requires https.
+func validateClientID(raw string, allowHTTP bool) (*url.URL, error) {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return nil, errInvalidClient
+	}
+	if u.Scheme != "https" && !(allowHTTP && u.Scheme == "http") {
+		return nil, errInvalidClient
+	}
+	// path component is required (url.Parse leaves "" for no path); normalize to "/".
+	if u.Path == "" {
+		u.Path = "/"
+	}
+	// no single-dot / double-dot path segments.
+	for _, seg := range strings.Split(u.Path, "/") {
+		if seg == "." || seg == ".." {
+			return nil, errInvalidClient
+		}
+	}
+	if u.Fragment != "" || strings.Contains(raw, "#") {
+		return nil, errInvalidClient
+	}
+	if u.User != nil {
+		return nil, errInvalidClient
+	}
+	// host names MUST be domain names or a loopback interface, NOT raw IPs
+	// (except loopback). A domain has a trailing `.tld`; loopback hosts are
+	// allowed explicitly.
+	host := u.Hostname()
+	loopback := host == "localhost" || host == "127.0.0.1" || host == "::1"
+	if !loopback && !domainHostRe.MatchString(host) {
+		return nil, errInvalidClient
+	}
+	return u, nil
+}
+
+// discoverClientInformation fetches the client_id document and extracts the
+// client metadata (redirect_uris, name, logo) via IndieAuth client discovery:
+// JSON client metadata (RFC7591-ish) when the document is application/json,
+// otherwise HTML h-app microformats. Link headers contribute redirect_uris in
+// both cases. The supplied client must be SSRF-guarded.
+func discoverClientInformation(httpClient *http.Client, id string) (*clientInfo, error) {
+	req, err := http.NewRequest(http.MethodGet, id, nil)
+	if err != nil {
+		return nil, errInvalidClient
+	}
+	req.Header.Set("Accept", "application/json, text/html;q=0.9, */*;q=0.8")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, errInvalidClient
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, errInvalidClient
+	}
+	// 最終 URL (redirect 後) を base にして相対 URL を解決する。
+	baseURL := id
+	if resp.Request != nil && resp.Request.URL != nil {
+		baseURL = resp.Request.URL.String()
+	}
+
+	info := &clientInfo{ID: id, Name: id}
+
+	// Link header rel=redirect_uri (both JSON and HTML paths)。
+	for _, lh := range resp.Header.Values("Link") {
+		info.RedirectURIs = append(info.RedirectURIs, parseLinkRedirectURIs(lh)...)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxClientDocBytes))
+	if err != nil {
+		return nil, errInvalidClient
+	}
+
+	mediaType := resp.Header.Get("Content-Type")
+	if i := strings.IndexByte(mediaType, ';'); i >= 0 {
+		mediaType = mediaType[:i]
+	}
+	mediaType = strings.TrimSpace(strings.ToLower(mediaType))
+
+	if mediaType == "application/json" {
+		if err := applyJSONMetadata(info, id, baseURL, body); err != nil {
+			return nil, err
+		}
+	} else {
+		applyHTMLMicroformats(info, baseURL, id, body)
+	}
+
+	// redirect_uris を base に対して解決して absolute 化する。
+	resolved := make([]string, 0, len(info.RedirectURIs))
+	for _, ru := range info.RedirectURIs {
+		if abs := resolveURL(baseURL, ru); abs != "" {
+			resolved = append(resolved, abs)
+		}
+	}
+	info.RedirectURIs = resolved
+	if info.Name == "" {
+		info.Name = id
+	}
+	return info, nil
+}
+
+// applyJSONMetadata parses IndieAuth JSON client metadata into info, enforcing
+// the client_id match and client_uri prefix rules.
+func applyJSONMetadata(info *clientInfo, id, baseURL string, body []byte) error {
+	var doc struct {
+		ClientID     string   `json:"client_id"`
+		ClientName   string   `json:"client_name"`
+		ClientURI    string   `json:"client_uri"`
+		LogoURI      string   `json:"logo_uri"`
+		RedirectURIs []string `json:"redirect_uris"`
+	}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return errInvalidClient
+	}
+	// "client_id in the document MUST match the client_id URL."
+	if doc.ClientID != id {
+		return errInvalidClient
+	}
+	// "client_uri MUST be a prefix of client_id."
+	if doc.ClientURI == "" || !strings.HasPrefix(id, doc.ClientURI) {
+		return errInvalidClient
+	}
+	if doc.ClientName != "" {
+		info.Name = doc.ClientName
+	}
+	if doc.LogoURI != "" {
+		// logo_uri は相対の場合があるので document URL に対して解決する。
+		info.Logo = resolveURL(baseURL, doc.LogoURI)
+	}
+	info.RedirectURIs = append(info.RedirectURIs, doc.RedirectURIs...)
+	return nil
+}
+
+// applyHTMLMicroformats extracts redirect_uris (link[rel=redirect_uri]) and the
+// h-app name/logo microformats from the client document. Best-effort: parse
+// failures simply leave the defaults.
+func applyHTMLMicroformats(info *clientInfo, baseURL, id string, body []byte) {
+	doc, err := html.Parse(strings.NewReader(string(body)))
+	if err != nil {
+		return
+	}
+	// link[rel=redirect_uri][href]
+	forEachNode(doc, func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "link" {
+			if relMatches(attr(n, "rel"), "redirect_uri") {
+				if href := attr(n, "href"); href != "" {
+					info.RedirectURIs = append(info.RedirectURIs, href)
+				}
+			}
+		}
+	})
+	// h-app microformat (first occurrence)。
+	hApp := findClass(doc, "h-app")
+	if hApp == nil {
+		return
+	}
+	// .p-name: upstream は href/src が client_id に一致するときだけ name を採用。
+	if nameEl := findClass(hApp, "p-name"); nameEl != nil {
+		href := attr(nameEl, "href")
+		if href == "" {
+			href = attr(nameEl, "src")
+		}
+		if href != "" && resolveURL(baseURL, href) == normalizeURL(id) {
+			if name := strings.TrimSpace(textContent(nameEl)); name != "" {
+				info.Name = name
+			}
+		}
+	}
+	// .u-logo: href/src を base 解決。
+	if logoEl := findClass(hApp, "u-logo"); logoEl != nil {
+		href := attr(logoEl, "href")
+		if href == "" {
+			href = attr(logoEl, "src")
+		}
+		if href != "" {
+			info.Logo = resolveURL(baseURL, href)
+		}
+	}
+}
+
+// --- HTML traversal helpers ---
+
+func forEachNode(n *html.Node, fn func(*html.Node)) {
+	fn(n)
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		forEachNode(c, fn)
+	}
+}
+
+func attr(n *html.Node, key string) string {
+	for _, a := range n.Attr {
+		if a.Key == key {
+			return a.Val
+		}
+	}
+	return ""
+}
+
+// relMatches reports whether a (space-separated) rel attribute contains token.
+func relMatches(rel, token string) bool {
+	for _, f := range strings.Fields(rel) {
+		if strings.EqualFold(f, token) {
+			return true
+		}
+	}
+	return false
+}
+
+// classMatches reports whether a (space-separated) class attribute contains cls.
+func classMatches(class, cls string) bool {
+	for _, f := range strings.Fields(class) {
+		if f == cls {
+			return true
+		}
+	}
+	return false
+}
+
+// findClass returns the first descendant (or self) element carrying the given
+// class token.
+func findClass(n *html.Node, cls string) *html.Node {
+	var found *html.Node
+	var walk func(*html.Node)
+	walk = func(node *html.Node) {
+		if found != nil {
+			return
+		}
+		if node.Type == html.ElementNode && classMatches(attr(node, "class"), cls) {
+			found = node
+			return
+		}
+		for c := node.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(n)
+	return found
+}
+
+func textContent(n *html.Node) string {
+	var sb strings.Builder
+	forEachNode(n, func(node *html.Node) {
+		if node.Type == html.TextNode {
+			sb.WriteString(node.Data)
+		}
+	})
+	return sb.String()
+}
+
+// --- URL helpers ---
+
+func resolveURL(base, ref string) string {
+	b, err := url.Parse(base)
+	if err != nil {
+		return ""
+	}
+	r, err := url.Parse(ref)
+	if err != nil {
+		return ""
+	}
+	return b.ResolveReference(r).String()
+}
+
+func normalizeURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return raw
+	}
+	return u.String()
+}
+
+// parseLinkRedirectURIs extracts the URIs of rel="redirect_uri" entries from a
+// Link header value (RFC8288). Minimal parser handling `<uri>; rel="..."`.
+func parseLinkRedirectURIs(header string) []string {
+	var uris []string
+	for _, part := range strings.Split(header, ",") {
+		part = strings.TrimSpace(part)
+		lt := strings.IndexByte(part, '<')
+		gt := strings.IndexByte(part, '>')
+		if lt != 0 || gt < 0 {
+			continue
+		}
+		uri := part[1:gt]
+		params := part[gt+1:]
+		hasRel := false
+		for _, p := range strings.Split(params, ";") {
+			p = strings.TrimSpace(p)
+			if !strings.HasPrefix(strings.ToLower(p), "rel") {
+				continue
+			}
+			val := strings.Trim(strings.TrimSpace(strings.TrimPrefix(p, "rel")), "=")
+			val = strings.Trim(strings.TrimSpace(val), `"`)
+			for _, t := range strings.Fields(val) {
+				if t == "redirect_uri" {
+					hasRel = true
+				}
+			}
+		}
+		if hasRel {
+			uris = append(uris, uri)
+		}
+	}
+	return uris
+}

--- a/internal/api/oauth/client_discovery_test.go
+++ b/internal/api/oauth/client_discovery_test.go
@@ -1,0 +1,150 @@
+package oauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateClientID(t *testing.T) {
+	cases := []struct {
+		name      string
+		raw       string
+		allowHTTP bool
+		ok        bool
+	}{
+		{"valid https with path", "https://app.example/", false, true},
+		{"valid https subpath", "https://app.example/oauth/client", false, true},
+		{"http rejected in prod", "http://app.example/", false, false},
+		{"http allowed in test", "http://app.example/", true, true},
+		{"loopback localhost", "http://localhost/", true, true},
+		{"loopback 127.0.0.1", "https://127.0.0.1/", false, true},
+		{"fragment rejected", "https://app.example/#x", false, false},
+		{"userinfo rejected", "https://user:pass@app.example/", false, false},
+		{"dot segment rejected", "https://app.example/./x", false, false},
+		{"dotdot segment rejected", "https://app.example/../x", false, false},
+		// upstream の `\.\w+$` regex は IPv4 を素通しする (host が dot+digits で
+		// 終わるため)。SSRF guard は fetch 時に private IP を弾くので、ここでは
+		// upstream 挙動に合わせて public raw IPv4 は許容する。
+		{"raw ipv4 accepted (upstream parity)", "https://93.184.216.34/", false, true},
+		{"bare host (no tld) rejected", "https://appexample/", false, false},
+		{"not a url", "::::not a url", false, false},
+		{"empty", "", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := validateClientID(tc.raw, tc.allowHTTP)
+			if tc.ok {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+// testClient builds an http.Client that talks to the given test server without
+// SSRF restrictions (the SSRF guard is exercised at the integration layer).
+func testClient() *http.Client { return &http.Client{} }
+
+func TestDiscoverClientInformation_HTMLMicroformats(t *testing.T) {
+	var srvURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte(`<html><body>
+			<div class="h-app">
+				<a class="u-url p-name" href="` + srvURL + `/">My Cool App</a>
+				<img class="u-logo" src="/logo.png">
+			</div>
+			<link rel="redirect_uri" href="/callback">
+		</body></html>`))
+	}))
+	defer srv.Close()
+	srvURL = srv.URL
+
+	info, err := discoverClientInformation(testClient(), srv.URL+"/")
+	require.NoError(t, err)
+	assert.Equal(t, "My Cool App", info.Name)
+	assert.Equal(t, srv.URL+"/logo.png", info.Logo)
+	assert.Contains(t, info.RedirectURIs, srv.URL+"/callback")
+}
+
+func TestDiscoverClientInformation_JSONMetadata(t *testing.T) {
+	var srvURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"client_id": "` + srvURL + `/",
+			"client_uri": "` + srvURL + `/",
+			"client_name": "JSON App",
+			"logo_uri": "/icon.png",
+			"redirect_uris": ["` + srvURL + `/cb", "/relcb"]
+		}`))
+	}))
+	defer srv.Close()
+	srvURL = srv.URL
+
+	info, err := discoverClientInformation(testClient(), srv.URL+"/")
+	require.NoError(t, err)
+	assert.Equal(t, "JSON App", info.Name)
+	assert.Equal(t, srv.URL+"/icon.png", info.Logo)
+	assert.Contains(t, info.RedirectURIs, srv.URL+"/cb")
+	assert.Contains(t, info.RedirectURIs, srv.URL+"/relcb")
+}
+
+func TestDiscoverClientInformation_JSONClientIDMismatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"client_id":"https://evil.example/","client_uri":"https://evil.example/"}`))
+	}))
+	defer srv.Close()
+
+	_, err := discoverClientInformation(testClient(), srv.URL+"/")
+	require.ErrorIs(t, err, errInvalidClient)
+}
+
+func TestDiscoverClientInformation_JSONClientURINotPrefix(t *testing.T) {
+	var srvURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"client_id":"` + srvURL + `/","client_uri":"https://other.example/"}`))
+	}))
+	defer srv.Close()
+	srvURL = srv.URL
+
+	_, err := discoverClientInformation(testClient(), srv.URL+"/")
+	require.ErrorIs(t, err, errInvalidClient)
+}
+
+func TestDiscoverClientInformation_LinkHeader(t *testing.T) {
+	var srvURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Link", `<`+srvURL+`/hdr-cb>; rel="redirect_uri"`)
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body>no microformats</body></html>`))
+	}))
+	defer srv.Close()
+	srvURL = srv.URL
+
+	info, err := discoverClientInformation(testClient(), srv.URL+"/")
+	require.NoError(t, err)
+	assert.Contains(t, info.RedirectURIs, srv.URL+"/hdr-cb")
+}
+
+func TestDiscoverClientInformation_Non2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := discoverClientInformation(testClient(), srv.URL+"/")
+	require.ErrorIs(t, err, errInvalidClient)
+}
+
+func TestParseLinkRedirectURIs(t *testing.T) {
+	got := parseLinkRedirectURIs(`<https://a.example/cb>; rel="redirect_uri", <https://a.example/other>; rel="canonical"`)
+	assert.Equal(t, []string{"https://a.example/cb"}, got)
+}

--- a/internal/api/oauth/pkce.go
+++ b/internal/api/oauth/pkce.go
@@ -1,0 +1,24 @@
+// Package oauth implements the OAuth2 / IndieAuth authorization-code provider
+// (authorize / decision / token) advertised by the RFC8414 discovery document,
+// mirroring upstream Misskey's OAuth2ProviderService (#1899). PKCE (S256) is
+// mandatory and client identification follows the IndieAuth client-id-as-URL
+// model with remote client metadata discovery.
+package oauth
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+)
+
+// verifyS256 reports whether a PKCE code_verifier matches the stored
+// code_challenge using the S256 method: BASE64URL(SHA256(verifier)) == challenge.
+// Comparison is constant-time. Empty inputs never match.
+func verifyS256(verifier, challenge string) bool {
+	if verifier == "" || challenge == "" {
+		return false
+	}
+	sum := sha256.Sum256([]byte(verifier))
+	computed := base64.RawURLEncoding.EncodeToString(sum[:])
+	return subtle.ConstantTimeCompare([]byte(computed), []byte(challenge)) == 1
+}

--- a/internal/api/oauth/pkce_test.go
+++ b/internal/api/oauth/pkce_test.go
@@ -1,0 +1,25 @@
+package oauth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func challengeFor(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func TestVerifyS256(t *testing.T) {
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	challenge := challengeFor(verifier)
+
+	assert.True(t, verifyS256(verifier, challenge), "matching verifier")
+	assert.False(t, verifyS256("wrong-verifier", challenge), "non-matching verifier")
+	assert.False(t, verifyS256("", challenge), "empty verifier")
+	assert.False(t, verifyS256(verifier, ""), "empty challenge")
+	assert.False(t, verifyS256("", ""), "both empty")
+}

--- a/internal/api/oauth/provider.go
+++ b/internal/api/oauth/provider.go
@@ -1,0 +1,394 @@
+package oauth
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/misc"
+	"github.com/shiroha-a/mk/internal/model"
+)
+
+// tokenLen is the length of generated authorization codes and access tokens.
+// The access_token.token column is varchar(128); 64 alphanumeric chars (~380
+// bits) is ample and well within the limit.
+const tokenLen = 64
+
+// UserResolver resolves a user by their native session token. Only native
+// login tokens (users.token) match — app/MiAuth access tokens live in a
+// separate table — so this naturally restricts the consent step to a logged-in
+// browser session.
+type UserResolver interface {
+	FindByToken(token string) (*model.User, error)
+}
+
+// TokenStore mints and revokes OAuth access tokens.
+type TokenStore interface {
+	Create(token *model.AccessToken) error
+	DeleteByID(id string) error
+}
+
+// IDGenerator generates access-token row IDs (aidx).
+type IDGenerator interface {
+	Generate(t time.Time) string
+}
+
+// ConsentMeta is injected into the consent page so the frontend OAuth component
+// can render the authorization prompt.
+type ConsentMeta struct {
+	TransactionID string
+	ClientName    string
+	ClientLogo    string
+	Scope         string // space-separated
+}
+
+// ConsentRenderer serves the frontend shell HTML with the OAuth meta tags for
+// the consent prompt. Wired from the server to frontendHTML.
+type ConsentRenderer func(c echo.Context, m ConsentMeta) error
+
+// Handler implements the OAuth2 authorization-code provider endpoints.
+type Handler struct {
+	store         Store
+	httpClient    *http.Client
+	userRepo      UserResolver
+	tokenRepo     TokenStore
+	idGen         IDGenerator
+	issuer        string
+	allowHTTP     bool
+	renderConsent ConsentRenderer
+}
+
+// NewHandler constructs the OAuth provider handler. httpClient must be
+// SSRF-guarded (it fetches attacker-suppliable client_id URLs). allowHTTP
+// permits http client_id schemes (tests only). renderConsent serves the
+// consent page.
+func NewHandler(store Store, httpClient *http.Client, userRepo UserResolver, tokenRepo TokenStore, idGen IDGenerator, issuer string, allowHTTP bool, renderConsent ConsentRenderer) *Handler {
+	return &Handler{
+		store:         store,
+		httpClient:    httpClient,
+		userRepo:      userRepo,
+		tokenRepo:     tokenRepo,
+		idGen:         idGen,
+		issuer:        issuer,
+		allowHTTP:     allowHTTP,
+		renderConsent: renderConsent,
+	}
+}
+
+// Authorize handles GET /oauth/authorize: validate the request, discover the
+// client, store the transaction, and serve the consent page. Errors that occur
+// before the redirect_uri is validated return a direct 400 (never redirect to
+// an unvalidated URI); errors after redirect to the client with ?error=.
+func (h *Handler) Authorize(c echo.Context) error {
+	q := c.Request().URL.Query()
+	clientID := q.Get("client_id")
+	redirectURI := q.Get("redirect_uri")
+	scopeParam := q.Get("scope")
+	codeChallenge := q.Get("code_challenge")
+	codeChallengeMethod := q.Get("code_challenge_method")
+	state := q.Get("state")
+
+	// 1. client_id 検証 (失敗時は信頼できる redirect 先が無いので直接 400)。
+	cu, err := validateClientID(clientID, h.allowHTTP)
+	if err != nil {
+		return directError(c, "invalid client_id")
+	}
+	canonicalID := cu.String()
+
+	// 2-3. client discovery (SSRF-guarded fetch + metadata parse)。
+	info, err := discoverClientInformation(h.httpClient, canonicalID)
+	if err != nil {
+		slog.Info("oauth: client discovery failed", "clientId", canonicalID, "err", err)
+		return directError(c, "failed to fetch client information")
+	}
+
+	// 4. redirect_uri が discovery list に exact 一致するか (open redirect 防止)。
+	// ここを通るまで redirect_uri へ error redirect してはならない。
+	if redirectURI == "" || !contains(info.RedirectURIs, redirectURI) {
+		return directError(c, "invalid redirect_uri")
+	}
+
+	// 5. scope を dedupe。空は invalid_scope (redirect で返せる)。
+	scopes := dedupeFields(scopeParam)
+	if len(scopes) == 0 {
+		return h.redirectError(c, redirectURI, state, "invalid_scope", "scope parameter has no scope")
+	}
+
+	// 6. PKCE は必須 (S256 のみ)。downgrade attack 防止。
+	if codeChallenge == "" {
+		return h.redirectError(c, redirectURI, state, "invalid_request", "code_challenge is required")
+	}
+	if codeChallengeMethod != "S256" {
+		return h.redirectError(c, redirectURI, state, "invalid_request", "code_challenge_method must be S256")
+	}
+
+	// 7. transaction 格納 (5min)。
+	txnID := misc.SecureRandomString(tokenLen, misc.AlphanumericChars)
+	txn := &transaction{
+		ClientID:      canonicalID,
+		ClientName:    info.Name,
+		ClientLogo:    info.Logo,
+		RedirectURI:   redirectURI,
+		Scopes:        scopes,
+		CodeChallenge: codeChallenge,
+		State:         state,
+	}
+	if err := h.store.PutTransaction(c.Request().Context(), txnID, txn); err != nil {
+		slog.Error("oauth: failed to store transaction", "err", err)
+		return h.redirectError(c, redirectURI, state, "server_error", "failed to store transaction")
+	}
+
+	// 8. consent page を frontend shell + meta で返す。
+	c.Response().Header().Set("Cache-Control", "no-store")
+	return h.renderConsent(c, ConsentMeta{
+		TransactionID: txnID,
+		ClientName:    info.Name,
+		ClientLogo:    info.Logo,
+		Scope:         strings.Join(scopes, " "),
+	})
+}
+
+// Decision handles POST /oauth/decision: the consent form posts the user's
+// native login_token, the transaction_id, and an optional cancel flag. On
+// allow it issues an authorization code and redirects to the client.
+func (h *Handler) Decision(c echo.Context) error {
+	ctx := c.Request().Context()
+	transactionID := c.FormValue("transaction_id")
+	loginToken := c.FormValue("login_token")
+	cancel := c.FormValue("cancel")
+
+	txn, err := h.store.TakeTransaction(ctx, transactionID)
+	if err != nil {
+		// txn が無い → redirect 先も不明なので直接 400。
+		return directError(c, "invalid or expired transaction")
+	}
+
+	if cancel != "" {
+		return h.redirectError(c, txn.RedirectURI, txn.State, "access_denied", "the user denied the request")
+	}
+
+	// login_token は native session token のみ一致する (app token は別テーブル)。
+	user, err := h.userRepo.FindByToken(loginToken)
+	if err != nil || user == nil {
+		return h.redirectError(c, txn.RedirectURI, txn.State, "access_denied", "no such user")
+	}
+
+	code := misc.SecureRandomString(tokenLen, misc.AlphanumericChars)
+	g := &grant{
+		ClientID:      txn.ClientID,
+		UserID:        user.ID,
+		RedirectURI:   txn.RedirectURI,
+		CodeChallenge: txn.CodeChallenge,
+		Scopes:        txn.Scopes,
+	}
+	if err := h.store.PutGrant(ctx, code, g); err != nil {
+		slog.Error("oauth: failed to store grant", "err", err)
+		return h.redirectError(c, txn.RedirectURI, txn.State, "server_error", "failed to issue code")
+	}
+
+	redirect := appendQuery(txn.RedirectURI, map[string]string{
+		"code":  code,
+		"state": txn.State,
+		"iss":   h.issuer,
+	})
+	return c.Redirect(http.StatusFound, redirect)
+}
+
+// Token handles POST /oauth/token: exchange an authorization code (+ PKCE
+// verifier) for an access token. Accepts urlencoded or JSON bodies.
+func (h *Handler) Token(c echo.Context) error {
+	ctx := c.Request().Context()
+	// CORS (cross-origin SPA / native client) は root の CORS middleware が
+	// 付与するのでここでは設定しない (二重 header 回避、#1899 review)。
+
+	// upstream は urlencoded / JSON 両方の body を受け付ける
+	// (bodyParser.urlencoded + bodyParser.json)。Content-Type が JSON の場合は
+	// FormValue が拾えないので明示的に decode する。
+	var grantType, code, clientID, redirectURI, codeVerifier string
+	if strings.HasPrefix(c.Request().Header.Get("Content-Type"), "application/json") {
+		var body struct {
+			GrantType    string `json:"grant_type"`
+			Code         string `json:"code"`
+			ClientID     string `json:"client_id"`
+			RedirectURI  string `json:"redirect_uri"`
+			CodeVerifier string `json:"code_verifier"`
+		}
+		_ = json.NewDecoder(c.Request().Body).Decode(&body)
+		grantType, code, clientID, redirectURI, codeVerifier = body.GrantType, body.Code, body.ClientID, body.RedirectURI, body.CodeVerifier
+	} else {
+		grantType = c.FormValue("grant_type")
+		code = c.FormValue("code")
+		clientID = c.FormValue("client_id")
+		redirectURI = c.FormValue("redirect_uri")
+		codeVerifier = c.FormValue("code_verifier")
+	}
+
+	if grantType != "authorization_code" {
+		return tokenError(c, http.StatusBadRequest, "unsupported_grant_type", "only authorization_code is supported")
+	}
+
+	g, err := h.store.GetGrant(ctx, code)
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		// store backend error (e.g. redis down) は invalid_grant ではなく
+		// server_error。code 自体の無効と区別する。
+		slog.Error("oauth: grant lookup failed", "err", err)
+		return tokenError(c, http.StatusInternalServerError, "server_error", "internal error")
+	}
+	if g == nil {
+		return tokenError(c, http.StatusBadRequest, "invalid_grant", "invalid authorization code")
+	}
+
+	// code を atomic に claim する。validation 成否に関わらず単回で焼き切れる。
+	firstUse, err := h.store.ClaimGrant(ctx, code)
+	if err != nil {
+		slog.Error("oauth: grant claim failed", "err", err)
+		return tokenError(c, http.StatusInternalServerError, "server_error", "internal error")
+	}
+	if !firstUse {
+		// replay: 以前発行した token を revoke する (RFC6749 §4.1.2)。
+		if tid, _ := h.store.GetGrantToken(ctx, code); tid != "" {
+			if derr := h.tokenRepo.DeleteByID(tid); derr != nil {
+				slog.Warn("oauth: failed to revoke token on code replay", "tokenId", tid, "err", derr)
+			}
+		}
+		slog.Info("oauth: authorization code replay detected", "clientId", g.ClientID, "userId", g.UserID)
+		return tokenError(c, http.StatusBadRequest, "invalid_grant", "authorization code already used")
+	}
+
+	if canonicalClientID(clientID, h.allowHTTP) != g.ClientID {
+		return tokenError(c, http.StatusBadRequest, "invalid_grant", "client_id mismatch")
+	}
+	if redirectURI != g.RedirectURI {
+		return tokenError(c, http.StatusBadRequest, "invalid_grant", "redirect_uri mismatch")
+	}
+	if !verifyS256(codeVerifier, g.CodeChallenge) {
+		return tokenError(c, http.StatusBadRequest, "invalid_grant", "PKCE verification failed")
+	}
+
+	now := time.Now()
+	accessToken := misc.SecureRandomString(tokenLen, misc.AlphanumericChars)
+	name := g.ClientID
+	row := &model.AccessToken{
+		ID:         h.idGen.Generate(now),
+		Token:      accessToken,
+		Hash:       accessToken, // OAuth token: hash == token (no app secret)。
+		UserID:     g.UserID,
+		Name:       &name,
+		Permission: g.Scopes,
+		LastUsedAt: &now,
+	}
+	if err := h.tokenRepo.Create(row); err != nil {
+		slog.Error("oauth: failed to create access token", "err", err)
+		return tokenError(c, http.StatusInternalServerError, "server_error", "failed to issue token")
+	}
+	// replay 時に revoke できるよう、code に紐づく token id を記録する。
+	if err := h.store.PutGrantToken(ctx, code, row.ID); err != nil {
+		slog.Warn("oauth: failed to record grant token id", "err", err)
+	}
+
+	slog.Info("oauth: issued access token", "clientId", g.ClientID, "userId", g.UserID, "scopes", g.Scopes)
+	return c.JSON(http.StatusOK, map[string]any{
+		"access_token": accessToken,
+		"token_type":   "Bearer",
+		"scope":        strings.Join(g.Scopes, " "),
+	})
+}
+
+// NotFound replies 404 for unknown /oauth/* paths so clients can probe endpoint
+// support, mirroring upstream's catch-all.
+func (h *Handler) NotFound(c echo.Context) error {
+	return c.JSON(http.StatusNotFound, map[string]any{
+		"error": map[string]any{
+			"message": "Unknown OAuth endpoint.",
+			"code":    "UNKNOWN_OAUTH_ENDPOINT",
+			"id":      "aa49e620-26cb-4e28-aad6-8cbcb58db147",
+			"kind":    "client",
+		},
+	})
+}
+
+// --- helpers ---
+
+// canonicalClientID returns the normalized client_id (path-completed) or "" if
+// invalid, so the token-exchange comparison matches the authorize-time form
+// regardless of a missing trailing slash.
+func canonicalClientID(raw string, allowHTTP bool) string {
+	u, err := validateClientID(raw, allowHTTP)
+	if err != nil {
+		return ""
+	}
+	return u.String()
+}
+
+func contains(list []string, v string) bool {
+	for _, s := range list {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}
+
+// dedupeFields splits a space-separated scope string and removes duplicates,
+// preserving order.
+func dedupeFields(s string) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, f := range strings.Fields(s) {
+		if _, ok := seen[f]; ok {
+			continue
+		}
+		seen[f] = struct{}{}
+		out = append(out, f)
+	}
+	return out
+}
+
+func appendQuery(base string, params map[string]string) string {
+	u, err := url.Parse(base)
+	if err != nil {
+		return base
+	}
+	q := u.Query()
+	for k, v := range params {
+		if v != "" {
+			q.Set(k, v)
+		}
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+// directError returns a plain 400 for authorization errors that occur before a
+// trusted redirect_uri is established.
+func directError(c echo.Context, desc string) error {
+	return c.JSON(http.StatusBadRequest, map[string]any{
+		"error":             "invalid_request",
+		"error_description": desc,
+	})
+}
+
+// redirectError redirects to the (validated) client redirect_uri with the OAuth
+// error parameters, including the RFC9207 iss.
+func (h *Handler) redirectError(c echo.Context, redirectURI, state, code, desc string) error {
+	redirect := appendQuery(redirectURI, map[string]string{
+		"error":             code,
+		"error_description": desc,
+		"state":             state,
+		"iss":               h.issuer,
+	})
+	return c.Redirect(http.StatusFound, redirect)
+}
+
+// tokenError returns an OAuth token-endpoint JSON error.
+func tokenError(c echo.Context, status int, code, desc string) error {
+	return c.JSON(status, map[string]any{
+		"error":             code,
+		"error_description": desc,
+	})
+}

--- a/internal/api/oauth/provider_test.go
+++ b/internal/api/oauth/provider_test.go
@@ -1,0 +1,567 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- in-memory fakes ---
+
+type fakeStore struct {
+	txns   map[string]*transaction
+	grants map[string]*grant
+	claims map[string]bool
+	tokens map[string]string // code -> issued token id
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{
+		txns:   map[string]*transaction{},
+		grants: map[string]*grant{},
+		claims: map[string]bool{},
+		tokens: map[string]string{},
+	}
+}
+
+func (s *fakeStore) PutTransaction(_ context.Context, id string, t *transaction) error {
+	s.txns[id] = t
+	return nil
+}
+func (s *fakeStore) TakeTransaction(_ context.Context, id string) (*transaction, error) {
+	t, ok := s.txns[id]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	delete(s.txns, id)
+	return t, nil
+}
+func (s *fakeStore) PutGrant(_ context.Context, code string, g *grant) error {
+	s.grants[code] = g
+	return nil
+}
+func (s *fakeStore) GetGrant(_ context.Context, code string) (*grant, error) {
+	g, ok := s.grants[code]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return g, nil
+}
+func (s *fakeStore) ClaimGrant(_ context.Context, code string) (bool, error) {
+	if s.claims[code] {
+		return false, nil
+	}
+	s.claims[code] = true
+	return true, nil
+}
+func (s *fakeStore) PutGrantToken(_ context.Context, code, tokenID string) error {
+	s.tokens[code] = tokenID
+	return nil
+}
+func (s *fakeStore) GetGrantToken(_ context.Context, code string) (string, error) {
+	return s.tokens[code], nil
+}
+
+type fakeUserRepo struct{ byToken map[string]*model.User }
+
+func (r *fakeUserRepo) FindByToken(token string) (*model.User, error) {
+	u, ok := r.byToken[token]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return u, nil
+}
+
+type fakeTokenStore struct {
+	created []*model.AccessToken
+	deleted []string
+}
+
+func (s *fakeTokenStore) Create(t *model.AccessToken) error {
+	s.created = append(s.created, t)
+	return nil
+}
+func (s *fakeTokenStore) DeleteByID(id string) error {
+	s.deleted = append(s.deleted, id)
+	return nil
+}
+
+type fakeIDGen struct{ n int }
+
+func (g *fakeIDGen) Generate(_ time.Time) string {
+	g.n++
+	return "tok" + string(rune('0'+g.n))
+}
+
+// testHarness wires a Handler against a discovery server that advertises the
+// given redirect_uri.
+type testHarness struct {
+	h        *Handler
+	store    *fakeStore
+	users    *fakeUserRepo
+	tokens   *fakeTokenStore
+	clientID string
+	redirect string
+	consent  *ConsentMeta // captured by the renderer
+}
+
+func newHarness(t *testing.T) *testHarness {
+	t.Helper()
+	// client discovery server: JSON metadata listing the redirect_uri.
+	var srvURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"client_id": "` + srvURL + `/",
+			"client_uri": "` + srvURL + `/",
+			"client_name": "Test App",
+			"redirect_uris": ["` + srvURL + `/cb"]
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+	srvURL = srv.URL
+
+	store := newFakeStore()
+	users := &fakeUserRepo{byToken: map[string]*model.User{}}
+	tokens := &fakeTokenStore{}
+	hn := &testHarness{store: store, users: users, tokens: tokens, clientID: srv.URL + "/", redirect: srv.URL + "/cb"}
+	hn.h = NewHandler(store, srv.Client(), users, tokens, &fakeIDGen{}, "https://mk.example", true,
+		func(c echo.Context, m ConsentMeta) error {
+			hn.consent = &m
+			return c.HTML(http.StatusOK, "<html>consent</html>")
+		})
+	return hn
+}
+
+func (hn *testHarness) authorize(t *testing.T, q url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+q.Encode(), nil)
+	rec := httptest.NewRecorder()
+	_ = hn.h.Authorize(e.NewContext(req, rec))
+	return rec
+}
+
+func (hn *testHarness) post(t *testing.T, handler echo.HandlerFunc, form url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(form.Encode()))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
+	rec := httptest.NewRecorder()
+	_ = handler(e.NewContext(req, rec))
+	return rec
+}
+
+func validAuthorizeQuery(hn *testHarness, challenge string) url.Values {
+	return url.Values{
+		"response_type":         {"code"},
+		"client_id":             {hn.clientID},
+		"redirect_uri":          {hn.redirect},
+		"scope":                 {"read:account write:notes"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {"st-123"},
+	}
+}
+
+// --- Authorize ---
+
+func TestAuthorize_RendersConsent(t *testing.T) {
+	hn := newHarness(t)
+	rec := hn.authorize(t, validAuthorizeQuery(hn, challengeFor("verifier-abc")))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, hn.consent)
+	assert.Equal(t, "Test App", hn.consent.ClientName)
+	assert.Equal(t, "read:account write:notes", hn.consent.Scope)
+	assert.NotEmpty(t, hn.consent.TransactionID)
+	// transaction が格納されている。
+	_, ok := hn.store.txns[hn.consent.TransactionID]
+	assert.True(t, ok)
+	assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+}
+
+func TestAuthorize_InvalidClientID(t *testing.T) {
+	hn := newHarness(t)
+	q := validAuthorizeQuery(hn, challengeFor("v"))
+	q.Set("client_id", "not-a-url")
+	rec := hn.authorize(t, q)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Nil(t, hn.consent)
+}
+
+func TestAuthorize_RedirectURINotRegistered(t *testing.T) {
+	hn := newHarness(t)
+	q := validAuthorizeQuery(hn, challengeFor("v"))
+	q.Set("redirect_uri", "https://evil.example/cb")
+	rec := hn.authorize(t, q)
+	// discovery list に無い redirect_uri → 直接 400 (redirect しない)。
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Nil(t, hn.consent)
+}
+
+func TestAuthorize_MissingPKCE(t *testing.T) {
+	hn := newHarness(t)
+	q := validAuthorizeQuery(hn, "")
+	q.Del("code_challenge")
+	rec := hn.authorize(t, q)
+	// redirect_uri は validated 済みなので error redirect (302)。
+	assert.Equal(t, http.StatusFound, rec.Code)
+	loc := rec.Header().Get("Location")
+	assert.Contains(t, loc, "error=invalid_request")
+}
+
+func TestAuthorize_NonS256Challenge(t *testing.T) {
+	hn := newHarness(t)
+	q := validAuthorizeQuery(hn, "plainchallenge")
+	q.Set("code_challenge_method", "plain")
+	rec := hn.authorize(t, q)
+	assert.Equal(t, http.StatusFound, rec.Code)
+	assert.Contains(t, rec.Header().Get("Location"), "error=invalid_request")
+}
+
+func TestAuthorize_EmptyScope(t *testing.T) {
+	hn := newHarness(t)
+	q := validAuthorizeQuery(hn, challengeFor("v"))
+	q.Del("scope")
+	rec := hn.authorize(t, q)
+	assert.Equal(t, http.StatusFound, rec.Code)
+	assert.Contains(t, rec.Header().Get("Location"), "error=invalid_scope")
+}
+
+// --- Decision ---
+
+func TestDecision_IssuesCode(t *testing.T) {
+	hn := newHarness(t)
+	hn.users.byToken["native-tok"] = &model.User{ID: "u1"}
+	hn.store.txns["txn1"] = &transaction{
+		ClientID: hn.clientID, RedirectURI: hn.redirect, Scopes: []string{"read:account"},
+		CodeChallenge: challengeFor("v"), State: "st-123",
+	}
+	rec := hn.post(t, hn.h.Decision, url.Values{
+		"transaction_id": {"txn1"}, "login_token": {"native-tok"},
+	})
+	require.Equal(t, http.StatusFound, rec.Code)
+	loc, _ := url.Parse(rec.Header().Get("Location"))
+	code := loc.Query().Get("code")
+	require.NotEmpty(t, code)
+	assert.Equal(t, "st-123", loc.Query().Get("state"))
+	assert.Equal(t, "https://mk.example", loc.Query().Get("iss"))
+	g := hn.store.grants[code]
+	require.NotNil(t, g)
+	assert.Equal(t, "u1", g.UserID)
+}
+
+func TestDecision_Cancel(t *testing.T) {
+	hn := newHarness(t)
+	hn.store.txns["txn1"] = &transaction{ClientID: hn.clientID, RedirectURI: hn.redirect, State: "st"}
+	rec := hn.post(t, hn.h.Decision, url.Values{"transaction_id": {"txn1"}, "cancel": {"1"}})
+	require.Equal(t, http.StatusFound, rec.Code)
+	assert.Contains(t, rec.Header().Get("Location"), "error=access_denied")
+}
+
+func TestDecision_BadLoginToken(t *testing.T) {
+	hn := newHarness(t)
+	hn.store.txns["txn1"] = &transaction{ClientID: hn.clientID, RedirectURI: hn.redirect}
+	rec := hn.post(t, hn.h.Decision, url.Values{"transaction_id": {"txn1"}, "login_token": {"bogus"}})
+	require.Equal(t, http.StatusFound, rec.Code)
+	assert.Contains(t, rec.Header().Get("Location"), "error=access_denied")
+}
+
+func TestDecision_ExpiredTransaction(t *testing.T) {
+	hn := newHarness(t)
+	rec := hn.post(t, hn.h.Decision, url.Values{"transaction_id": {"gone"}, "login_token": {"x"}})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// --- Token ---
+
+func seedGrant(hn *testHarness, code string) {
+	hn.store.grants[code] = &grant{
+		ClientID: hn.clientID, UserID: "u1", RedirectURI: hn.redirect,
+		CodeChallenge: challengeFor("the-verifier"), Scopes: []string{"read:account", "write:notes"},
+	}
+}
+
+func validTokenForm(hn *testHarness, code string) url.Values {
+	return url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"client_id":     {hn.clientID},
+		"redirect_uri":  {hn.redirect},
+		"code_verifier": {"the-verifier"},
+	}
+}
+
+func TestToken_Success(t *testing.T) {
+	hn := newHarness(t)
+	seedGrant(hn, "code1")
+	rec := hn.post(t, hn.h.Token, validTokenForm(hn, "code1"))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp["access_token"])
+	assert.Equal(t, "Bearer", resp["token_type"])
+	assert.Equal(t, "read:account write:notes", resp["scope"])
+
+	require.Len(t, hn.tokens.created, 1)
+	tok := hn.tokens.created[0]
+	assert.Equal(t, "u1", tok.UserID)
+	assert.Equal(t, tok.Token, tok.Hash, "OAuth token: hash == token")
+	require.NotNil(t, tok.Name)
+	assert.Equal(t, hn.clientID, *tok.Name)
+	assert.ElementsMatch(t, []string{"read:account", "write:notes"}, []string(tok.Permission))
+	assert.Nil(t, tok.AppID, "OAuth token has no registered app")
+}
+
+// TestToken_JSONBody confirms the token endpoint also accepts an
+// application/json body (upstream bodyParser.json parity, #1899).
+func TestToken_JSONBody(t *testing.T) {
+	hn := newHarness(t)
+	seedGrant(hn, "code1")
+	e := echo.New()
+	jsonBody := `{"grant_type":"authorization_code","code":"code1","client_id":"` + hn.clientID +
+		`","redirect_uri":"` + hn.redirect + `","code_verifier":"the-verifier"}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(jsonBody))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	_ = hn.h.Token(e.NewContext(req, rec))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp["access_token"])
+	require.Len(t, hn.tokens.created, 1)
+}
+
+func TestToken_ReplayRevokesAndRejects(t *testing.T) {
+	hn := newHarness(t)
+	seedGrant(hn, "code1")
+	// 1 回目: 成功。
+	rec1 := hn.post(t, hn.h.Token, validTokenForm(hn, "code1"))
+	require.Equal(t, http.StatusOK, rec1.Code)
+	require.Len(t, hn.tokens.created, 1)
+	issuedID := hn.tokens.created[0].ID
+
+	// 2 回目 (replay): invalid_grant + 既発行 token を revoke。
+	rec2 := hn.post(t, hn.h.Token, validTokenForm(hn, "code1"))
+	assert.Equal(t, http.StatusBadRequest, rec2.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp))
+	assert.Equal(t, "invalid_grant", resp["error"])
+	assert.Contains(t, hn.tokens.deleted, issuedID, "replay は発行済み token を revoke する")
+}
+
+func TestToken_WrongVerifier(t *testing.T) {
+	hn := newHarness(t)
+	seedGrant(hn, "code1")
+	form := validTokenForm(hn, "code1")
+	form.Set("code_verifier", "wrong")
+	rec := hn.post(t, hn.h.Token, form)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Empty(t, hn.tokens.created)
+}
+
+func TestToken_RedirectURIMismatch(t *testing.T) {
+	hn := newHarness(t)
+	seedGrant(hn, "code1")
+	form := validTokenForm(hn, "code1")
+	form.Set("redirect_uri", "https://evil.example/cb")
+	rec := hn.post(t, hn.h.Token, form)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Empty(t, hn.tokens.created)
+}
+
+func TestToken_ClientIDMismatch(t *testing.T) {
+	hn := newHarness(t)
+	seedGrant(hn, "code1")
+	form := validTokenForm(hn, "code1")
+	form.Set("client_id", "https://other.example/")
+	rec := hn.post(t, hn.h.Token, form)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Empty(t, hn.tokens.created)
+}
+
+func TestToken_UnsupportedGrantType(t *testing.T) {
+	hn := newHarness(t)
+	seedGrant(hn, "code1")
+	form := validTokenForm(hn, "code1")
+	form.Set("grant_type", "client_credentials")
+	rec := hn.post(t, hn.h.Token, form)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "unsupported_grant_type", resp["error"])
+}
+
+func TestToken_UnknownCode(t *testing.T) {
+	hn := newHarness(t)
+	rec := hn.post(t, hn.h.Token, validTokenForm(hn, "nope"))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "invalid_grant", resp["error"])
+}
+
+// --- End-to-end ---
+
+func TestEndToEnd_AuthorizeDecisionToken(t *testing.T) {
+	hn := newHarness(t)
+	hn.users.byToken["native-tok"] = &model.User{ID: "u1"}
+	verifier := "e2e-verifier-1234567890"
+
+	// 1. authorize → consent meta + txn。
+	rec := hn.authorize(t, validAuthorizeQuery(hn, challengeFor(verifier)))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, hn.consent)
+	txnID := hn.consent.TransactionID
+
+	// 2. decision → code。
+	drec := hn.post(t, hn.h.Decision, url.Values{"transaction_id": {txnID}, "login_token": {"native-tok"}})
+	require.Equal(t, http.StatusFound, drec.Code)
+	loc, _ := url.Parse(drec.Header().Get("Location"))
+	code := loc.Query().Get("code")
+	require.NotEmpty(t, code)
+
+	// 3. token → access token。
+	form := url.Values{
+		"grant_type": {"authorization_code"}, "code": {code},
+		"client_id": {hn.clientID}, "redirect_uri": {hn.redirect}, "code_verifier": {verifier},
+	}
+	trec := hn.post(t, hn.h.Token, form)
+	require.Equal(t, http.StatusOK, trec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(trec.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp["access_token"])
+	require.Len(t, hn.tokens.created, 1)
+	assert.Equal(t, "u1", hn.tokens.created[0].UserID)
+}
+
+// flakyStore wraps fakeStore and forces a non-NotFound error from one method
+// to exercise the handlers' server_error branches.
+type flakyStore struct {
+	*fakeStore
+	failPutTxn   bool
+	failPutGrant bool
+	failGetGrant bool
+	failClaim    bool
+}
+
+func (s *flakyStore) PutTransaction(ctx context.Context, id string, t *transaction) error {
+	if s.failPutTxn {
+		return assertErr
+	}
+	return s.fakeStore.PutTransaction(ctx, id, t)
+}
+func (s *flakyStore) PutGrant(ctx context.Context, code string, g *grant) error {
+	if s.failPutGrant {
+		return assertErr
+	}
+	return s.fakeStore.PutGrant(ctx, code, g)
+}
+func (s *flakyStore) GetGrant(ctx context.Context, code string) (*grant, error) {
+	if s.failGetGrant {
+		return nil, assertErr
+	}
+	return s.fakeStore.GetGrant(ctx, code)
+}
+func (s *flakyStore) ClaimGrant(ctx context.Context, code string) (bool, error) {
+	if s.failClaim {
+		return false, assertErr
+	}
+	return s.fakeStore.ClaimGrant(ctx, code)
+}
+
+var assertErr = errStore("boom")
+
+type errStore string
+
+func (e errStore) Error() string { return string(e) }
+
+func TestAuthorize_DiscoveryFailure(t *testing.T) {
+	// discovery server が 404 → client metadata 取得失敗 → 直接 400。
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	h := NewHandler(newFakeStore(), srv.Client(), &fakeUserRepo{}, &fakeTokenStore{}, &fakeIDGen{}, "https://mk.example", true,
+		func(c echo.Context, _ ConsentMeta) error { return c.HTML(http.StatusOK, "x") })
+	e := echo.New()
+	q := url.Values{
+		"client_id": {srv.URL + "/"}, "redirect_uri": {srv.URL + "/cb"},
+		"scope": {"read:account"}, "code_challenge": {challengeFor("v")}, "code_challenge_method": {"S256"},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+q.Encode(), nil)
+	rec := httptest.NewRecorder()
+	_ = h.Authorize(e.NewContext(req, rec))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestAuthorize_StoreError(t *testing.T) {
+	hn := newHarness(t)
+	hn.h.store = &flakyStore{fakeStore: hn.store, failPutTxn: true}
+	rec := hn.authorize(t, validAuthorizeQuery(hn, challengeFor("v")))
+	// redirect_uri は validated 済みなので server_error redirect。
+	require.Equal(t, http.StatusFound, rec.Code)
+	assert.Contains(t, rec.Header().Get("Location"), "error=server_error")
+}
+
+func TestDecision_PutGrantError(t *testing.T) {
+	hn := newHarness(t)
+	hn.users.byToken["native-tok"] = &model.User{ID: "u1"}
+	hn.store.txns["txn1"] = &transaction{ClientID: hn.clientID, RedirectURI: hn.redirect, Scopes: []string{"read:account"}, CodeChallenge: challengeFor("v")}
+	hn.h.store = &flakyStore{fakeStore: hn.store, failPutGrant: true}
+	rec := hn.post(t, hn.h.Decision, url.Values{"transaction_id": {"txn1"}, "login_token": {"native-tok"}})
+	require.Equal(t, http.StatusFound, rec.Code)
+	assert.Contains(t, rec.Header().Get("Location"), "error=server_error")
+}
+
+func TestToken_GrantLookupError(t *testing.T) {
+	hn := newHarness(t)
+	seedGrant(hn, "code1")
+	hn.h.store = &flakyStore{fakeStore: hn.store, failGetGrant: true}
+	rec := hn.post(t, hn.h.Token, validTokenForm(hn, "code1"))
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestToken_ClaimError(t *testing.T) {
+	hn := newHarness(t)
+	seedGrant(hn, "code1")
+	hn.h.store = &flakyStore{fakeStore: hn.store, failClaim: true}
+	rec := hn.post(t, hn.h.Token, validTokenForm(hn, "code1"))
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestToken_InvalidClientIDForm(t *testing.T) {
+	hn := newHarness(t)
+	seedGrant(hn, "code1")
+	form := validTokenForm(hn, "code1")
+	form.Set("client_id", "not-a-url") // canonicalClientID → "" → mismatch
+	rec := hn.post(t, hn.h.Token, form)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Empty(t, hn.tokens.created)
+}
+
+func TestNotFound(t *testing.T) {
+	hn := newHarness(t)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/oauth/whatever", nil)
+	rec := httptest.NewRecorder()
+	_ = hn.h.NotFound(e.NewContext(req, rec))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	errObj := resp["error"].(map[string]any)
+	assert.Equal(t, "UNKNOWN_OAUTH_ENDPOINT", errObj["code"])
+}

--- a/internal/api/oauth/store.go
+++ b/internal/api/oauth/store.go
@@ -1,0 +1,154 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// cacheTTL is how long an authorization transaction / grant code lives, matching
+// upstream's MemoryKVCache 5-minute expiry.
+const cacheTTL = 5 * time.Minute
+
+// ErrNotFound is returned by the Store when a transaction / grant is missing or
+// expired.
+var ErrNotFound = errors.New("oauth: not found")
+
+// transaction holds the validated /oauth/authorize parameters between the
+// authorize step (store) and the decision step (take). Single-use.
+type transaction struct {
+	ClientID      string   `json:"clientId"`
+	ClientName    string   `json:"clientName"`
+	ClientLogo    string   `json:"clientLogo"`
+	RedirectURI   string   `json:"redirectUri"`
+	Scopes        []string `json:"scopes"`
+	CodeChallenge string   `json:"codeChallenge"`
+	State         string   `json:"state"`
+}
+
+// grant binds an issued authorization code to its consented parameters. Used by
+// the token exchange to validate the code_verifier / client_id / redirect_uri
+// and to mint the access token with the consented scopes.
+type grant struct {
+	ClientID      string   `json:"clientId"`
+	UserID        string   `json:"userId"`
+	RedirectURI   string   `json:"redirectUri"`
+	CodeChallenge string   `json:"codeChallenge"`
+	Scopes        []string `json:"scopes"`
+}
+
+// Store persists OAuth transactions and grant codes with TTL. Backed by Redis
+// in production (so authorize/decision/token can hit different instances); a
+// test fake implements the same single-use / atomic-claim semantics.
+type Store interface {
+	// PutTransaction stores a validated authorize transaction under id.
+	PutTransaction(ctx context.Context, id string, t *transaction) error
+	// TakeTransaction atomically loads and removes a transaction (single use).
+	// Returns ErrNotFound if absent/expired.
+	TakeTransaction(ctx context.Context, id string) (*transaction, error)
+	// PutGrant stores an authorization code's bound parameters.
+	PutGrant(ctx context.Context, code string, g *grant) error
+	// GetGrant loads a grant without consuming it. ErrNotFound if absent.
+	GetGrant(ctx context.Context, code string) (*grant, error)
+	// ClaimGrant atomically marks the code as exchanged. firstUse is true only
+	// for the caller that won the claim; a later call (replay) returns false.
+	ClaimGrant(ctx context.Context, code string) (firstUse bool, err error)
+	// PutGrantToken records the access-token id minted for a code so a later
+	// replay can revoke it (upstream RFC6749 §4.1.2 behavior).
+	PutGrantToken(ctx context.Context, code, tokenID string) error
+	// GetGrantToken returns the recorded token id for a code ("" if none).
+	GetGrantToken(ctx context.Context, code string) (string, error)
+}
+
+// RedisStore is the production Store backed by a Redis client.
+type RedisStore struct {
+	rdb *redis.Client
+}
+
+// NewRedisStore constructs a RedisStore.
+func NewRedisStore(rdb *redis.Client) *RedisStore {
+	return &RedisStore{rdb: rdb}
+}
+
+func txnKey(id string) string     { return "oauth:txn:" + id }
+func grantKey(code string) string { return "oauth:grant:" + code }
+func claimKey(code string) string { return "oauth:grant:" + code + ":claimed" }
+func tokenKey(code string) string { return "oauth:grant:" + code + ":token" }
+
+func (s *RedisStore) PutTransaction(ctx context.Context, id string, t *transaction) error {
+	b, err := json.Marshal(t)
+	if err != nil {
+		return err
+	}
+	return s.rdb.Set(ctx, txnKey(id), b, cacheTTL).Err()
+}
+
+func (s *RedisStore) TakeTransaction(ctx context.Context, id string) (*transaction, error) {
+	// GETDEL で atomic に load + 消費する (transaction は単回使用)。
+	v, err := s.rdb.GetDel(ctx, txnKey(id)).Result()
+	if errors.Is(err, redis.Nil) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	var t transaction
+	if err := json.Unmarshal([]byte(v), &t); err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+func (s *RedisStore) PutGrant(ctx context.Context, code string, g *grant) error {
+	b, err := json.Marshal(g)
+	if err != nil {
+		return err
+	}
+	return s.rdb.Set(ctx, grantKey(code), b, cacheTTL).Err()
+}
+
+func (s *RedisStore) GetGrant(ctx context.Context, code string) (*grant, error) {
+	v, err := s.rdb.Get(ctx, grantKey(code)).Result()
+	if errors.Is(err, redis.Nil) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	var g grant
+	if err := json.Unmarshal([]byte(v), &g); err != nil {
+		return nil, err
+	}
+	return &g, nil
+}
+
+func (s *RedisStore) ClaimGrant(ctx context.Context, code string) (bool, error) {
+	// SETNX で「最初に exchange を試みた呼び出し」だけが claim を獲得する。
+	// 既に claim 済み (= replay) なら false。validation 成否に関わらず claim は
+	// 残るため、誤った code_verifier での exchange でも code は単回で焼き切れる
+	// (upstream が validation 前に used=true にするのと同じ)。
+	err := s.rdb.SetArgs(ctx, claimKey(code), "1", redis.SetArgs{Mode: "NX", TTL: cacheTTL}).Err()
+	if errors.Is(err, redis.Nil) {
+		// key が既に存在 (= 既に claim 済み) → replay。
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (s *RedisStore) PutGrantToken(ctx context.Context, code, tokenID string) error {
+	return s.rdb.Set(ctx, tokenKey(code), tokenID, cacheTTL).Err()
+}
+
+func (s *RedisStore) GetGrantToken(ctx context.Context, code string) (string, error) {
+	v, err := s.rdb.Get(ctx, tokenKey(code)).Result()
+	if errors.Is(err, redis.Nil) {
+		return "", nil
+	}
+	return v, err
+}

--- a/internal/api/oauth/store_test.go
+++ b/internal/api/oauth/store_test.go
@@ -1,0 +1,63 @@
+package oauth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRedisStore_Integration exercises the Redis-backed Store end to end,
+// including the single-use transaction (GETDEL), atomic grant claim (SETNX),
+// and grant-token recording used for replay revocation (#1899).
+func TestRedisStore_Integration(t *testing.T) {
+	ctx := context.Background()
+	tr, err := testutil.SetupRedis(ctx)
+	if err != nil {
+		t.Skipf("Redis not available: %v", err)
+	}
+	defer tr.Teardown(ctx)
+	tr.FlushAll(ctx)
+
+	s := NewRedisStore(tr.Client)
+
+	// transaction: put → take (single use) → take again is ErrNotFound。
+	txn := &transaction{ClientID: "https://c/", RedirectURI: "https://c/cb", Scopes: []string{"read:account"}, CodeChallenge: "ch", State: "st"}
+	require.NoError(t, s.PutTransaction(ctx, "tx1", txn))
+	got, err := s.TakeTransaction(ctx, "tx1")
+	require.NoError(t, err)
+	assert.Equal(t, "https://c/", got.ClientID)
+	assert.Equal(t, "st", got.State)
+	_, err = s.TakeTransaction(ctx, "tx1")
+	assert.ErrorIs(t, err, ErrNotFound)
+	_, err = s.TakeTransaction(ctx, "missing")
+	assert.ErrorIs(t, err, ErrNotFound)
+
+	// grant: put → get。
+	g := &grant{ClientID: "https://c/", UserID: "u1", RedirectURI: "https://c/cb", CodeChallenge: "ch", Scopes: []string{"read:account"}}
+	require.NoError(t, s.PutGrant(ctx, "code1", g))
+	gotG, err := s.GetGrant(ctx, "code1")
+	require.NoError(t, err)
+	assert.Equal(t, "u1", gotG.UserID)
+	_, err = s.GetGrant(ctx, "missing")
+	assert.ErrorIs(t, err, ErrNotFound)
+
+	// claim: first true, replay false。
+	first, err := s.ClaimGrant(ctx, "code1")
+	require.NoError(t, err)
+	assert.True(t, first)
+	second, err := s.ClaimGrant(ctx, "code1")
+	require.NoError(t, err)
+	assert.False(t, second)
+
+	// grant token: empty → set → get。
+	tid, err := s.GetGrantToken(ctx, "code1")
+	require.NoError(t, err)
+	assert.Empty(t, tid)
+	require.NoError(t, s.PutGrantToken(ctx, "code1", "tokABC"))
+	tid, err = s.GetGrantToken(ctx, "code1")
+	require.NoError(t, err)
+	assert.Equal(t, "tokABC", tid)
+}

--- a/internal/repository/access_token.go
+++ b/internal/repository/access_token.go
@@ -36,6 +36,9 @@ type AccessTokenRepository interface {
 	//   それ以外 ("" 含む) → token.id ASC (TS の default)
 	ListByUserIDPreloadApp(userID, sort string) ([]*model.AccessToken, error)
 	DeleteByID(id string) error
+	// Create inserts a new access token. Used by the OAuth2 provider to mint a
+	// token after a successful authorization-code exchange (#1899)。
+	Create(token *model.AccessToken) error
 }
 
 type accessTokenRepository struct {
@@ -45,6 +48,10 @@ type accessTokenRepository struct {
 // NewAccessTokenRepository creates a new AccessTokenRepository.
 func NewAccessTokenRepository(db *gorm.DB) AccessTokenRepository {
 	return &accessTokenRepository{db: db}
+}
+
+func (r *accessTokenRepository) Create(token *model.AccessToken) error {
+	return r.db.Create(token).Error
 }
 
 func (r *accessTokenRepository) FindByHash(hash string) (*model.AccessToken, error) {

--- a/internal/server/frontend.go
+++ b/internal/server/frontend.go
@@ -3,14 +3,17 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	stdhtml "html"
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/meta"
+	"github.com/shiroha-a/mk/internal/api/oauth"
 	"github.com/shiroha-a/mk/internal/config"
 	"github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/frontendutil"
@@ -29,48 +32,56 @@ func frontendHTML(cfg *config.Config, metaRepo repository.MetaRepository, proxyA
 	clientEntry := frontendutil.DetectClientEntry()
 
 	return func(c echo.Context) error {
-		instanceName := "Misskey"
-		instanceDesc := ""
-		iconURL := "/static-assets/icons/192.png"
-		themeColor := "#86b300"
-		// splash 中央のアイコンは upstream `_splash.tsx` 互換で server
-		// iconUrl を使う (= 管理者が設定したインスタンス画像)。未設定なら
-		// `/static-assets/splash.png` (Misskey ロゴ) にフォールバック。
-		// mascotImageUrl (Ai キャラ) は別 field で splash には使わない (#993)。
-		splashIconURL := "/static-assets/splash.png"
-		metaJSON := "{}"
-		if m, err := metaRepo.Fetch(); err == nil {
-			if m.Name != nil && *m.Name != "" {
-				instanceName = *m.Name
-			}
-			if m.Description != nil {
-				instanceDesc = *m.Description
-			}
-			if m.IconURL != nil && *m.IconURL != "" {
-				iconURL = *m.IconURL
-				splashIconURL = *m.IconURL
-			}
-			if m.ThemeColor != nil && *m.ThemeColor != "" {
-				themeColor = *m.ThemeColor
-			}
-			metaJSON = buildMetaJSON(cfg, m, proxyAccountResolver)
-		}
+		return renderFrontendShell(c, cfg, metaRepo, proxyAccountResolver, clientEntry, "")
+	}
+}
 
-		// CLIENT_ENTRYの設定
-		clientEntryJS := "null"
-		viteClientTag := `<script type="module" src="/vite/@vite/client"></script>`
-		cssLinkTags := ""
-		if clientEntry.Script != "" {
-			clientEntryJS = fmt.Sprintf("'%s'", clientEntry.Script)
-			viteClientTag = "" // production ではVite clientは不要
-			// Vite manifest の CSS 依存を <link> タグとして挿入する。
-			// これがないとエントリの CSS (100KB+) が読み込まれずスタイル崩れになる。
-			for _, css := range clientEntry.CSS {
-				cssLinkTags += fmt.Sprintf(`<link rel="stylesheet" href="/vite/%s">`, css) + "\n"
-			}
+// renderFrontendShell renders the Misskey frontend SPA shell. extraHead is
+// injected verbatim into <head> (used by the OAuth consent page to add the
+// misskey:oauth:* meta tags, #1899); pass "" for the normal shell.
+func renderFrontendShell(c echo.Context, cfg *config.Config, metaRepo repository.MetaRepository, proxyAccountResolver meta.ProxyAccountResolver, clientEntry frontendutil.ClientEntryInfo, extraHead string) error {
+	instanceName := "Misskey"
+	instanceDesc := ""
+	iconURL := "/static-assets/icons/192.png"
+	themeColor := "#86b300"
+	// splash 中央のアイコンは upstream `_splash.tsx` 互換で server
+	// iconUrl を使う (= 管理者が設定したインスタンス画像)。未設定なら
+	// `/static-assets/splash.png` (Misskey ロゴ) にフォールバック。
+	// mascotImageUrl (Ai キャラ) は別 field で splash には使わない (#993)。
+	splashIconURL := "/static-assets/splash.png"
+	metaJSON := "{}"
+	if m, err := metaRepo.Fetch(); err == nil {
+		if m.Name != nil && *m.Name != "" {
+			instanceName = *m.Name
 		}
+		if m.Description != nil {
+			instanceDesc = *m.Description
+		}
+		if m.IconURL != nil && *m.IconURL != "" {
+			iconURL = *m.IconURL
+			splashIconURL = *m.IconURL
+		}
+		if m.ThemeColor != nil && *m.ThemeColor != "" {
+			themeColor = *m.ThemeColor
+		}
+		metaJSON = buildMetaJSON(cfg, m, proxyAccountResolver)
+	}
 
-		html := fmt.Sprintf(`<!DOCTYPE html>
+	// CLIENT_ENTRYの設定
+	clientEntryJS := "null"
+	viteClientTag := `<script type="module" src="/vite/@vite/client"></script>`
+	cssLinkTags := ""
+	if clientEntry.Script != "" {
+		clientEntryJS = fmt.Sprintf("'%s'", clientEntry.Script)
+		viteClientTag = "" // production ではVite clientは不要
+		// Vite manifest の CSS 依存を <link> タグとして挿入する。
+		// これがないとエントリの CSS (100KB+) が読み込まれずスタイル崩れになる。
+		for _, css := range clientEntry.CSS {
+			cssLinkTags += fmt.Sprintf(`<link rel="stylesheet" href="/vite/%s">`, css) + "\n"
+		}
+	}
+
+	html := fmt.Sprintf(`<!DOCTYPE html>
 <html><head>
 <meta charset="UTF-8">
 <meta name="application-name" content="Misskey">
@@ -90,6 +101,7 @@ func frontendHTML(cfg *config.Config, metaRepo repository.MetaRepository, proxyA
 <link rel="manifest" href="/manifest.json">
 %s
 %s
+%s
 <link rel="stylesheet" href="/vite/loader/style.css">
 <script>const VERSION = '%s'; const CLIENT_ENTRY = %s; const LANGS = ["ja-JP","en-US"];</script>
 <script type="application/json" id="misskey_meta" data-generated-at="%d">%s</script>
@@ -104,11 +116,28 @@ func frontendHTML(cfg *config.Config, metaRepo repository.MetaRepository, proxyA
 </div>
 </div>
 </body></html>`, instanceName, instanceName, instanceDesc, iconURL, cfg.URL,
-			themeColor, cfg.URL, instanceName, iconURL, viteClientTag, cssLinkTags,
-			cfg.Version, clientEntryJS,
-			time.Now().UnixMilli(), metaJSON, splashIconURL)
+		themeColor, cfg.URL, instanceName, iconURL, extraHead, viteClientTag, cssLinkTags,
+		cfg.Version, clientEntryJS,
+		time.Now().UnixMilli(), metaJSON, splashIconURL)
 
-		return c.HTML(http.StatusOK, html)
+	return c.HTML(http.StatusOK, html)
+}
+
+// frontendConsentHTML returns an oauth.ConsentRenderer that serves the frontend
+// SPA shell with the misskey:oauth:* meta tags injected, so the frontend's
+// OAuth component can render the authorization prompt (#1899). Values are
+// HTML-escaped (client name/logo are attacker-suppliable via discovery).
+func frontendConsentHTML(cfg *config.Config, metaRepo repository.MetaRepository, proxyAccountResolver meta.ProxyAccountResolver) oauth.ConsentRenderer {
+	clientEntry := frontendutil.DetectClientEntry()
+	return func(c echo.Context, m oauth.ConsentMeta) error {
+		var sb strings.Builder
+		sb.WriteString(`<meta name="misskey:oauth:transaction-id" content="` + stdhtml.EscapeString(m.TransactionID) + `">` + "\n")
+		sb.WriteString(`<meta name="misskey:oauth:client-name" content="` + stdhtml.EscapeString(m.ClientName) + `">` + "\n")
+		if m.ClientLogo != "" {
+			sb.WriteString(`<meta name="misskey:oauth:client-logo" content="` + stdhtml.EscapeString(m.ClientLogo) + `">` + "\n")
+		}
+		sb.WriteString(`<meta name="misskey:oauth:scope" content="` + stdhtml.EscapeString(m.Scope) + `">`)
+		return renderFrontendShell(c, cfg, metaRepo, proxyAccountResolver, clientEntry, sb.String())
 	}
 }
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -46,6 +46,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/notehide"
 	"github.com/shiroha-a/mk/internal/api/notes"
 	"github.com/shiroha-a/mk/internal/api/notifications"
+	"github.com/shiroha-a/mk/internal/api/oauth"
 	"github.com/shiroha-a/mk/internal/api/pages"
 	apiproxy "github.com/shiroha-a/mk/internal/api/proxy"
 	"github.com/shiroha-a/mk/internal/api/renotemute"
@@ -120,6 +121,7 @@ import (
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/queue/processors"
 	"github.com/shiroha-a/mk/internal/repository"
+	"github.com/shiroha-a/mk/internal/safehttp"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 	"github.com/shiroha-a/mk/internal/stream"
 	"github.com/shiroha-a/mk/internal/stream/channels"
@@ -1807,6 +1809,31 @@ func (s *Server) setupRoutes() {
 	s.echo.GET("/.well-known/host-meta.json", wellknownHandler.HostMetaJSON)
 	s.echo.GET("/.well-known/nodeinfo", wellknownHandler.NodeInfoDiscovery)
 	s.echo.GET("/.well-known/oauth-authorization-server", wellknownHandler.OAuthAuthorizationServer)
+
+	// OAuth2 / IndieAuth provider (#1899)。RFC8414 discovery が広告する
+	// /oauth/authorize /decision /token を実装する。client discovery fetch は
+	// attacker-suppliable な client_id URL を叩くため SSRF-guarded transport を使う。
+	// 明示ルートは SPA catchall (s.echo.GET("/*")) より Echo router 上で優先される。
+	oauthHandler := oauth.NewHandler(
+		oauth.NewRedisStore(s.redis.Default),
+		&http.Client{
+			Timeout:   10 * time.Second,
+			Transport: safehttp.NewSSRFSafeTransport(s.config.AllowedPrivateNetworks),
+		},
+		userRepo,
+		repository.NewAccessTokenRepository(s.db),
+		idGen,
+		s.config.URL,
+		false, // production は https client_id のみ
+		frontendConsentHTML(s.config, metaRepo, proxyAccountResolver),
+	)
+	s.echo.GET("/oauth/authorize", oauthHandler.Authorize)
+	s.echo.POST("/oauth/decision", oauthHandler.Decision)
+	s.echo.POST("/oauth/token", oauthHandler.Token)
+	// unknown /oauth/* は 404 (client が endpoint 対応有無を判別できるよう、
+	// upstream の catch-all 同様)。明示ルートが優先されるので authorize/decision/
+	// token はここに落ちない。
+	s.echo.Any("/oauth/*", oauthHandler.NotFound)
 
 	nodeinfoHandler := nodeinfo.NewHandler(s.config)
 	nodeinfoHandler.SetMetaRepo(metaRepo)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -2681,6 +2681,15 @@ func (m *MockAccessTokenRepository) SetApp(app *model.App) {
 	m.Apps[app.ID] = app
 }
 
+// Create inserts a token keyed by its hash (mirrors the real repo's INSERT).
+func (m *MockAccessTokenRepository) Create(token *model.AccessToken) error {
+	if m.Tokens == nil {
+		m.Tokens = make(map[string]*model.AccessToken)
+	}
+	m.Tokens[token.Hash] = token
+	return nil
+}
+
 func (m *MockAccessTokenRepository) FindByHash(hash string) (*model.AccessToken, error) {
 	t, ok := m.Tokens[hash]
 	if !ok {


### PR DESCRIPTION
## Summary

`#1829` (auth-oauth 再監査(2)) の sub-issue (F1、MEDIUM/missing_endpoint、大型 feature)。RFC8414 discovery が既に広告している `/oauth/authorize` `/oauth/token` を**機能させる**。これまで discovery を見て認可を始める OAuth2/IndieAuth クライアントは GET `/oauth/authorize` が SPA catchall に落ち、POST `/oauth/token` が 404 で認可を完了できなかった。upstream `OAuth2ProviderService` (oauth2orize + PKCE + IndieAuth client discovery) を Go で自前実装する。

## 新規 `internal/api/oauth` package

### provider.go (Authorize / Decision / Token / NotFound)
- **authorize**: `validateClientID` → SSRF-guarded client discovery → redirect_uri を discovery list と **exact match** (open redirect 防止) → scope dedupe (非空) → **PKCE code_challenge 必須 + method=S256 必須** (downgrade 防止) → transaction 格納 → consent page (frontend shell + `misskey:oauth:*` meta) を返す。**redirect_uri validated 前の error は直接 400** (未検証 URI へ redirect しない)。
- **decision**: txn load → cancel は error redirect → **native login_token** から user 解決 (`FindByToken` は native token のみ一致) → authorization code 発行 → `redirect_uri?code=&state=&iss=`。
- **token**: `grant_type=authorization_code` → code を **atomic single-use claim** (replay は発行済み token を revoke + `invalid_grant`) → client_id/redirect_uri 一致 → **PKCE S256 verify** → access token 発行 (`hash==token`, `appId=nil`, `name=clientId`, `permission=scopes`)。**urlencoded / JSON body 両対応**。

### 他
- **client_discovery.go**: IndieAuth client-id-as-URL 検証 + client metadata discovery (JSON metadata / HTML h-app microformats / Link header `rel=redirect_uri`)。
- **pkce.go**: S256 verify (constant-time)。
- **store.go**: transaction / grant cache (Redis backed、GETDEL で単回 txn、SETNX で atomic code claim、replay revoke 用 token id 記録)。

## 統合
- `frontend.go`: `renderFrontendShell` に `extraHead` を追加し、consent page で `misskey:oauth:*` meta tag を **HTML-escape** して注入 (frontend の `pages/oauth.vue` が読む契約。frontend は drop-in、未変更)。
- `router.go`: `/oauth/authorize` `/oauth/decision` `/oauth/token` を SPA catchall より前に登録 + `/oauth/*` unknown は 404。client discovery fetch は `safehttp.NewSSRFSafeTransport` で **SSRF guard**。
- `AccessTokenRepository` に `Create` を追加 (+ `MockAccessTokenRepository`)。

## テスト
- `validateClientID` 各 reject、client discovery (HTML/JSON/Link header)、PKCE 正誤、authorize/decision/token **全 flow** + replay revoke + PKCE mismatch + redirect_uri/client_id mismatch + JSON body + server_error path、Redis store integration。
- oauth package **coverage 92.1%**。`make fmt && make lint` clean、`go test ./...` 全 package green (0 failures)。

## 敵対的セキュリティレビュー
PKCE / code 単回・replay / open redirect / SSRF / token binding / client confusion / CSRF / meta XSS / scope を監査: **BLOCKER なし**、core security 健全。指摘修正:
- **MAJOR**: token endpoint が JSON body 未対応 → 修正 (urlencoded/JSON 両対応)。
- CORS 二重 header (root middleware と重複) → manual header 除去。
- token の grant-lookup error が `invalid_grant` を返していた (store error は `server_error` であるべき) → error ordering 修正。

## 備考 / follow-up
- scope を既知 kinds に filter + discovery の `scopes_supported` を granular kinds に整合する parity 残課題 (非 exploitable、kinds list 未整備のため) は **#1904** に分離。

Closes #1899

🤖 Generated with [Claude Code](https://claude.com/claude-code)