### PR TITLE
Fix auth-oauth parity (#1904): OAuth scope を既知 kinds に filter + discovery の scopes_supported を granular kinds に整合

### DIFF
--- a/internal/api/oauth/provider.go
+++ b/internal/api/oauth/provider.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/misc"
+	"github.com/shiroha-a/mk/internal/misc/permissions"
 	"github.com/shiroha-a/mk/internal/model"
 )
 
@@ -113,10 +114,12 @@ func (h *Handler) Authorize(c echo.Context) error {
 		return directError(c, "invalid redirect_uri")
 	}
 
-	// 5. scope を dedupe。空は invalid_scope (redirect で返せる)。
-	scopes := dedupeFields(scopeParam)
+	// 5. scope を dedupe して既知 kinds に filter。既知 scope が無ければ
+	// invalid_scope (upstream OAuth2ProviderService と同じ、#1904)。未知 scope を
+	// token.permission に格納しないことで RequireScope の判定対象を健全に保つ。
+	scopes := filterKnownScopes(dedupeFields(scopeParam))
 	if len(scopes) == 0 {
-		return h.redirectError(c, redirectURI, state, "invalid_scope", "scope parameter has no scope")
+		return h.redirectError(c, redirectURI, state, "invalid_scope", "scope parameter has no known scope")
 	}
 
 	// 6. PKCE は必須 (S256 のみ)。downgrade attack 防止。
@@ -332,6 +335,18 @@ func contains(list []string, v string) bool {
 		}
 	}
 	return false
+}
+
+// filterKnownScopes keeps only recognized permission kinds, preserving order,
+// matching upstream's `.filter(s => kinds.includes(s))` (#1904)。
+func filterKnownScopes(scopes []string) []string {
+	out := scopes[:0:0]
+	for _, s := range scopes {
+		if permissions.IsKnown(s) {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // dedupeFields splits a space-separated scope string and removes duplicates,

--- a/internal/api/oauth/provider_test.go
+++ b/internal/api/oauth/provider_test.go
@@ -239,6 +239,34 @@ func TestAuthorize_EmptyScope(t *testing.T) {
 	assert.Contains(t, rec.Header().Get("Location"), "error=invalid_scope")
 }
 
+// TestAuthorize_AllUnknownScope: 既知 kinds に 1 つも該当しない scope は
+// invalid_scope (#1904)。
+func TestAuthorize_AllUnknownScope(t *testing.T) {
+	hn := newHarness(t)
+	q := validAuthorizeQuery(hn, challengeFor("v"))
+	q.Set("scope", "bogus another:unknown")
+	rec := hn.authorize(t, q)
+	assert.Equal(t, http.StatusFound, rec.Code)
+	assert.Contains(t, rec.Header().Get("Location"), "error=invalid_scope")
+	assert.Nil(t, hn.consent)
+}
+
+// TestAuthorize_FiltersUnknownScopes: 未知 scope は除去され、既知 kinds のみが
+// consent / token に渡る (#1904)。
+func TestAuthorize_FiltersUnknownScopes(t *testing.T) {
+	hn := newHarness(t)
+	q := validAuthorizeQuery(hn, challengeFor("v"))
+	q.Set("scope", "read:account bogus write:notes read:*")
+	rec := hn.authorize(t, q)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, hn.consent)
+	assert.Equal(t, "read:account write:notes", hn.consent.Scope)
+	// 格納された txn の scopes も filter 済み。
+	txn := hn.store.txns[hn.consent.TransactionID]
+	require.NotNil(t, txn)
+	assert.Equal(t, []string{"read:account", "write:notes"}, txn.Scopes)
+}
+
 // --- Decision ---
 
 func TestDecision_IssuesCode(t *testing.T) {

--- a/internal/api/wellknown/handler.go
+++ b/internal/api/wellknown/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/core/user"
+	"github.com/shiroha-a/mk/internal/misc/permissions"
 )
 
 // Handler handles webfinger / host-meta / nodeinfo discovery.
@@ -135,7 +136,7 @@ func (h *Handler) OAuthAuthorizationServer(c echo.Context) error {
 		"issuer":                                         h.origin,
 		"authorization_endpoint":                         h.origin + "/oauth/authorize",
 		"token_endpoint":                                 h.origin + "/oauth/token",
-		"scopes_supported":                               []string{"read", "write", "follow"},
+		"scopes_supported":                               permissions.All,
 		"response_types_supported":                       []string{"code"},
 		"grant_types_supported":                          []string{"authorization_code"},
 		"service_documentation":                          "https://misskey-hub.net",

--- a/internal/api/wellknown/handler_test.go
+++ b/internal/api/wellknown/handler_test.go
@@ -214,4 +214,11 @@ func TestOAuthAuthorizationServer(t *testing.T) {
 	assert.Equal(t, "https://example.com", resp["issuer"])
 	assert.Equal(t, "https://example.com/oauth/authorize", resp["authorization_endpoint"])
 	assert.Equal(t, "https://example.com/oauth/token", resp["token_endpoint"])
+	// scopes_supported は granular な permission kinds を広告する
+	// (Mastodon 風の "read"/"write"/"follow" ではない、#1904)。
+	scopes, ok := resp["scopes_supported"].([]any)
+	require.True(t, ok)
+	require.NotEmpty(t, scopes)
+	assert.Contains(t, scopes, "read:account")
+	assert.Contains(t, scopes, "write:notes")
 }

--- a/internal/misc/permissions/permissions.go
+++ b/internal/misc/permissions/permissions.go
@@ -1,0 +1,112 @@
+// Package permissions defines the canonical set of OAuth / app permission
+// "kinds" (scopes), mirroring upstream misskey-js `permissions`
+// (packages/misskey-js/src/consts.ts). Used to filter requested OAuth scopes to
+// known kinds and to advertise scopes_supported in the RFC8414 discovery
+// document (#1904). read:messaging / write:messaging are deprecated upstream but
+// retained verbatim for parity.
+package permissions
+
+// All is the ordered list of known permission kinds, matching upstream
+// misskey-js `permissions` exactly.
+var All = []string{
+	"read:account",
+	"write:account",
+	"read:blocks",
+	"write:blocks",
+	"read:drive",
+	"write:drive",
+	"read:favorites",
+	"write:favorites",
+	"read:following",
+	"write:following",
+	"read:messaging",
+	"write:messaging",
+	"read:mutes",
+	"write:mutes",
+	"write:notes",
+	"read:notifications",
+	"write:notifications",
+	"read:reactions",
+	"write:reactions",
+	"write:votes",
+	"read:pages",
+	"write:pages",
+	"write:page-likes",
+	"read:page-likes",
+	"read:user-groups",
+	"write:user-groups",
+	"read:channels",
+	"write:channels",
+	"read:gallery",
+	"write:gallery",
+	"read:gallery-likes",
+	"write:gallery-likes",
+	"read:flash",
+	"write:flash",
+	"read:flash-likes",
+	"write:flash-likes",
+	"read:admin:abuse-user-reports",
+	"write:admin:delete-account",
+	"write:admin:delete-all-files-of-a-user",
+	"read:admin:index-stats",
+	"read:admin:table-stats",
+	"read:admin:user-ips",
+	"read:admin:meta",
+	"write:admin:reset-password",
+	"write:admin:resolve-abuse-user-report",
+	"write:admin:send-email",
+	"read:admin:server-info",
+	"read:admin:show-moderation-log",
+	"read:admin:show-user",
+	"write:admin:suspend-user",
+	"write:admin:unset-user-avatar",
+	"write:admin:unset-user-banner",
+	"write:admin:unsuspend-user",
+	"write:admin:meta",
+	"write:admin:user-note",
+	"write:admin:roles",
+	"read:admin:roles",
+	"write:admin:relays",
+	"read:admin:relays",
+	"write:admin:invite-codes",
+	"read:admin:invite-codes",
+	"write:admin:announcements",
+	"read:admin:announcements",
+	"write:admin:avatar-decorations",
+	"read:admin:avatar-decorations",
+	"write:admin:federation",
+	"write:admin:account",
+	"read:admin:account",
+	"write:admin:emoji",
+	"read:admin:emoji",
+	"write:admin:queue",
+	"read:admin:queue",
+	"write:admin:promo",
+	"write:admin:drive",
+	"read:admin:drive",
+	"write:admin:ad",
+	"read:admin:ad",
+	"write:invite-codes",
+	"read:invite-codes",
+	"write:clip-favorite",
+	"read:clip-favorite",
+	"read:federation",
+	"write:report-abuse",
+	"write:chat",
+	"read:chat",
+}
+
+// set is a lookup set built from All for O(1) IsKnown checks.
+var set = func() map[string]struct{} {
+	m := make(map[string]struct{}, len(All))
+	for _, p := range All {
+		m[p] = struct{}{}
+	}
+	return m
+}()
+
+// IsKnown reports whether s is a recognized permission kind.
+func IsKnown(s string) bool {
+	_, ok := set[s]
+	return ok
+}

--- a/internal/misc/permissions/permissions_test.go
+++ b/internal/misc/permissions/permissions_test.go
@@ -1,0 +1,32 @@
+package permissions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsKnown(t *testing.T) {
+	assert.True(t, IsKnown("read:account"))
+	assert.True(t, IsKnown("write:notes"))
+	assert.True(t, IsKnown("read:chat"))
+	assert.True(t, IsKnown("write:admin:emoji"))
+	assert.False(t, IsKnown("bogus"))
+	assert.False(t, IsKnown("read:*"))
+	assert.False(t, IsKnown(""))
+	assert.False(t, IsKnown("read")) // coarse Mastodon-style scope is not a kind
+}
+
+func TestAll_NonEmptyUnique(t *testing.T) {
+	require := assert.New(t)
+	require.NotEmpty(All)
+	seen := map[string]bool{}
+	for _, p := range All {
+		require.False(seen[p], "duplicate permission kind: %s", p)
+		seen[p] = true
+	}
+	// All の各要素は IsKnown で引ける。
+	for _, p := range All {
+		require.True(IsKnown(p))
+	}
+}


### PR DESCRIPTION
## Summary

`#1899` (OAuth2 provider) の敵対的レビューで確認した parity 残課題 (MINOR、非 exploitable)。OAuth の scope 検証と RFC8414 discovery を upstream に整合させる。

## 問題
- **authorize の scope filter**: upstream は要求 scope を `kinds.includes(s)` で filter し、既知 scope が無ければ `invalid_scope` を返す。mk-go は dedupe + 非空チェックのみで未知 scope も `token.permission` に格納していた。
- **discovery の scopes_supported**: `["read","write","follow"]` (Mastodon 風) を広告していたが provider は granular kinds (`read:account` 等) を扱う。RFC8414 discovery する client に誤解を招く (pre-existing)。

## 修正
- **`internal/misc/permissions`** (新規): upstream misskey-js `permissions` (consts.ts) を **verbatim port** した `All` (85 kinds) + `IsKnown()`。`read:messaging`/`write:messaging` は upstream 同様 deprecated だが parity のため残す。
- **OAuth authorize**: 要求 scope を dedupe 後に既知 kinds へ filter (`filterKnownScopes`)、既知 scope が無ければ `invalid_scope`。未知 scope を `token.permission` に格納しない。
- **discovery**: `scopes_supported` を `permissions.All` に差し替え。advertise と filter が**同一 list**を使う。

## 範囲外 (意図的)
- `app/create` / MiAuth は upstream 同様 permission を kinds filter しない (dedupe のみ) ため変更しない (filter を足すと parity を壊す)。レビューで確認済み。

## テスト
- `permissions` (IsKnown true/false/empty、All uniqueness、round-trip) **100% coverage**。
- OAuth authorize: all-unknown scope → `invalid_scope`、mixed → 既知 kinds のみ filter (consent + 格納 txn)。
- discovery が granular kinds (`read:account`/`write:notes`) を広告することを pin。
- `make fmt && make lint` clean、`go test ./...` 全 package green (0 failures)。oauth package 92.2% cover。
- 敵対的レビュー: list fidelity (upstream と 85 個 byte-exact)、`filterKnownScopes` aliasing 無し、parity、no regression を確認、**指摘なし**。

Closes #1904

🤖 Generated with [Claude Code](https://claude.com/claude-code)