### PR TITLE
Fix content-features parity (#1830): pages/featured 固定化 / clips/my-favorites visibility 無検査 / i/page-likes isLiked

### DIFF
--- a/internal/api/clips/favorites.go
+++ b/internal/api/clips/favorites.go
@@ -110,7 +110,11 @@ func (h *Handler) MyFavorites(c echo.Context) error {
 	}
 	out := make([]map[string]any, 0, len(favs))
 	for _, f := range favs {
-		cl, err := h.svc.Show(user.ID, f.ClipID)
+		// upstream clips/my-favorites は favorite に紐づく clip を visibility 無検査で
+		// 全件返す (公開時に favorite した clip を所有者が後で非公開化しても自分の
+		// favorites には残る、#1830)。Show は他人所有の非公開 clip を弾くので使わず、
+		// 可視性 gate 無しの Get を使う。clip 削除済み (orphan favorite) のみ drop。
+		cl, err := h.svc.Get(f.ClipID)
 		if err != nil {
 			continue
 		}

--- a/internal/api/clips/favorites_test.go
+++ b/internal/api/clips/favorites_test.go
@@ -141,3 +141,31 @@ func TestClipMyFavorites_WithData(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &arr))
 	assert.Len(t, arr, 1)
 }
+
+// TestClipMyFavorites_IncludesNonPublicNonOwned: upstream は favorite に紐づく
+// clip を visibility 無検査で返す。公開時に favorite した他人所有 clip を所有者が
+// 後で非公開化しても、自分の favorites からは消えない (#1830)。
+func TestClipMyFavorites_IncludesNonPublicNonOwned(t *testing.T) {
+	h, clipRepo, favRepo := newStubHandler(t)
+	// u2 所有の非公開 clip を u1 が favorite している。
+	clipRepo.Clips["cl2"] = &model.Clip{ID: "cl2", UserID: "u2", Name: "private", IsPublic: false}
+	favRepo.Favorites["u1:cl2"] = &model.ClipFavorite{ID: "f2", UserID: "u1", ClipID: "cl2"}
+	rec := postStubWithBody(t, h.MyFavorites, `{}`, "u1")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var arr []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &arr))
+	require.Len(t, arr, 1, "他人所有の非公開 favorited clip も返す (visibility 無検査)")
+	assert.Equal(t, "cl2", arr[0]["id"])
+}
+
+// TestClipMyFavorites_DropsDeletedClip: clip が削除済み (orphan favorite) の
+// 場合だけ drop する。
+func TestClipMyFavorites_DropsDeletedClip(t *testing.T) {
+	h, _, favRepo := newStubHandler(t)
+	favRepo.Favorites["u1:gone"] = &model.ClipFavorite{ID: "f3", UserID: "u1", ClipID: "gone"}
+	rec := postStubWithBody(t, h.MyFavorites, `{}`, "u1")
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var arr []any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &arr))
+	assert.Empty(t, arr)
+}

--- a/internal/api/i/page.go
+++ b/internal/api/i/page.go
@@ -69,6 +69,11 @@ func (h *Handler) PageLikes(c echo.Context) error {
 		ownersByID[o.ID] = o
 	}
 
+	// i/page-likes は自分が like した page 一覧なので、埋め込み page の isLiked は
+	// 常に true。upstream は packMany(likes, me) で me を渡し isLiked を出す
+	// (PageEntityService.ts isLiked: meId ? exists(...) : undefined)。mk-go も
+	// IsLiked を立てて shape を揃える (#1830)。
+	liked := true
 	out := make([]map[string]any, 0, len(likes))
 	for _, l := range likes {
 		p, ok := pagesByID[l.PageID]
@@ -86,8 +91,9 @@ func (h *Handler) PageLikes(c echo.Context) error {
 		out = append(out, map[string]any{
 			"id": l.ID,
 			"page": entity.PackPageWithContext(p, entity.PackPageContext{
-				IDGen: h.idGen,
-				Owner: owner,
+				IDGen:   h.idGen,
+				Owner:   owner,
+				IsLiked: &liked,
 			}),
 		})
 	}

--- a/internal/api/i/page_test.go
+++ b/internal/api/i/page_test.go
@@ -67,6 +67,8 @@ func TestPageLikes_FullShape(t *testing.T) {
 	user, ok := page["user"].(map[string]any)
 	require.True(t, ok, "page must include user field (#1136)")
 	assert.Equal(t, "author", user["username"])
+	// i/page-likes は自分の like 一覧なので埋め込み page の isLiked は true (#1830)。
+	assert.Equal(t, true, page["isLiked"], "embedded page must carry isLiked=true")
 	shapetest.Assert(t, "Page", page) // L3 (#1324)
 }
 

--- a/internal/api/pages/handler.go
+++ b/internal/api/pages/handler.go
@@ -347,15 +347,9 @@ func (h *Handler) My(c echo.Context) error {
 	return c.JSON(http.StatusOK, h.pagesToList(rows, func(string) *model.User { return user }))
 }
 
-// FeaturedRequest is the request body for pages/featured.
-type FeaturedRequest struct {
-	Limit     int    `json:"limit"`
-	Offset    int    `json:"offset"`
-	SinceID   string `json:"sinceId"`
-	UntilID   string `json:"untilId"`
-	SinceDate *int64 `json:"sinceDate"`
-	UntilDate *int64 `json:"untilDate"`
-}
+// featuredPageLimit is the fixed page count pages/featured returns, matching
+// upstream's `.limit(10)` (featured.ts)。
+const featuredPageLimit = 10
 
 // Featured handles POST /api/pages/featured.
 //
@@ -363,13 +357,10 @@ type FeaturedRequest struct {
 // pagesToList に owner closure で渡す (#1134)。userSource が未配線の test 経路
 // では owner 取得不能なので空 list を返す (= silent fail-soft、501 にしない)。
 func (h *Handler) Featured(c echo.Context) error {
-	var req FeaturedRequest
-	if err := c.Bind(&req); err != nil {
-		return apierr.JSONInvalidParam(c)
-	}
-	// sinceDate / untilDate を aidx prefix に正規化 (#1166)。
-	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
-	rows, err := h.svc.Featured(sinceID, untilID, req.Limit, req.Offset)
+	// upstream pages/featured は paramDef 空。limit/offset/sinceId/untilId を一切
+	// 受け取らず、常に visibility=public かつ likedCount>0 の page を likedCount
+	// DESC で固定 10 件返す (#1830)。REST 経由で順序・件数を変えさせない。
+	rows, err := h.svc.Featured("", "", featuredPageLimit, 0)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/pages/handler_test.go
+++ b/internal/api/pages/handler_test.go
@@ -614,11 +614,41 @@ func TestFeatured_DropsRowsWithoutOwner(t *testing.T) {
 	assert.Empty(t, rows, "rows without owner must be dropped, not emitted with missing user field")
 }
 
-func TestFeatured_BadJSON(t *testing.T) {
+// TestFeatured_IgnoresBadJSON: upstream pages/featured は paramDef 空で body を
+// 読まないため、不正な JSON body でも 400 ではなく通常の featured 一覧を返す (#1830)。
+func TestFeatured_IgnoresBadJSON(t *testing.T) {
 	h, _, _ := newHandler(t)
 	c, rec := newReq(t, `{not`)
 	require.NoError(t, h.Featured(c))
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// featuredSpyRepo records the args ListFeatured was called with.
+type featuredSpyRepo struct {
+	*testutil.MockPageRepository
+	gotSince, gotUntil  string
+	gotLimit, gotOffset int
+}
+
+func (r *featuredSpyRepo) ListFeatured(since, until string, limit, offset int) ([]*model.Page, error) {
+	r.gotSince, r.gotUntil, r.gotLimit, r.gotOffset = since, until, limit, offset
+	return r.MockPageRepository.ListFeatured(since, until, limit, offset)
+}
+
+// TestFeatured_IgnoresRequestParams: limit/offset/sinceId/untilId を body で
+// 渡しても無視し、常に固定 10 件 / カーソル無しで問い合わせる (#1830)。
+func TestFeatured_IgnoresRequestParams(t *testing.T) {
+	repo := &featuredSpyRepo{MockPageRepository: testutil.NewMockPageRepository()}
+	idGen, _ := id.NewGenerator("aidx")
+	svc := corepage.NewService(repo, testutil.NewMockPageLikeRepository(), idGen)
+	h := NewHandler(svc, idGen)
+	c, rec := newReq(t, `{"limit":3,"offset":5,"sinceId":"aaa","untilId":"zzz"}`)
+	require.NoError(t, h.Featured(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "", repo.gotSince, "sinceId は無視される")
+	assert.Equal(t, "", repo.gotUntil, "untilId は無視される")
+	assert.Equal(t, 10, repo.gotLimit, "limit は固定 10")
+	assert.Equal(t, 0, repo.gotOffset, "offset は無視される")
 }
 
 // featuredFailRepo causes ListFeatured to fail.

--- a/internal/core/clip/clip_service.go
+++ b/internal/core/clip/clip_service.go
@@ -152,6 +152,18 @@ func (s *Service) Exists(clipID string) (bool, error) {
 	return true, nil
 }
 
+// Get returns a clip by ID WITHOUT a visibility gate. Used by
+// clips/my-favorites which mirrors upstream (favorite 行に紐づく clip を
+// visibility 無検査で全件返す: 公開 clip を favorite した後に所有者が非公開化
+// しても自分の favorites には残す、#1830)。可視性判定が必要な経路は Show を使う。
+func (s *Service) Get(clipID string) (*model.Clip, error) {
+	c, err := s.repo.FindByID(clipID)
+	if err != nil {
+		return nil, ErrClipNotFound
+	}
+	return c, nil
+}
+
 // UpdateInput holds the editable fields of a clip.
 type UpdateInput struct {
 	Name        *string

--- a/internal/core/clip/clip_service_test.go
+++ b/internal/core/clip/clip_service_test.go
@@ -110,6 +110,22 @@ func TestShow_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, clip.ErrClipNotFound)
 }
 
+// TestGet_RawNoVisibilityGate: Get は visibility gate 無しで raw に引く
+// (clips/my-favorites 用、#1830)。他人所有の非公開 clip も返す。
+func TestGet_RawNoVisibilityGate(t *testing.T) {
+	svc, repo, _, _ := newSvc(t)
+	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "owner", IsPublic: false, Name: "private"}
+	got, err := svc.Get("c1")
+	require.NoError(t, err)
+	assert.Equal(t, "private", got.Name)
+}
+
+func TestGet_NotFound(t *testing.T) {
+	svc, _, _, _ := newSvc(t)
+	_, err := svc.Get("missing")
+	assert.ErrorIs(t, err, clip.ErrClipNotFound)
+}
+
 func TestShow_PrivateHiddenFromOthers(t *testing.T) {
 	svc, repo, _, _ := newSvc(t)
 	repo.Clips["c1"] = &model.Clip{ID: "c1", UserID: "u1", IsPublic: false}


### PR DESCRIPTION
## Summary

`content-features` 領域 (再監査(2)) の 3 件の parity divergence を upstream に揃える (現コード再検証で 3 件とも LIVE)。

## F1 (MEDIUM): pages/featured を固定化
upstream `pages/featured.ts` は paramDef 空で、常に `visibility=public` + `likedCount>0` を `likedCount DESC` で**固定 10 件**返す。mk-go は `limit/offset/sinceId/untilId` を受理し既定 `limit=30`、cursor 指定で order を `id ASC/DESC` に切替えていた。
- handler が body を一切読まず `Featured("", "", 10, 0)` を呼ぶよう変更 (`FeaturedRequest` 削除)。REST 経由で順序・件数を変えさせない。bad JSON body は upstream 同様 400 でなく無視 (200)。isLiked-via-viewer (#1773) は不変。

## F2 (MEDIUM): clips/my-favorites を visibility 無検査に
upstream `clips/my-favorites.ts` は favorite に紐づく clip を**可視性無検査で全件**返す (公開時に favorite した他人所有 clip を所有者が後で非公開化しても自分の favorites には残る)。mk-go は fav ごとに `Show(viewer)` を呼び他人所有の非公開 clip を `ErrClipNotFound` で drop していた。
- 可視性 gate 無しの `clip.Service.Get` を新設し `MyFavorites` で使用 (clip 削除済み orphan favorite のみ drop)。`clipToMap` は純粋 packer で `notesCount` は owner のみ等 upstream `packMany` と同 field のみ露出。`ListByUser` は viewer scoped なので IDOR ではない。

## F3 (LOW): i/page-likes に isLiked
upstream は `packMany(likes, me)` で埋め込み page の `isLiked` を出す (自分の like 一覧なので常に true)。mk-go は `IsLiked` 無しで pack し omit していた。
- `PackPageContext.IsLiked` を立てて shape を揃える (likes は viewer scoped なので常に true)。

## テスト
- featured が params を無視し固定 10/cursor 無しで問い合わせる (spy repo)、bad JSON 無視。
- my-favorites が他人所有の非公開 favorited clip を返す + 削除済みのみ drop。
- page-likes の埋め込み page が `isLiked=true`。
- `clip.Service.Get` の raw 取得 (core/clip、100% cover)。
- `make fmt && make lint` clean、`go test ./...` 全 package green (0 failures)、影響 package 全て 90% 以上。
- 敵対的レビュー: **指摘なし**。F2 が IDOR でないこと (viewer scoped + upstream と同 field 露出)、F1/F3 の parity を確認。

Closes #1830

🤖 Generated with [Claude Code](https://claude.com/claude-code)