### PR TITLE
Fix drive parity (#1831): folders owner-mismatch を NO_SUCH_FOLDER に / usage の isLink filter / find の空文字受理

### DIFF
--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -401,7 +401,10 @@ type FilesFindByHashRequest struct {
 func (h *Handler) FilesFindByHash(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req FilesFindByHashRequest
-	if err := c.Bind(&req); err != nil || req.MD5 == "" {
+	// upstream find-by-hash の paramDef は md5 {type:'string'} で空文字も valid
+	// (required は presence のみ)。空 md5 は findBy で 0 件一致し 200 + [] を返す。
+	// INVALID_PARAM で弾かない (#1831)。
+	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
 	files, err := h.svc.FindByHash(user, req.MD5)
@@ -764,7 +767,9 @@ func (h *Handler) FilesFind(c echo.Context) error {
 		Name     string  `json:"name"`
 		FolderID *string `json:"folderId"`
 	}
-	if err := c.Bind(&req); err != nil || req.Name == "" {
+	// upstream files/find の paramDef は name {type:'string'} で空文字も valid。
+	// 空 name は findBy で 0 件一致し 200 + [] を返す (#1831)。
+	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
 	if h.fileRepo == nil {
@@ -1028,7 +1033,9 @@ func (h *Handler) FoldersFind(c echo.Context) error {
 		Name     string  `json:"name"`
 		ParentID *string `json:"parentId"`
 	}
-	if err := c.Bind(&req); err != nil || req.Name == "" {
+	// upstream folders/find の paramDef は name {type:'string'} で空文字も valid。
+	// 空 name は findBy で 0 件一致し 200 + [] を返す (#1831)。
+	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
 	if h.folderRepo == nil {

--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -501,12 +501,15 @@ func TestFilesFindByHash_Success(t *testing.T) {
 	assert.Nil(t, resp[0]["user"])
 }
 
-func TestFilesFindByHash_InvalidParam(t *testing.T) {
+// upstream find-by-hash は md5 {type:'string'} で空文字も valid。空 md5 は 0 件
+// 一致で 200 + [] を返す (INVALID_PARAM で弾かない、#1831)。
+func TestFilesFindByHash_EmptyMD5ReturnsEmpty(t *testing.T) {
 	h, _, _ := newHandler(t)
 	c, rec := newJSONReq(t, `{}`)
 	setUser(c, "u1")
 	require.NoError(t, h.FilesFindByHash(c))
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.JSONEq(t, `[]`, rec.Body.String())
 }
 
 func TestFilesFindByHash_NotFound(t *testing.T) {
@@ -567,14 +570,17 @@ func TestFoldersCreate_ParentNotFound(t *testing.T) {
 	assert.Equal(t, "53326628-a00d-40a6-a3cd-8975105c0f95", errObj["id"])
 }
 
-func TestFoldersCreate_AccessDenied(t *testing.T) {
+// 他人所有 parent は upstream folders/create 同様 NO_SUCH_FOLDER(404)、
+// ACCESS_DENIED(403) にしない (#1831)。
+func TestFoldersCreate_ParentOtherOwnerNotFound(t *testing.T) {
 	h, _, folderRepo := newHandler(t)
 	other := "other"
 	folderRepo.Folders["p"] = &model.DriveFolder{ID: "p", UserID: &other}
 	c, rec := newJSONReq(t, `{"name":"x","parentId":"p"}`)
 	setUser(c, "u1")
 	require.NoError(t, h.FoldersCreate(c))
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_FOLDER")
 }
 
 // failingFolderRepo causes Create to fail
@@ -674,14 +680,17 @@ func TestFoldersShow_NotFound(t *testing.T) {
 	assert.Equal(t, "d74ab9eb-bb09-4bba-bf24-fb58f761e1e9", errObj["id"])
 }
 
-func TestFoldersShow_AccessDenied(t *testing.T) {
+// 他人所有 folder は upstream folders/show 同様 NO_SUCH_FOLDER(404)、
+// ACCESS_DENIED(403) にしない (folder ID 存在 oracle 防止、#1831)。
+func TestFoldersShow_OtherOwnerNotFound(t *testing.T) {
 	h, _, folderRepo := newHandler(t)
 	other := "other"
 	folderRepo.Folders["p"] = &model.DriveFolder{ID: "p", UserID: &other}
 	c, rec := newJSONReq(t, `{"folderId":"p"}`)
 	setUser(c, "u1")
 	require.NoError(t, h.FoldersShow(c))
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_FOLDER")
 }
 
 // --- FoldersUpdate ---
@@ -869,12 +878,15 @@ func TestFilesFind_Success(t *testing.T) {
 	assert.Nil(t, resp[0]["user"])
 }
 
-func TestFilesFind_InvalidParam(t *testing.T) {
+// upstream files/find は name {type:'string'} で空文字も valid。空 name は 0 件
+// 一致で 200 + [] を返す (INVALID_PARAM で弾かない、#1831)。
+func TestFilesFind_EmptyNameReturnsEmpty(t *testing.T) {
 	h, _, _ := newHandlerWithRepos(t)
 	c, rec := newJSONReq(t, `{}`)
 	setUser(c, "u1")
 	require.NoError(t, h.FilesFind(c))
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.JSONEq(t, `[]`, rec.Body.String())
 }
 
 func TestFilesFind_NilRepo(t *testing.T) {
@@ -1162,12 +1174,15 @@ func TestFoldersFind_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
-func TestFoldersFind_InvalidParam(t *testing.T) {
+// upstream folders/find は name {type:'string'} で空文字も valid。空 name は
+// 0 件一致で 200 + [] を返す (INVALID_PARAM で弾かない、#1831)。
+func TestFoldersFind_EmptyNameReturnsEmpty(t *testing.T) {
 	h, _, _ := newHandlerWithRepos(t)
 	c, rec := newJSONReq(t, `{}`)
 	setUser(c, "u1")
 	require.NoError(t, h.FoldersFind(c))
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.JSONEq(t, `[]`, rec.Body.String())
 }
 
 func TestFoldersFind_NilRepo(t *testing.T) {

--- a/internal/core/drive/drive_service.go
+++ b/internal/core/drive/drive_service.go
@@ -792,8 +792,10 @@ func (s *Service) CreateFolder(user *model.User, name string, parentID *string) 
 		if err != nil {
 			return nil, ErrFolderNotFound
 		}
+		// upstream folders/create は parent を findOneBy({id, userId: me.id}) で
+		// 引き、他人所有 parent も「不在」として NO_SUCH_FOLDER を返す (#1831)。
 		if parent.UserID == nil || *parent.UserID != user.ID {
-			return nil, ErrAccessDenied
+			return nil, ErrFolderNotFound
 		}
 	}
 	userID := user.ID
@@ -821,8 +823,12 @@ func (s *Service) ShowFolder(user *model.User, id string) (*model.DriveFolder, e
 	if err != nil {
 		return nil, ErrFolderNotFound
 	}
+	// upstream folders/{show,update,delete} は findOneBy({id, userId: me.id}) で
+	// 他人所有 folder を「不在」と区別せず NO_SUCH_FOLDER(404) を返す。owner
+	// mismatch を ACCESS_DENIED(403) にすると folder ID 存在 oracle になる (mild
+	// IDOR)。ErrFolderNotFound に統一して 404 に揃える (#1831)。
 	if f.UserID == nil || *f.UserID != user.ID {
-		return nil, ErrAccessDenied
+		return nil, ErrFolderNotFound
 	}
 	return f, nil
 }
@@ -857,8 +863,11 @@ func (s *Service) UpdateFolder(user *model.User, id string, in UpdateFolderInput
 				// ErrFolderNotFound と区別する。
 				return nil, ErrParentFolderNotFound
 			}
+			// upstream folders/update は parent を findOneBy({id, userId: me.id})
+			// で引き、他人所有 parent も「不在」として NO_SUCH_PARENT_FOLDER を
+			// 返す (#1831、update.ts の noSuchParentFolder)。
 			if parent.UserID == nil || *parent.UserID != user.ID {
-				return nil, ErrAccessDenied
+				return nil, ErrParentFolderNotFound
 			}
 			// upstream checkCircle: 新 parent の祖先 chain に folder 自身が
 			// いたら循環 (#1564)。mk-go は過去に循環を作れてしまっていたため、

--- a/internal/core/drive/drive_service_test.go
+++ b/internal/core/drive/drive_service_test.go
@@ -746,13 +746,15 @@ func TestCreateFolder_ParentNotFound(t *testing.T) {
 	require.ErrorIs(t, err, drive.ErrFolderNotFound)
 }
 
-func TestCreateFolder_ParentAccessDenied(t *testing.T) {
+// 他人所有 parent は upstream folders/create 同様「不在」扱いで
+// ErrFolderNotFound (=> NO_SUCH_FOLDER)、ACCESS_DENIED にしない (#1831)。
+func TestCreateFolder_ParentOtherOwnerNotFound(t *testing.T) {
 	svc, _, folderRepo := newSvc(t)
 	other := "other"
 	folderRepo.Folders["p"] = &model.DriveFolder{ID: "p", UserID: &other}
 	pid := "p"
 	_, err := svc.CreateFolder(&model.User{ID: "u1"}, "x", &pid)
-	require.ErrorIs(t, err, drive.ErrAccessDenied)
+	require.ErrorIs(t, err, drive.ErrFolderNotFound)
 }
 
 // failingCreateFolderRepo causes Create to fail.
@@ -785,12 +787,15 @@ func TestShowFolder_NotFound(t *testing.T) {
 	require.ErrorIs(t, err, drive.ErrFolderNotFound)
 }
 
-func TestShowFolder_AccessDenied(t *testing.T) {
+// 他人所有 folder は upstream folders/{show,update,delete} 同様「不在」扱いで
+// ErrFolderNotFound (=> 404 NO_SUCH_FOLDER)。owner mismatch を 403 にすると
+// folder ID 存在 oracle になる (#1831)。
+func TestShowFolder_OtherOwnerNotFound(t *testing.T) {
 	svc, _, folderRepo := newSvc(t)
 	other := "other"
 	folderRepo.Folders["p"] = &model.DriveFolder{ID: "p", UserID: &other}
 	_, err := svc.ShowFolder(&model.User{ID: "u1"}, "p")
-	require.ErrorIs(t, err, drive.ErrAccessDenied)
+	require.ErrorIs(t, err, drive.ErrFolderNotFound)
 }
 
 func TestUpdateFolder_HappyPath(t *testing.T) {
@@ -821,7 +826,10 @@ func TestUpdateFolder_ParentNotFound(t *testing.T) {
 	require.ErrorIs(t, err, drive.ErrParentFolderNotFound)
 }
 
-func TestUpdateFolder_ParentAccessDenied(t *testing.T) {
+// 他人所有 parent は upstream folders/update 同様「不在」扱いで
+// ErrParentFolderNotFound (=> NO_SUCH_PARENT_FOLDER)、ACCESS_DENIED にしない
+// (#1831、update.ts は parent を findOneBy({id,userId}) で引き noSuchParentFolder)。
+func TestUpdateFolder_ParentOtherOwnerNotFound(t *testing.T) {
 	svc, _, folderRepo := newSvc(t)
 	uid := "u1"
 	other := "other"
@@ -830,7 +838,7 @@ func TestUpdateFolder_ParentAccessDenied(t *testing.T) {
 	pid := "p"
 	pidPtr := &pid
 	_, err := svc.UpdateFolder(&model.User{ID: "u1"}, "c", drive.UpdateFolderInput{ParentID: &pidPtr})
-	require.ErrorIs(t, err, drive.ErrAccessDenied)
+	require.ErrorIs(t, err, drive.ErrParentFolderNotFound)
 }
 
 func TestUpdateFolder_NullParent(t *testing.T) {

--- a/internal/repository/drive_file.go
+++ b/internal/repository/drive_file.go
@@ -335,7 +335,13 @@ func (r *driveFileRepository) ListByFileIDs(fileIDs []string) ([]*model.DriveFil
 
 func (r *driveFileRepository) UsageByUser(userID string) (int64, error) {
 	var total int64
-	if err := r.db.Model(&model.DriveFile{}).Where(`"userId" = ?`, userID).Select("COALESCE(SUM(size), 0)").Scan(&total).Error; err != nil {
+	// upstream calcDriveUsageOf は isLink=FALSE の行のみ SUM(size) する
+	// (link = リモート/プロキシ file は実体を保持しないため usage に含めない、
+	// #1831)。これが無いと link 行を持つ user の usage が本家より大きく出る。
+	if err := r.db.Model(&model.DriveFile{}).
+		Where(`"userId" = ?`, userID).
+		Where(`"isLink" = ?`, false).
+		Select("COALESCE(SUM(size), 0)").Scan(&total).Error; err != nil {
 		return 0, err
 	}
 	return total, nil

--- a/internal/repository/drive_file_test.go
+++ b/internal/repository/drive_file_test.go
@@ -754,6 +754,29 @@ func TestDriveFileRepository_UsageByUser(t *testing.T) {
 	assert.Equal(t, int64(0), total)
 }
 
+// TestDriveFileRepository_UsageByUser_ExcludesLink: upstream calcDriveUsageOf は
+// isLink=FALSE の行のみ SUM(size) する。link (リモート/プロキシ) file の size は
+// usage に含めない (#1831)。
+func TestDriveFileRepository_UsageByUser_ExcludesLink(t *testing.T) {
+	repo := NewDriveFileRepository(testDB)
+	seedUser(t, "df_link_u1")
+
+	own := newTestDriveFile("df_link_own", "df_link_u1", "own", nil)
+	own.Size = 100
+	require.NoError(t, repo.Create(own))
+	t.Cleanup(func() { cleanupDriveFile(t, own.ID) })
+
+	link := newTestDriveFile("df_link_remote", "df_link_u1", "remote", nil)
+	link.Size = 999
+	link.IsLink = true
+	require.NoError(t, repo.Create(link))
+	t.Cleanup(func() { cleanupDriveFile(t, link.ID) })
+
+	total, err := repo.UsageByUser("df_link_u1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(100), total, "link file の size は usage に含めない")
+}
+
 func TestDriveFileRepository_UpdateBulkFolder(t *testing.T) {
 	repo := NewDriveFileRepository(testDB)
 	seedUser(t, "df_bulk_u1")

--- a/internal/testutil/mock_drive.go
+++ b/internal/testutil/mock_drive.go
@@ -178,6 +178,10 @@ func (m *MockDriveFileRepository) ListByFileIDs(ids []string) ([]*model.DriveFil
 func (m *MockDriveFileRepository) UsageByUser(userID string) (int64, error) {
 	var total int64
 	for _, f := range m.Files {
+		// 本番 repo 同様 isLink=false の行のみ合算する (#1831)。
+		if f.IsLink {
+			continue
+		}
 		if f.UserID != nil && *f.UserID == userID {
 			total += int64(f.Size)
 		}


### PR DESCRIPTION
## Summary

`drive` 領域 (再監査(2)) の 3 件の parity divergence を upstream に揃える (現コード再検証で 3 件とも LIVE)。

## F1 (MEDIUM): folders の owner-mismatch を NO_SUCH_FOLDER に
upstream `drive/folders/{show,update,delete,create}` は `findOneBy({id, userId: me.id})` で他人所有 folder を「不在」と区別せず **NO_SUCH_FOLDER(404)** を返す。mk-go は owner mismatch で `ErrAccessDenied` → **ACCESS_DENIED(403)** を返しており、folder ID の存在 oracle (mild IDOR) になっていた。
- `ShowFolder` / `CreateFolder` parent の owner mismatch → `ErrFolderNotFound` (create.ts は noSuchFolder)。
- `UpdateFolder` parent の owner mismatch → `ErrParentFolderNotFound` (update.ts は parent を `findOneBy({id,userId})` で引き noSuchParentFolder)。
- `UpdateFolder`/`DeleteFolder` は target を `ShowFolder` 経由で引くため fix を継承。
- **drive/files 系は upstream も ACCESS_DENIED を定義するため不変**。

## F2 (LOW): drive usage の isLink filter
`UsageByUser` に `isLink = false` filter を追加。upstream `calcDriveUsageOf` は link (リモート/プロキシ) file の size を usage に含めない。mock も同様に link を除外して production と揃える。

## F3 (LOW): find の空文字受理
`drive/files/find`・`folders/find`・`files/find-by-hash` が空文字 name/md5 を `INVALID_PARAM(400)` で弾いていたのを廃止。upstream paramDef は `{type:'string'}` で空文字も valid、`findBy` で 0 件一致し **200 + []**。repo の find は値を常に WHERE に bind するため空文字でも全件 dump にはならない (レビューで確認)。

## テスト
- folder others'-owner が 404 NO_SUCH_FOLDER になること (service + handler)、usage が link file を除外すること (real DB)、find の空文字が 200 [] を返すことを pin。旧 ACCESS_DENIED / INVALID_PARAM を期待していた test を更新。
- `make fmt && make lint` clean、`go test ./...` 全 package green (0 failures)、影響 package 全て 90% 以上。
- 敵対的レビュー: BLOCKER/MAJOR なし。F1 が全 folder-endpoint site を網羅し file site を変えていないこと、IDOR oracle が閉じたこと、F3 が全件 dump にならないことを確認。

## 備考 / follow-up
- レビューで `drive/files/{update,create}` の**宛先 folder** owner-mismatch も同じ oracle (ACCESS_DENIED) が残ると判明 → 別 issue **#1908** に分離 (本 PR は #1831 が scope した folders 系のみ)。

Closes #1831

🤖 Generated with [Claude Code](https://claude.com/claude-code)