### PR TITLE
Fix drive parity (#1908): drive/files/{update,create} の宛先 folder owner-mismatch を NO_SUCH_FOLDER に

### DIFF
--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -178,14 +178,17 @@ func TestFilesCreate_FolderNotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
-func TestFilesCreate_FolderAccessDenied(t *testing.T) {
+// 他人所有の宛先 folder は NO_SUCH_FOLDER(404) で返す (missing と同じ response、
+// folder 存在 oracle を閉じる、#1908)。
+func TestFilesCreate_OtherOwnerFolderNotFound(t *testing.T) {
 	h, _, folderRepo := newHandler(t)
 	other := "other"
 	folderRepo.Folders["fid"] = &model.DriveFolder{ID: "fid", UserID: &other}
 	c, rec := newMultipartReq(t, "hello.txt", "hello", map[string]string{"folderId": "fid"})
 	setUser(c, "u1")
 	require.NoError(t, h.FilesCreate(c))
-	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_FOLDER")
 }
 
 // failingFileRepo causes Create to fail.
@@ -427,6 +430,22 @@ func TestFilesUpdate_FolderNotFound(t *testing.T) {
 	setUser(c, "u1")
 	require.NoError(t, h.FilesUpdate(c))
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// 他人所有の宛先 folder は missing と同じ NO_SUCH_FOLDER(404) を返す (upstream
+// files/update の NoSuchFolderError ea8fb7a5、folder 存在 oracle を閉じる、#1908)。
+func TestFilesUpdate_OtherOwnerFolderNotFound(t *testing.T) {
+	h, fileRepo, folderRepo := newHandler(t)
+	uid := "u1"
+	other := "other"
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &uid}
+	folderRepo.Folders["fid"] = &model.DriveFolder{ID: "fid", UserID: &other}
+	c, rec := newJSONReq(t, `{"fileId":"f1","folderId":"fid"}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesUpdate(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_FOLDER")
+	assert.Contains(t, rec.Body.String(), "ea8fb7a5-af77-4a08-b608-c0218176cd73")
 }
 
 // failingUpdateFileRepo causes Update to fail with non-mapped error.

--- a/internal/core/drive/drive_service.go
+++ b/internal/core/drive/drive_service.go
@@ -321,14 +321,18 @@ func (s *Service) Upload(ctx context.Context, in UploadInput) (*model.DriveFile,
 		}
 	}
 
-	// folderの所有権チェック (system file は folder を持たない前提なので skip)
+	// 宛先 folder の所有権チェック (system file は folder を持たない前提なので skip)。
+	// 他人所有 folder も「不在」として ErrFolderNotFound に統一する: missing と
+	// others' で response が変わると folder 存在 oracle になる。upstream addFile は
+	// 両者とも folder-not-found error (→ 500) で区別しない。mk-go は missing を
+	// 既に NO_SUCH_FOLDER(404) で返すため others' も揃えて oracle を閉じる (#1908)。
 	if in.User != nil && in.FolderID != nil {
 		folder, err := s.folderRepo.FindByID(*in.FolderID)
 		if err != nil {
 			return nil, ErrFolderNotFound
 		}
 		if folder.UserID == nil || *folder.UserID != in.User.ID {
-			return nil, ErrAccessDenied
+			return nil, ErrFolderNotFound
 		}
 	}
 
@@ -671,14 +675,17 @@ func (s *Service) Update(user *model.User, id string, in UpdateInput) (*model.Dr
 		fields["comment"] = *in.Comment
 	}
 	if in.FolderID != nil {
-		// folderの所有権チェック
+		// 宛先 folder の所有権チェック。upstream files/update は宛先 folder を
+		// findOneBy({id, userId}) で引き、他人所有も「不在」として
+		// NoSuchFolderError(ea8fb7a5) を返す。owner mismatch を ACCESS_DENIED に
+		// すると folder 存在 oracle になるため ErrFolderNotFound に統一する (#1908)。
 		if *in.FolderID != nil {
 			folder, err := s.folderRepo.FindByID(**in.FolderID)
 			if err != nil {
 				return nil, ErrFolderNotFound
 			}
 			if folder.UserID == nil || *folder.UserID != user.ID {
-				return nil, ErrAccessDenied
+				return nil, ErrFolderNotFound
 			}
 		}
 		fields["folderId"] = *in.FolderID

--- a/internal/core/drive/drive_service_test.go
+++ b/internal/core/drive/drive_service_test.go
@@ -137,13 +137,15 @@ func TestUpload_FolderNotFound(t *testing.T) {
 	require.ErrorIs(t, err, drive.ErrFolderNotFound)
 }
 
-func TestUpload_FolderAccessDenied(t *testing.T) {
+// 他人所有の宛先 folder は「不在」扱いで ErrFolderNotFound、ACCESS_DENIED に
+// しない (folder 存在 oracle を閉じる、#1908)。
+func TestUpload_OtherOwnerFolderNotFound(t *testing.T) {
 	svc, _, folderRepo := newSvc(t)
 	other := "other"
 	folderRepo.Folders["fid"] = &model.DriveFolder{ID: "fid", UserID: &other}
 	folderID := "fid"
 	_, err := svc.Upload(context.Background(), drive.UploadInput{User: &model.User{ID: "u1"}, Body: []byte("x"), FolderID: &folderID})
-	require.ErrorIs(t, err, drive.ErrAccessDenied)
+	require.ErrorIs(t, err, drive.ErrFolderNotFound)
 }
 
 // failingFileRepo causes Create to fail.
@@ -649,7 +651,9 @@ func TestUpdate_FolderNotFound(t *testing.T) {
 	require.ErrorIs(t, err, drive.ErrFolderNotFound)
 }
 
-func TestUpdate_FolderAccessDenied(t *testing.T) {
+// 他人所有の宛先 folder は upstream files/update 同様「不在」扱いで
+// ErrFolderNotFound (→ NO_SUCH_FOLDER ea8fb7a5)、ACCESS_DENIED にしない (#1908)。
+func TestUpdate_OtherOwnerFolderNotFound(t *testing.T) {
 	svc, fileRepo, folderRepo := newSvc(t)
 	uid := "u1"
 	other := "other"
@@ -659,7 +663,7 @@ func TestUpdate_FolderAccessDenied(t *testing.T) {
 	folderID := "fid"
 	folderPtr := &folderID
 	_, err := svc.Update(&model.User{ID: "u1"}, "f1", drive.UpdateInput{FolderID: &folderPtr})
-	require.ErrorIs(t, err, drive.ErrAccessDenied)
+	require.ErrorIs(t, err, drive.ErrFolderNotFound)
 }
 
 func TestUpdate_FolderNullable(t *testing.T) {


### PR DESCRIPTION
## Summary

`#1831` (folder endpoint の owner-mismatch → NO_SUCH_FOLDER 化) の敵対的レビューで確認した隣接 divergence。`drive/files` の**宛先 folder** owner-mismatch が ACCESS_DENIED のまま残り、missing(404 NO_SUCH_FOLDER) と他人所有(403 ACCESS_DENIED) を判別できる folder 存在 oracle (mild IDOR) になっていた。

## 修正 (`internal/core/drive/drive_service.go`)
- **files/update** (`Update`): 宛先 folder owner-mismatch を `ErrFolderNotFound` に。`mapFileError(fileEndpointUpdate)` が NO_SUCH_FOLDER (`ea8fb7a5`) にマップ。upstream `files/update.ts` は宛先 folder を `findOneBy({id, userId})` で引き他人所有も `NoSuchFolderError` を返すため **true parity**。
- **files/create** (`Upload`): 宛先 folder owner-mismatch を `ErrFolderNotFound` に。upstream `addFile` は missing/others' 両方を generic Error(→500)で区別しないが、mk-go は既に missing を NO_SUCH_FOLDER(404) で返すため others' も揃えて oracle を閉じる(upstream の 500 より clean な意図的 divergence)。

file 自身の ownership check (`authorizeFileRead` / `findOwnedFile`) は upstream 同様 **ACCESS_DENIED のまま不変**。

## テスト
- Upload/Update の他人所有 folder が `ErrFolderNotFound` (service)、FilesCreate/FilesUpdate が 404 NO_SUCH_FOLDER (handler、update は `ea8fb7a5` UUID まで) を返すこと、missing と others' で同一 response になることを pin。旧 ACCESS_DENIED 期待 test を更新。
- `make fmt && make lint` clean、`go test ./...` 全 package green (0 failures)。
- 敵対的レビュー: **指摘なし**。oracle が両 endpoint で閉じたこと (missing==others')、file ownership check が ACCESS_DENIED のまま保たれること、UUID が upstream 一致を確認。

Closes #1908

🤖 Generated with [Claude Code](https://claude.com/claude-code)