### PR TITLE
Fix following-relations parity (#1911): following/requests/{reject,accept} の error code を upstream に整合

### DIFF
--- a/internal/api/following/handler.go
+++ b/internal/api/following/handler.go
@@ -134,6 +134,12 @@ func (h *Handler) AcceptRequest(c echo.Context) error {
 		return apierr.JSONInvalidParam(c)
 	}
 
+	// upstream accept.ts は getUser を先に呼び、userId が無効なら NO_SUCH_USER
+	// (id 66ce1645) を返す。request 不在は別 error NO_FOLLOW_REQUEST (bcde4f8b)
+	// で区別する (#1911)。
+	if _, err := h.userService.ShowByID(req.UserID); err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "66ce1645-d66c-46bb-8b79-96739af885bd"))
+	}
 	if err := h.followingService.AcceptRequest(me.ID, req.UserID); err != nil {
 		if errors.Is(err, corefollowing.ErrRequestNotFound) {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_FOLLOW_REQUEST", "No such follow request.", "bcde4f8b-0913-4614-8881-614e522fb041"))
@@ -152,9 +158,16 @@ func (h *Handler) RejectRequest(c echo.Context) error {
 		return apierr.JSONInvalidParam(c)
 	}
 
+	// upstream reject.ts は getUser を先に呼び、userId が無効なら NO_SUCH_USER
+	// (id abc2ffa6) を返す。reject.ts に NO_FOLLOW_REQUEST 系 error は無い (#1911)。
+	if _, err := h.userService.ShowByID(req.UserID); err != nil {
+		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "abc2ffa6-25b2-4380-ba99-321ff3a94555"))
+	}
+	// request 不在は upstream removeFollowRequest が silent return するため成功
+	// 扱い (204 No Content)。404 にしない (#1911)。
 	if err := h.followingService.RejectRequest(me.ID, req.UserID); err != nil {
 		if errors.Is(err, corefollowing.ErrRequestNotFound) {
-			return c.JSON(http.StatusNotFound, apierr.Error("NO_FOLLOW_REQUEST", "No such follow request.", "abc2ffa6-25b2-4380-ba99-321ff3a94555"))
+			return c.NoContent(http.StatusNoContent)
 		}
 		return apierr.JSONInternalError(c)
 	}

--- a/internal/api/following/handler_test.go
+++ b/internal/api/following/handler_test.go
@@ -363,12 +363,27 @@ func TestRequests_AcceptRejectCancel(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
-func TestAcceptRequest_NotFound(t *testing.T) {
+// alice が存在しない → upstream accept.ts は getUser 先行で NO_SUCH_USER (66ce1645)。
+func TestAcceptRequest_NoSuchUser(t *testing.T) {
 	h, repo := newTestHandler(t)
 	bob := addUser(repo, "bob", false)
 
 	rec := postJSON(h.AcceptRequest, `{"userId": "alice"}`, bob)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_USER")
+	assert.Contains(t, rec.Body.String(), "66ce1645-d66c-46bb-8b79-96739af885bd")
+}
+
+// alice は存在するが pending request 無し → NO_FOLLOW_REQUEST (bcde4f8b)。
+func TestAcceptRequest_NoFollowRequest(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addUser(repo, "alice", false)
+	bob := addUser(repo, "bob", false)
+
+	rec := postJSON(h.AcceptRequest, `{"userId": "alice"}`, bob)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_FOLLOW_REQUEST")
+	assert.Contains(t, rec.Body.String(), "bcde4f8b-0913-4614-8881-614e522fb041")
 }
 
 func TestAcceptRequest_InvalidParam(t *testing.T) {
@@ -389,12 +404,26 @@ func TestRejectRequest_Success(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
-func TestRejectRequest_NotFound(t *testing.T) {
+// alice が存在しない → upstream reject.ts は getUser 先行で NO_SUCH_USER (abc2ffa6)。
+func TestRejectRequest_NoSuchUser(t *testing.T) {
 	h, repo := newTestHandler(t)
 	bob := addUser(repo, "bob", false)
 
 	rec := postJSON(h.RejectRequest, `{"userId": "alice"}`, bob)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_USER")
+	assert.Contains(t, rec.Body.String(), "abc2ffa6-25b2-4380-ba99-321ff3a94555")
+}
+
+// alice は存在するが pending request 無し → upstream removeFollowRequest は silent
+// return なので 204 No Content (NO_FOLLOW_REQUEST 系 error は reject.ts に無い、#1911)。
+func TestRejectRequest_NoRequestSilent204(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addUser(repo, "alice", false)
+	bob := addUser(repo, "bob", false)
+
+	rec := postJSON(h.RejectRequest, `{"userId": "alice"}`, bob)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
 func TestRejectRequest_InvalidParam(t *testing.T) {


### PR DESCRIPTION
## Summary

`#1832` (following-relations) の sub-issue (F1 MEDIUM + F3 LOW、error_code)。`following/requests/{reject,accept}` の error code/flow を upstream に揃える。

## 問題
upstream `reject.ts` / `accept.ts` は `getterService.getUser` を先に呼び、userId が無効なら NO_SUCH_USER を返す。mk-go は user 解決を省いて service の `ErrRequestNotFound` のみを 404 に変換しており、**不在 userId でも NO_SUCH_USER でなく NO_FOLLOW_REQUEST** を返していた (id 対応も崩れていた)。

## 修正 (`internal/api/following/handler.go`)
- **reject**: user を `ShowByID` で先に解決し、無効なら NO_SUCH_USER (id `abc2ffa6`)。request 不在は upstream `removeFollowRequest` が silent return するため 404 でなく **204 No Content** (reject.ts に NO_FOLLOW_REQUEST 系 error は無い)。
- **accept**: 同様に user を先に解決し無効なら NO_SUCH_USER (id `66ce1645`)。request 不在は NO_FOLLOW_REQUEST (id `bcde4f8b`、本家一致) を維持。

## テスト
- reject/accept とも (1) 不在 user → NO_SUCH_USER + 各 UUID、(2) 既存 user で request 無し → reject は 204 / accept は NO_FOLLOW_REQUEST(bcde4f8b)、を pin。旧 NO_FOLLOW_REQUEST-for-reject を期待する test は除去。
- `make fmt && make lint` clean、`go test ./...` 全 package green (0 failures)、following package 93.9% cover。
- 敵対的レビュー: BLOCKER/MAJOR なし。UUID/code が upstream exact 一致、getUser-first ordering、204 semantics、internal-error 非 mask を確認。

Closes #1911

🤖 Generated with [Claude Code](https://claude.com/claude-code)