### PR TITLE
Fix following-relations parity (#1912): following/list・mute/list・renote-mute/list の埋め込み user に viewer-relation flag を付与

### DIFF
--- a/internal/api/following/handler.go
+++ b/internal/api/following/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
+	"github.com/shiroha-a/mk/internal/api/userrelation"
 	corefollowing "github.com/shiroha-a/mk/internal/core/following"
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
 	"github.com/shiroha-a/mk/internal/entity"
@@ -23,6 +24,16 @@ type Handler struct {
 	// idGen は /api/following/list の Following.createdAt 生成で使う。nil
 	// なら createdAt は空文字列で返す (= 互換性は維持しつつ degrade)。
 	idGen id.Generator
+	// relation は following/list の埋め込み followee に viewer-relation flag
+	// (isFollowing 等) を付与するための repo 束 (#1912)。未配線なら flag は omit
+	// (= legacy 挙動)。upstream は followee を UserDetailedNotMe + me で pack する。
+	relation userrelation.Repos
+}
+
+// SetRelationRepos wires the repositories used to populate viewer-relation flags
+// on the embedded followee in following/list (#1912)。
+func (h *Handler) SetRelationRepos(r userrelation.Repos) {
+	h.relation = r
 }
 
 // NewHandler creates a new following Handler.
@@ -262,7 +273,16 @@ func (h *Handler) List(c echo.Context) error {
 
 	out := make([]entity.Following, 0, len(rows))
 	for _, r := range rows {
-		out = append(out, entity.PackFollowing(r, true, false, lookup, h.idGen))
+		packed := entity.PackFollowing(r, true, false, lookup, h.idGen)
+		// 埋め込み followee に viewer-relation flag を付与する (#1912)。upstream は
+		// followee を UserDetailedNotMe + me で pack し isFollowing 等を出す。これは
+		// 自分の following 一覧なので isFollowing=true が出る。
+		if packed.Followee != nil {
+			if b, ok := userIdx[r.FolloweeID]; ok {
+				h.relation.Apply(packed.Followee, me.ID, b.User, b.Profile)
+			}
+		}
+		out = append(out, packed)
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/following/handler_test.go
+++ b/internal/api/following/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/userrelation"
 	corefollowing "github.com/shiroha-a/mk/internal/core/following"
 	coreuser "github.com/shiroha-a/mk/internal/core/user"
 	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
@@ -341,6 +342,45 @@ func TestDelete_InvalidParam(t *testing.T) {
 
 	rec := postJSON(h.Delete, `{}`, alice)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// TestList_EmbedsRelationFlags: following/list の埋め込み followee に
+// viewer-relation flag が付与される (#1912)。自分の following 一覧なので
+// isFollowing=true、block/mute 系は false で present。
+func TestList_EmbedsRelationFlags(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	fRepo := testutil.NewMockFollowingRepository()
+	frRepo := testutil.NewMockFollowRequestRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	fSvc := corefollowing.NewService(userRepo, fRepo, frRepo, idGen)
+	uSvc := coreuser.NewService(userRepo, nil, nil, nil)
+	h := NewHandler(fSvc, uSvc)
+	h.SetIDGen(idGen)
+	h.SetRelationRepos(userrelation.Repos{
+		Following:     fRepo,
+		Blocking:      testutil.NewMockBlockingRepository(),
+		Muting:        testutil.NewMockMutingRepository(),
+		RenoteMuting:  testutil.NewMockRenoteMutingRepository(),
+		FollowRequest: frRepo,
+	})
+
+	addUser(userRepo, "alice", false)
+	bob := addUser(userRepo, "bob", false)
+	// bob -> alice (alice not locked → 即 follow)。
+	require.Equal(t, http.StatusOK, postJSON(h.Create, `{"userId":"alice"}`, bob).Code)
+
+	rec := postJSON(h.List, `{}`, bob)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	followee, ok := out[0]["followee"].(map[string]any)
+	require.True(t, ok, "following row must embed followee")
+	assert.Equal(t, true, followee["isFollowing"], "following 一覧の followee は isFollowing=true")
+	// UserDetailedNotMe の relation block は block/mute flag も present (false)。
+	assert.Equal(t, false, followee["isMuted"])
+	assert.Equal(t, false, followee["isBlocking"])
+	assert.Equal(t, false, followee["hasPendingFollowRequestFromYou"])
 }
 
 func TestRequests_AcceptRejectCancel(t *testing.T) {

--- a/internal/api/mute/handler.go
+++ b/internal/api/mute/handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
+	"github.com/shiroha-a/mk/internal/api/userrelation"
 	coremuting "github.com/shiroha-a/mk/internal/core/muting"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -23,6 +24,15 @@ type Handler struct {
 	svc      *coremuting.Service
 	userRepo repository.UserRepository
 	idGen    id.Generator
+	// relation は mute/list の埋め込み mutee に viewer-relation flag (isMuted 等)
+	// を付与する repo 束 (#1912)。未配線なら flag は omit (= legacy 挙動)。
+	relation userrelation.Repos
+}
+
+// SetRelationRepos wires the repositories used to populate viewer-relation flags
+// on the embedded mutee in mute/list (#1912)。
+func (h *Handler) SetRelationRepos(r userrelation.Repos) {
+	h.relation = r
 }
 
 // NewHandler creates a new mute Handler.
@@ -124,7 +134,7 @@ func (h *Handler) List(c echo.Context) error {
 	// MkUserCardMini を描画する。userRepo が wire されていない場合は
 	// muteeId だけ返してフォールバック (legacy test)。本番ルートでは
 	// 必ず wire されるので batch fetch で N+1 を回避する。
-	muteeMap := h.fetchMuteeMap(rows)
+	muteeMap := h.fetchMuteeMap(user.ID, rows)
 	const tsFormat = "2006-01-02T15:04:05.000Z"
 	out := make([]map[string]any, 0, len(rows))
 	for _, m := range rows {
@@ -154,7 +164,7 @@ func (h *Handler) List(c echo.Context) error {
 
 // fetchMuteeMap batches user + profile lookups for the muteeIds in rows so
 // the response build loop performs zero per-row DB queries.
-func (h *Handler) fetchMuteeMap(rows []*model.Muting) map[string]entity.UserDetailed {
+func (h *Handler) fetchMuteeMap(viewerID string, rows []*model.Muting) map[string]entity.UserDetailed {
 	if h.userRepo == nil || len(rows) == 0 {
 		return nil
 	}
@@ -181,7 +191,10 @@ func (h *Handler) fetchMuteeMap(rows []*model.Muting) map[string]entity.UserDeta
 	}
 	out := make(map[string]entity.UserDetailed, len(users))
 	for _, u := range users {
-		out[u.ID] = entity.PackUserDetailed(u, profileByUser[u.ID], h.idGen)
+		d := entity.PackUserDetailed(u, profileByUser[u.ID], h.idGen)
+		// viewer-relation flag を付与 (#1912)。mute 一覧なので isMuted=true が出る。
+		h.relation.Apply(&d, viewerID, u, profileByUser[u.ID])
+		out[u.ID] = d
 	}
 	return out
 }

--- a/internal/api/mute/handler_test.go
+++ b/internal/api/mute/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/userrelation"
 	coremuting "github.com/shiroha-a/mk/internal/core/muting"
 	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -215,6 +216,41 @@ func TestList_OK(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	require.Len(t, resp, 1)
 	shapetest.Assert(t, "Muting", resp[0]) // L3 (#1286)
+}
+
+// TestList_EmbedsRelationFlags: mute/list の埋め込み mutee に viewer-relation
+// flag が付与される (#1912)。mute 一覧なので isMuted=true。
+func TestList_EmbedsRelationFlags(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	mutingRepo := testutil.NewMockMutingRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := coremuting.NewService(userRepo, mutingRepo, idGen)
+	h := NewHandler(svc, userRepo, idGen)
+	h.SetRelationRepos(userrelation.Repos{
+		Following:     testutil.NewMockFollowingRepository(),
+		Blocking:      testutil.NewMockBlockingRepository(),
+		Muting:        mutingRepo,
+		RenoteMuting:  testutil.NewMockRenoteMutingRepository(),
+		FollowRequest: testutil.NewMockFollowRequestRepository(),
+	})
+	addUser(userRepo, "alice")
+	addUser(userRepo, "bob")
+	c1, _ := newReq(t, `{"userId":"bob"}`)
+	setUser(c1, "alice")
+	require.NoError(t, h.Create(c1))
+
+	c, rec := newReq(t, `{}`)
+	setUser(c, "alice")
+	require.NoError(t, h.List(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	mutee, ok := resp[0]["mutee"].(map[string]any)
+	require.True(t, ok, "muting row must embed mutee")
+	assert.Equal(t, true, mutee["isMuted"], "mute 一覧の mutee は isMuted=true")
+	assert.Equal(t, false, mutee["isFollowing"])
+	assert.Equal(t, false, mutee["isBlocking"])
 }
 
 func TestList_LimitClamping(t *testing.T) {

--- a/internal/api/renotemute/handler.go
+++ b/internal/api/renotemute/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
+	"github.com/shiroha-a/mk/internal/api/userrelation"
 	coremuting "github.com/shiroha-a/mk/internal/core/muting"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -22,6 +23,15 @@ type Handler struct {
 	svc      *coremuting.RenoteService
 	userRepo repository.UserRepository
 	idGen    id.Generator
+	// relation は renote-mute/list の埋め込み mutee に viewer-relation flag
+	// (isRenoteMuted 等) を付与する repo 束 (#1912)。未配線なら flag は omit。
+	relation userrelation.Repos
+}
+
+// SetRelationRepos wires the repositories used to populate viewer-relation flags
+// on the embedded mutee in renote-mute/list (#1912)。
+func (h *Handler) SetRelationRepos(r userrelation.Repos) {
+	h.relation = r
 }
 
 // NewHandler creates a new Handler.
@@ -103,7 +113,7 @@ func (h *Handler) List(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	muteeMap := h.fetchMuteeMap(rows)
+	muteeMap := h.fetchMuteeMap(user.ID, rows)
 	const tsFormat = "2006-01-02T15:04:05.000Z"
 	out := make([]map[string]any, 0, len(rows))
 	for _, m := range rows {
@@ -128,7 +138,7 @@ func (h *Handler) List(c echo.Context) error {
 
 // fetchMuteeMap batches user + profile lookups for the muteeIds in rows so
 // the response build loop performs zero per-row DB queries.
-func (h *Handler) fetchMuteeMap(rows []*model.RenoteMuting) map[string]entity.UserDetailed {
+func (h *Handler) fetchMuteeMap(viewerID string, rows []*model.RenoteMuting) map[string]entity.UserDetailed {
 	if h.userRepo == nil || len(rows) == 0 {
 		return nil
 	}
@@ -155,7 +165,11 @@ func (h *Handler) fetchMuteeMap(rows []*model.RenoteMuting) map[string]entity.Us
 	}
 	out := make(map[string]entity.UserDetailed, len(users))
 	for _, u := range users {
-		out[u.ID] = entity.PackUserDetailed(u, profileByUser[u.ID], h.idGen)
+		d := entity.PackUserDetailed(u, profileByUser[u.ID], h.idGen)
+		// viewer-relation flag を付与 (#1912)。renote-mute 一覧なので
+		// isRenoteMuted=true が出る。
+		h.relation.Apply(&d, viewerID, u, profileByUser[u.ID])
+		out[u.ID] = d
 	}
 	return out
 }

--- a/internal/api/renotemute/handler_test.go
+++ b/internal/api/renotemute/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/api/userrelation"
 	coremuting "github.com/shiroha-a/mk/internal/core/muting"
 	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -204,6 +205,42 @@ func TestList_OK(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	require.Len(t, resp, 1)
 	shapetest.Assert(t, "RenoteMuting", resp[0]) // L3 (#1286)
+}
+
+// TestList_EmbedsRelationFlags: renote-mute/list の埋め込み mutee に
+// viewer-relation flag が付与される (#1912)。renote-mute 一覧なので
+// isRenoteMuted=true。
+func TestList_EmbedsRelationFlags(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	rmRepo := testutil.NewMockRenoteMutingRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := coremuting.NewRenoteService(userRepo, rmRepo, idGen)
+	h := NewHandler(svc, userRepo, idGen)
+	h.SetRelationRepos(userrelation.Repos{
+		Following:     testutil.NewMockFollowingRepository(),
+		Blocking:      testutil.NewMockBlockingRepository(),
+		Muting:        testutil.NewMockMutingRepository(),
+		RenoteMuting:  rmRepo,
+		FollowRequest: testutil.NewMockFollowRequestRepository(),
+	})
+	addUser(userRepo, "alice")
+	addUser(userRepo, "bob")
+	c1, _ := newReq(t, `{"userId":"bob"}`)
+	setUser(c1, "alice")
+	require.NoError(t, h.Create(c1))
+
+	c, rec := newReq(t, `{}`)
+	setUser(c, "alice")
+	require.NoError(t, h.List(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	mutee, ok := resp[0]["mutee"].(map[string]any)
+	require.True(t, ok, "renote-muting row must embed mutee")
+	assert.Equal(t, true, mutee["isRenoteMuted"], "renote-mute 一覧の mutee は isRenoteMuted=true")
+	assert.Equal(t, false, mutee["isMuted"])
+	assert.Equal(t, false, mutee["isFollowing"])
 }
 
 func TestList_LimitClamping(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1687,14 +1687,27 @@ func (s *Server) setupRoutes() {
 	api.POST("/blocking/delete", blockingHandler.Delete, middleware.RequireAuth(), middleware.RequireScope("write:blocks"))
 	api.POST("/blocking/list", blockingHandler.List, middleware.RequireAuth(), middleware.RequireScope("read:blocks"))
 
+	// following/list・mute/list・renote-mute/list の埋め込み user に viewer-relation
+	// flag (isFollowing/isMuted 等) を付与するための共有 repo 束 (#1912)。
+	listRelationRepos := userrelation.Repos{
+		Following:     followingRepo,
+		Blocking:      blockingRepo,
+		Muting:        mutingRepo,
+		RenoteMuting:  renoteMutingRepo,
+		FollowRequest: followRequestRepo,
+		Memo:          repository.NewUserMemoRepository(s.db),
+	}
+
 	// Mute endpoints
 	muteHandler := mute.NewHandler(mutingService, userRepo, idGen)
+	muteHandler.SetRelationRepos(listRelationRepos)
 	api.POST("/mute/create", muteHandler.Create, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:mutes"))
 	api.POST("/mute/delete", muteHandler.Delete, middleware.RequireAuth(), middleware.RequireScope("write:mutes"))
 	api.POST("/mute/list", muteHandler.List, middleware.RequireAuth(), middleware.RequireScope("read:mutes"))
 
 	// Renote mute endpoints
 	renoteMuteHandler := renotemute.NewHandler(renoteMutingService, userRepo, idGen)
+	renoteMuteHandler.SetRelationRepos(listRelationRepos)
 	api.POST("/renote-mute/create", renoteMuteHandler.Create, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:mutes"))
 	api.POST("/renote-mute/delete", renoteMuteHandler.Delete, middleware.RequireAuth(), middleware.RequireScope("write:mutes"))
 	api.POST("/renote-mute/list", renoteMuteHandler.List, middleware.RequireAuth(), middleware.RequireScope("read:mutes"))
@@ -2202,6 +2215,7 @@ func (s *Server) setupRoutes() {
 	// Following endpoints
 	followingHandler := following.NewHandler(followingService, userService)
 	followingHandler.SetIDGen(idGen)
+	followingHandler.SetRelationRepos(listRelationRepos)
 	api.POST("/following/create", followingHandler.Create, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:following"))
 	api.POST("/following/delete", followingHandler.Delete, middleware.RequireAuth(), middleware.RequireScope("write:following"))
 	api.POST("/following/list", followingHandler.List, middleware.RequireAuth(), middleware.RequireScope("read:following"))


### PR DESCRIPTION
## Summary

`#1832` (following-relations) の sub-issue (F2 MEDIUM + F4 LOW、missing_field)。upstream は following/list の followee / mute/list・renote-mute/list の mutee を **UserDetailedNotMe + me** で pack し viewer-relation flag を必ず含めるが、mk-go は `PackUserDetailed` のみで viewer 関係を解決せず、`isFollowing`/`isFollowed`/`isBlocking`/`isBlocked`/`isMuted`/`isRenoteMuted`/`hasPendingFollowRequest{From,To}You`/notify/withReplies/followedMessage/memo を全 omit していた (frontend `MkFollowButton` 初期 state / followsYou 表示が壊れる)。

## 修正
- following / mute / renotemute handler に `relation userrelation.Repos` + `SetRelationRepos` を追加。`List` の埋め込み user に対し**共有の `userrelation.Repos.Apply`** (users/show・ap/show・blocking と同じ機構、#1802) を呼んで全 relation flag を解決:
  - following/list: 自分の following 一覧なので **isFollowing=true**。
  - mute/list: **isMuted=true**。renote-mute/list: **isRenoteMuted=true**。
- `router.go` で 3 handler に共有 `listRelationRepos` (Following/Blocking/Muting/RenoteMuting/FollowRequest/Memo) を wire。

## テスト
- 3 endpoint とも relation repos を wire して `List` を叩き、埋め込み user に既知 flag (isFollowing/isMuted/isRenoteMuted)=true + 近傍 flag が present (false) で出ることを pin。未配線時は Apply が no-op で flag omit (backward compat)。
- `make fmt && make lint` clean、`go test ./...` 全 package green (0 failures)、3 package とも ≥94% cover。
- 敵対的レビュー: BLOCKER/MAJOR なし。flag direction が upstream `getRelation` と完全一致、self/anon guard、wiring 完全性、shape parity (全 8 flag + notify/withReplies/memo)、no-regression を確認。

## 備考
- `Apply` は per-user query (upstream は `packMany` で batch)。settings 画面の低頻度 read で**出力 shape は upstream 一致**のため許容 (batch 最適化は perf nicety、別途)。

Closes #1912

🤖 Generated with [Claude Code](https://claude.com/claude-code)