### PR TITLE
Fix following-relations parity (#1913): following/{create,delete,update,invalidate,requests/*} を UserLite で返す

### DIFF
--- a/internal/api/following/handler.go
+++ b/internal/api/following/handler.go
@@ -95,7 +95,7 @@ func (h *Handler) Create(c echo.Context) error {
 		}
 	}
 
-	return c.JSON(http.StatusOK, entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen))
+	return c.JSON(http.StatusOK, entity.PackUserLite(bundle.User))
 }
 
 // DeleteRequest is the request body for following/delete.
@@ -128,7 +128,7 @@ func (h *Handler) Delete(c echo.Context) error {
 		}
 	}
 
-	return c.JSON(http.StatusOK, entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen))
+	return c.JSON(http.StatusOK, entity.PackUserLite(bundle.User))
 }
 
 // RequestActionRequest is the shared request body for following/requests/{accept,reject,cancel}.
@@ -209,14 +209,14 @@ func (h *Handler) CancelRequest(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen))
+	return c.JSON(http.StatusOK, entity.PackUserLite(bundle.User))
 }
 
 // ListRequestsResponseItem represents a single received follow request.
 type ListRequestsResponseItem struct {
-	ID       string              `json:"id"`
-	Follower entity.UserDetailed `json:"follower"`
-	Followee entity.UserDetailed `json:"followee"`
+	ID       string          `json:"id"`
+	Follower entity.UserLite `json:"follower"`
+	Followee entity.UserLite `json:"followee"`
 }
 
 // ListRequest is the request body for /api/following/list (upstream 2026.5.2
@@ -311,10 +311,10 @@ func (h *Handler) ListRequests(c echo.Context) error {
 	for _, r := range requests {
 		item := ListRequestsResponseItem{ID: r.ID}
 		if b, err := h.userService.ShowByID(r.FollowerID); err == nil {
-			item.Follower = entity.PackUserDetailed(b.User, b.Profile, h.idGen)
+			item.Follower = entity.PackUserLite(b.User)
 		}
 		if b, err := h.userService.ShowByID(r.FolloweeID); err == nil {
-			item.Followee = entity.PackUserDetailed(b.User, b.Profile, h.idGen)
+			item.Followee = entity.PackUserLite(b.User)
 		}
 		out = append(out, item)
 	}

--- a/internal/api/following/handler_test.go
+++ b/internal/api/following/handler_test.go
@@ -140,9 +140,22 @@ func TestCreate_Success(t *testing.T) {
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Equal(t, "bob", resp["id"])
-	// following/create は PackUserDetailed (UserLite & UserDetailedNotMeOnly) を返す。
-	shapetest.Assert(t, "UserLite", resp)              // L3 (#1312)
-	shapetest.Assert(t, "UserDetailedNotMeOnly", resp) // L3 (#1312)
+	// upstream following/create は userEntityService.pack を schema 指定なしで呼ぶため
+	// 戻り値は UserLite (#1913)。UserDetailed 固有 field は出さない。
+	shapetest.Assert(t, "UserLite", resp) // L3 (#1312)
+	assertNoDetailedFields(t, resp)
+}
+
+// assertNoDetailedFields verifies a UserLite response carries none of the
+// UserDetailed-only fields. shapetest.Assert("UserLite") alone does NOT catch
+// extra fields (they degrade to SevInfo), so this guard locks the UserLite
+// parity for #1913.
+func assertNoDetailedFields(t *testing.T, resp map[string]any) {
+	t.Helper()
+	for _, f := range []string{"followersCount", "followingCount", "notesCount", "createdAt", "roles", "description"} {
+		_, has := resp[f]
+		assert.False(t, has, "UserLite 応答に UserDetailed 固有 field %q が混ざってはいけない", f)
+	}
 }
 
 func TestCreate_LockedReturnsOK(t *testing.T) {
@@ -307,8 +320,9 @@ func TestDelete_Success(t *testing.T) {
 
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	shapetest.Assert(t, "UserLite", resp)              // L3 (#1312)
-	shapetest.Assert(t, "UserDetailedNotMeOnly", resp) // L3 (#1312)
+	// upstream following/delete も UserLite を返す (#1913)。
+	shapetest.Assert(t, "UserLite", resp) // L3 (#1312)
+	assertNoDetailedFields(t, resp)
 }
 
 func TestDelete_UserNotFound(t *testing.T) {

--- a/internal/api/following/relation.go
+++ b/internal/api/following/relation.go
@@ -40,7 +40,7 @@ func (h *Handler) Invalidate(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen))
+	return c.JSON(http.StatusOK, entity.PackUserLite(bundle.User))
 }
 
 // UpdateFollow handles POST /api/following/update.
@@ -90,7 +90,7 @@ func (h *Handler) UpdateFollow(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, entity.PackUserDetailed(meBundle.User, meBundle.Profile, h.idGen))
+	return c.JSON(http.StatusOK, entity.PackUserLite(meBundle.User))
 }
 
 // normalizeNotify converts the upstream `notify` enum ("normal" / "none") to

--- a/internal/api/following/requests_sent.go
+++ b/internal/api/following/requests_sent.go
@@ -36,10 +36,10 @@ func (h *Handler) RequestsSent(c echo.Context) error {
 	for _, r := range rows {
 		item := ListRequestsResponseItem{ID: r.ID}
 		if b, err := h.userService.ShowByID(r.FollowerID); err == nil {
-			item.Follower = entity.PackUserDetailed(b.User, b.Profile, h.idGen)
+			item.Follower = entity.PackUserLite(b.User)
 		}
 		if b, err := h.userService.ShowByID(r.FolloweeID); err == nil {
-			item.Followee = entity.PackUserDetailed(b.User, b.Profile, h.idGen)
+			item.Followee = entity.PackUserLite(b.User)
 		}
 		out = append(out, item)
 	}


### PR DESCRIPTION
## Summary

`#1832` (following-relations) の最後の sub-issue (F5 LOW、shape)。upstream の `following/{create,delete,update,invalidate}` と `requests/cancel` は `userEntityService.pack` を **schema 指定なし**で呼ぶため戻り値は **UserLite** (最小集合)。`requests/{list,sent}` の埋め込み user も UserLite。mk-go は全て `entity.PackUserDetailed` を返し `notesCount`/`followersCount`/`description`/`fields`/`createdAt`/`roles` 等 UserDetailed 固有 field を含む superset で本家 shape と不一致だった。

## 修正
- following package の **9 PackUserDetailed site** (handler.go Create/Delete/CancelRequest + ListRequests follower/followee、relation.go Invalidate/UpdateFollow、requests_sent.go follower/followee) を `entity.PackUserLite` に変更。
- 共有 `ListRequestsResponseItem` の Follower/Followee 型を UserDetailed → UserLite に。
- `following/list` (#1912 の path) は UserDetailedNotMe followee を返すので**不変**。emoji は従来から embedded UserLite で空 map (pre-existing、本変更で挙動不変)。

## テスト
- Create/Delete の shapetest を UserDetailedNotMeOnly assertion 除去 → UserLite のみに。
- `shapetest("UserLite")` は extra field を SevInfo 扱いで見逃すため、UserDetailed 固有 field の**非混入**を明示的に assert する `assertNoDetailedFields` helper を追加し Create/Delete 両 test で適用 (レビュー指摘の Delete 側 shape-lock 欠落を解消)。
- `make fmt && make lint` clean、`go test ./...` 全 package green (0 failures)、following package 94.1% cover。
- 敵対的レビュー: BLOCKER/MAJOR なし。9 site 完全網羅・list path 非変更・PackUserLite が upstream UserLite 完全一致・detail leak 無しを確認。

## 親 issue 完了
本 PR で `#1832` (following-relations) の 3 sub-issue (#1911 / #1912 / #1913) がすべて完了。

Closes #1913

🤖 Generated with [Claude Code](https://claude.com/claude-code)