### PR TITLE
Fix i-self parity (#1919): i/update が native session で email/emailVerified/securityKeysList を返す (includeSecrets gate)

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -1119,6 +1119,47 @@ func (h *Handler) meDetailedWithUnread(ctx context.Context, u *model.User, profi
 	return resp
 }
 
+// appendIncludeSecrets adds the includeSecrets-gated MeDetailed fields (email /
+// emailVerified / securityKeysList) to resp when the request is a native login
+// session, mirroring upstream pack(..., {includeSecrets: isSecure}). isSecure =
+// the request's raw token equals users.token (= RequireSecure と同一判定);
+// OAuth/MiAuth の app token (token != users.token) では出さない。
+//
+// /api/i (Me) は同等の判定を inline で持つ (#1824)。/api/i/update もこの helper で
+// native session に email 系を返す (#1919)。両者が drift しないよう、変更時は
+// Me handler の isSecure ブロックと揃えること。
+func (h *Handler) appendIncludeSecrets(c echo.Context, u *model.User, profile *model.UserProfile, resp map[string]any) {
+	if u == nil || u.Token == nil || *u.Token != middleware.GetToken(c) {
+		return
+	}
+	if profile != nil {
+		resp["email"] = profile.Email
+		resp["emailVerified"] = profile.EmailVerified
+	}
+	resp["securityKeysList"] = h.securityKeysList(u.ID)
+}
+
+// securityKeysList returns the user's WebAuthn key list for the includeSecrets
+// block, returning [] when no repo is wired or no keys exist.
+func (h *Handler) securityKeysList(userID string) []map[string]any {
+	list := []map[string]any{}
+	if h.securityKeyRepo == nil {
+		return list
+	}
+	keys, err := h.securityKeyRepo.ListByUser(userID)
+	if err != nil {
+		return list
+	}
+	for _, k := range keys {
+		list = append(list, map[string]any{
+			"id":       k.ID,
+			"name":     k.Name,
+			"lastUsed": k.LastUsed.UTC().Format("2006-01-02T15:04:05.000Z"),
+		})
+	}
+	return list
+}
+
 // countMuteWords returns the total number of entries in a muted-words
 // payload, flattening AND-groups. mirrors upstream Misskey TS i/update.ts
 // `checkMuteWordCount`: 各 entry が string なら 1、array なら array.length
@@ -1590,7 +1631,13 @@ func (h *Handler) Update(c echo.Context) error {
 	// 側に無いと session の `$i` が更新されず stale なまま残る (#968)。
 	// unread 系は meDetailedWithUnread で実値を埋める。生 PackMeDetailed だと
 	// unreadNotificationsCount:0 等の default が `$i` を clobber する (#1258 fu)。
-	return c.JSON(http.StatusOK, h.meDetailedWithUnread(c.Request().Context(), bundle.User, bundle.Profile))
+	resp := h.meDetailedWithUnread(c.Request().Context(), bundle.User, bundle.Profile)
+	// upstream i/update は pack(..., {includeSecrets: isSecure}) を返すため native
+	// session では email / emailVerified / securityKeysList を含める (#1919)。Token
+	// 判定は middleware が確実に load する me を使い、email は更新後の最新 profile を
+	// 使う。app token (token != users.token) では出さない。
+	h.appendIncludeSecrets(c, me, bundle.Profile, resp)
+	return c.JSON(http.StatusOK, resp)
 }
 
 // avatarDecorationAPIError carries a (status, body) pair from

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -890,6 +890,71 @@ func TestUpdate_EmptyValuesPassValidation(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// updateWithToken は i/update を UserContextKey + TokenContextKey 付きで叩く。
+func updateWithToken(h *Handler, body string, user *model.User, token string) *httptest.ResponseRecorder {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/i/update", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), user)
+	c.Set(string(middleware.TokenContextKey), token)
+	_ = h.Update(c)
+	return rec
+}
+
+// #1919: native session (request token == users.token) で i/update を呼ぶと
+// email / emailVerified / securityKeysList を含む (includeSecrets)。
+func TestUpdate_NativeSessionIncludesSecrets(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	nativeTok := "native-login-token"
+	user := &model.User{ID: "user1", Username: "testuser", Token: &nativeTok, AvatarDecorations: datatypes.JSON([]byte("[]")), ChatScope: "mutual"}
+	require.NoError(t, userRepo.Create(user))
+	email := "secret@example.com"
+	userRepo.Profiles["user1"] = &model.UserProfile{UserID: "user1", Email: &email, EmailVerified: true, Fields: datatypes.JSON([]byte("[]"))}
+	// securityKeyRepo に 1 件登録し、native session で list が format されて
+	// 返ること (id/name/lastUsed) も確認する。
+	skRepo := newInMemSKRepo()
+	require.NoError(t, skRepo.Create(&model.UserSecurityKey{ID: "key1", UserID: "user1", Name: "yubikey", PublicKey: "pk"}))
+	h.SetWebAuthn(nil, skRepo)
+
+	rec := updateWithToken(h, `{"name":"newname"}`, user, nativeTok)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "secret@example.com", resp["email"])
+	assert.Equal(t, true, resp["emailVerified"])
+	list, ok := resp["securityKeysList"].([]any)
+	require.True(t, ok, "native session は securityKeysList を array で含む")
+	require.Len(t, list, 1)
+	key := list[0].(map[string]any)
+	assert.Equal(t, "key1", key["id"])
+	assert.Equal(t, "yubikey", key["name"])
+	assert.Contains(t, key, "lastUsed")
+}
+
+// #1919: app access token (request token != users.token) で i/update を呼ぶと
+// email / emailVerified / securityKeysList を出さない (over-leak 防止、Me と整合)。
+func TestUpdate_AppTokenOmitsSecrets(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	nativeTok := "native-login-token"
+	user := &model.User{ID: "user1", Username: "testuser", Token: &nativeTok, AvatarDecorations: datatypes.JSON([]byte("[]")), ChatScope: "mutual"}
+	require.NoError(t, userRepo.Create(user))
+	email := "secret@example.com"
+	userRepo.Profiles["user1"] = &model.UserProfile{UserID: "user1", Email: &email, EmailVerified: true, Fields: datatypes.JSON([]byte("[]"))}
+
+	rec := updateWithToken(h, `{"name":"newname"}`, user, "app-access-token-xyz")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	_, hasEmail := resp["email"]
+	assert.False(t, hasEmail, "app token に email を漏らさない")
+	_, hasEmailVerified := resp["emailVerified"]
+	assert.False(t, hasEmailVerified)
+	_, hasSKL := resp["securityKeysList"]
+	assert.False(t, hasSKL, "app token に securityKeysList を漏らさない")
+}
+
 func TestUpdate_BannerID_RestrictedByRole(t *testing.T) {
 	h, repo, _, _ := newTestHandler(t)
 	user := &model.User{ID: "u1", Username: "alice", AvatarDecorations: datatypes.JSON([]byte("[]"))}


### PR DESCRIPTION
## Summary

`#1833` (i-self) の sub-issue (F2 LOW、behavior_diff)。`i/update` が native session でも includeSecrets 相当 (email/emailVerified/securityKeysList) を返していなかった divergence を修正する。

## 問題
upstream i/update は `pack(..., {includeSecrets: isSecure})` を返すため、native login session で呼ぶと email/emailVerified/securityKeysList を含む MeDetailed を返し、frontend の `updateCurrentAccountPartial` が `$i.email` 等を refresh できる。mk-go の Update は `meDetailedWithUnread` → `entity.PackMeDetailed` 経由で、これら 3 field が欠落していた。

## 修正
- **`appendIncludeSecrets` / `securityKeysList` helper** を追加。isSecure (= request token が users.token と一致、RequireSecure と同一判定) のときだけ email/emailVerified (profile から) + securityKeysList (WebAuthn keys) を resp に乗せる。OAuth/MiAuth の app token (token != users.token) では**出さない** (over-leak 防止)。
- i/update の return で `meDetailedWithUnread` の resp に適用。Token 判定は middleware が確実に load する `me`、email は更新後の最新 `bundle.Profile`。
- **Me handler (#1824) の inline isSecure gate は security 実績があるため touch せず**、helper はそれを mirror (drift しないよう GoDoc に明記)。`meDetailedWithUnread` の他 caller (2FA endpoint) には call site 適用で影響させない。

## テスト
- native session で email/emailVerified/securityKeysList (id/name/lastUsed format) が返ること、**app token ではこれら 3 field を出さない**ことを pin。
- `make fmt && make lint` clean、`go test ./...` 0 failures、i package 90.2% cover。

## 敵対的レビュー (security-critical)
- gate が #1824 inline gate の **完全な逆 (De Morgan)** + RequireSecure と一致、app token は gate を通れない (secret leak 不可) を確認。`me`/`bundle` ID 一致、nil-deref 無し、2FA caller 非影響も確認。**security issue 無し**。
- 派生 nit: upstream は securityKeysList を `twoFactorEnabled` で gate するが mk-go は Me/helper 両方 ungated (pre-existing、benign)。drift を避けるため両方同時に直す follow-up #1921 として分離。

Closes #1919

🤖 Generated with [Claude Code](https://claude.com/claude-code)