### PR TITLE
Fix i-self parity (#1921): securityKeys / securityKeysList を twoFactorEnabled で gate

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -883,7 +883,10 @@ func (h *Handler) Me(c echo.Context) error {
 		resp["publicReactions"] = profile.PublicReactions
 		resp["loggedInDays"] = len(profile.LoggedInDates)
 		resp["achievements"] = jsonbArray(profile.Achievements)
-		resp["securityKeys"] = profile.SecurityKeysAvailable
+		// upstream UserEntityService.ts:580 と同じく securityKeys は 2FA 有効時のみ
+		// 真。PackMeDetailed も同 gate だが、ここで profile 値を override するため
+		// 揃える (#1921)。
+		resp["securityKeys"] = profile.TwoFactorEnabled && profile.SecurityKeysAvailable
 		// hardMutedWords / twoFactorBackupCodesStock は PackMeDetailed (AsMeDetailed)
 		// が profile から正しい shape で乗せるので override 不要 (#1258 follow-up)。
 		// clientData / room は jsonb を生のまま返すと frontend (本家) が
@@ -934,22 +937,12 @@ func (h *Handler) Me(c echo.Context) error {
 	resp["roles"] = userRoles
 	// securityKeysList: WebAuthnキーの一覧。includeSecrets 限定 (upstream
 	// UserEntityService.ts:627-639) なので native session のときだけ出す。app token
-	// では key 自体を省く (#1824、misskey-js golden で optional)。
+	// では key 自体を省く (#1824、misskey-js golden で optional)。さらに upstream は
+	// `twoFactorEnabled ? find() : []` で 2FA 有効時のみ実リストを返すため、無効時は
+	// repo を引かず [] にする (#1921)。
 	if isSecure {
-		if h.securityKeyRepo != nil {
-			if keys, err := h.securityKeyRepo.ListByUser(u.ID); err == nil && len(keys) > 0 {
-				list := make([]map[string]any, len(keys))
-				for i, k := range keys {
-					list[i] = map[string]any{
-						"id":       k.ID,
-						"name":     k.Name,
-						"lastUsed": k.LastUsed.UTC().Format("2006-01-02T15:04:05.000Z"),
-					}
-				}
-				resp["securityKeysList"] = list
-			} else {
-				resp["securityKeysList"] = []any{}
-			}
+		if profile != nil && profile.TwoFactorEnabled {
+			resp["securityKeysList"] = h.securityKeysList(u.ID)
 		} else {
 			resp["securityKeysList"] = []any{}
 		}
@@ -1136,7 +1129,14 @@ func (h *Handler) appendIncludeSecrets(c echo.Context, u *model.User, profile *m
 		resp["email"] = profile.Email
 		resp["emailVerified"] = profile.EmailVerified
 	}
-	resp["securityKeysList"] = h.securityKeysList(u.ID)
+	// upstream UserEntityService.ts:627 は `twoFactorEnabled ? find() : []` なので
+	// 2FA 有効時のみ実リスト、無効時は [] (#1921)。Me handler の isSecure ブロックと
+	// 同 gate を保つこと。
+	if profile != nil && profile.TwoFactorEnabled {
+		resp["securityKeysList"] = h.securityKeysList(u.ID)
+	} else {
+		resp["securityKeysList"] = []map[string]any{}
+	}
 }
 
 // securityKeysList returns the user's WebAuthn key list for the includeSecrets

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -911,9 +911,8 @@ func TestUpdate_NativeSessionIncludesSecrets(t *testing.T) {
 	user := &model.User{ID: "user1", Username: "testuser", Token: &nativeTok, AvatarDecorations: datatypes.JSON([]byte("[]")), ChatScope: "mutual"}
 	require.NoError(t, userRepo.Create(user))
 	email := "secret@example.com"
-	userRepo.Profiles["user1"] = &model.UserProfile{UserID: "user1", Email: &email, EmailVerified: true, Fields: datatypes.JSON([]byte("[]"))}
-	// securityKeyRepo に 1 件登録し、native session で list が format されて
-	// 返ること (id/name/lastUsed) も確認する。
+	// 2FA 有効 + key 登録済 → securityKeysList が format されて返る (#1921 gate を通る)。
+	userRepo.Profiles["user1"] = &model.UserProfile{UserID: "user1", Email: &email, EmailVerified: true, TwoFactorEnabled: true, SecurityKeysAvailable: true, Fields: datatypes.JSON([]byte("[]"))}
 	skRepo := newInMemSKRepo()
 	require.NoError(t, skRepo.Create(&model.UserSecurityKey{ID: "key1", UserID: "user1", Name: "yubikey", PublicKey: "pk"}))
 	h.SetWebAuthn(nil, skRepo)
@@ -931,6 +930,31 @@ func TestUpdate_NativeSessionIncludesSecrets(t *testing.T) {
 	assert.Equal(t, "key1", key["id"])
 	assert.Equal(t, "yubikey", key["name"])
 	assert.Contains(t, key, "lastUsed")
+	// securityKeys bool も 2FA 有効 + key 有りなので true。
+	assert.Equal(t, true, resp["securityKeys"])
+}
+
+// #1921: native session でも 2FA 無効なら securityKeysList は [] (repo を引かない)、
+// securityKeys bool も SecurityKeysAvailable に関わらず false。
+func TestUpdate_SecurityKeysGatedByTwoFactorDisabled(t *testing.T) {
+	h, userRepo, _, _ := newTestHandler(t)
+	nativeTok := "native-login-token"
+	user := &model.User{ID: "user1", Username: "testuser", Token: &nativeTok, AvatarDecorations: datatypes.JSON([]byte("[]")), ChatScope: "mutual"}
+	require.NoError(t, userRepo.Create(user))
+	// 2FA 無効だが key 登録 + SecurityKeysAvailable=true (stale flag) の状況。
+	userRepo.Profiles["user1"] = &model.UserProfile{UserID: "user1", TwoFactorEnabled: false, SecurityKeysAvailable: true, Fields: datatypes.JSON([]byte("[]"))}
+	skRepo := newInMemSKRepo()
+	require.NoError(t, skRepo.Create(&model.UserSecurityKey{ID: "key1", UserID: "user1", Name: "yubikey", PublicKey: "pk"}))
+	h.SetWebAuthn(nil, skRepo)
+
+	rec := updateWithToken(h, `{"name":"newname"}`, user, nativeTok)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	list, ok := resp["securityKeysList"].([]any)
+	require.True(t, ok, "securityKeysList は存在する (includeSecrets)")
+	assert.Empty(t, list, "2FA 無効なら securityKeysList は [] (key があっても)")
+	assert.Equal(t, false, resp["securityKeys"], "2FA 無効なら securityKeys は false")
 }
 
 // #1919: app access token (request token != users.token) で i/update を呼ぶと

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -362,7 +362,10 @@ func AsMeDetailed(d UserDetailed, u *model.User, profile *model.UserProfile) MeD
 		// security 系は profile から正確に埋める (#1237)。
 		out.TwoFactorEnabled = profile.TwoFactorEnabled
 		out.UsePasswordLessLogin = profile.UsePasswordLessLogin
-		out.SecurityKeys = profile.SecurityKeysAvailable
+		// upstream UserEntityService.ts:580 は securityKeys を
+		// `twoFactorEnabled ? (key 数 >= 1) : false` とするため、2FA 無効時は
+		// 登録済みキーがあっても false にする (#1921)。
+		out.SecurityKeys = profile.TwoFactorEnabled && profile.SecurityKeysAvailable
 		// twoFactorBackupCodesStock は profile 由来なので全 view で正しい値にする
 		// (handler override 不要 = meUpdated / i-update でも clobber しない)。
 		out.TwoFactorBackupCodesStock = backupCodesStock(profile)
@@ -642,7 +645,9 @@ func ApplyModeratorSecurityFields(d *UserDetailed, iAmModerator bool, profile *m
 	}
 	tfa := profile.TwoFactorEnabled
 	pwl := profile.UsePasswordLessLogin
-	sk := profile.SecurityKeysAvailable
+	// upstream UserEntityService.ts:580 と同じく securityKeys は 2FA 有効時のみ
+	// 真になりうる (#1921)。
+	sk := profile.TwoFactorEnabled && profile.SecurityKeysAvailable
 	d.TwoFactorEnabled = &tfa
 	d.UsePasswordLessLogin = &pwl
 	d.SecurityKeys = &sk

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -229,6 +229,17 @@ func TestApplyModeratorSecurityFields(t *testing.T) {
 		ApplyModeratorSecurityFields(&d, true, nil)
 		assert.Nil(t, d.TwoFactorEnabled)
 	})
+
+	// #1921: 2FA 無効なら securityKeys は SecurityKeysAvailable に関わらず false。
+	t.Run("securityKeys false when 2FA disabled", func(t *testing.T) {
+		off := &model.UserProfile{UserID: "u1", TwoFactorEnabled: false, SecurityKeysAvailable: true}
+		d := UserDetailed{}
+		ApplyModeratorSecurityFields(&d, true, off)
+		require.NotNil(t, d.TwoFactorEnabled)
+		assert.False(t, *d.TwoFactorEnabled)
+		require.NotNil(t, d.SecurityKeys)
+		assert.False(t, *d.SecurityKeys, "2FA 無効なら securityKeys は false")
+	})
 }
 
 func TestPackUserDetailed_MoveFields(t *testing.T) {
@@ -895,17 +906,23 @@ func TestPackMeDetailed_ProfileDerivedHighFields(t *testing.T) {
 		Fields:                datatypes.JSON([]byte("[]")),
 		HardMutedWords:        datatypes.JSON([]byte(`[["foo","bar"],["baz"]]`)),
 		TwoFactorEnabled:      true,
+		SecurityKeysAvailable: true,
 		TwoFactorBackupSecret: pq.StringArray{"a", "b"}, // 2 codes -> partial
 	}
 	me := PackMeDetailed(u, profile)
 	assert.Len(t, me.HardMutedWords, 2, "hardMutedWords は jsonb から展開")
 	assert.Equal(t, "partial", me.TwoFactorBackupCodesStock)
+	// #1921: 2FA 有効 + key 有り → securityKeys true。
+	assert.True(t, me.SecurityKeys, "2FA 有効 + key 有りで securityKeys true")
 
 	profile.TwoFactorBackupSecret = pq.StringArray{"a", "b", "c", "d", "e"} // >=5 -> full
 	assert.Equal(t, "full", PackMeDetailed(u, profile).TwoFactorBackupCodesStock)
 
 	profile.TwoFactorEnabled = false // 2FA off -> none
-	assert.Equal(t, "none", PackMeDetailed(u, profile).TwoFactorBackupCodesStock)
+	off := PackMeDetailed(u, profile)
+	assert.Equal(t, "none", off.TwoFactorBackupCodesStock)
+	// #1921: 2FA 無効なら SecurityKeysAvailable=true でも securityKeys false。
+	assert.False(t, off.SecurityKeys, "2FA 無効なら securityKeys false")
 }
 
 // #1240: PackMeDetailed 単体 (policies override 無し) は policies を **出さない**


### PR DESCRIPTION
## Summary

`#1919` の敵対的レビューで検出した隣接 parity nit (benign、leak ではない)。upstream は WebAuthn security-key 情報を `twoFactorEnabled` で gate するが、mk-go はどちらも gate していなかった divergence を修正する。

## 問題
upstream `UserEntityService.ts`:
- `:580` `securityKeys: twoFactorEnabled ? (key 数 >= 1) : false`
- `:627` `securityKeysList: twoFactorEnabled ? find() : []`(includeSecrets ブロック内)

mk-go は 2FA 無効でも key 登録済(`SecurityKeysAvailable=true` の stale flag や残存 key)なら `securityKeys=true` / `securityKeysList=実リスト`を返していた。

## 修正(5 sites を一貫 gate)
- **entity** `PackMeDetailed` / `ApplyModeratorSecurityFields`: `securityKeys` を `TwoFactorEnabled && SecurityKeysAvailable` に gate(i/update と moderator-view 双方)。
- **i Me handler**: `securityKeys` override も同 gate に(PackMeDetailed を再 ungate しないため)。`securityKeysList` ブロックは 2FA 有効時のみ repo を引き、無効時 []。inline repo logic は #1919 で抽出した `securityKeysList()` helper 再利用に集約。
- **appendIncludeSecrets helper** (i/update): `securityKeysList` を 2FA 有効時のみ実リスト、無効時 []。

`includeSecrets` (isSecure) gate は維持: **app token は依然これら field を一切出さない**、native+2FA無効は `[]`/`securityKeys=false`、native+2FA有効は実リスト/`true`。

## テスト
- i/update: 2FA有効→list+`true` / **2FA無効(key有り stale flag)→[]+false**(critical case)。
- entity: `PackMeDetailed` + `ApplyModeratorSecurityFields` の 2FA on/off gate。
- `make fmt && make lint` clean、`go test ./...` 0 failures、i 90.5% / entity 96.2% cover。

## 敵対的レビュー
CLEAN(指摘なし)。`SecurityKeysAvailable` が key 登録/削除で `countBy>=1` 相当に保たれること、5 sites の gate 一貫性、isSecure gate 非破壊、users/show moderator(2FA on→true)survive、admin stub / golden 非影響を確認。

Closes #1921

🤖 Generated with [Claude Code](https://claude.com/claude-code)