### PR TITLE
Fix meta-federation parity (#1925): nodeinfo software.homepage を 2.0/2.1 双方で出力

### DIFF
--- a/internal/api/nodeinfo/handler.go
+++ b/internal/api/nodeinfo/handler.go
@@ -21,6 +21,12 @@ const maxNoteTextLength = 3000
 // `meta.themeColor ?? '#86b300'` fallback。
 const defaultThemeColor = "#86b300"
 
+// softwareRepository is the mk-go source repository URL advertised in the
+// nodeinfo software block. Upstream advertises homepage/repository in the same
+// object (2.0: homepage only; 2.1: homepage=repository=repositoryUrl); mk-go has
+// no separate hub, so both point at the repository (#1925)。
+const softwareRepository = "https://github.com/shiroha-a/mk"
+
 // Handler handles nodeinfo endpoints.
 type Handler struct {
 	cfg          *config.Config
@@ -212,13 +218,17 @@ func (h *Handler) buildDocument(version string) map[string]any {
 		}
 	}
 
+	// upstream NodeinfoServerService: software は name/version/homepage/repository
+	// を持ち、2.0 は repository を delete (homepage は残す)、2.1 は homepage=repository。
+	// mk-go は homepage=repository=softwareRepository で両 version に homepage を出す (#1925)。
 	software := map[string]any{
-		"name":    "mk-go",
-		"version": config.MkGoVersion,
+		"name":     "mk-go",
+		"version":  config.MkGoVersion,
+		"homepage": softwareRepository,
 	}
 	// schema 2.0 には software.repository が無い (upstream は 2.0 で delete する)。
 	if version == "2.1" {
-		software["repository"] = "https://github.com/shiroha-a/mk"
+		software["repository"] = softwareRepository
 	}
 
 	return map[string]any{

--- a/internal/api/nodeinfo/handler_test.go
+++ b/internal/api/nodeinfo/handler_test.go
@@ -31,6 +31,9 @@ func TestVersion2_1(t *testing.T) {
 	sw := resp["software"].(map[string]any)
 	assert.Equal(t, "mk-go", sw["name"])
 	assert.Equal(t, config.MkGoVersion, sw["version"])
+	// #1925: 2.1 は homepage=repository=softwareRepository。
+	assert.Equal(t, softwareRepository, sw["homepage"])
+	assert.Equal(t, softwareRepository, sw["repository"])
 }
 
 // admin で設定した Meta.Name / Description がnodeinfo.metadata に反映される
@@ -85,6 +88,8 @@ func TestVersion2_0(t *testing.T) {
 	assert.Equal(t, "mk-go", sw["name"])
 	_, hasRepo := sw["repository"]
 	assert.False(t, hasRepo, "schema 2.0 は software.repository を含めない")
+	// #1925: 2.0 は repository を delete するが homepage は残す。
+	assert.Equal(t, softwareRepository, sw["homepage"], "schema 2.0 も software.homepage を含む")
 
 	// 対照: 2.1 は repository を含む。
 	rec21 := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

`#1834` (meta-federation) の sub-issue (F4 LOW、missing_field)。nodeinfo の `software.homepage` がどちらの schema version でも欠落していた divergence を修正する。

## 問題
upstream NodeinfoServerService の software は name/version/homepage/repository を持つ:
- 2.0: software = {name, version, homepage} (repository を delete、homepage は残す)
- 2.1: software = {name, version, homepage: repositoryUrl, repository: repositoryUrl}

mk-go は name/version のみで `software.homepage` が両 version で欠落 → NodeInfo crawler 向けの shape drift。

## 修正
- `softwareRepository` 定数 (`https://github.com/shiroha-a/mk`) を追加し、base software map に `homepage`、2.1 では `repository` を同 URL で出す。mk-go は misskey-hub のような別 hub を持たないため `homepage=repository=repo URL` とする (`name` も "mk-go" で upstream と異なるため自己整合的)。
- 結果: 2.0 → `{name, version, homepage}`、2.1 → `{name, version, homepage, repository}`。

## テスト
2.1 の `homepage==repository==softwareRepository`、2.0 の `homepage` 存在 (repository は引き続き省略) を pin。`make fmt && make lint` clean、`go test ./...` 0 failures、nodeinfo 98.6% cover。

## 敵対的レビュー
CLEAN (指摘なし)。2.0/2.1 双方で homepage 出力・2.0 の repository 省略維持・const 値一致・nodeinfo に golden/shapetest 無しを確認。`metadata.repositoryUrl` は引き続き admin 設定値を反映 (software は固定 const という既存設計を踏襲)。

Closes #1925

🤖 Generated with [Claude Code](https://claude.com/claude-code)