### PR TITLE
Fix notes-lifecycle parity (#1928): notes/create が reply note の threadId を thread root に揃える

### DIFF
--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -644,6 +644,15 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 	if replyTarget != nil {
 		note.ReplyUserID = &replyTarget.UserID
 		note.ReplyUserHost = replyTarget.UserHost
+		// thread-muting が深い thread でも効くよう threadId を thread root に揃える
+		// (upstream NoteCreateService.ts:623-627: threadId = data.reply.threadId ??
+		// data.reply.id)。reply の threadId が NULL だと thread-muting / isMutedThread /
+		// timeline filter が reply を root と紐付けられず深さ2以上で破綻する (#1928)。
+		threadID := replyTarget.ID
+		if replyTarget.ThreadID != nil && *replyTarget.ThreadID != "" {
+			threadID = *replyTarget.ThreadID
+		}
+		note.ThreadID = &threadID
 	}
 	if renoteTarget != nil {
 		note.RenoteUserID = &renoteTarget.UserID

--- a/internal/core/note/note_create_service_test.go
+++ b/internal/core/note/note_create_service_test.go
@@ -740,6 +740,40 @@ func TestCreateService_ReplyAndChannelVisibilityAdjustment(t *testing.T) {
 	})
 }
 
+// #1928: reply note の threadId は thread root (= reply 先の threadId ?? id) を指す。
+// これが NULL だと深さ2以上の thread で thread-muting が破綻する。
+func TestCreateService_ReplyThreadID(t *testing.T) {
+	t.Run("reply to root sets threadId to root id", func(t *testing.T) {
+		svc, noteRepo, _ := newCreateService(t)
+		noteRepo.Notes["root"] = &model.Note{ID: "root", UserID: "other", Visibility: model.NoteVisibilityPublic}
+		text := "re"
+		rid := "root"
+		created, err := svc.Create(note.CreateInput{User: &model.User{ID: "u1"}, Text: &text, ReplyID: &rid, Visibility: model.NoteVisibilityPublic})
+		require.NoError(t, err)
+		require.NotNil(t, created.ThreadID)
+		assert.Equal(t, "root", *created.ThreadID, "root への reply は threadId=root.id")
+	})
+	t.Run("reply to a reply inherits root threadId (deep thread)", func(t *testing.T) {
+		svc, noteRepo, _ := newCreateService(t)
+		rootThread := "root"
+		// mid は root への reply で threadId=root を持つ。これへの reply は root を継承する。
+		noteRepo.Notes["mid"] = &model.Note{ID: "mid", UserID: "other", Visibility: model.NoteVisibilityPublic, ThreadID: &rootThread}
+		text := "re"
+		rid := "mid"
+		created, err := svc.Create(note.CreateInput{User: &model.User{ID: "u1"}, Text: &text, ReplyID: &rid, Visibility: model.NoteVisibilityPublic})
+		require.NoError(t, err)
+		require.NotNil(t, created.ThreadID)
+		assert.Equal(t, "root", *created.ThreadID, "深い reply も threadId=root (reply.threadId を継承)")
+	})
+	t.Run("non-reply note has nil threadId", func(t *testing.T) {
+		svc, _, _ := newCreateService(t)
+		text := "top"
+		created, err := svc.Create(note.CreateInput{User: &model.User{ID: "u1"}, Text: &text, Visibility: model.NoteVisibilityPublic})
+		require.NoError(t, err)
+		assert.Nil(t, created.ThreadID, "reply でない note は threadId=nil")
+	})
+}
+
 // #1859: 空文字 channelId は非 channel に正規化し、channel 強制対象外とする。
 func TestCreateService_EmptyChannelIDNormalized(t *testing.T) {
 	svc, _, _ := newCreateService(t)


### PR DESCRIPTION
## Summary

`#1835` (notes-lifecycle) の sub-issue (F1 MEDIUM、behavior_diff)。reply note の `threadId` が常に NULL で、深さ2以上の thread で thread-muting が破綻していた divergence を修正する。

## 問題
upstream insertNote は reply note に `threadId = data.reply.threadId ?? data.reply.id` を設定 (NoteCreateService.ts:623-627) するが、mk-go の CreateService は note 構築で ThreadID を設定せず常に NULL だった。

threadId が NULL だと thread-muting の 3 reader (`threadIDForMute` / `isMutedThread` / `ApplyThreadMute`、いずれも `note.ThreadID ?? note.ID`) が reply を thread root と紐付けられず、深さ2以上で thread-muting が破綻 (reply 経由で mute すると root の代わりに reply.id が保存され thread の一部しか mute されない)。

## 修正
- note 構築の reply ブロックで `note.ThreadID = replyTarget.ThreadID ?? replyTarget.ID` を設定 (pointer aliasing を避け local にコピー)。

## テスト
reply-to-root (threadId=root.id)、**deep reply-to-reply (threadId=root 継承、実バグ)**、非 reply (nil) を pin。`make fmt && make lint` clean、`go test ./...` 0 failures、note package 94.9% cover。

## 注意 (F2 は stale)
親 issue の F2 (reply→home 降格 / reply・renote localOnly 継承) は現コード再検証で**実装済 (#1849/#1855/#1821)** と判明し対象外。

## 敵対的レビュー
CLEAN。upstream parity・thread-muting chain (deep reply が root mute に捕捉される)・pointer 安全性・AP renderer/golden 非影響を確認。**派生 gap**: AP inbound path (resolver.go) も reply の threadId を埋めていない (remote thread の deep muting 不可) → follow-up #1931 に分離。

Closes #1928

🤖 Generated with [Claude Code](https://claude.com/claude-code)