### PR TITLE
Fix notes-lifecycle parity (#1929): notes/replies・notes/children は親不在/不可視で 200 空配列を返す

### DIFF
--- a/internal/api/notes/handler_query_test.go
+++ b/internal/api/notes/handler_query_test.go
@@ -177,11 +177,27 @@ func TestReplies_OK(t *testing.T) {
 	shapetest.Assert(t, "Note", resp[0]) // L3 (#1316)
 }
 
-func TestReplies_NotFound(t *testing.T) {
+// #1929: 親 note が存在しない場合、upstream replies.ts は親チェックを行わず
+// 200 空配列を返す (404 NO_SUCH_NOTE ではない)。
+func TestReplies_ParentMissingReturnsEmpty(t *testing.T) {
 	h, _ := newQueryHandler(t)
 	c, rec := newJSONRequest(t, "/api/notes/replies", `{"noteId":"ghost"}`)
 	require.NoError(t, h.Replies(c))
-	assert.Equal(t, http.StatusNotFound, rec.Code)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Empty(t, resp)
+}
+
+// #1929: children も親不在で 200 空配列。
+func TestChildren_ParentMissingReturnsEmpty(t *testing.T) {
+	h, _ := newQueryHandler(t)
+	c, rec := newJSONRequest(t, "/api/notes/children", `{"noteId":"ghost"}`)
+	require.NoError(t, h.Children(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Empty(t, resp)
 }
 
 func TestChildren_OK(t *testing.T) {

--- a/internal/core/note/note_query_service.go
+++ b/internal/core/note/note_query_service.go
@@ -117,19 +117,21 @@ func (s *QueryService) ListRenotes(viewer *model.User, noteID, untilID, sinceID 
 }
 
 // ListReplies returns replies to the given noteID after filtering for visibility.
+//
+// upstream replies.ts は親 note の存在/可視性チェックを行わず、replyId=noteId の
+// visibility-filtered query を実行し空なら 200 [] を返す (getNote を呼ばない、#1929)。
+// reply 自体は repository が viewer 可視性で filter するため、親が不在/不可視でも
+// leak は増えない。renotes.ts は getNote で 404 にするため ListRenotes は requireVisible
+// を維持する点と非対称 (upstream の各 endpoint 仕様に合わせる)。
 func (s *QueryService) ListReplies(viewer *model.User, noteID, untilID, sinceID string, limit int) ([]*model.Note, error) {
-	if _, err := s.requireVisible(viewer, noteID); err != nil {
-		return nil, err
-	}
 	// visibility は repository が LIMIT 前に SQL push-down する (#1500)。
 	return s.noteRepo.ListRepliesOf(noteID, viewerIDOf(viewer), untilID, sinceID, limit)
 }
 
 // ListChildren returns notes that reply to or quote the given noteID.
+//
+// upstream children.ts も replies.ts 同様に親 note チェックを行わず空なら 200 [] (#1929)。
 func (s *QueryService) ListChildren(viewer *model.User, noteID, untilID, sinceID string, limit int) ([]*model.Note, error) {
-	if _, err := s.requireVisible(viewer, noteID); err != nil {
-		return nil, err
-	}
 	// visibility は repository が LIMIT 前に SQL push-down する (#1500)。
 	return s.noteRepo.ListChildrenOf(noteID, viewerIDOf(viewer), untilID, sinceID, limit)
 }

--- a/internal/core/note/note_query_service_test.go
+++ b/internal/core/note/note_query_service_test.go
@@ -125,10 +125,13 @@ func TestQueryService_ListReplies(t *testing.T) {
 	assert.Len(t, out, 1)
 }
 
+// #1929: 親 note が存在しない/不可視でも 404 ではなく空リストを返す
+// (upstream replies.ts は親チェックを行わない)。
 func TestQueryService_ListReplies_ParentMissing(t *testing.T) {
 	svc, _, _ := newQueryService(t)
-	_, err := svc.ListReplies(nil, "ghost", "", "", 10)
-	require.ErrorIs(t, err, note.ErrNoteNotFound)
+	out, err := svc.ListReplies(nil, "ghost", "", "", 10)
+	require.NoError(t, err)
+	assert.Empty(t, out)
 }
 
 func TestQueryService_ListChildren(t *testing.T) {
@@ -167,10 +170,30 @@ func TestQueryService_ListChildren_PureRenoteExcluded(t *testing.T) {
 	assert.NotContains(t, got, "pure")
 }
 
+// #1929: children も親不在/不可視で 404 ではなく空リスト (upstream children.ts)。
 func TestQueryService_ListChildren_ParentMissing(t *testing.T) {
 	svc, _, _ := newQueryService(t)
-	_, err := svc.ListChildren(nil, "ghost", "", "", 10)
-	require.ErrorIs(t, err, note.ErrNoteNotFound)
+	out, err := svc.ListChildren(nil, "ghost", "", "", 10)
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+// #1929: 親が viewer に不可視 (followers-only) でも 404 にせず、reply 自体の
+// 可視性で filter した結果を返す (upstream は親チェックを行わない)。public reply は
+// 返り、followers-only reply は匿名 viewer から filter される (= leak しない)。
+func TestQueryService_ListReplies_InvisibleParentStillFiltersReplies(t *testing.T) {
+	svc, noteRepo, _ := newQueryService(t)
+	// 親 P は followers-only (匿名 viewer には不可視)。
+	noteRepo.Notes["P"] = &model.Note{ID: "P", UserID: "a", Visibility: model.NoteVisibilityFollowers}
+	pid := "P"
+	noteRepo.Notes["pub"] = &model.Note{ID: "pub", UserID: "b", Visibility: model.NoteVisibilityPublic, ReplyID: &pid}
+	noteRepo.Notes["fol"] = &model.Note{ID: "fol", UserID: "a", Visibility: model.NoteVisibilityFollowers, ReplyID: &pid}
+
+	// 匿名 viewer: 親不可視でも 404 にならず、public reply のみ返る (followers reply は filter)。
+	out, err := svc.ListReplies(nil, "P", "", "", 10)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, "pub", out[0].ID, "不可視親でも public reply は返る / followers reply は leak しない")
 }
 
 // #1500: visibility は repository の SQL push-down に委譲される。QueryService は


### PR DESCRIPTION
## Summary

`#1835` (notes-lifecycle) の sub-issue (F3 LOW、error_code)。notes/replies・notes/children が親 note 不在/不可視で 404 NO_SUCH_NOTE を返していた divergence を修正する。

## 問題
upstream replies.ts / children.ts は親 note の存在/可視性チェックを行わず、visibility-filtered query が空なら 200 `[]` を返す (getNote を呼ばない)。mk-go は ListReplies/ListChildren が冒頭で `requireVisible(viewer, noteID)` を呼び、親が不在/不可視なら 404 NO_SUCH_NOTE。

## 修正
- ListReplies / ListChildren の `requireVisible` gate を除去。reply 自体は `ListRepliesOf`/`ListChildrenOf` が viewer 可視性を **SQL push-down で filter** (#1500) するため、親不可視でも公開 reply のみ返り followers/specified reply は **leak しない**。
- **renotes.ts は upstream が getNote で 404** にするため `ListRenotes` は requireVisible を維持 (endpoint ごとの upstream 仕様に合わせた非対称)。conversation も gate 維持。

## テスト
親不在で 200 [] (query + handler 両層、replies + children)、**不可視親でも public reply は返り followers reply は filter される (no-leak)** を pin。`make fmt && make lint` clean、`go test ./...` 0 failures、note 94.9% / notes 90.5% cover。

## 敵対的レビュー (security-critical)
**CLEAN — leak 無し**。crux (per-reply 可視性が parent gate と独立に SQL で enforce される) を repository (`applyViewerVisibility`) で確認。upstream replies/children (no getNote) vs renotes (getNote→404) の非対称が一致、pure-renote 除外維持、conversation 非影響を確認。MINOR 指摘 (不可視親 test 不足) に対し no-leak test を追加。

Closes #1929

🤖 Generated with [Claude Code](https://claude.com/claude-code)