### PR TITLE
Fix notes-lifecycle parity (#1930): notes/create が visibility / reactionAcceptance の enum を検証する

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -504,6 +504,22 @@ func validateCreateInput(req *CreateRequest, fileIDs []string) error {
 			return errors.New("text must contain at least one non-whitespace character")
 		}
 	}
+	// visibility enum (upstream create.ts:132)。空文字は service が public に default
+	// するため許容し、非空の不正値のみ弾く (#1930)。
+	switch model.NoteVisibility(req.Visibility) {
+	case "", model.NoteVisibilityPublic, model.NoteVisibilityHome, model.NoteVisibilityFollowers, model.NoteVisibilitySpecified:
+	default:
+		return errors.New("visibility must be one of public, home, followers, specified")
+	}
+	// reactionAcceptance enum (upstream create.ts:138)。null (nil) は制限なしとして
+	// 許容、非 nil は 4 値のいずれかでなければ INVALID_PARAM (#1930)。
+	if req.ReactionAcceptance != nil {
+		switch *req.ReactionAcceptance {
+		case "likeOnly", "likeOnlyForRemote", "nonSensitiveOnly", "nonSensitiveOnlyForLocalLikeOnlyForRemote":
+		default:
+			return errors.New("invalid reactionAcceptance")
+		}
+	}
 	return nil
 }
 

--- a/internal/api/notes/handler_parity1538_test.go
+++ b/internal/api/notes/handler_parity1538_test.go
@@ -48,6 +48,20 @@ func TestValidateCreateInput(t *testing.T) {
 		{"whitespace-only text-only", &CreateRequest{Text: strPtr("   \n\t")}, nil, true},
 		{"whitespace text with file ok", &CreateRequest{Text: strPtr("   ")}, []string{"f1"}, false},
 		{"whitespace text with renote ok", &CreateRequest{Text: strPtr("   "), RenoteID: strPtr("r1")}, nil, false},
+		// #1930: visibility / reactionAcceptance enum 検証。
+		{"visibility empty defaults ok", &CreateRequest{Text: strPtr("x"), Visibility: ""}, nil, false},
+		{"visibility public", &CreateRequest{Text: strPtr("x"), Visibility: "public"}, nil, false},
+		{"visibility home", &CreateRequest{Text: strPtr("x"), Visibility: "home"}, nil, false},
+		{"visibility followers", &CreateRequest{Text: strPtr("x"), Visibility: "followers"}, nil, false},
+		{"visibility specified", &CreateRequest{Text: strPtr("x"), Visibility: "specified"}, nil, false},
+		{"visibility invalid", &CreateRequest{Text: strPtr("x"), Visibility: "foo"}, nil, true},
+		{"reactionAcceptance nil ok", &CreateRequest{Text: strPtr("x"), ReactionAcceptance: nil}, nil, false},
+		{"reactionAcceptance likeOnly", &CreateRequest{Text: strPtr("x"), ReactionAcceptance: strPtr("likeOnly")}, nil, false},
+		{"reactionAcceptance likeOnlyForRemote", &CreateRequest{Text: strPtr("x"), ReactionAcceptance: strPtr("likeOnlyForRemote")}, nil, false},
+		{"reactionAcceptance nonSensitiveOnly", &CreateRequest{Text: strPtr("x"), ReactionAcceptance: strPtr("nonSensitiveOnly")}, nil, false},
+		{"reactionAcceptance nonSensitiveOnlyForLocalLikeOnlyForRemote", &CreateRequest{Text: strPtr("x"), ReactionAcceptance: strPtr("nonSensitiveOnlyForLocalLikeOnlyForRemote")}, nil, false},
+		{"reactionAcceptance invalid", &CreateRequest{Text: strPtr("x"), ReactionAcceptance: strPtr("bogus")}, nil, true},
+		{"reactionAcceptance empty rejected", &CreateRequest{Text: strPtr("x"), ReactionAcceptance: strPtr("")}, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -572,6 +572,36 @@ func TestCreate_InvalidJSON(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// #1930: 不正な visibility enum は 400 INVALID_PARAM。
+func TestCreate_InvalidVisibility(t *testing.T) {
+	h, _ := newTestHandler(t)
+	user := &model.User{ID: "user1", Username: "testuser"}
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/notes/create", strings.NewReader(`{"text":"x","visibility":"foo"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	setAuthUser(c, user)
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_PARAM")
+}
+
+// #1930: 不正な reactionAcceptance enum は 400 INVALID_PARAM。
+func TestCreate_InvalidReactionAcceptance(t *testing.T) {
+	h, _ := newTestHandler(t)
+	user := &model.User{ID: "user1", Username: "testuser"}
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/notes/create", strings.NewReader(`{"text":"x","reactionAcceptance":"bogus"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	setAuthUser(c, user)
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_PARAM")
+}
+
 func TestCreate_WithVisibleUserIDs(t *testing.T) {
 	h, noteRepo := newTestHandler(t)
 


### PR DESCRIPTION
## Summary

`#1835` (notes-lifecycle) の sub-issue (F4 LOW、validation)。notes/create が visibility / reactionAcceptance の enum を検証せず不正値を 200 で受理していた divergence を修正する。

## 問題
upstream create.ts paramDef は visibility を enum `['public','home','followers','specified']`、reactionAcceptance を enum `[null,'likeOnly','likeOnlyForRemote','nonSensitiveOnly','nonSensitiveOnlyForLocalLikeOnlyForRemote']` に制約し外れた値は INVALID_PARAM。mk-go の validateCreateInput は text/cw/poll/fileIds 数しか検証せず両 field を素通ししていた。

## 修正
- validateCreateInput に enum 検証を追加。**visibility** は空文字 (service が public に default) を許容し非空の不正値を弾く。**reactionAcceptance** は nil (制限なし) を許容し非 nil は 4 値のいずれかを要求 ("" は upstream 同様 reject)。違反は handler が INVALID_PARAM(400) にマップ。

## テスト
各 valid visibility / ""→ok / 不正→error、各 valid reactionAcceptance / nil→ok / 不正→error / ""→error (table)、handler 層の 400 INVALID_PARAM mapping (両 field) を pin。`make fmt && make lint` clean、`go test ./...` 0 failures、notes 90.7% cover。

## 敵対的レビュー
CLEAN (no BLOCKER/MAJOR)。enum 値の upstream 完全一致 (4 値 character-for-character)、""→public default の等価性、null/"" の扱い、drop-in frontend が "" を送らないこと、400 mapping を確認。**派生 gap**: notes/drafts/create + scheduled-note processor も同 enum 未検証 → follow-up #1934 に分離。

Closes #1930

🤖 Generated with [Claude Code](https://claude.com/claude-code)