### PR TITLE
Fix notes-lifecycle parity (#1931): AP inbound の reply note も threadId を thread root に揃える

### DIFF
--- a/internal/core/federation/processor_test.go
+++ b/internal/core/federation/processor_test.go
@@ -1715,6 +1715,69 @@ func TestProcess_CreateReplyPassesReplyTarget(t *testing.T) {
 	assert.Equal(t, "local-parent", calls[0].replyTarget.ID)
 }
 
+// #1931: AP 経由で取り込んだ reply note も threadId を thread root に揃える
+// (local create path #1928 と同 logic)。これが無いと remote thread の deep muting が効かない。
+func TestProcess_CreateReplySetsThreadID(t *testing.T) {
+	p, _, _, noteRepo := newProcessor(t, aliceActor)
+	localURI := "https://example.com/notes/root-parent"
+	// root-parent は threadId 無し (= thread root)。
+	noteRepo.Notes["root-parent"] = &model.Note{
+		ID: "root-parent", UserID: "bob", URI: &localURI, Visibility: model.NoteVisibilityPublic,
+	}
+	body := []byte(`{
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"type": "Note",
+			"id": "https://remote.example/notes/reply1",
+			"attributedTo": "https://remote.example/users/alice",
+			"inReplyTo": "https://example.com/notes/root-parent",
+			"content": "remote reply",
+			"to": ["https://www.w3.org/ns/activitystreams#Public"]
+		}
+	}`)
+	require.NoError(t, p.Process(body))
+	require.Eventually(t, func() bool {
+		n, err := noteRepo.FindByURI("https://remote.example/notes/reply1")
+		return err == nil && n != nil
+	}, time.Second, 10*time.Millisecond)
+	created, err := noteRepo.FindByURI("https://remote.example/notes/reply1")
+	require.NoError(t, err)
+	require.NotNil(t, created.ThreadID)
+	assert.Equal(t, "root-parent", *created.ThreadID, "AP reply の threadId は root.id を指す")
+}
+
+// #1931: 深い AP reply (親が既に threadId を持つ) は root threadId を継承する。
+func TestProcess_CreateReplyInheritsThreadID(t *testing.T) {
+	p, _, _, noteRepo := newProcessor(t, aliceActor)
+	rootThread := "root"
+	localURI := "https://example.com/notes/mid-parent"
+	noteRepo.Notes["mid-parent"] = &model.Note{
+		ID: "mid-parent", UserID: "bob", URI: &localURI, Visibility: model.NoteVisibilityPublic, ThreadID: &rootThread,
+	}
+	body := []byte(`{
+		"type": "Create",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"type": "Note",
+			"id": "https://remote.example/notes/reply2",
+			"attributedTo": "https://remote.example/users/alice",
+			"inReplyTo": "https://example.com/notes/mid-parent",
+			"content": "deep remote reply",
+			"to": ["https://www.w3.org/ns/activitystreams#Public"]
+		}
+	}`)
+	require.NoError(t, p.Process(body))
+	require.Eventually(t, func() bool {
+		n, err := noteRepo.FindByURI("https://remote.example/notes/reply2")
+		return err == nil && n != nil
+	}, time.Second, 10*time.Millisecond)
+	created, err := noteRepo.FindByURI("https://remote.example/notes/reply2")
+	require.NoError(t, err)
+	require.NotNil(t, created.ThreadID)
+	assert.Equal(t, "root", *created.ThreadID, "深い AP reply は root threadId を継承")
+}
+
 func TestProcess_CreateWithoutNotificationHook(t *testing.T) {
 	// notificationHook が nil でも Create は panic しない。
 	p, _, _, noteRepo := newProcessor(t, aliceActor)

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -1204,6 +1204,16 @@ func (r *Resolver) ingestNoteWithCreated(body []byte, deliveringActorURI string,
 			note.ReplyID = &replyTarget.ID
 			note.ReplyUserID = &replyTarget.UserID
 			note.ReplyUserHost = replyTarget.UserHost
+			// thread-muting が深い thread でも効くよう threadId を thread root に
+			// 揃える (local create path #1928 と同 logic、upstream NoteCreateService:
+			// 623-627: threadId = data.reply.threadId ?? data.reply.id)。AP 経由で
+			// 取り込んだ remote reply にも適用しないと remote thread の deep muting が
+			// 効かない (#1931)。
+			threadID := replyTarget.ID
+			if replyTarget.ThreadID != nil && *replyTarget.ThreadID != "" {
+				threadID = *replyTarget.ThreadID
+			}
+			note.ThreadID = &threadID
 		}
 	}
 	// AP vote 判定: reply target が poll を持ち apNote.Name (choice 名) が


### PR DESCRIPTION
## Summary

`#1928` のレビュー派生 follow-up。#1928 で local create path は reply note の `threadId` を設定するようになったが、AP inbound path が取りこぼしていた divergence を埋める。

## 問題
AP inbound path (federation/resolver.go) は reply note に `ReplyID` のみ設定し `ThreadID` を埋めていなかった。よって AP 経由で取り込んだ remote reply は `threadId=NULL` のまま残り、remote thread に対する深さ2以上の thread-muting が効かなかった (#1928 と同じ bug が AP path に残存)。

## 修正
- resolver.go の reply note 構築で `note.ThreadID = replyTarget.ThreadID ?? replyTarget.ID` を設定 (NoteCreateService #1928 と同 logic、pointer aliasing を避け local コピー)。inbound UPDATE path は reply target を変更しないため recompute 不要。

## テスト
AP reply-to-root (threadId=root.id)、deep AP reply (threadId=root 継承) を `FindByURI` で created note を取得して pin。`make fmt && make lint` clean、`go test ./...` 0 failures、federation 90.4% cover。

## 敵対的レビュー
CLEAN。#1928 との logic 一致 (byte-for-byte)、placement・persistence (Create で永続化)・thread-muting chain・pointer 安全性・inbound UPDATE 非影響・AP 非シリアライズ (wire 影響なし) を確認。

Closes #1931

🤖 Generated with [Claude Code](https://claude.com/claude-code)