### PR TITLE
Fix notes-lifecycle parity (#1934): notes/drafts/create・update も visibility / reactionAcceptance enum を検証する

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -504,17 +504,24 @@ func validateCreateInput(req *CreateRequest, fileIDs []string) error {
 			return errors.New("text must contain at least one non-whitespace character")
 		}
 	}
-	// visibility enum (upstream create.ts:132)。空文字は service が public に default
-	// するため許容し、非空の不正値のみ弾く (#1930)。
-	switch model.NoteVisibility(req.Visibility) {
+	// visibility / reactionAcceptance enum (#1930)。notes/drafts/create と共有する
+	// (#1934)。
+	return validateNoteEnums(req.Visibility, req.ReactionAcceptance)
+}
+
+// validateNoteEnums checks the visibility / reactionAcceptance enum values shared
+// by notes/create and notes/drafts/create (upstream create.ts:132,138 /
+// drafts/create.ts:161,168). An empty visibility (the service defaults it to
+// public) and a nil reactionAcceptance (no restriction) are allowed; any other
+// value outside the enum returns an error that maps to INVALID_PARAM (#1930 / #1934).
+func validateNoteEnums(visibility string, reactionAcceptance *string) error {
+	switch model.NoteVisibility(visibility) {
 	case "", model.NoteVisibilityPublic, model.NoteVisibilityHome, model.NoteVisibilityFollowers, model.NoteVisibilitySpecified:
 	default:
 		return errors.New("visibility must be one of public, home, followers, specified")
 	}
-	// reactionAcceptance enum (upstream create.ts:138)。null (nil) は制限なしとして
-	// 許容、非 nil は 4 値のいずれかでなければ INVALID_PARAM (#1930)。
-	if req.ReactionAcceptance != nil {
-		switch *req.ReactionAcceptance {
+	if reactionAcceptance != nil {
+		switch *reactionAcceptance {
 		case "likeOnly", "likeOnlyForRemote", "nonSensitiveOnly", "nonSensitiveOnlyForLocalLikeOnlyForRemote":
 		default:
 			return errors.New("invalid reactionAcceptance")

--- a/internal/api/notes/handler_drafts.go
+++ b/internal/api/notes/handler_drafts.go
@@ -85,6 +85,12 @@ func (h *Handler) DraftsCreate(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("Invalid parameters."))
 	}
+	// visibility / reactionAcceptance enum 検証 (notes/create と共有、#1934)。
+	// draft 経由でも upstream drafts/create.ts:161,168 の enum 制約に揃え、不正値が
+	// scheduled-note 処理経由で投稿されるのを防ぐ。
+	if err := validateNoteEnums(req.Visibility, req.ReactionAcceptance); err != nil {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", err.Error(), apierr.UUIDInvalidParam))
+	}
 	if req.Visibility == "" {
 		req.Visibility = "public"
 	}
@@ -216,6 +222,12 @@ func (h *Handler) DraftsUpdate(c echo.Context) error {
 	}
 	if err := c.Bind(&req); err != nil || req.DraftID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("draftId is required."))
+	}
+	// visibility / reactionAcceptance enum 検証 (drafts/create と共有、#1934)。"" /
+	// nil は「変更しない」セマンティクスなので許容し、非空の不正値のみ弾く。paramDef
+	// 相当なので draft 不在 (404) より先に 400 を返す。
+	if err := validateNoteEnums(req.Visibility, req.ReactionAcceptance); err != nil {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", err.Error(), apierr.UUIDInvalidParam))
 	}
 	draft, err := h.draftRepo.FindByIDAndUser(req.DraftID, user.ID)
 	if err != nil {

--- a/internal/api/notes/handler_drafts_test.go
+++ b/internal/api/notes/handler_drafts_test.go
@@ -176,6 +176,23 @@ func TestDraftsCreate_DefaultVisibility(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// #1934: drafts/create も visibility / reactionAcceptance enum を検証する。
+func TestDraftsCreate_InvalidVisibility(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	rec := postDraft(h.DraftsCreate, `{"text":"x","visibility":"foo"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_PARAM")
+	assert.Empty(t, repo.drafts, "不正値の draft は保存しない")
+}
+
+func TestDraftsCreate_InvalidReactionAcceptance(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	rec := postDraft(h.DraftsCreate, `{"text":"x","reactionAcceptance":"bogus"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_PARAM")
+	assert.Empty(t, repo.drafts)
+}
+
 // create が replyId/renoteId/channelId/visibleUserIds/reactionAcceptance/
 // localOnly/hashtag/poll を永続化し、{createdDraft} で full shape を返す。
 func TestDraftsCreate_PersistsAllFieldsAndWraps(t *testing.T) {
@@ -454,6 +471,27 @@ func TestDraftsUpdate_InvalidParam(t *testing.T) {
 	h, _ := newDraftHandlerWithRepo()
 	rec := postDraft(h.DraftsUpdate, `{}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// #1934: drafts/update も visibility / reactionAcceptance enum を検証する。
+// 不正 enum は draft 不在 (404) より先に 400 で弾く (paramDef 相当)。
+func TestDraftsUpdate_InvalidVisibility(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	text := "old"
+	repo.drafts["d1"] = &model.NoteDraft{ID: "d1", UserID: "u1", Text: &text, Visibility: "public"}
+	rec := postDraft(h.DraftsUpdate, `{"draftId":"d1","visibility":"foo"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_PARAM")
+	assert.Equal(t, "public", repo.drafts["d1"].Visibility, "不正値で draft は変更されない")
+}
+
+func TestDraftsUpdate_InvalidReactionAcceptance(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	text := "old"
+	repo.drafts["d1"] = &model.NoteDraft{ID: "d1", UserID: "u1", Text: &text, Visibility: "public"}
+	rec := postDraft(h.DraftsUpdate, `{"draftId":"d1","reactionAcceptance":"bogus"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_PARAM")
 }
 
 // #1421: 他人 draftID を投げると NO_SUCH_NOTE_DRAFT 404 で reject される


### PR DESCRIPTION
## Summary

`#1930` のレビュー派生 follow-up。#1930 で notes/create は enum 検証するようになったが、**notes/drafts/create・update** は raw 値を NoteDraft にそのまま格納し、scheduled-note processor が後で CreateService.Create に渡すため enum 検証を bypass して不正値が保存・投稿されえた。upstream drafts/{create,update}.ts は両 enum を paramDef で制約している。

## 修正
- #1930 の inline enum check を **`validateNoteEnums` helper に抽出**し notes/create と共有 (behavior-identical refactor、drift 防止)。
- **DraftsCreate**: bind 後・persist 前に validateNoteEnums を適用、違反は INVALID_PARAM。
- **DraftsUpdate**: bind 後・draft 取得 (404) より先に validateNoteEnums を適用 (paramDef 相当の順序)。`""` / nil は「変更しない」セマンティクスなので許容。

## スコープ
issue は drafts/create で起票したが、実装時に sibling の drafts/update も同 enum 未検証と判明 (同一 1-line fix) のため両方を対応 (#1934 を拡大)。

## テスト
drafts/create・update の不正 visibility / reactionAcceptance が 400 INVALID_PARAM かつ draft 不変、既存 valid draft が 200 のままを pin。`make fmt && make lint` clean、`go test ./...` 0 failures、notes 90.7% cover。

## 敵対的レビュー
CLEAN。helper 抽出が #1930 と byte-for-byte 一致 (既存 test pass)、draft create/update が persist 前に gate、upstream drafts/{create,update}.ts と enum 完全一致、over-rejection 無し ("" / nil 許容) を確認。DraftsUpdate は同レビューで未 guard を指摘済 → 同一 fix なので本 PR に取り込み。

Closes #1934

🤖 Generated with [Claude Code](https://claude.com/claude-code)