### PR TITLE
Fix search parity (#1938): notes/search が suspended/blocked-host/blocked/muted note を除外 + SQLLike の userId/channelId 排他

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -836,6 +836,15 @@ func (h *Handler) Search(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
+	// upstream searchNoteByLike / searchNoteByMeilisearch は generateBaseNoteFilteringQuery
+	// で suspended-user / blocked-host (匿名でも) と被block/mute/renote-mute user の note を
+	// 除外する。provider は visibility しか掛けないため、search-by-tag 等と同じく post-fetch で
+	// applyMuteBlock を適用する (#1938)。upstream search は thread-mute を掛けないため
+	// applyThreadMute は不要。
+	notes, err = h.applyMuteBlock(viewer, notes)
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
 	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))
 }
 

--- a/internal/api/notes/handler_query_test.go
+++ b/internal/api/notes/handler_query_test.go
@@ -433,6 +433,39 @@ func TestSearch_OK(t *testing.T) {
 	shapetest.Assert(t, "Note", resp[0]) // L3 (#1316)
 }
 
+// #1938 F1: notes/search は suspended author の note を除外する (applyMuteBlock 経由、
+// upstream generateBaseNoteFilteringQuery 相当)。匿名でも効く。
+func TestSearch_ExcludesSuspendedAuthor(t *testing.T) {
+	h, repo := newQueryHandler(t)
+	hello := "hello suspended"
+	n := seedPublicNote(repo, "n1")
+	n.Text = &hello
+	n.User.IsSuspended = true
+
+	c, rec := newJSONRequest(t, "/api/notes/search", `{"query":"hello"}`)
+	require.NoError(t, h.Search(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Empty(t, resp, "suspended author の note は search 結果から除外")
+}
+
+// #1938 F5: userId 指定時は channelId を無視する (upstream の userId 優先排他)。
+// author の note (channel 無し) は channelId="other" を指定しても userId 一致で返る。
+func TestSearch_UserIDOverridesChannelID(t *testing.T) {
+	h, repo := newQueryHandler(t)
+	hello := "hello exclusive"
+	n := seedPublicNote(repo, "n1") // UserID="author", channel 無し
+	n.Text = &hello
+
+	c, rec := newJSONRequest(t, "/api/notes/search", `{"query":"hello","userId":"author","channelId":"other"}`)
+	require.NoError(t, h.Search(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp, 1, "userId 一致なら channelId 不一致でも返る (channelId は無視)")
+}
+
 // #1783: canSearchNotes policy が false の viewer (匿名含む) は UNAVAILABLE。
 func TestSearch_CanSearchNotesDenied(t *testing.T) {
 	h, _ := newQueryHandler(t)

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -541,10 +541,12 @@ func (r *noteRepository) SearchByFilter(f model.NoteSearchFilter) ([]*model.Note
 	// 非空なら viewer 自身の followers/specified/visibleUserIds note も含む。
 	// core/note.CanSeeNote と同条件 (mentions / search-by-tag と同じ helper)。
 	q = applyViewerVisibility(q, f.ViewerID)
+	// upstream searchNoteByLike は userId 優先の排他: userId があれば channelId は
+	// 無視する (`if (opts.userId) {} else if (opts.channelId) {}`、SearchService.ts:208-212、
+	// #1938)。両指定時に mk-go が両方 AND していた divergence を解消する。
 	if f.UserID != "" {
 		q = q.Where("\"userId\" = ?", f.UserID)
-	}
-	if f.ChannelID != "" {
+	} else if f.ChannelID != "" {
 		q = q.Where("\"channelId\" = ?", f.ChannelID)
 	}
 	if f.Host != "" {

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -1456,6 +1456,12 @@ func TestNoteRepository_SearchByFilter(t *testing.T) {
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"n_se_5"}, idsOf(out))
 
+	// #1938: userId と channelId 両指定時は userId 優先 (channelId 無視)。旧実装は両
+	// AND で n_se_5 のみだったが、upstream else-if では localUser の全 hello note (n_se_1 含む)。
+	out, err = repo.SearchByFilter(model.NoteSearchFilter{Query: "hello", UserID: localUser.ID, ChannelID: channelID, Limit: 10})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"n_se_1", "n_se_5"}, idsOf(out), "userId 指定時は channelId を無視 (userId 優先排他)")
+
 	// host フィルタ "." → ローカル限定
 	out, err = repo.SearchByFilter(model.NoteSearchFilter{Query: "hello", Host: ".", Limit: 10})
 	require.NoError(t, err)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1051,10 +1051,13 @@ func (m *MockNoteRepository) SearchByFilter(f model.NoteSearchFilter) ([]*model.
 		if !strings.Contains(strings.ToLower(*n.Text), q) {
 			return false
 		}
-		if f.UserID != "" && n.UserID != f.UserID {
-			return false
-		}
-		if f.ChannelID != "" {
+		// upstream searchNoteByLike は userId 優先の排他 (userId があれば channelId は
+		// 無視)。real repo (SearchByFilter) の else-if と挙動を揃える (#1938)。
+		if f.UserID != "" {
+			if n.UserID != f.UserID {
+				return false
+			}
+		} else if f.ChannelID != "" {
 			if n.ChannelID == nil || *n.ChannelID != f.ChannelID {
 				return false
 			}


### PR DESCRIPTION
## Summary

`#1836` (search) の sub-issue。notes/search の base note filtering 欠落 (F1 MEDIUM visibility_idor) と SQLLike の userId/channelId AND (F5 LOW) を upstream に整合する。

## F1 [MEDIUM] base note filtering 欠落 (leak)
upstream searchNoteByLike / searchNoteByMeilisearch は `generateBaseNoteFilteringQuery(query, me)` を必ず適用し、**匿名でも suspended-user / blocked-host note を除外**、viewer があれば block/mute/renote-mute/instance-mute user の note も除外する。mk-go の notes/search handler は provider の visibility filter のみで、suspended/blocked-host/被block/mute user の note が漏れていた (notes/search-by-tag は `applyMuteBlock` 済なのに notes/search は未適用という非対称)。

- Search handler の SearchNote 後に search-by-tag と同じ **`applyMuteBlock` を post-fetch 適用** (両 provider を handler 層で一括カバー)。upstream search は thread-mute を掛けないため `applyThreadMute` は不要。repo error は fail-closed で 500。

## F5 [LOW] SQLLike の userId/channelId が AND
upstream searchNoteByLike は userId 優先の排他 (`if (userId) {} else if (channelId) {}`) だが mk-go の SearchByFilter は独立 AND。両指定時に乖離。

- SearchByFilter (real repo) を else-if に変更。mock SearchByFilter も揃える。**meilisearch 経路は upstream が両 push のため AND のまま** (変更不要)。

## テスト
匿名 search が suspended author note を除外 (F1)、userId+channelId 指定時に channelId が無視される (handler mock + real-DB SearchByFilter で userId の全 note `{n_se_1,n_se_5}` が返る、F5)。`make fmt && make lint` clean、`go test ./...` 0 failures、notes 90.7% cover。

## 敵対的レビュー (security-critical)
**CLEAN — leak 残無し**。applyMuteBlock が generateBaseNoteFilteringQuery と parity-exact (suspended/blocked-host 匿名適用・block/mute viewer 適用、muted-channel は base に無いので非適用)、両 provider が handler 層でカバー、router で metaRepo/mutingRepo/blockingRepo 配線済 (prod no-op 無し)、fail-closed、no-thread-mute 判断を確認。F5 の else-if が upstream 一致・real/mock 整合・meilisearch 非変更を確認。

Closes #1938

🤖 Generated with [Claude Code](https://claude.com/claude-code)