### PR TITLE
Fix search parity (#1939): users/search を UserSearchService 相当に (display name / description / isSuspended / activeThreshold / muting / sort)

### DIFF
--- a/internal/api/resetpassword/handler_test.go
+++ b/internal/api/resetpassword/handler_test.go
@@ -39,7 +39,7 @@ func (m *mockUserRepo) FindByURI(string) (*model.User, error)     { return nil, 
 func (m *mockUserRepo) FindByToken(string) (*model.User, error)   { return nil, errMock }
 func (m *mockUserRepo) IncrementFollowingCount(string, int) error { return nil }
 func (m *mockUserRepo) IncrementFollowersCount(string, int) error { return nil }
-func (m *mockUserRepo) SearchByUsername(string, int, int, string) ([]*model.User, error) {
+func (m *mockUserRepo) SearchUsers(string, string, int, int, string) ([]*model.User, error) {
 	return nil, nil
 }
 func (m *mockUserRepo) SearchByUsernameAndHost(string, *string, bool, int) ([]*model.User, error) {

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -627,12 +627,17 @@ func (h *Handler) Search(c echo.Context) error {
 		return apierr.JSONInvalidParam(c)
 	}
 
-	users, err := h.userService.Search(req.Query, req.Limit, req.Offset, req.Origin)
+	// meID を渡して muting 除外を効かせる (upstream UserSearchService、#1939)。
+	viewer := middleware.GetUser(c)
+	meID := ""
+	if viewer != nil {
+		meID = viewer.ID
+	}
+	users, err := h.userService.Search(req.Query, meID, req.Limit, req.Offset, req.Origin)
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
 
-	viewer := middleware.GetUser(c)
 	iAmModerator := viewer != nil && h.moderatorChecker != nil && h.moderatorChecker.IsModerator(viewer.ID)
 
 	resolver := entity.NewInstanceResolver(h.instanceLookup(), users...)

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -707,6 +707,31 @@ func TestSearch_Success(t *testing.T) {
 	shapetest.Assert(t, "UserDetailedNotMeOnly", out[0]) // L3 (#1314)
 }
 
+// #1939: users/search は isSuspended ユーザーを除外する。
+func TestSearch_ExcludesSuspendedUser(t *testing.T) {
+	h, repo := newTestHandler(t)
+	name := "Test Suspended"
+	repo.Users["sus1"] = &model.User{ID: "sus1", Username: "testsuspended", UsernameLower: "testsuspended", Name: &name, IsSuspended: true, AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	rec := post(h.Search, `{"query":"testsuspended"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	assert.Empty(t, out, "suspended user は users/search に出ない")
+}
+
+// #1939: users/search は display name 部分一致で hit する (username 不一致でも)。
+func TestSearch_MatchesDisplayName(t *testing.T) {
+	h, repo := newTestHandler(t)
+	name := "Zqx Display Name"
+	repo.Users["dn1"] = &model.User{ID: "dn1", Username: "randomhandle", UsernameLower: "randomhandle", Name: &name, AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	rec := post(h.Search, `{"query":"zqx display"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1, "display name 部分一致で hit")
+	assert.Equal(t, "dn1", out[0]["id"])
+}
+
 // users/search bulk path is now batch (#517). Per-row FindProfileByUserID
 // must not be called and the new batch FindProfilesByUserIDs is invoked once
 // with all matched user IDs.
@@ -1917,7 +1942,7 @@ type failingUserRepo struct {
 	*testutil.MockUserRepository
 }
 
-func (f *failingUserRepo) SearchByUsername(_ string, _, _ int, _ string) ([]*model.User, error) {
+func (f *failingUserRepo) SearchUsers(_, _ string, _, _ int, _ string) ([]*model.User, error) {
 	return nil, assertErr
 }
 

--- a/internal/core/retention/service_test.go
+++ b/internal/core/retention/service_test.go
@@ -52,7 +52,7 @@ func (s *stubUserRepo) FindByUsernameLower(string, *string) (*model.User, error)
 func (s *stubUserRepo) FindProfileByUserID(string) (*model.UserProfile, error)   { return nil, nil }
 func (s *stubUserRepo) IncrementFollowingCount(string, int) error                { return nil }
 func (s *stubUserRepo) IncrementFollowersCount(string, int) error                { return nil }
-func (s *stubUserRepo) SearchByUsername(string, int, int, string) ([]*model.User, error) {
+func (s *stubUserRepo) SearchUsers(string, string, int, int, string) ([]*model.User, error) {
 	return nil, nil
 }
 func (s *stubUserRepo) SearchByUsernameAndHost(string, *string, bool, int) ([]*model.User, error) {

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -316,15 +316,20 @@ func (s *Service) ListRecommendations(viewerID string, activeSince time.Time, li
 //   - "local"    → host IS NULL のみ
 //   - "remote"   → host IS NOT NULL のみ
 //   - "combined" / 空 → filter なし (default)
-func (s *Service) Search(query string, limit, offset int, origin string) ([]*model.User, error) {
-	q := strings.TrimSpace(strings.TrimPrefix(query, "@"))
-	if q == "" {
+//
+// meID is the requesting user's ID ("" for anonymous), used to exclude muted
+// users from the results (upstream UserSearchService、#1939)。
+func (s *Service) Search(query, meID string, limit, offset int, origin string) ([]*model.User, error) {
+	// raw query を repo に渡す (name ILIKE / @handle 判定 / username 部分一致は
+	// repo 側で行うため、@ 除去・lowercase はここで行わない、#1939)。
+	query = strings.TrimSpace(query)
+	if query == "" {
 		return nil, nil
 	}
 	if limit <= 0 {
 		limit = 10
 	}
-	return s.userRepo.SearchByUsername(strings.ToLower(q), limit, offset, origin)
+	return s.userRepo.SearchUsers(query, meID, limit, offset, origin)
 }
 
 // SearchByUsernameAndHost narrows username prefix matches with a host filter.

--- a/internal/core/user/user_service_test.go
+++ b/internal/core/user/user_service_test.go
@@ -327,7 +327,7 @@ func TestService_GetProfile_Missing(t *testing.T) {
 
 func TestService_Search_Empty(t *testing.T) {
 	svc, _, _, _ := newFullSvc(t)
-	out, err := svc.Search("   ", 10, 0, "")
+	out, err := svc.Search("   ", "", 10, 0, "")
 	require.NoError(t, err)
 	assert.Empty(t, out)
 }
@@ -335,7 +335,7 @@ func TestService_Search_Empty(t *testing.T) {
 func TestService_Search_AtPrefix(t *testing.T) {
 	svc, repo, _, _ := newFullSvc(t)
 	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice", UsernameLower: "alice"}
-	out, err := svc.Search("@al", 10, 0, "")
+	out, err := svc.Search("@al", "", 10, 0, "")
 	require.NoError(t, err)
 	assert.Len(t, out, 1)
 }
@@ -343,7 +343,7 @@ func TestService_Search_AtPrefix(t *testing.T) {
 func TestService_Search_DefaultLimit(t *testing.T) {
 	svc, repo, _, _ := newFullSvc(t)
 	repo.Users["u1"] = &model.User{ID: "u1", Username: "alice", UsernameLower: "alice"}
-	out, err := svc.Search("a", 0, 0, "")
+	out, err := svc.Search("a", "", 0, 0, "")
 	require.NoError(t, err)
 	assert.Len(t, out, 1)
 }

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -1,12 +1,18 @@
 package repository
 
 import (
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/gorm"
 )
+
+// localUsernameSearchPattern mirrors upstream localUsernameSchema (^\w{1,20}$),
+// used by SearchUsers to decide whether a bare (non-@) query should also match
+// usernames by partial (#1939)。`\w` = [a-zA-Z0-9_]。
+var localUsernameSearchPattern = regexp.MustCompile(`^[a-zA-Z0-9_]{1,20}$`)
 
 // SearchOrigin は users/search の origin 引数の enum。upstream Misskey TS の
 // paramDef enum (`local` / `remote` / `combined`) に揃える (#763)。
@@ -44,11 +50,10 @@ type UserRepository interface {
 	// UPDATE していたが、CachedUserRepository wrapper の invalidate を
 	// 通すため userRepo 経由に統一する (Devin review #552 BUG-2)。
 	IncrementNotesCount(userID string, delta int) error
-	// SearchByUsername は usernameLower の prefix で user を検索する。
-	// origin は upstream Misskey TS と同じ semantics (#763)。値は
-	// SearchOriginLocal / SearchOriginRemote / SearchOriginCombined を使う。
-	// 空文字列 / 未知値は SearchOriginCombined と同等扱い。
-	SearchByUsername(query string, limit, offset int, origin string) ([]*model.User, error)
+	// SearchUsers は display name / username / description で user を検索する
+	// (upstream UserSearchService 相当、#1939)。origin は SearchOriginLocal /
+	// SearchOriginRemote / SearchOriginCombined。空文字列 / 未知値は Combined 扱い。
+	SearchUsers(query, meID string, limit, offset int, origin string) ([]*model.User, error)
 	// SearchByUsernameAndHost は username prefix と host を SQL で絞り込む
 	// (#766 / #1054 / #1064)。upstream Misskey TS の同名 endpoint と同じ
 	// semantics:
@@ -219,32 +224,93 @@ func (r *userRepository) IncrementNotesCount(userID string, delta int) error {
 		UpdateColumn("notesCount", gorm.Expr("\"notesCount\" + ?", delta)).Error
 }
 
-// SearchByUsername returns users whose usernameLower starts with the given query.
-// Phase 4でMeilisearch統合予定だが、現状は単純なLIKE検索のみ。
-//
-// origin で host filter を切り替える (#763)。
-//
-// query は escapeSQLLikePattern で SQL LIKE wildcard (`\` / `%` / `_`) を
-// escape する (#1061)。username は仕様上 `_` を含めうるため、escape 無しだと
-// `alice_bob` を search すると `alice1bob` 等の関係ない user も hit してしまう。
-// upstream Misskey TS UserSearchService.ts:197 と同じ semantics。
-func (r *userRepository) SearchByUsername(query string, limit, offset int, origin string) ([]*model.User, error) {
-	var users []*model.User
-	q := r.db.Where(`"usernameLower" LIKE ? ESCAPE '\'`, escapeSQLLikePattern(query)+"%")
-	switch origin {
-	case SearchOriginLocal:
-		q = q.Where("\"host\" IS NULL")
-	case SearchOriginRemote:
-		q = q.Where("\"host\" IS NOT NULL")
+// SearchUsers searches users by display name (ILIKE partial) OR username (prefix
+// for an @handle query, partial for a username-shaped query), with a
+// userProfile.description ILIKE fallback appended when fewer than `limit` rows
+// match. Mirrors upstream UserSearchService.search (#1939): only active users
+// (updatedAt within 30 days or NULL), isSuspended excluded, muted users excluded
+// when meID is set, ordered by updatedAt DESC NULLS LAST. query is the raw user
+// input (with any leading @ and original case preserved).
+func (r *userRepository) SearchUsers(query, meID string, limit, offset int, origin string) ([]*model.User, error) {
+	if limit <= 0 {
+		limit = 10
 	}
-	if err := q.
-		Order("\"followersCount\" DESC, id ASC").
-		Limit(limit).
-		Offset(offset).
-		Find(&users).Error; err != nil {
+	activeThreshold := time.Now().Add(-30 * 24 * time.Hour)
+	escaped := escapeSQLLikePattern(query)
+
+	// name ILIKE '%query%' OR username 一致 (upstream nameQuery の Brackets)。
+	// @handle (空白なし・@ が先頭のみ) は usernameLower 前方一致、username 形式の
+	// query は usernameLower 部分一致。それ以外は name のみ。
+	nameOrUsername := r.db.Where(`"name" ILIKE ? ESCAPE '\'`, "%"+escaped+"%")
+	isUsername := strings.HasPrefix(query, "@") && !strings.Contains(query, " ") && !strings.Contains(query[1:], "@")
+	if isUsername {
+		uname := escapeSQLLikePattern(strings.ToLower(strings.ReplaceAll(query, "@", "")))
+		nameOrUsername = nameOrUsername.Or(`"usernameLower" LIKE ? ESCAPE '\'`, uname+"%")
+	} else if localUsernameSearchPattern.MatchString(query) {
+		nameOrUsername = nameOrUsername.Or(`"usernameLower" LIKE ? ESCAPE '\'`, "%"+escapeSQLLikePattern(strings.ToLower(query))+"%")
+	}
+
+	mutingSub := func() *gorm.DB {
+		return r.db.Table("muting").Select(`"muteeId"`).Where(`"muterId" = ?`, meID)
+	}
+
+	q := r.db.Model(&model.User{}).
+		Where(nameOrUsername).
+		Where(`("updatedAt" IS NULL OR "updatedAt" > ?)`, activeThreshold).
+		Where(`"isSuspended" = false`)
+	q = applyUserSearchOrigin(q, origin)
+	if meID != "" {
+		q = q.Where(`"id" NOT IN (?)`, mutingSub())
+	}
+
+	var users []*model.User
+	if err := q.Order(`"updatedAt" DESC NULLS LAST`).Limit(limit).Offset(offset).Find(&users).Error; err != nil {
 		return nil, err
 	}
-	return users, nil
+	if len(users) >= limit {
+		return users, nil
+	}
+
+	// description fallback (upstream profQuery)。既に name/username で hit した ID は
+	// 除外して重複を避ける (upstream は重複しうるが mk-go では dedup する)。
+	foundIDs := make([]string, 0, len(users))
+	for _, u := range users {
+		foundIDs = append(foundIDs, u.ID)
+	}
+	profSub := r.db.Table("user_profile").Select(`"userId"`).Where(`"description" ILIKE ? ESCAPE '\'`, "%"+escaped+"%")
+	switch origin {
+	case SearchOriginLocal:
+		profSub = profSub.Where(`"userHost" IS NULL`)
+	case SearchOriginRemote:
+		profSub = profSub.Where(`"userHost" IS NOT NULL`)
+	}
+	if meID != "" {
+		profSub = profSub.Where(`"userId" NOT IN (?)`, mutingSub())
+	}
+	dq := r.db.Model(&model.User{}).
+		Where(`"id" IN (?)`, profSub).
+		Where(`("updatedAt" IS NULL OR "updatedAt" > ?)`, activeThreshold).
+		Where(`"isSuspended" = false`)
+	if len(foundIDs) > 0 {
+		dq = dq.Where(`"id" NOT IN ?`, foundIDs)
+	}
+	var descUsers []*model.User
+	if err := dq.Order(`"updatedAt" DESC NULLS LAST`).Limit(limit).Offset(offset).Find(&descUsers).Error; err != nil {
+		return nil, err
+	}
+	return append(users, descUsers...), nil
+}
+
+// applyUserSearchOrigin adds the local/remote host filter shared by the name and
+// description user-search queries.
+func applyUserSearchOrigin(q *gorm.DB, origin string) *gorm.DB {
+	switch origin {
+	case SearchOriginLocal:
+		return q.Where(`"host" IS NULL`)
+	case SearchOriginRemote:
+		return q.Where(`"host" IS NOT NULL`)
+	}
+	return q
 }
 
 // SearchByUsernameAndHost narrows username prefix matches with a host filter.

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -334,7 +335,7 @@ func TestUserRepository_SearchByUsername(t *testing.T) {
 	b := insertTestUser(t, "u_sb_2", "searchbeta")
 	defer cleanupUser(t, b.ID)
 
-	out, err := repo.SearchByUsername("search", 10, 0, "")
+	out, err := repo.SearchUsers("search", "", 10, 0, "")
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, len(out), 2)
 }
@@ -354,7 +355,7 @@ func TestUserRepository_SearchByUsername_LikeWildcardEscape(t *testing.T) {
 	t.Run("underscore in query is escaped to literal", func(t *testing.T) {
 		// `wild_` prefix で escape 有り → literal `_` として扱われ
 		// `wild_user` のみ hit、`wild1user` は hit しない
-		out, err := repo.SearchByUsername("wild_", 10, 0, "")
+		out, err := repo.SearchUsers("wild_", "", 10, 0, "")
 		require.NoError(t, err)
 		ids := make(map[string]bool, len(out))
 		for _, u := range out {
@@ -378,7 +379,7 @@ func TestUserRepository_SearchByUsername_OriginFilter(t *testing.T) {
 	defer cleanupUser(t, remote.ID)
 
 	t.Run("local only excludes remote", func(t *testing.T) {
-		out, err := repo.SearchByUsername("origin", 10, 0, SearchOriginLocal)
+		out, err := repo.SearchUsers("origin", "", 10, 0, SearchOriginLocal)
 		require.NoError(t, err)
 		ids := make(map[string]bool, len(out))
 		for _, u := range out {
@@ -389,7 +390,7 @@ func TestUserRepository_SearchByUsername_OriginFilter(t *testing.T) {
 	})
 
 	t.Run("remote only excludes local", func(t *testing.T) {
-		out, err := repo.SearchByUsername("origin", 10, 0, SearchOriginRemote)
+		out, err := repo.SearchUsers("origin", "", 10, 0, SearchOriginRemote)
 		require.NoError(t, err)
 		ids := make(map[string]bool, len(out))
 		for _, u := range out {
@@ -400,7 +401,7 @@ func TestUserRepository_SearchByUsername_OriginFilter(t *testing.T) {
 	})
 
 	t.Run("combined returns both", func(t *testing.T) {
-		out, err := repo.SearchByUsername("origin", 10, 0, SearchOriginCombined)
+		out, err := repo.SearchUsers("origin", "", 10, 0, SearchOriginCombined)
 		require.NoError(t, err)
 		ids := make(map[string]bool, len(out))
 		for _, u := range out {
@@ -411,7 +412,7 @@ func TestUserRepository_SearchByUsername_OriginFilter(t *testing.T) {
 	})
 
 	t.Run("empty origin treated as combined", func(t *testing.T) {
-		out, err := repo.SearchByUsername("origin", 10, 0, "")
+		out, err := repo.SearchUsers("origin", "", 10, 0, "")
 		require.NoError(t, err)
 		ids := make(map[string]bool, len(out))
 		for _, u := range out {
@@ -420,6 +421,62 @@ func TestUserRepository_SearchByUsername_OriginFilter(t *testing.T) {
 		assert.True(t, ids[local.ID])
 		assert.True(t, ids[remote.ID])
 	})
+}
+
+// #1939: SearchUsers の UserSearchService parity — display name 部分一致 /
+// description fallback / isSuspended 除外 / activeThreshold(30日) 除外 / muting 除外。
+func TestUserRepository_SearchUsers_Parity(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	now := time.Now()
+	stale := now.Add(-40 * 24 * time.Hour)
+	const q = "zqxparity"
+
+	mk := func(id, uname string, name *string, updatedAt *time.Time, suspended bool) *model.User {
+		u := &model.User{
+			ID: id, Username: uname, UsernameLower: strings.ToLower(uname),
+			Name: name, UpdatedAt: updatedAt, IsSuspended: suspended,
+			AvatarDecorations: datatypes.JSON([]byte("[]")),
+		}
+		require.NoError(t, testDB.Create(u).Error)
+		t.Cleanup(func() { cleanupUser(t, id) })
+		return u
+	}
+	idSet := func(users []*model.User) map[string]bool {
+		s := make(map[string]bool, len(users))
+		for _, u := range users {
+			s[u.ID] = true
+		}
+		return s
+	}
+
+	// username に q を含まない → name / description 経路でのみ hit する。
+	byName := mk("u_par_name", "plainuser1", strPtr2("Zqxparity Display"), &now, false)
+	byDesc := mk("u_par_desc", "plainuser2", nil, &now, false)
+	require.NoError(t, testDB.Create(&model.UserProfile{UserID: byDesc.ID, Description: strPtr2("loves zqxparity stuff")}).Error)
+	t.Cleanup(func() { testDB.Exec(`DELETE FROM "user_profile" WHERE "userId" = ?`, byDesc.ID) })
+	susp := mk("u_par_susp", "plainuser3", strPtr2("Zqxparity Suspended"), &now, true)
+	staleU := mk("u_par_stale", "plainuser4", strPtr2("Zqxparity Stale"), &stale, false)
+	muted := mk("u_par_muted", "plainuser5", strPtr2("Zqxparity Muted"), &now, false)
+
+	// anonymous (meID="")。
+	out, err := repo.SearchUsers(q, "", 50, 0, "")
+	require.NoError(t, err)
+	ids := idSet(out)
+	assert.True(t, ids[byName.ID], "display name 部分一致 (username 不一致でも)")
+	assert.True(t, ids[byDesc.ID], "description fallback")
+	assert.False(t, ids[susp.ID], "isSuspended は除外")
+	assert.False(t, ids[staleU.ID], "activeThreshold (40日前) は除外")
+	assert.True(t, ids[muted.ID], "anonymous は muting 除外しない")
+
+	// logged-in (me mutes `muted`)。
+	me := mk("u_par_me", "plainme", nil, &now, false)
+	require.NoError(t, testDB.Create(&model.Muting{ID: "mut_par", MuterID: me.ID, MuteeID: muted.ID}).Error)
+	t.Cleanup(func() { testDB.Exec(`DELETE FROM "muting" WHERE id = ?`, "mut_par") })
+	out, err = repo.SearchUsers(q, me.ID, 50, 0, "")
+	require.NoError(t, err)
+	ids = idSet(out)
+	assert.True(t, ids[byName.ID])
+	assert.False(t, ids[muted.ID], "muting 除外 (meID 指定時)")
 }
 
 // host filter 3-state semantics (#766 / #1054 / #1064):
@@ -641,7 +698,7 @@ func TestUserRepository_SearchByUsername_QueryError(t *testing.T) {
 	db := testDB.WithContext(ctx)
 	repo := NewUserRepository(db)
 
-	_, err := repo.SearchByUsername("anything", 10, 0, "")
+	_, err := repo.SearchUsers("anything", "", 10, 0, "")
 	assert.Error(t, err)
 }
 

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -12,6 +13,10 @@ import (
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
+
+// mockLocalUsernamePattern mirrors localUsernameSchema (^\w{1,20}$) for the mock
+// SearchUsers username-shape check (#1939).
+var mockLocalUsernamePattern = regexp.MustCompile(`^[a-zA-Z0-9_]{1,20}$`)
 
 // MockUserRepository is a test double for repository.UserRepository.
 type MockUserRepository struct {
@@ -185,10 +190,42 @@ func (m *MockUserRepository) IncrementFollowersCount(userID string, delta int) e
 	return nil
 }
 
-func (m *MockUserRepository) SearchByUsername(query string, limit, offset int, origin string) ([]*model.User, error) {
+// SearchUsers mirrors the production SearchUsers contract closely enough for
+// handler/service tests: display-name partial OR username (prefix for an @handle,
+// partial for a username-shaped query) OR description fallback, excluding
+// suspended users and honouring the origin filter. activeThreshold / muting /
+// updatedAt sort are NOT modelled (covered by the real-DB repository test, #1939).
+func (m *MockUserRepository) SearchUsers(query, meID string, limit, offset int, origin string) ([]*model.User, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+	lq := strings.ToLower(query)
+	isUsername := strings.HasPrefix(query, "@") && !strings.Contains(query, " ") && !strings.Contains(query[1:], "@")
+	unamePrefix := strings.ToLower(strings.ReplaceAll(query, "@", ""))
+	isUsernameShape := mockLocalUsernamePattern.MatchString(query)
 	var matches []*model.User
 	for _, u := range m.Users {
-		if len(u.UsernameLower) >= len(query) && u.UsernameLower[:len(query)] == query {
+		if u.IsSuspended {
+			continue
+		}
+		if origin == "local" && u.Host != nil {
+			continue
+		}
+		if origin == "remote" && u.Host == nil {
+			continue
+		}
+		match := u.Name != nil && strings.Contains(strings.ToLower(*u.Name), lq)
+		if !match && isUsername {
+			match = strings.HasPrefix(u.UsernameLower, unamePrefix)
+		} else if !match && isUsernameShape {
+			match = strings.Contains(u.UsernameLower, lq)
+		}
+		if !match {
+			if p, ok := m.Profiles[u.ID]; ok && p != nil && p.Description != nil && strings.Contains(strings.ToLower(*p.Description), lq) {
+				match = true
+			}
+		}
+		if match {
 			matches = append(matches, u)
 		}
 	}


### PR DESCRIPTION
## Summary

`#1836` (search) の sub-issue (F2 MEDIUM + F3 MEDIUM visibility_idor + F4 LOW)。users/search が username prefix 一致のみで本家 UserSearchService と検索結果集合が大きく乖離していたのを parity 化する。

## 問題
mk-go の users/search は `usernameLower LIKE 'q%'` の前方一致だけで、以下をすべて欠いていた:
- **F2**: 表示名(name)部分一致・username 部分一致・description fallback
- **F3 (visibility_idor)**: isSuspended=FALSE 除外 (停止ユーザーが検索に露出)
- **F4**: activeThreshold(30日)・muting 除外・updatedAt DESC sort

## 修正
- **repository**: `SearchByUsername` → `SearchUsers(query, meID, ...)` に rewrite。`WHERE (name ILIKE '%q%' OR username 一致) AND (updatedAt IS NULL OR > now-30日) AND isSuspended=FALSE [AND id NOT IN (muting subquery)] [AND origin]`、`ORDER BY updatedAt DESC NULLS LAST`。username 一致は @handle なら prefix、username 形式(`^\w{1,20}$`)なら部分一致。ヒット < limit のとき `user_profile.description ILIKE` fallback を既出 ID 除外で append。LIKE は `escapeSQLLikePattern` + `ESCAPE`。
- **F3**: isSuspended=FALSE を **name query / description query 双方**に適用。
- **Service.Search** に meID 追加 + raw query を repo に渡す。handler は viewer.ID(匿名 "")を渡す。
- mock SearchUsers を name/username/description + isSuspended + origin で揃える(activeThreshold/muting/sort は real-DB test でカバー)。interface + 手動 fake 3件更新。

## テスト
real-DB: name 一致(username 不一致)・description fallback・**isSuspended 除外**・activeThreshold(40日)除外・**muting 除外(meID)**・anonymous は muting 非除外。handler: suspended 除外・display name 一致。`make fmt && make lint` clean、`go test ./...` 0 failures、repository 90.0% / users 90.1% cover。

## 敵対的レビュー
**CLEAN**。query-logic を upstream UserSearchService.search と全項目照合(isUsername 判定・@handle prefix・username 部分一致・name raw query・activeThreshold・isSuspended 両 path・muting subquery・origin・sort・description fallback)。**F3 が name/description 双方で isSuspended 除外**を確認(leak 無し)。LIKE escape + parameterized subquery + GORM の OR 括弧/session 非変更を GORM source で確認。dedup(既出 ID 除外)は安全な改善。go vet ./... clean、手動 fake 全更新。

Closes #1939

🤖 Generated with [Claude Code](https://claude.com/claude-code)