### PR TITLE
Fix streaming-channels parity (#1942): LTL/GTL/HTL の ltlAvailable/gtlAvailable policy gate + anon requireSignin drop

### DIFF
--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2060,6 +2060,10 @@ func (s *Server) setupRoutes() {
 	// 漏れる (HTTP 側 #1444 i/notifications IDOR の WS 版)。noteQueryService
 	// の RequireVisible が NoteVisibilityChecker interface を自動 satisfy する。
 	streamManager.SetNoteVisibilityChecker(noteQueryService)
+	// timeline channel (LTL/GTL/HTL) の ltlAvailable / gtlAvailable gate 用に role
+	// policy provider を配線する (#1942)。REST timeline と同じく WS でも policy で
+	// 無効化された timeline を subscribe させない (policy bypass 解消)。
+	streamManager.SetPolicyProvider(roleService)
 	// hardMutedWords 変更時に reload event を受け取って該当 connection の
 	// rules を refresh する subscriber を起動 (#791)。i/update 側 publisher
 	// と同じ topic 名を共有 (= stream.WordMuteReloadTopic)。

--- a/internal/stream/channel.go
+++ b/internal/stream/channel.go
@@ -73,6 +73,11 @@ type ChannelContext interface {
 	// (#1711). Returns nil when the connection is anonymous or the lookup is
 	// unwired — callers must treat nil as "no filtering" (fail-open).
 	MuteBlockSnapshot() *MuteBlockSnapshot
+	// UserPolicies returns the viewer's effective role policies, fetched once at
+	// connect time. Timeline channels gate ltlAvailable / gtlAvailable on it
+	// (#1942). Returns nil when the policy provider is unwired — callers treat
+	// nil as "no gating" (fail-open).
+	UserPolicies() map[string]any
 }
 
 // PermittedChannel is an optional interface a Channel can implement to

--- a/internal/stream/channels/timeline.go
+++ b/internal/stream/channels/timeline.go
@@ -10,6 +10,19 @@ import (
 	"github.com/shiroha-a/mk/internal/stream"
 )
 
+// timelinePolicyAllows reports whether the connection may subscribe to a
+// policy-gated timeline. nil policies (provider 未配線、test/旧挙動) → allow
+// (fail-open)。それ以外は named policy が true でなければ不許可 (upstream
+// `if (!policies.ltlAvailable) return` 相当、#1942)。
+func timelinePolicyAllows(ctx stream.ChannelContext, key string) bool {
+	policies := ctx.UserPolicies()
+	if policies == nil {
+		return true
+	}
+	v, ok := policies[key].(bool)
+	return ok && v
+}
+
 // LocalTimelineChannel forwards local-public/home notes.
 type LocalTimelineChannel struct {
 	ctx    stream.ChannelContext
@@ -22,9 +35,14 @@ func NewLocalTimeline(ctx stream.ChannelContext) stream.Channel {
 	return &LocalTimelineChannel{ctx: ctx}
 }
 
-// Init subscribes to the local-timeline pubsub topic.
+// Init subscribes to the local-timeline pubsub topic, gated by ltlAvailable.
 func (c *LocalTimelineChannel) Init(params json.RawMessage) error {
 	c.filter = parseNoteFilter(params)
+	// upstream local-timeline.ts init(): ltlAvailable=false なら subscribe せず
+	// return (接続は成立するが note は流れない、#1942)。
+	if !timelinePolicyAllows(c.ctx, "ltlAvailable") {
+		return nil
+	}
 	c.ctx.Subscribe("localTimeline")
 	return nil
 }
@@ -35,6 +53,12 @@ func (c *LocalTimelineChannel) Init(params json.RawMessage) error {
 // 3 escape hatch を OR で評価する。
 func (c *LocalTimelineChannel) OnRedisEvent(payload []byte) {
 	viewerID := viewerIDFromCtx(c.ctx)
+	// anon viewer + note/renote/reply 著者が requireSigninToViewContents なら note を
+	// 丸ごと drop (#1942、upstream local-timeline.ts の 3 連 gate)。hideEmbeds の
+	// blank 化より前に弾いて「何も送らない」upstream 挙動に揃える。
+	if anonRequireSigninDrop(payload, viewerID) {
+		return
+	}
 	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerID) {
 		return
 	}
@@ -72,6 +96,10 @@ func NewGlobalTimeline(ctx stream.ChannelContext) stream.Channel {
 
 func (c *GlobalTimelineChannel) Init(params json.RawMessage) error {
 	c.filter = parseNoteFilter(params)
+	// upstream global-timeline.ts init(): gtlAvailable=false なら subscribe しない (#1942)。
+	if !timelinePolicyAllows(c.ctx, "gtlAvailable") {
+		return nil
+	}
 	c.ctx.Subscribe("globalTimeline")
 	return nil
 }
@@ -81,6 +109,11 @@ func (c *GlobalTimelineChannel) Init(params json.RawMessage) error {
 // ので、ここでも replyShouldEmit を呼ばずに pass-through 相当の挙動になる。
 func (c *GlobalTimelineChannel) OnRedisEvent(payload []byte) {
 	viewerID := viewerIDFromCtx(c.ctx)
+	// anon viewer + note/renote/reply 著者が requireSigninToViewContents なら drop
+	// (#1942、upstream global-timeline.ts の 3 連 gate)。hideEmbeds より前に弾く。
+	if anonRequireSigninDrop(payload, viewerID) {
+		return
+	}
 	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerID) {
 		return
 	}
@@ -178,6 +211,11 @@ func NewHybridTimeline(ctx stream.ChannelContext) stream.Channel {
 
 func (c *HybridTimelineChannel) Init(params json.RawMessage) error {
 	c.filter = parseNoteFilter(params)
+	// upstream hybrid-timeline.ts init(): ltlAvailable=false なら subscribe しない
+	// (local / home 両方、#1942)。
+	if !timelinePolicyAllows(c.ctx, "ltlAvailable") {
+		return nil
+	}
 	c.ctx.Subscribe("localTimeline")
 	if user, ok := c.ctx.User().(*model.User); ok && user != nil {
 		c.homeTopic = "homeTimeline:" + user.ID
@@ -192,6 +230,14 @@ func (c *HybridTimelineChannel) Init(params json.RawMessage) error {
 // が違う (#1063)。
 func (c *HybridTimelineChannel) OnRedisEvent(payload []byte) {
 	viewerID := viewerIDFromCtx(c.ctx)
+	// anon viewer + requireSigninToViewContents は note を丸ごと drop (#1942)。
+	// upstream hybrid-timeline.ts は requireCredential=true で anon が到達しない
+	// 前提のため明示 gate を持たないが、mk-go は cookie/anon が hybrid の
+	// localTimeline topic を購読できるため、LTL/GTL と同じく blank shell を送らず
+	// drop して揃える (requireCredential 非適用の root cause は別 issue)。
+	if anonRequireSigninDrop(payload, viewerID) {
+		return
+	}
 	if !c.filter.shouldEmit(payload, c.ctx.HardMuteRules(), viewerID) {
 		return
 	}

--- a/internal/stream/channels/timeline_test.go
+++ b/internal/stream/channels/timeline_test.go
@@ -25,6 +25,7 @@ type stubContext struct {
 	followingSnap map[string]bool
 	followingUpd  []followingUpdate
 	muteBlockSnap *stream.MuteBlockSnapshot
+	policies      map[string]any
 }
 
 // followingUpdate records a call to UpdateFollowingSnapshot for assertions.
@@ -57,6 +58,7 @@ func (s *stubContext) FollowingSnapshot() map[string]bool { return s.followingSn
 func (s *stubContext) MuteBlockSnapshot() *stream.MuteBlockSnapshot {
 	return s.muteBlockSnap
 }
+func (s *stubContext) UserPolicies() map[string]any { return s.policies }
 func (s *stubContext) UpdateFollowingSnapshot(followeeID string, following bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -122,6 +124,80 @@ func TestLocalTimeline_Lifecycle(t *testing.T) {
 	ch.OnClientMessage("ignored", json.RawMessage(`{}`))
 	ch.Dispose()
 	assert.Equal(t, []string{"localTimeline"}, ctx.unsubs)
+}
+
+// #1942 F1: ltlAvailable=false の connection は localTimeline を subscribe しない
+// (= 接続は成立するが note が流れない、upstream init() return 相当)。nil policies
+// (provider 未配線) は fail-open で subscribe する (TestLocalTimeline_Lifecycle で担保)。
+func TestLocalTimeline_PolicyGate(t *testing.T) {
+	disabled := newCtx(&model.User{ID: "v"})
+	disabled.policies = map[string]any{"ltlAvailable": false}
+	NewLocalTimeline(disabled).Init(nil)
+	assert.Empty(t, disabled.subs, "ltlAvailable=false は subscribe しない")
+
+	enabled := newCtx(&model.User{ID: "v"})
+	enabled.policies = map[string]any{"ltlAvailable": true}
+	NewLocalTimeline(enabled).Init(nil)
+	assert.Equal(t, []string{"localTimeline"}, enabled.subs, "ltlAvailable=true は subscribe する")
+}
+
+// #1942 F1: gtlAvailable gate。
+func TestGlobalTimeline_PolicyGate(t *testing.T) {
+	disabled := newCtx(&model.User{ID: "v"})
+	disabled.policies = map[string]any{"gtlAvailable": false}
+	NewGlobalTimeline(disabled).Init(nil)
+	assert.Empty(t, disabled.subs)
+
+	enabled := newCtx(&model.User{ID: "v"})
+	enabled.policies = map[string]any{"gtlAvailable": true}
+	NewGlobalTimeline(enabled).Init(nil)
+	assert.Equal(t, []string{"globalTimeline"}, enabled.subs)
+}
+
+// #1942 F1: hybrid は ltlAvailable=false なら local も home も subscribe しない。
+func TestHybridTimeline_PolicyGate(t *testing.T) {
+	disabled := newCtx(&model.User{ID: "v"})
+	disabled.policies = map[string]any{"ltlAvailable": false}
+	NewHybridTimeline(disabled).Init(nil)
+	assert.Empty(t, disabled.subs, "ltlAvailable=false は local も home も subscribe しない")
+}
+
+// #1942 F2: anon viewer + note/renote/reply 著者 requireSigninToViewContents の note は
+// 丸ごと drop する (blank shell を送らない)。
+func TestLocalTimeline_AnonRequireSigninDrop(t *testing.T) {
+	anon := newCtx(nil) // viewerID ""
+	ch := NewLocalTimeline(anon)
+	ch.Init(nil)
+	ch.OnRedisEvent([]byte(`{"id":"n1","user":{"requireSigninToViewContents":true}}`))
+	assert.Empty(t, anon.sentType, "anon に requireSignin note を送らない")
+	ch.OnRedisEvent([]byte(`{"id":"n2","user":{"requireSigninToViewContents":false}}`))
+	assert.Len(t, anon.sentType, 1, "通常 note は通す")
+
+	// authed viewer には requireSignin note も流れる (gate は anon 限定)。
+	authed := newCtx(&model.User{ID: "v"})
+	ca := NewLocalTimeline(authed)
+	ca.Init(nil)
+	ca.OnRedisEvent([]byte(`{"id":"n3","user":{"requireSigninToViewContents":true}}`))
+	assert.Len(t, authed.sentType, 1, "authed viewer には流れる")
+}
+
+// #1942 F2: GTL は reply 著者の requireSignin も anon に対して drop する。
+func TestGlobalTimeline_AnonRequireSigninDrop(t *testing.T) {
+	anon := newCtx(nil)
+	ch := NewGlobalTimeline(anon)
+	ch.Init(nil)
+	ch.OnRedisEvent([]byte(`{"id":"n1","reply":{"user":{"requireSigninToViewContents":true}}}`))
+	assert.Empty(t, anon.sentType, "anon に reply 著者 requireSignin の note を送らない")
+}
+
+// #1942 F2: mk-go は anon が hybrid を購読できる (upstream は requireCredential)
+// ため hybrid も anon に requireSignin note を blank shell で送らず drop する。
+func TestHybridTimeline_AnonRequireSigninDrop(t *testing.T) {
+	anon := newCtx(nil)
+	ch := NewHybridTimeline(anon)
+	ch.Init(nil)
+	ch.OnRedisEvent([]byte(`{"id":"n1","user":{"requireSigninToViewContents":true}}`))
+	assert.Empty(t, anon.sentType, "anon hybrid に requireSignin note を送らない")
 }
 
 func TestGlobalTimeline_Lifecycle(t *testing.T) {

--- a/internal/stream/connection.go
+++ b/internal/stream/connection.go
@@ -92,6 +92,14 @@ type Connection struct {
 	// read (per-publish) と write (set) が並行するので muteBlockMu で protect。
 	muteBlockMu sync.RWMutex
 	muteBlock   *MuteBlockSnapshot
+
+	// policies は viewer の role policy snapshot (#1942)。timeline channel が
+	// init() で ltlAvailable / gtlAvailable を gate するのに使う。接続確立時に
+	// 1 回 fetch する (anon は base policy)。set-once だが Manager goroutine で
+	// 書き接続後の read-loop goroutine で読むため mutex で happens-before を張る。
+	// nil = provider 未配線 (test/旧挙動) → gate skip (fail-open)。
+	policiesMu sync.RWMutex
+	policies   map[string]any
 }
 
 // NewConnection wraps an upgraded WebSocket. id は呼び出し側 (Manager) が一意
@@ -176,6 +184,23 @@ func (c *Connection) FollowingSnapshot() map[string]bool {
 	c.followingMu.RLock()
 	defer c.followingMu.RUnlock()
 	return c.followingSnapshot
+}
+
+// SetPolicies attaches the viewer's role-policy snapshot (#1942). Called once
+// at connect time by the Manager. nil leaves timeline policy gating disabled
+// (fail-open).
+func (c *Connection) SetPolicies(p map[string]any) {
+	c.policiesMu.Lock()
+	c.policies = p
+	c.policiesMu.Unlock()
+}
+
+// Policies returns the viewer's role-policy snapshot, or nil when the policy
+// provider is unwired. Read-only; callers must not mutate.
+func (c *Connection) Policies() map[string]any {
+	c.policiesMu.RLock()
+	defer c.policiesMu.RUnlock()
+	return c.policies
 }
 
 // UpdateFollowingSnapshot mutates the live followee snapshot after a

--- a/internal/stream/dispatcher.go
+++ b/internal/stream/dispatcher.go
@@ -462,6 +462,13 @@ func (c *channelContext) MuteBlockSnapshot() *MuteBlockSnapshot {
 	return c.dispatcher.conn.MuteBlockSnapshot()
 }
 
+func (c *channelContext) UserPolicies() map[string]any {
+	if c.dispatcher.conn == nil {
+		return nil
+	}
+	return c.dispatcher.conn.Policies()
+}
+
 // --- readNotification / subNote / unsubNote ---
 
 // handleReadNotification marks all notifications as read for the connected user.

--- a/internal/stream/dispatcher_test.go
+++ b/internal/stream/dispatcher_test.go
@@ -1111,3 +1111,23 @@ func TestChannelContext_MuteBlockSnapshot_NilConn(t *testing.T) {
 		t.Fatalf("expected nil, got %v", got)
 	}
 }
+
+// #1942: channelContext.UserPolicies forwards from Connection.
+func TestChannelContext_UserPolicies(t *testing.T) {
+	conn := NewConnection("c1", nil, newFakeConn())
+	conn.SetPolicies(map[string]any{"ltlAvailable": false, "gtlAvailable": true})
+	d := NewDispatcher(conn, nil, newStubBus())
+	ctx := &channelContext{dispatcher: d, id: "ch1"}
+	got := ctx.UserPolicies()
+	if got == nil || got["ltlAvailable"] != false || got["gtlAvailable"] != true {
+		t.Fatalf("UserPolicies = %v", got)
+	}
+}
+
+func TestChannelContext_UserPolicies_NilConn(t *testing.T) {
+	d := &Dispatcher{}
+	ctx := &channelContext{dispatcher: d, id: "ch1"}
+	if got := ctx.UserPolicies(); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}

--- a/internal/stream/manager.go
+++ b/internal/stream/manager.go
@@ -42,6 +42,14 @@ type Manager struct {
 	followingLookup FollowingSnapshotLookup
 	muteBlockLookup MuteBlockSnapshotLookup
 	noteVisibility  NoteVisibilityChecker
+	policyProvider  RolePolicyProvider
+}
+
+// RolePolicyProvider returns a user's effective role policies. Timeline channels
+// gate ltlAvailable / gtlAvailable on it (#1942). userID == "" yields the base
+// (anonymous) policies, mirroring upstream getUserPolicies(null).
+type RolePolicyProvider interface {
+	GetUserPolicies(userID string) map[string]any
 }
 
 // NewManager constructs a Manager with no live connections. registry / bus が
@@ -93,6 +101,13 @@ func (m *Manager) SetNoteVisibilityChecker(c NoteVisibilityChecker) {
 	m.noteVisibility = c
 }
 
+// SetPolicyProvider wires a RolePolicyProvider so timeline channels can gate
+// ltlAvailable / gtlAvailable at connect time (#1942). nil disables the gate
+// (fail-open, test/旧挙動).
+func (m *Manager) SetPolicyProvider(p RolePolicyProvider) {
+	m.policyProvider = p
+}
+
 // Accept implements api/streaming.ConnectionAcceptor. *websocket.Conn から
 // Connection を組み立て、Dispatcher 経由で channel framework に橋渡しする。
 func (m *Manager) Accept(ws *websocket.Conn, user *model.User) {
@@ -114,6 +129,16 @@ func (m *Manager) Accept(ws *websocket.Conn, user *model.User) {
 		// 失敗 (= nil 返却) は fail-open に degrade し、main / notifications は
 		// filter 無しで動き続ける (#1711)。
 		c.SetMuteBlockSnapshot(m.muteBlockLookup.MuteBlockSnapshotForUser(user.ID))
+	}
+	if m.policyProvider != nil {
+		// timeline channel の ltlAvailable / gtlAvailable gate 用に role policy を
+		// 接続確立時に 1 回 fetch (#1942)。anon (user==nil) は base policy
+		// (GetUserPolicies("")) を引く (upstream getUserPolicies(null) 相当)。
+		uid := ""
+		if user != nil {
+			uid = user.ID
+		}
+		c.SetPolicies(m.policyProvider.GetUserPolicies(uid))
 	}
 	dispatcher := NewDispatcher(c, m.registry, m.bus)
 	if m.notifReader != nil {

--- a/internal/stream/manager_test.go
+++ b/internal/stream/manager_test.go
@@ -137,6 +137,48 @@ func TestManager_AcceptInvokesMuteBlockLookup(t *testing.T) {
 	require.Eventually(t, func() bool { return lookup.called() == "alice" }, time.Second, 10*time.Millisecond)
 }
 
+// #1942: Accept は policy provider を接続確立時に呼び、Connection に policies を attach する。
+type stubPolicyProvider struct {
+	mu         sync.Mutex
+	calledWith string
+}
+
+func (s *stubPolicyProvider) GetUserPolicies(userID string) map[string]any {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calledWith = userID
+	return map[string]any{"ltlAvailable": false}
+}
+func (s *stubPolicyProvider) called() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calledWith
+}
+
+func TestManager_AcceptInvokesPolicyProvider(t *testing.T) {
+	m := NewManager(nil, nil)
+	provider := &stubPolicyProvider{}
+	m.SetPolicyProvider(provider)
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		go m.Accept(conn, &model.User{ID: "alice"})
+	}))
+	defer srv.Close()
+
+	url := "ws" + strings.TrimPrefix(srv.URL, "http")
+	dialer := websocket.Dialer{HandshakeTimeout: time.Second}
+	conn, _, err := dialer.Dial(url, nil)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	require.Eventually(t, func() bool { return provider.called() == "alice" }, time.Second, 10*time.Millisecond)
+}
+
 // TestManager_AcceptDispatchesConnectMessages verifies that Accept wires the
 // Dispatcher into the Connection so that client `connect` envelopes reach the
 // registered Channel factory and the topic is registered on the bus.


### PR DESCRIPTION
## Summary

`#1837` (streaming-channels) の sub-issue (F1+F2、2M)。streaming timeline channel の policy bypass (F1) と anon blank-shell leak (F2) を upstream に整合する。

## F1 [MEDIUM] policy gate 欠落 (WS bypass)
upstream は local/global/hybrid timeline channel の `init()` で `getUserPolicies()` を呼び `ltlAvailable`/`gtlAvailable` が false なら subscribe しない。mk-go の streaming channel は policy check が無く、**REST が 403 gate する LTL/GTL を WS 経由では無効化 user でも受信できた** (REST/WS enforcement 乖離、policy bypass)。

- stream 層に `RolePolicyProvider` を配線 (Manager → 接続確立時に Connection へ policies attach → `ChannelContext.UserPolicies` で公開)。LTL/HTL→ltlAvailable、GTL→gtlAvailable が false なら Init で subscribe を skip (upstream `init() return` 相当)。anon は base policy (`GetUserPolicies("")`)。未配線時は fail-open (test/旧挙動)、prod は router で `SetPolicyProvider(roleService)` 配線。

## F2 [MEDIUM] anon blank-shell leak
upstream LTL/GTL は anon viewer かつ note/renote/reply 著者が requireSigninToViewContents の note を 3 連 if で drop。mk-go は `anonRequireSigninDrop` を呼ばず hideEmbeds で blank shell を送っていた。

- LTL/GTL/HTL の OnRedisEvent に `anonRequireSigninDrop` を hideEmbeds より前に適用。hybrid は upstream が requireCredential で anon 不到達のため明示 gate を持たないが、**mk-go は anon が hybrid を購読できる**ため同じ drop を適用(レビュー指摘、root cause の requireCredential 非適用は follow-up #1944)。

## テスト
LTL/GTL/HTL の policy gate (disabled→subscribe せず / enabled→subscribe / nil→fail-open)、anon requireSignin drop (anon→drop / authed→pass)、Manager の provider 呼び出し、`channelContext.UserPolicies` forwarding を pin。`make fmt && make lint` clean、`go test ./...` 0 failures、stream 91.0% cover。

## 敵対的レビュー
essentially CLEAN (no BLOCKER/MAJOR)。F1 の policy parity (LTL/GTL/HTL の key)・anon base policy・disabled→non-subscribe・fail-open/closed・concurrency (happens-before + mutex)・prod 配線、F2 の 3-check parity・placement・authed 非影響を確認。MINOR (hybrid の anon leak、pre-existing) を同 PR で hybrid drop 追加して解消、root-cause (requireCredential 非適用) を follow-up #1944 に分離。

Closes #1942

🤖 Generated with [Claude Code](https://claude.com/claude-code)