### PR TITLE
Fix streaming-channels parity (#1943): 1 接続あたりの channel 数上限 (MAX_CHANNELS_PER_CONNECTION=32) を enforce する

### DIFF
--- a/internal/stream/dispatcher.go
+++ b/internal/stream/dispatcher.go
@@ -47,6 +47,12 @@ type NoteVisibilityChecker interface {
 // Dispatcher is the per-Connection state holding registered channels and the
 // reverse map "topic → channel id" used to route inbound pubsub events.
 //
+// maxChannelsPerConnection は 1 WebSocket 接続が保持できる channel 数の上限
+// (upstream Connection.ts MAX_CHANNELS_PER_CONNECTION、#1943)。超過した connect
+// 要求は silent に無視する。各 channel は pubsub subscribe を伴うため resource
+// exhaustion を防ぐ。
+const maxChannelsPerConnection = 32
+
 // 1 つの Connection に対して 1 つの Dispatcher がぶら下がり、複数の Channel
 // を保持する。pubsub の global subscription 管理は Manager の Router (K-4)
 // に集約するため、Dispatcher は per-channel の subscribe/unsubscribe API を
@@ -146,6 +152,13 @@ func (d *Dispatcher) handleConnect(body json.RawMessage) {
 	if d.hasShareableChannelLocked(req.Channel) {
 		d.mu.Unlock()
 		d.sendConnectedIfRequested(req.ID, req.Pong)
+		return
+	}
+	// 1 接続あたりの channel 数上限 (upstream MAX_CHANNELS_PER_CONNECTION=32、#1943)。
+	// 超過した connect 要求は silent に無視する (upstream connectChannel と同じ)。
+	// 既存 id / shareable hit は上で return 済なので、新規 channel 追加のみを制限する。
+	if len(d.channels) >= maxChannelsPerConnection {
+		d.mu.Unlock()
 		return
 	}
 	entry := &channelEntry{id: req.ID, name: req.Channel, topics: map[string]struct{}{}}

--- a/internal/stream/dispatcher_test.go
+++ b/internal/stream/dispatcher_test.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -482,6 +483,32 @@ func TestDispatcher_NonShareableChannel_AllowsMultiple(t *testing.T) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	assert.Len(t, d.channels, 2)
+}
+
+// #1943: 1 接続あたり maxChannelsPerConnection(32) を超えた connect は silent に無視する。
+func TestDispatcher_MaxChannelsPerConnection(t *testing.T) {
+	bus := newStubBus()
+	registry := NewRegistry()
+	registry.Register("test", func(ctx ChannelContext) Channel { return &fakeChannel{ctx: ctx} })
+	conn := NewConnection("c1", &model.User{ID: "alice"}, newFakeConn())
+	d := NewDispatcher(conn, registry, bus)
+
+	for i := 0; i < maxChannelsPerConnection; i++ {
+		d.HandleClientMessage("connect", json.RawMessage(fmt.Sprintf(`{"id":"ch%d","channel":"test"}`, i)))
+	}
+	d.mu.RLock()
+	n := len(d.channels)
+	d.mu.RUnlock()
+	require.Equal(t, maxChannelsPerConnection, n, "32 個までは登録できる")
+
+	// 33 個目は無視される (silent、登録されない)。
+	d.HandleClientMessage("connect", json.RawMessage(`{"id":"overflow","channel":"test"}`))
+	d.mu.RLock()
+	_, exists := d.channels["overflow"]
+	n = len(d.channels)
+	d.mu.RUnlock()
+	assert.Equal(t, maxChannelsPerConnection, n, "上限超過の connect は無視")
+	assert.False(t, exists, "overflow channel は登録されない")
 }
 
 // --- OAuth2 scope check (PermittedChannel) ---


### PR DESCRIPTION
## Summary

`#1837` (streaming-channels) の sub-issue (F3 LOW、validation)。1 WebSocket 接続が無制限に channel を登録できる resource exhaustion 経路を upstream に整合する。

## 問題
upstream Connection.ts は 1 接続あたりの channel を 32 (MAX_CHANNELS_PER_CONNECTION) に制限し超過を silent に無視する。mk-go の Dispatcher.handleConnect は id 重複と shareable 検査のみで総数上限を持たず、単一接続から無制限に channel を登録できた (各 channel は pubsub subscribe を伴う)。

## 修正
- `maxChannelsPerConnection=32` 定数を追加し、handleConnect で**新規 channel 追加の直前** (id 重複 / shareable hit の early return より後) に `len(d.channels) >= 32` なら silent return。既存 id / shareable hit は subscribe を増やさないため上限の対象外とし、新規 channel 追加のみを制限 (resource exhaustion 防止の趣旨)。lock 下で check + insert は atomic。

## テスト
32 個までは登録でき、33 個目は silent に無視され登録されないことを pin。`make fmt && make lint` clean、`go test ./...` 0 failures、stream 91.0% cover。

## 敵対的レビュー
clean (no BLOCKER/MAJOR)。upstream の cap=32 / silent-ignore parity、placement (新規のみ制限・lock 下・unlock 漏れ無し)、off-by-one、connected-ack 非送出、concurrency (read-loop 単一 goroutine) を確認。MINOR: shareable check を size より先に置く (upstream は size 先) ため cap 丁度での shareable hit の ack timing が僅かに異なるが、shareable は subscribe を増やさない no-op なので resource 観点では現配置が正しく、コメントで意図を明記済 (非 blocking)。

Closes #1943

🤖 Generated with [Claude Code](https://claude.com/claude-code)