### PR TITLE
Fix streaming-channels parity (#1944): stream 層が requireCredential を enforce し anon を authed 専用 channel から弾く

### DIFF
--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2014,19 +2014,19 @@ func (s *Server) setupRoutes() {
 
 	// 2. Channel registry: Misskey 互換のチャンネル名で各 factory を登録する
 	streamRegistry := stream.NewRegistry()
-	streamRegistry.Register("homeTimeline", channels.NewHomeTimeline)
+	streamRegistry.RegisterCredentialed("homeTimeline", channels.NewHomeTimeline)
 	streamRegistry.Register("localTimeline", channels.NewLocalTimeline)
 	streamRegistry.Register("globalTimeline", channels.NewGlobalTimeline)
-	streamRegistry.Register("hybridTimeline", channels.NewHybridTimeline)
-	streamRegistry.Register("notifications", channels.NewNotifications)
-	streamRegistry.Register("main", channels.NewMain)
-	streamRegistry.Register("drive", channels.NewDrive)
+	streamRegistry.RegisterCredentialed("hybridTimeline", channels.NewHybridTimeline)
+	streamRegistry.RegisterCredentialed("notifications", channels.NewNotifications)
+	streamRegistry.RegisterCredentialed("main", channels.NewMain)
+	streamRegistry.RegisterCredentialed("drive", channels.NewDrive)
 	streamRegistry.Register("hashtag", channels.NewHashtag)
-	streamRegistry.Register("antenna", channels.NewAntennaFactory(antennaRepo).New)
+	streamRegistry.RegisterCredentialed("antenna", channels.NewAntennaFactory(antennaRepo).New)
 	streamRegistry.Register("channel", channels.NewChannelTimeline)
 	streamRegistry.Register("userList", channels.NewUserList)
 	streamRegistry.Register("roleTimeline", channels.NewRoleTimelineFactory(roleService).New)
-	streamRegistry.Register("admin", channels.NewAdminFactory(roleService).New)
+	streamRegistry.RegisterCredentialed("admin", channels.NewAdminFactory(roleService).New)
 	// serverStats / queueStats は publisher を後段で構築するため、ここでは
 	// 仮 register せず、publisher 生成後に登録する (1497 行付近)。
 
@@ -2150,7 +2150,7 @@ func (s *Server) setupRoutes() {
 	// 5. Reversi WebSocket channel (Phase 9.6) を登録する
 	reversiService := corereversi.NewService(reversiRepo, reversiPublisher, s.redis.Default)
 	streamRegistry.Register("reversiGame", channels.NewReversiGameFactory(reversiService).New)
-	streamRegistry.Register("reversi", channels.NewReversi)
+	streamRegistry.RegisterCredentialed("reversi", channels.NewReversi)
 
 	// 6. Chat WebSocket channels (Phase 9.8): chatRoom と chatUser を登録する
 	chatPublisher := stream.NewChatPublisher(streamPubSub)
@@ -2171,8 +2171,8 @@ func (s *Server) setupRoutes() {
 	chatService.SetEmojiRepo(emojiRepo)
 	// 1-on-1 DM の chatApproval bypass + 送信後 approval 挿入に使う (#1748)。
 	chatService.SetApprovalRepo(repository.NewChatApprovalRepository(s.db))
-	streamRegistry.Register("chatRoom", channels.NewChatRoomFactory(chatService).New)
-	streamRegistry.Register("chatUser", channels.NewChatUserFactory(chatService).New)
+	streamRegistry.RegisterCredentialed("chatRoom", channels.NewChatRoomFactory(chatService).New)
+	streamRegistry.RegisterCredentialed("chatUser", channels.NewChatUserFactory(chatService).New)
 	// Phase 9.7: federation processor / reversi handler に reversi 依存を注入。
 	// FederationIDCache は本家 Misskey DB スキーマ互換のため DB カラムを持たず
 	// Redis のみで session↔gameID の双方向 mapping を保持する。api handler と

--- a/internal/stream/channel.go
+++ b/internal/stream/channel.go
@@ -112,13 +112,14 @@ type ChannelFactory func(ctx ChannelContext) Channel
 // Registry maps channel name → ChannelFactory. router.go で各 Channel 実装を
 // register することで Manager が参照できる。
 type Registry struct {
-	mu        sync.RWMutex
-	factories map[string]ChannelFactory
+	mu           sync.RWMutex
+	factories    map[string]ChannelFactory
+	credentialed map[string]bool
 }
 
 // NewRegistry constructs an empty Registry.
 func NewRegistry() *Registry {
-	return &Registry{factories: make(map[string]ChannelFactory)}
+	return &Registry{factories: make(map[string]ChannelFactory), credentialed: make(map[string]bool)}
 }
 
 // Register binds name → factory. 同名で複数回 register した場合は最後の登録が
@@ -127,6 +128,26 @@ func (r *Registry) Register(name string, factory ChannelFactory) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.factories[name] = factory
+}
+
+// RegisterCredentialed binds name → factory and marks the channel as requiring
+// an authenticated connection (upstream requireCredential=true). Anonymous
+// (user==nil) connect requests to such a channel are silently rejected by the
+// Dispatcher (#1944)。requireCredential は channel ごとの登録時プロパティなので、
+// scope (PermittedChannel) と分けて registry 側で一括宣言する。
+func (r *Registry) RegisterCredentialed(name string, factory ChannelFactory) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.factories[name] = factory
+	r.credentialed[name] = true
+}
+
+// RequiresCredential reports whether the named channel requires an authenticated
+// connection (#1944). Unknown names return false.
+func (r *Registry) RequiresCredential(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.credentialed[name]
 }
 
 // Lookup returns the factory for name, or nil when name is unknown.

--- a/internal/stream/dispatcher.go
+++ b/internal/stream/dispatcher.go
@@ -143,6 +143,12 @@ func (d *Dispatcher) handleConnect(body json.RawMessage) {
 	if factory == nil {
 		return
 	}
+	// requireCredential channel (hybrid/home/main/notifications/antenna/drive/
+	// admin/reversi/chat 等) は anon (user==nil) 接続を弾く (upstream connectChannel
+	// の requireCredential gate、silent return で connected ack も送らない、#1944)。
+	if d.registry.RequiresCredential(req.Channel) && (d.conn == nil || d.conn.User() == nil) {
+		return
+	}
 	d.mu.Lock()
 	if _, exists := d.channels[req.ID]; exists {
 		d.mu.Unlock()

--- a/internal/stream/dispatcher_test.go
+++ b/internal/stream/dispatcher_test.go
@@ -104,6 +104,48 @@ func TestRegistry_RegisterAndLookup(t *testing.T) {
 	assert.Nil(t, r.Lookup("missing"))
 }
 
+// #1944: RegisterCredentialed marks a channel as requiring auth; Register does not.
+func TestRegistry_Credentialed(t *testing.T) {
+	r := NewRegistry()
+	r.Register("anon", func(ctx ChannelContext) Channel { return &fakeChannel{ctx: ctx} })
+	r.RegisterCredentialed("authed", func(ctx ChannelContext) Channel { return &fakeChannel{ctx: ctx} })
+	assert.False(t, r.RequiresCredential("anon"))
+	assert.True(t, r.RequiresCredential("authed"))
+	assert.False(t, r.RequiresCredential("unknown"))
+	assert.NotNil(t, r.Lookup("authed"), "RegisterCredentialed も factory を登録する")
+}
+
+// #1944: anon (user==nil) は requireCredential channel に接続できず、認証済みは接続できる。
+// non-credentialed channel は anon も接続できる。
+func TestDispatcher_RequireCredential(t *testing.T) {
+	newReg := func() *Registry {
+		r := NewRegistry()
+		r.RegisterCredentialed("authed", func(ctx ChannelContext) Channel { return &fakeChannel{ctx: ctx} })
+		r.Register("open", func(ctx ChannelContext) Channel { return &fakeChannel{ctx: ctx} })
+		return r
+	}
+	hasChannel := func(d *Dispatcher, id string) bool {
+		d.mu.RLock()
+		defer d.mu.RUnlock()
+		_, ok := d.channels[id]
+		return ok
+	}
+
+	// anon → credentialed: 拒否。
+	anon := NewDispatcher(NewConnection("c1", nil, newFakeConn()), newReg(), newStubBus())
+	anon.HandleClientMessage("connect", json.RawMessage(`{"id":"a","channel":"authed"}`))
+	assert.False(t, hasChannel(anon, "a"), "anon は requireCredential channel に接続できない")
+
+	// anon → non-credentialed: 許可。
+	anon.HandleClientMessage("connect", json.RawMessage(`{"id":"o","channel":"open"}`))
+	assert.True(t, hasChannel(anon, "o"), "anon でも非 credentialed channel は接続できる")
+
+	// authed → credentialed: 許可。
+	authed := NewDispatcher(NewConnection("c2", &model.User{ID: "alice"}, newFakeConn()), newReg(), newStubBus())
+	authed.HandleClientMessage("connect", json.RawMessage(`{"id":"b","channel":"authed"}`))
+	assert.True(t, hasChannel(authed, "b"), "認証済みは requireCredential channel に接続できる")
+}
+
 func TestDispatcher_HandleConnect(t *testing.T) {
 	d, _, _, bus, _ := newDispatcherWithFake(t)
 	d.HandleClientMessage("connect", json.RawMessage(`{"id":"abc","channel":"test","params":{}}`))


### PR DESCRIPTION
## Summary

`#1942` のレビュー派生 follow-up (root cause)。mk-go の stream 層が `requireCredential` を enforce せず、anon (cookie/未ログイン、user==nil) が authed 専用 channel を購読できていた divergence を修正する。

## 問題
upstream の hybrid/home/main/antenna/drive/admin/reversi/chat 系 channel は `requireCredential=true` で anon 接続が到達しない。mk-go は `requireCredential` 概念を持たず、anon が hybridTimeline 等を購読できていた (#1942 で hybrid の blank-shell leak は塞いだが、anon が購読できること自体が shape divergence)。

## 修正
- **Registry** に credentialed set + `RegisterCredentialed(name, factory)` + `RequiresCredential(name)` を追加。requireCredential は登録時プロパティなので scope (PermittedChannel) と分けて registry で一括宣言し、upstream との対照を 1 箇所に集約。
- **Dispatcher.handleConnect**: Lookup 後・lock/entry 作成・connected ack より前に `RequiresCredential && user==nil` なら silent return (upstream connectChannel と同じ、ack も送らない)。
- **router**: `homeTimeline / hybridTimeline / notifications / main / drive / antenna / admin / reversi / chatRoom / chatUser` を `RegisterCredentialed` に(upstream `requireCredential=true` と一致、notifications は mk-go が main から分離した per-user channel)。`localTimeline / globalTimeline / hashtag / channel / userList / roleTimeline / serverStats / queueStats / reversiGame` は anon OK のまま。

これで #1942 の hybrid anon-drop は dispatcher 層の **defense-in-depth** になる(channel 単体 test は Init/OnRedisEvent を直接呼ぶため drop は引き続き検証)。

## テスト
Registry `RequiresCredential` (marked/unmarked/unknown)、Dispatcher の anon→credentialed 拒否 / anon→open 許可 / authed→credentialed 許可 を pin。`make fmt && make lint` clean、`go test ./...` 0 failures、stream 91.1% cover。

## 敵対的レビュー
**CLEAN**。全 19 channel の classification を upstream `requireCredential` flag と照合し**完全一致**(過剰/不足なし)。enforcement (anon test・silent reject before ack)・no over-rejection・concurrency・checkPermission との dual-gate・#1942 hybrid drop が defense-in-depth 化することを確認。router wiring の unit test 不在は `internal/server` の 0% 例外方針 (CLAUDE.md §8) に整合。

Closes #1944

🤖 Generated with [Claude Code](https://claude.com/claude-code)