### PR TITLE
Fix AP inbox parity (#1949): HTTP Signature の Digest body-integrity 検証と host 署名+一致を enforce する

### DIFF
--- a/internal/activitypub/inbox_admission.go
+++ b/internal/activitypub/inbox_admission.go
@@ -1,0 +1,120 @@
+package activitypub
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"strings"
+)
+
+// Inbox admission errors mirror the 401 conditions Misskey's
+// ActivityPubServerService.inbox enforces before queueing an inbound activity.
+var (
+	// ErrInboxHostUnsigned is returned when `host` is not part of the signed
+	// header set. Upstream requires the Host header to be covered by the
+	// signature so it cannot be swapped after signing.
+	ErrInboxHostUnsigned = errors.New("inbox: host header is not signed")
+	// ErrInboxHostMismatch is returned when the Host header does not equal the
+	// configured host. This binds the signature to this server's own inbox.
+	ErrInboxHostMismatch = errors.New("inbox: host header does not match configured host")
+	// ErrInboxDigestUnsigned is returned when `digest` is not part of the
+	// signed header set. Without it the Digest value is not authenticated and
+	// the body could be replaced while the signature still verifies.
+	ErrInboxDigestUnsigned = errors.New("inbox: digest header is not signed")
+	// ErrInboxDigestMissing is returned when the request carries no Digest header.
+	ErrInboxDigestMissing = errors.New("inbox: digest header is missing")
+	// ErrInboxDigestMalformed is returned when the Digest header is not of the
+	// form `algorithm=value`.
+	ErrInboxDigestMalformed = errors.New("inbox: digest header is malformed")
+	// ErrInboxDigestAlgo is returned when the Digest algorithm is not SHA-256.
+	ErrInboxDigestAlgo = errors.New("inbox: unsupported digest algorithm")
+	// ErrInboxDigestMismatch is returned when the SHA-256 of the body does not
+	// match the Digest value (body integrity violation).
+	ErrInboxDigestMismatch = errors.New("inbox: digest does not match request body")
+)
+
+// VerifyInboxAdmission performs the body-integrity and host-binding checks that
+// Misskey applies to every inbound activity before it is queued (see
+// ActivityPubServerService.inbox). It is the authoritative Digest verification
+// for mk-go: the generic signature verifier only validates the Digest header
+// *format*, while this function recomputes SHA-256(body) and compares it.
+//
+// The checks, mirroring upstream:
+//   - host must be signed and equal expectedHost (skipped when expectedHost is
+//     empty, e.g. unit tests / unconfigured callers that cannot compare);
+//   - digest must be signed;
+//   - the Digest header must be `SHA-256=<base64>` and its value must equal
+//     base64(sha256(body)), compared in constant time.
+//
+// parsed is the parsed Signature header (parsed.Headers is the signed header
+// set), hostHeader is the request Host, digestHeader is the raw Digest header,
+// and body is the raw request body. A non-nil error means the request must be
+// rejected with 401.
+func VerifyInboxAdmission(parsed *ParsedSignature, hostHeader, expectedHost, digestHeader string, body []byte) error {
+	if parsed == nil {
+		return errors.New("inbox: missing parsed signature")
+	}
+
+	// host: 署名対象 + 自ホスト一致。expectedHost が未設定の呼び出し元
+	// (config 非配線のテスト等) では比較対象が無いため host check 全体を skip する。
+	// production では router が config.Host を必ず配線するので upstream と等価。
+	if expectedHost != "" {
+		if !containsHeaderFold(parsed.Headers, "host") {
+			return ErrInboxHostUnsigned
+		}
+		if !strings.EqualFold(strings.TrimSpace(hostHeader), expectedHost) {
+			return ErrInboxHostMismatch
+		}
+	}
+
+	// digest: 署名対象であること。署名されていないと Digest 値が認証されず、
+	// 署名を保ったまま body を差し替えられる。
+	if !containsHeaderFold(parsed.Headers, "digest") {
+		return ErrInboxDigestUnsigned
+	}
+
+	algo, value, ok := splitDigestHeader(digestHeader)
+	if !ok {
+		if strings.TrimSpace(digestHeader) == "" {
+			return ErrInboxDigestMissing
+		}
+		return ErrInboxDigestMalformed
+	}
+	if !strings.EqualFold(algo, "SHA-256") {
+		return ErrInboxDigestAlgo
+	}
+
+	sum := sha256.Sum256(body)
+	want := base64.StdEncoding.EncodeToString(sum[:])
+	if subtle.ConstantTimeCompare([]byte(want), []byte(value)) != 1 {
+		return ErrInboxDigestMismatch
+	}
+	return nil
+}
+
+// containsHeaderFold reports whether name appears in the signed header set,
+// case-insensitively. Signature headers are conventionally lowercase, but we
+// compare case-insensitively for robustness.
+func containsHeaderFold(headers []string, name string) bool {
+	for _, h := range headers {
+		if strings.EqualFold(h, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// splitDigestHeader parses a `algorithm=value` Digest header, mirroring
+// upstream's `^([a-zA-Z0-9\-]+)=(.+)$` regex by splitting on the first `=`
+// (base64 values can themselves contain `=` padding, so only the first
+// separator is significant). Returns ok=false when there is no `=` or either
+// side is empty.
+func splitDigestHeader(header string) (algo, value string, ok bool) {
+	header = strings.TrimSpace(header)
+	idx := strings.IndexByte(header, '=')
+	if idx <= 0 || idx == len(header)-1 {
+		return "", "", false
+	}
+	return header[:idx], header[idx+1:], true
+}

--- a/internal/activitypub/inbox_admission_test.go
+++ b/internal/activitypub/inbox_admission_test.go
@@ -1,0 +1,185 @@
+package activitypub
+
+import (
+	"errors"
+	"testing"
+)
+
+// sig builds a ParsedSignature carrying the given signed header set.
+func sig(headers ...string) *ParsedSignature {
+	return &ParsedSignature{KeyID: "k", Signature: "s", Headers: headers}
+}
+
+func TestVerifyInboxAdmission(t *testing.T) {
+	body := []byte(`{"type":"Follow"}`)
+	goodDigest := SHA256Digest(body) // "sha-256=<base64>"
+	const host = "example.com"
+
+	tests := []struct {
+		name         string
+		parsed       *ParsedSignature
+		hostHeader   string
+		expectedHost string
+		digestHeader string
+		body         []byte
+		wantErr      error
+	}{
+		{
+			name:         "valid with host and digest signed",
+			parsed:       sig("(request-target)", "date", "host", "digest"),
+			hostHeader:   host,
+			expectedHost: host,
+			digestHeader: goodDigest,
+			body:         body,
+			wantErr:      nil,
+		},
+		{
+			name:         "tampered body fails digest value comparison",
+			parsed:       sig("(request-target)", "date", "host", "digest"),
+			hostHeader:   host,
+			expectedHost: host,
+			digestHeader: goodDigest,
+			body:         []byte(`{"type":"Follow","tampered":true}`),
+			wantErr:      ErrInboxDigestMismatch,
+		},
+		{
+			name:         "digest not in signed headers",
+			parsed:       sig("(request-target)", "date", "host"),
+			hostHeader:   host,
+			expectedHost: host,
+			digestHeader: goodDigest,
+			body:         body,
+			wantErr:      ErrInboxDigestUnsigned,
+		},
+		{
+			name:         "digest header missing",
+			parsed:       sig("(request-target)", "date", "host", "digest"),
+			hostHeader:   host,
+			expectedHost: host,
+			digestHeader: "",
+			body:         body,
+			wantErr:      ErrInboxDigestMissing,
+		},
+		{
+			name:         "digest header malformed",
+			parsed:       sig("(request-target)", "date", "host", "digest"),
+			hostHeader:   host,
+			expectedHost: host,
+			digestHeader: "not-a-digest",
+			body:         body,
+			wantErr:      ErrInboxDigestMalformed,
+		},
+		{
+			name:         "unsupported digest algorithm",
+			parsed:       sig("(request-target)", "date", "host", "digest"),
+			hostHeader:   host,
+			expectedHost: host,
+			digestHeader: "SHA-512=abc",
+			body:         body,
+			wantErr:      ErrInboxDigestAlgo,
+		},
+		{
+			name:         "host not signed when expectedHost set",
+			parsed:       sig("(request-target)", "date", "digest"),
+			hostHeader:   host,
+			expectedHost: host,
+			digestHeader: goodDigest,
+			body:         body,
+			wantErr:      ErrInboxHostUnsigned,
+		},
+		{
+			name:         "host mismatch when expectedHost set",
+			parsed:       sig("(request-target)", "date", "host", "digest"),
+			hostHeader:   "evil.example",
+			expectedHost: host,
+			digestHeader: goodDigest,
+			body:         body,
+			wantErr:      ErrInboxHostMismatch,
+		},
+		{
+			name:         "host check skipped when expectedHost empty",
+			parsed:       sig("(request-target)", "date", "digest"),
+			hostHeader:   "anything",
+			expectedHost: "",
+			digestHeader: goodDigest,
+			body:         body,
+			wantErr:      nil,
+		},
+		{
+			name:         "host comparison is case-insensitive",
+			parsed:       sig("(request-target)", "date", "host", "digest"),
+			hostHeader:   "Example.COM",
+			expectedHost: host,
+			digestHeader: goodDigest,
+			body:         body,
+			wantErr:      nil,
+		},
+		{
+			name:         "digest algo is case-insensitive",
+			parsed:       sig("(request-target)", "date", "host", "digest"),
+			hostHeader:   host,
+			expectedHost: host,
+			digestHeader: "sha-256=" + goodDigest[len("sha-256="):],
+			body:         body,
+			wantErr:      nil,
+		},
+		{
+			name:         "nil parsed signature",
+			parsed:       nil,
+			hostHeader:   host,
+			expectedHost: host,
+			digestHeader: goodDigest,
+			body:         body,
+			wantErr:      errNilParsed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := VerifyInboxAdmission(tt.parsed, tt.hostHeader, tt.expectedHost, tt.digestHeader, tt.body)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if tt.wantErr == errNilParsed {
+				// nil parsed returns a generic error, not a sentinel.
+				if err == nil {
+					t.Fatalf("expected error for nil parsed, got nil")
+				}
+				return
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("expected %v, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+// errNilParsed is a test marker; VerifyInboxAdmission returns a generic (non-sentinel)
+// error for a nil parsed signature, so the table uses this to branch.
+var errNilParsed = errors.New("nil parsed marker")
+
+func TestSplitDigestHeader(t *testing.T) {
+	tests := []struct {
+		in    string
+		algo  string
+		value string
+		ok    bool
+	}{
+		{"SHA-256=abc123", "SHA-256", "abc123", true},
+		{"SHA-256=ab+c/12==", "SHA-256", "ab+c/12==", true}, // base64 padding survives
+		{"  SHA-256=x  ", "SHA-256", "x", true},             // trimmed
+		{"=value", "", "", false},                           // empty algo
+		{"algo=", "", "", false},                            // empty value
+		{"noequals", "", "", false},
+		{"", "", "", false},
+	}
+	for _, tt := range tests {
+		algo, value, ok := splitDigestHeader(tt.in)
+		if ok != tt.ok || algo != tt.algo || value != tt.value {
+			t.Errorf("splitDigestHeader(%q) = (%q,%q,%v), want (%q,%q,%v)", tt.in, algo, value, ok, tt.algo, tt.value, tt.ok)
+		}
+	}
+}

--- a/internal/activitypub/signature.go
+++ b/internal/activitypub/signature.go
@@ -267,10 +267,11 @@ func verifyParsed(req *http.Request, parsed *ParsedSignature, pub crypto.PublicK
 	if err := verifyAlgorithm(parsed.Algorithm, kt, pub, []byte(signingString), sig); err != nil {
 		return err
 	}
-	// Digest check (for POST bodies)
+	// Digest check (for POST bodies). 形式 (sha-256= prefix) のみを見る軽い
+	// guard で、authoritative な値検証 (sha256(body) との一致) は inbox handler の
+	// admission (VerifyInboxAdmission) 側で行う (#1949)。ここで body を読むと
+	// legacy 経路では既に drain 済みのため値比較できない。
 	if expected := req.Header.Get("Digest"); expected != "" && req.Body != nil {
-		// Caller is responsible for already-buffered body verification; we
-		// only check the format here.
 		if !strings.HasPrefix(strings.ToLower(expected), "sha-256=") {
 			return errors.New("unsupported digest algorithm")
 		}

--- a/internal/api/inbox/handler.go
+++ b/internal/api/inbox/handler.go
@@ -63,6 +63,10 @@ type Handler struct {
 	// verify で公開鍵パースをメモ化する (#1426)。worker 側 InboxProcessor と
 	// 同じ最適化を、enqueue せず inline verify する構成にも適用する。
 	keyCache *activitypub.PublicKeyCache
+	// expectedHost は config 由来の自ホスト (host:port)。inbox admission の
+	// host 署名必須 + 一致チェックに使う。未設定時は host チェックを skip する
+	// (#1949)。
+	expectedHost string
 }
 
 // NewHandler constructs a Handler.
@@ -89,6 +93,13 @@ func (h *Handler) SetHostBlockChecker(c HostBlockChecker) {
 // 成功するたびに対応 instance row の latestRequestReceivedAt が更新される。
 func (h *Handler) SetInstanceTracker(t InstanceTracker) {
 	h.instanceTracker = t
+}
+
+// SetExpectedHost wires the configured host (host:port) used by inbox admission
+// to require the request Host header to be signed and to match this server.
+// Mirrors upstream `request.headers.host !== this.config.host` (#1949).
+func (h *Handler) SetExpectedHost(host string) {
+	h.expectedHost = host
 }
 
 // SetChartHook attaches a ChartHook invoked after each successfully
@@ -157,14 +168,18 @@ func (h *Handler) Inbox(c echo.Context) error {
 		c.Request().Header.Set("Host", c.Request().Host)
 	}
 
+	// upstream ActivityPubServerService.inbox と同じく、queue/処理に回す前に
+	// host 署名+一致・digest 署名・digest 値 (sha256(body)) を検証する。RSA は
+	// 走らない O(body) の安価なチェックで、fast write / legacy 両 path 共通。
+	// Signature ヘッダ欠落/malformed もここで 401 になる (#1949 body integrity)。
+	if err := h.admitInbox(c.Request(), body); err != nil {
+		slog.Warn("inbox admission rejected", "err", err)
+		return c.NoContent(http.StatusUnauthorized)
+	}
+
 	if h.enqueuer != nil {
-		// Fast write path. signature 検証は worker 側で再現するので
-		// handler では実施しない。最低限のチェックだけ handler で行う:
-		// Signature ヘッダの presence (= 明らかな malformed を 401 で
-		// 即返す)。これは O(1) の文字列存在 check で RSA は走らない。
-		if c.Request().Header.Get("Signature") == "" {
-			return c.NoContent(http.StatusUnauthorized)
-		}
+		// Fast write path. signature の crypto 検証は worker 側で再現する。
+		// admitInbox を上で通しているので handler 側の presence check は不要。
 		payload := queue.InboxPayload{
 			Body:    body,
 			Method:  c.Request().Method,
@@ -216,6 +231,19 @@ func (h *Handler) processSynchronously(c echo.Context, body []byte) error {
 		return c.NoContent(http.StatusBadRequest)
 	}
 	return c.NoContent(http.StatusAccepted)
+}
+
+// admitInbox enforces the upstream inbox admission checks before the activity
+// is queued or processed: the Host header must be signed and match the
+// configured host, the Digest header must be signed, and its SHA-256 value must
+// equal the body hash. Returns an error to reject with 401 (#1949). The Signature
+// header must parse; a missing/malformed Signature also fails here.
+func (h *Handler) admitInbox(req *http.Request, body []byte) error {
+	parsed, err := activitypub.ParseSignatureHeader(req.Header.Get("Signature"))
+	if err != nil {
+		return err
+	}
+	return activitypub.VerifyInboxAdmission(parsed, req.Host, h.expectedHost, req.Header.Get("Digest"), body)
 }
 
 // verifySignature parses the Signature header, resolves the actor, and

--- a/internal/api/inbox/handler_test.go
+++ b/internal/api/inbox/handler_test.go
@@ -534,3 +534,83 @@ func TestInbox_AsyncMode_EnqueueFailureReturns500(t *testing.T) {
 	require.NoError(t, h.Inbox(c))
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
+
+// --- #1949 inbox admission (digest body integrity + host binding) ---
+
+func TestInbox_TamperedBodyRejected(t *testing.T) {
+	priv, pub, err := activitypub.GenerateRSAKeypair()
+	require.NoError(t, err)
+	key, err := activitypub.NewPrivateKey("https://remote.example/users/alice#main-key", priv)
+	require.NoError(t, err)
+	h, _, _ := newHandler(t, pub)
+
+	original := []byte(`{"type":"Follow","actor":"https://remote.example/users/alice","object":"https://example.com/users/bob"}`)
+	tampered := []byte(`{"type":"Follow","actor":"https://remote.example/users/alice","object":"https://example.com/users/eve"}`)
+
+	c, rec := newPost(t, tampered)
+	req := c.Request()
+	// Digest は original の hash で署名するが、reader には tampered を流す。
+	require.NoError(t, activitypub.SignRequest(req, key, activitypub.SHA256Digest(original), []string{"(request-target)", "date", "host", "digest"}))
+	req.Host = "example.com"
+
+	require.NoError(t, h.Inbox(c))
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestInbox_DigestNotSignedRejected(t *testing.T) {
+	priv, pub, err := activitypub.GenerateRSAKeypair()
+	require.NoError(t, err)
+	key, err := activitypub.NewPrivateKey("https://remote.example/users/alice#main-key", priv)
+	require.NoError(t, err)
+	h, _, _ := newHandler(t, pub)
+
+	body := []byte(`{"type":"Follow","actor":"https://remote.example/users/alice","object":"https://example.com/users/bob"}`)
+	c, rec := newPost(t, body)
+	req := c.Request()
+	// Digest header は正しく付くが、署名対象ヘッダに digest を含めない。
+	require.NoError(t, activitypub.SignRequest(req, key, activitypub.SHA256Digest(body), []string{"(request-target)", "date", "host"}))
+	req.Host = "example.com"
+
+	require.NoError(t, h.Inbox(c))
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestInbox_HostMismatchRejected(t *testing.T) {
+	priv, pub, err := activitypub.GenerateRSAKeypair()
+	require.NoError(t, err)
+	key, err := activitypub.NewPrivateKey("https://remote.example/users/alice#main-key", priv)
+	require.NoError(t, err)
+	h, _, _ := newHandler(t, pub)
+	h.SetExpectedHost("example.com")
+
+	body := []byte(`{"type":"Follow","actor":"https://remote.example/users/alice","object":"https://example.com/users/bob"}`)
+	c, rec := newPost(t, body)
+	req := c.Request()
+	require.NoError(t, activitypub.SignRequest(req, key, activitypub.SHA256Digest(body), []string{"(request-target)", "date", "host", "digest"}))
+	req.Host = "evil.example"
+
+	require.NoError(t, h.Inbox(c))
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestInbox_HostSignedAndMatchAccepted(t *testing.T) {
+	priv, pub, err := activitypub.GenerateRSAKeypair()
+	require.NoError(t, err)
+	key, err := activitypub.NewPrivateKey("https://remote.example/users/alice#main-key", priv)
+	require.NoError(t, err)
+	h, repo, followingRepo := newHandler(t, pub)
+	h.SetExpectedHost("example.com")
+
+	bobURI := "https://example.com/users/bob"
+	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob", URI: &bobURI}
+
+	body := []byte(`{"type":"Follow","actor":"https://remote.example/users/alice","object":"https://example.com/users/bob"}`)
+	c, rec := newPost(t, body)
+	req := c.Request()
+	require.NoError(t, activitypub.SignRequest(req, key, activitypub.SHA256Digest(body), []string{"(request-target)", "date", "host", "digest"}))
+	req.Host = "example.com"
+
+	require.NoError(t, h.Inbox(c))
+	assert.Equal(t, http.StatusAccepted, rec.Code)
+	assert.Len(t, followingRepo.Followings, 1)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1864,6 +1864,8 @@ func (s *Server) setupRoutes() {
 	inboxHandler.SetHostBlockChecker(instanceService)
 	inboxHandler.SetInstanceTracker(instanceService)
 	inboxHandler.SetChartHook(chartHooks)
+	// inbox admission の host 署名+一致チェックに自ホストを配線する (#1949)。
+	inboxHandler.SetExpectedHost(s.config.Host)
 	// #534: signature 検証成功後の Process(body) を inbox queue に逃がす。
 	// 未配線時は legacy 同期処理にフォールバック (テスト互換)。
 	inboxHandler.SetEnqueuer(s.queueClient)


### PR DESCRIPTION
## Summary

AP inbox の HTTP Signature 検証に欠けていた **body integrity 検証**を追加する (#1949)。

upstream `ActivityPubServerService.inbox` は inbound activity を queue に積む前に同期で
以下を検証する (`packages/backend/src/server/ActivityPubServerService.ts:109-180`):

1. `host` が署名対象ヘッダにあり、かつ `request.headers.host === config.host`
2. `digest` が署名対象ヘッダにある
3. `Digest` = `SHA-256=<base64>` で、`sha256(rawBody)` の base64 と一致

mk-go はこの 3 つを全て欠いており、`verifyParsed` は Digest ヘッダの**形式 prefix
(`sha-256=`) しか見ず** `sha256(body)` の値比較をしていなかった。結果、署名は通るが
body を差し替えた inbox POST を 202 受理する body integrity gap になっていた
(production の fast-write→worker 経路でも値比較なし)。

## 主な変更点

- `internal/activitypub/inbox_admission.go` (新規): 純粋関数 `VerifyInboxAdmission` を追加。
  upstream 124-174 のロジックを移植 (host 署名+一致 / digest 署名 / `sha256(body)` を
  `crypto/subtle.ConstantTimeCompare` で定数時間比較)。digest header parse は upstream
  regex `^([a-zA-Z0-9\-]+)=(.+)$` 相当。
- `internal/api/inbox/handler.go`: `Inbox` の body 読み込み + Host backfill 後・enqueue 分岐
  前に `admitInbox` を呼ぶ。これで fast-write / legacy sync の両 path、`/inbox` と
  `/users/:id/inbox` の両 route をカバー。`expectedHost` field + `SetExpectedHost` 追加。
  冗長になった fast-path の `Signature == ""` チェックは admission に包含。
- `internal/server/router.go`: `inboxHandler.SetExpectedHost(s.config.Host)` を配線。
- `internal/activitypub/signature.go`: `verifyParsed` の digest 形式チェックのコメントを更新し、
  authoritative な値検証が inbox admission 側にあることを明示 (挙動変更なし)。

### 設計メモ

- host 一致チェックは `expectedHost != ""` の時のみ強制する。config 由来の値が無い
  呼び出し元 (単体テスト) では比較対象が無いため skip するが、production では router が
  `config.Host` を必ず配線するので upstream と等価。
- **deployment 注意**: host 一致は reverse proxy が `Host` ヘッダを保持していること
  (`proxy_set_header Host $host`) が前提。upstream Misskey も同一要件なので、TS で連合
  できていた構成なら影響しない。

## テスト

- `internal/activitypub/inbox_admission_test.go` (新規): table test で host unsigned/mismatch/skip,
  digest unsigned/missing/malformed/algo/mismatch, nil parsed, case-insensitive host・algo,
  `splitDigestHeader` の境界 (先頭/末尾 `=`, base64 padding, 空文字) を網羅。
- `internal/api/inbox/handler_test.go` (追記): tampered body→401 / digest 未署名→401 /
  host mismatch→401 / host 一致→202 を handler レベルで検証。
- 新規コードは 100% カバレッジ。`internal/activitypub` 91.0% / `internal/api/inbox` 97.2%。
- `make fmt` / `go vet ./...` / `make test` green。

実行方法:
```
go test ./internal/activitypub/ ./internal/api/inbox/
```

## 隣接 issue

実装時の敵対的レビューで upstream `inbox()` にあって mk-go inbox に欠けている隣接 gap を
2 件発見し、本 PR のスコープ外として別 issue 化した:
- #1958 AP inbox に bodyLimit (64KB) が無く未認証 DoS surface
- #1959 AP inbox に `federation === 'none'` の早期 403 gate が無い

## 関連

- 親: #1948 (全面互換性 再監査フォローアップ)

Closes #1949
