### PR TITLE
Fix clips parity (#1950): clips/notes を clip_note.id でなく note.id でページネーションする

### DIFF
--- a/internal/core/transfer/export_edge_test.go
+++ b/internal/core/transfer/export_edge_test.go
@@ -3,6 +3,7 @@ package transfer_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -201,6 +202,44 @@ func TestExport_Clips_WithNotes(t *testing.T) {
 	assert.Contains(t, body, "c1")
 	assert.Contains(t, body, "clipped")
 	assert.NotContains(t, body, "missing")
+}
+
+// TestExport_Clips_MultiPage は #1950 の export 経路回帰テスト。collectClipNotes は
+// ListByClip を keyset でページネーションするが、#1950 で比較列が note.id になったため
+// 次ページの cursor も note.id を渡さなければならない (clip_note.id を渡すと無関係 ULID
+// で比較され 2 ページ目が空になり全件 export できない)。clip_note.id と note.id の prefix
+// を変えて cross-column バグを顕在化させ、101 件超でも全件 export されることを検証する。
+func TestExport_Clips_MultiPage(t *testing.T) {
+	saver, _, deps, user := newExportDeps(t)
+	clipRepo := deps.ClipRepo.(*testutil.MockClipRepository)
+	clipNoteRepo := deps.ClipNoteRepo.(*testutil.MockClipNoteRepository)
+	noteRepo := deps.NoteRepo.(*testutil.MockNoteRepository)
+
+	clipRepo.Clips["c1"] = &model.Clip{ID: "c1", UserID: user.ID, Name: "big", IsPublic: true}
+
+	const total = 150 // > 1 ページ (100)
+	for i := 1; i <= total; i++ {
+		noteID := fmt.Sprintf("n_%03d", i)
+		// clip_note.id は note.id と prefix を変える (cross-column バグを露出させる)。
+		clipNoteRepo.Entries[fmt.Sprintf("link_%03d", i)] = &model.ClipNote{
+			ID: fmt.Sprintf("link_%03d", i), ClipID: "c1", NoteID: noteID,
+		}
+		text := "n" + noteID
+		noteRepo.Notes[noteID] = &model.Note{ID: noteID, UserID: user.ID, Text: &text}
+	}
+
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportClips)
+	require.NoError(t, err)
+
+	body := string(saver.uploads[0].Body)
+	missing := 0
+	for i := 1; i <= total; i++ {
+		if !strings.Contains(body, fmt.Sprintf(`"%s"`, fmt.Sprintf("n_%03d", i))) {
+			missing++
+		}
+	}
+	assert.Equal(t, 0, missing, "all %d clipped notes must be exported across pages", total)
 }
 
 // UserLists: members without preloaded User trigger the UserRepo.FindByID fallback.

--- a/internal/core/transfer/export_json.go
+++ b/internal/core/transfer/export_json.go
@@ -49,7 +49,8 @@ func (e *Exporter) exportFavorites(userID string) ([]byte, error) {
 			break
 		}
 		// 結果は id DESC で帰ってくるので最後の (= 最も古い) ID を次の
-		// untilID に渡して次ページを取得する。
+		// untilID に渡して次ページを取得する。favorites は note_favorite.id で
+		// ページネーションするので cursor も note_favorite.id (= rows[].ID)。
 		untilID = rows[len(rows)-1].ID
 	}
 	buf.WriteByte(']')
@@ -134,7 +135,10 @@ func (e *Exporter) collectClipNotes(clipID string) ([]*model.Note, error) {
 			}
 			out = append(out, n)
 		}
-		untilID = rows[len(rows)-1].ID
+		// ListByClip は note.id (= clip_note.noteId) で keyset ページネーションする
+		// ため、次ページの cursor も note.id を渡す。clip_note.id を渡すと無関係な
+		// ULID で比較されページ抜け/重複が起きる (#1950)。
+		untilID = rows[len(rows)-1].NoteID
 		if len(rows) < 100 {
 			break
 		}

--- a/internal/repository/clip_note.go
+++ b/internal/repository/clip_note.go
@@ -79,8 +79,9 @@ func (r *clipNoteRepository) ListClipIDsByNote(noteID string) ([]string, error) 
 }
 
 // ListByClip returns the entries for a clip with since/until pagination on
-// the clip_note id. Order flips to ASC when only sinceID is supplied,
-// matching paginationOrder (upstream QueryService.makePaginationQuery parity).
+// the referenced note id (clip_note.noteId == note.id). Order flips to ASC when
+// only sinceID is supplied, matching paginationOrder (upstream
+// QueryService.makePaginationQuery on the note builder parity, #1950).
 func (r *clipNoteRepository) ListByClip(clipID string, untilID, sinceID string, limit int) ([]*model.ClipNote, error) {
 	return r.listByClip(clipID, "", false, untilID, sinceID, limit, nil)
 }
@@ -120,14 +121,21 @@ func (r *clipNoteRepository) listByClip(clipID, viewerID string, filterVisibilit
 		cond.WriteString(`)`)
 		q = q.Where(cond.String(), args...)
 	}
+	// upstream clips/notes は makePaginationQuery を note builder に対して掛けるため
+	// sinceId/untilId は note.id と比較され note.id DESC (作成順, 新しい note が先頭)
+	// で並ぶ。client は最後に返った note.id を untilId として渡すので、比較列も
+	// 並び替え列も note.id でなければならない。clip_note.noteId は note.id (FK) と
+	// 同値なので、join せず noteId 列でページネーションすれば等価になる。clip_note.id
+	// (AddNote 時に独立採番される PK) で比較していた旧実装は、client が渡す note.id と
+	// 無関係な ULID を比較してページ窓が壊れていた (#1950)。
 	if untilID != "" {
-		q = q.Where("id < ?", untilID)
+		q = q.Where(`"clip_note"."noteId" < ?`, untilID)
 	}
 	if sinceID != "" {
-		q = q.Where("id > ?", sinceID)
+		q = q.Where(`"clip_note"."noteId" > ?`, sinceID)
 	}
 	var rows []*model.ClipNote
-	if err := q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit).Find(&rows).Error; err != nil {
+	if err := q.Order(paginationOrder(sinceID, untilID, `"clip_note"."noteId"`)).Limit(limit).Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil

--- a/internal/repository/clip_note_test.go
+++ b/internal/repository/clip_note_test.go
@@ -131,13 +131,69 @@ func TestClipNoteRepository_ListByClip_LimitClampAndPagination(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, rows, 3)
 
-	rows, err = repo.ListByClip(c.ID, "cn_n_cn_2c", "", 10)
+	// cursor は client が渡す note.id (= clip_note.noteId)。clip_note.id ではない (#1950)。
+	rows, err = repo.ListByClip(c.ID, "n_cn_2c", "", 10)
 	require.NoError(t, err)
 	assert.Len(t, rows, 2)
 
-	rows, err = repo.ListByClip(c.ID, "", "cn_n_cn_2a", 10)
+	rows, err = repo.ListByClip(c.ID, "", "n_cn_2a", 10)
 	require.NoError(t, err)
 	assert.Len(t, rows, 2)
+}
+
+// TestClipNoteRepository_ListByClip_PaginatesOnNoteID は #1950 の回帰テスト。
+// clip_note.id (AddNote 時に独立採番) の並びと note.id (作成順) の並びが食い違う
+// ように、古い note を後から clip し新しい note を先に clip する。ページネーションが
+// note.id でなされること (upstream clips/notes parity) を、(1) 並び順が newest-NOTE-first
+// であること、(2) client が最後の note.id を untilId に渡すと正しく次ページに進むこと
+// で検証する。旧実装 (clip_note.id 比較) では並び順が逆転し untilId も無関係 ULID と
+// 比較されて壊れる。
+func TestClipNoteRepository_ListByClip_PaginatesOnNoteID(t *testing.T) {
+	clipRepo := NewClipRepository(testDB)
+	repo := NewClipNoteRepository(testDB)
+	noteRepo := NewNoteRepository(testDB)
+	user := insertTestUser(t, "u_cn_3", "cnuser3")
+	defer cleanupUser(t, user.ID)
+
+	c := newTestClip("clp_cn_3", user.ID, "gamma")
+	require.NoError(t, clipRepo.Create(c))
+	defer cleanupClip(t, c.ID)
+
+	mkNote := func(id string) {
+		n := &model.Note{ID: id, UserID: user.ID, Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}"))}
+		require.NoError(t, noteRepo.Create(n))
+		t.Cleanup(func() { cleanupNote(t, n.ID) })
+	}
+	mkClipNote := func(clipNoteID, noteID string) {
+		cn := &model.ClipNote{ID: clipNoteID, ClipID: c.ID, NoteID: noteID}
+		require.NoError(t, repo.Create(cn))
+		t.Cleanup(func() { testDB.Exec(`DELETE FROM "clip_note" WHERE id = ?`, cn.ID) })
+	}
+
+	mkNote("n_p001") // 古い note (小さい note.id)
+	mkNote("n_p999") // 新しい note (大きい note.id)
+	// 新しい note を先に clip (小さい clip_note.id)、古い note を後で clip (大きい clip_note.id)。
+	mkClipNote("cn_001_early", "n_p999")
+	mkClipNote("cn_999_late", "n_p001")
+
+	// 並び順は note.id DESC (newest-note-first)。clip_note.id 順なら逆になる。
+	rows, err := repo.ListByClip(c.ID, "", "", 50)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, "n_p999", rows[0].NoteID, "newest note must be first (note.id order, not clip order)")
+	assert.Equal(t, "n_p001", rows[1].NoteID)
+
+	// client は最後に返った note.id (n_p999) を untilId として渡す -> 次は n_p001 のみ。
+	rows, err = repo.ListByClip(c.ID, "n_p999", "", 50)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "n_p001", rows[0].NoteID)
+
+	// sinceId に古い note.id を渡すと新しい側 (n_p999) のみ。
+	rows, err = repo.ListByClip(c.ID, "", "n_p001", 50)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "n_p999", rows[0].NoteID)
 }
 
 // TestClipNoteRepository_ListByClipVisible は clips/notes の visibility

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -3780,24 +3780,26 @@ func (m *MockClipNoteRepository) listByClip(clipID, viewerID string, filterVisib
 		if !noteMatchesSearchWords(m.Notes[cn.NoteID], searchWords) {
 			continue
 		}
-		if untilID != "" && cn.ID >= untilID {
+		// cursor / sort は note.id (= clip_note.noteId) で行う。client は note.id を
+		// 渡し upstream も note.id でページネーションする (#1950、production listByClip と一致)。
+		if untilID != "" && cn.NoteID >= untilID {
 			continue
 		}
-		if sinceID != "" && cn.ID <= sinceID {
+		if sinceID != "" && cn.NoteID <= sinceID {
 			continue
 		}
 		rows = append(rows, cn)
 	}
-	// production の paginationOrder と同じ ASC-flip (#405 Devin指摘)。
+	// production の paginationOrder と同じ ASC-flip (#405 Devin指摘)。比較列は noteId。
 	asc := sinceID != "" && untilID == ""
 	for i := 0; i < len(rows); i++ {
 		for j := i + 1; j < len(rows); j++ {
 			if asc {
-				if rows[i].ID > rows[j].ID {
+				if rows[i].NoteID > rows[j].NoteID {
 					rows[i], rows[j] = rows[j], rows[i]
 				}
 			} else {
-				if rows[i].ID < rows[j].ID {
+				if rows[i].NoteID < rows[j].NoteID {
 					rows[i], rows[j] = rows[j], rows[i]
 				}
 			}


### PR DESCRIPTION
## Summary

clips/notes のページネーション列を `clip_note.id` → `note.id` に修正する (#1950)。

upstream `clips/notes` (`packages/backend/src/server/api/endpoints/clips/notes.ts:84-116`) は
`makePaginationQuery(notesRepository.createQueryBuilder('note'), ...)` で **note.id** に対して
sinceId/untilId を比較し `note.id DESC` (作成順、新しい note が先頭) で並べる。

mk-go は `clip_note` join テーブルの **clip_note.id** (AddNote 時に独立採番される PK) で
比較・並べ替えしていた。client は最後に返った note.id を untilId として渡すので、無関係な
ULID 同士の比較になりページ窓が壊れ (抜け/重複)、さらに並び順も newest-CLIPPED-first と
upstream の newest-NOTE-first で食い違っていた。

## 主な変更点

- `internal/repository/clip_note.go` `listByClip`: 比較列・並べ替え列を `clip_note.id` →
  `"clip_note"."noteId"` に変更。`clip_note.noteId` は `note.id` (FK) と同値なので、join せず
  note.id ページネーションと等価になる (aidx/ulid は辞書順=作成順)。
- `internal/core/transfer/export_json.go` `collectClipNotes`: 上記変更に伴い、keyset の
  次ページ cursor も `rows[].ID` (clip_note.id) → `rows[].NoteID` に修正。これを直さないと
  100 件超の clip の export で同じ cross-column 不整合が再発する (敵対的レビューで発見)。
- `internal/testutil/mock_repository.go` `MockClipNoteRepository.listByClip`: production と
  同じく cursor/sort を `NoteID` に揃える (テスト fidelity)。

## テスト

- `internal/repository/clip_note_test.go`:
  - `TestClipNoteRepository_ListByClip_PaginatesOnNoteID` (新規): clip_note.id 順と note.id 順が
    逆相関する状況を作り、並び順が newest-NOTE-first であること・untilId/sinceId に note.id を
    渡して正しくページ送りされることを検証。
  - 既存 `..._LimitClampAndPagination` の cursor を clip_note.id → note.id に修正。
- `internal/core/transfer/export_edge_test.go`:
  - `TestExport_Clips_MultiPage` (新規): 150 件 (>1 ページ) の clip を export し、cross-column
    バグなら 2 ページ目が空になり欠落するところを、全件 export されることで検証。buggy 行に
    戻すと FAIL することを確認済み。
- 新規/変更コードはカバー済み。`make fmt` / `go vet ./...` / `make test` green。

実行方法:
```
go test ./internal/repository/ -run ClipNote
go test ./internal/core/transfer/ -run Export_Clips
```

## 関連

- 親: #1948 (全面互換性 再監査フォローアップ)

Closes #1950
