### PR TITLE
Fix AP Flag parity (#1951): 連合配信する Flag activity に id を付与する

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -1215,8 +1215,16 @@ func (r *Renderer) RenderUndoDeleteActor(user *model.User) *Undo {
 func (r *Renderer) RenderFlag(actor *model.User, targetURI, content string) *Flag {
 	f := &Flag{
 		Activity: Activity{
-			Object: Object{Type: "Flag"},
-			Actor:  r.urls.UserURI(actor.ID),
+			// upstream AbuseReportService は renderFlag を addContext で包み、
+			// addContext が id 不在時に `{config.url}/{uuid}` を必ず注入する。
+			// id を持たない activity は受信側 InboxProcessor に
+			// "activity id is not a string" で silent drop されるため、
+			// RenderAccept/Reject/Invite と同様にここで id を埋める (#1951)。
+			Object: Object{
+				ID:   r.urls.baseURL + "/" + uuid.NewString(),
+				Type: "Flag",
+			},
+			Actor: r.urls.UserURI(actor.ID),
 		},
 		Object:  targetURI,
 		Content: content,

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -1148,6 +1148,13 @@ func TestRenderer_RenderFlag(t *testing.T) {
 	assert.Equal(t, "spam comment", flag.Content)
 	// AddContext 済 (Context が設定される)
 	assert.NotNil(t, flag.Context)
+	// id を持たない Flag は受信側 InboxProcessor に silent drop されるため、
+	// 非空の id が埋まり marshal 後の JSON にも残ること (#1951)。
+	assert.NotEmpty(t, flag.ID)
+	assert.True(t, strings.HasPrefix(flag.ID, "https://example.com/"))
+	raw, err := json.Marshal(flag)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"id":"https://example.com/`)
 }
 
 // --- Poll (Question) rendering ---

--- a/internal/core/abuse/forwarder_test.go
+++ b/internal/core/abuse/forwarder_test.go
@@ -3,6 +3,7 @@ package abuse_test
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/shiroha-a/mk/internal/activitypub"
@@ -118,6 +119,28 @@ func TestForwardReport_RemoteTargetEnqueuesFlag(t *testing.T) {
 	assert.Equal(t, "instance", render.lastActor.ID)
 	assert.Equal(t, "https://remote.example/users/alice", render.lastURI)
 	assert.Equal(t, "spam!", render.lastBody)
+}
+
+// TestForwardReport_RealRendererIncludesID は #1951 の回帰テスト。stub ではなく実
+// activitypub.Renderer を通し、配信される Flag body に非空の id が乗ることを検証する。
+// id を持たない activity は受信側 InboxProcessor に silent drop されるため。
+func TestForwardReport_RealRendererIncludesID(t *testing.T) {
+	report := &model.AbuseUserReport{ID: "r1", Comment: "spam!", TargetUser: remoteTarget()}
+	store := &stubReportStore{report: report}
+	sys := &stubSystemActor{actor: &model.User{ID: "instance"}}
+	render := activitypub.NewRenderer(activitypub.NewURLBuilder("https://local.example"))
+	deliver := &spyDeliverer{}
+
+	f := abuse.NewForwarder(store, sys, render, deliver)
+	require.NoError(t, f.ForwardReport("r1"))
+
+	require.Equal(t, 1, deliver.called)
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(deliver.body, &payload))
+	id, ok := payload["id"].(string)
+	require.True(t, ok, "delivered Flag must carry a string id")
+	assert.NotEmpty(t, id)
+	assert.True(t, strings.HasPrefix(id, "https://local.example/"))
 }
 
 func TestForwardReport_LocalTargetMarksForwardedOnly(t *testing.T) {


### PR DESCRIPTION
## Summary

連合配信される Flag activity に `id` を付与する (#1951)。

upstream の `AbuseReportService` は `renderFlag(...)` を `addContext()` で包んで配信し、
`addContext` (`ApRendererService.ts:681-687`) は id を持たないオブジェクトに
`{config.url}/{randomUUID()}` を必ず注入する。よって連合配信される Flag は常に `id` を持つ。

受信側 `InboxProcessorService` は `activity.id` が文字列でない activity を
`skip: activity id is not a string` で drop するため、id 無しの Flag は remote moderator に
**silent drop** される。

mk-go の `RenderFlag` は inner Object に ID を設定しておらず、`AddContext` も upstream の
id 自動注入を複製していなかった。`Object.ID` は `json:"id,omitempty"` なので配信 JSON に
id が出ず、`forwarder.go` がそのまま marshal・配信していた。`RenderAccept`/`RenderReject`/
`RenderInvite` は同じ理由で既に id を設定済みだったが、`RenderFlag` が漏れていた。

## 主な変更点

- `internal/activitypub/renderer.go` `RenderFlag`: inner Object に
  `ID: r.urls.baseURL + "/" + uuid.NewString()` を設定 (RenderAccept/Reject/Invite と同パターン、
  upstream addContext の `{config.url}/{uuid}` と一致)。

## テスト

- `internal/activitypub/renderer_test.go` `TestRenderer_RenderFlag`: id が非空でホスト prefix を
  持ち、marshal 後 JSON のトップレベルに `"id"` が出ることを assert。
- `internal/core/abuse/forwarder_test.go` `TestForwardReport_RealRendererIncludesID` (新規):
  stub でなく実 `activitypub.Renderer` を forwarder に通し、配信 body に非空の string id が
  乗ることを検証 (silent-drop 回帰の統合テスト)。
- `make fmt` / `go vet ./...` / `make test` green。

実行方法:
```
go test ./internal/activitypub/ -run RenderFlag
go test ./internal/core/abuse/ -run ForwardReport
```

## 補足

敵対的レビューで、注入 id のホストが署名者 (system actor) のホストと一致するため受信側の
`signerHost === activityIdHost` gate も通過することを確認 (host 不一致による別 drop は無し)。
配信される他の top-level activity renderer は全て id 設定済みで、取りこぼしは本件のみ。

## 関連

- 親: #1948 (全面互換性 再監査フォローアップ)
- 関連方針: Misskey/CherryPick InboxProcessor は activity.id 無しを silent drop する

Closes #1951
