### PR TITLE
Fix i/2fa parity (#1952): update-key の password 必須を撤回し secure session 認証に揃える

### DIFF
--- a/internal/api/i/handler_2fa.go
+++ b/internal/api/i/handler_2fa.go
@@ -487,16 +487,28 @@ func (h *Handler) TwoFARemoveKey(c echo.Context) error {
 // 鍵の表示名を変更する。
 func (h *Handler) TwoFAUpdateKey(c echo.Context) error {
 	var req struct {
-		Password     string `json:"password"`
 		CredentialID string `json:"credentialId"`
 		Name         string `json:"name"`
 	}
-	if err := c.Bind(&req); err != nil || req.Password == "" || req.CredentialID == "" || req.Name == "" {
-		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "password / credentialId / name are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	if err := c.Bind(&req); err != nil || req.CredentialID == "" || req.Name == "" {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "credentialId / name are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
-	user, _, ok := h.requireWebAuthn(c, req.Password, "932c904e-9460-45b7-9ce6-7ed33be7eb2c")
-	if !ok {
-		return nil
+	// upstream paramDef は name: { minLength: 1, maxLength: 30 }。TwoFAKeyDone と
+	// 同じく API 直叩き経路の defense-in-depth として上限も enforce する (#1952)。
+	if len(req.Name) > twoFAKeyNameMaxLen {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "name is too long.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	}
+	// upstream update-key.ts は paramDef を {name, credentialId} のみで宣言し、
+	// secure:true の session 認証だけで password を再確認しない。standard misskey-js
+	// client ({name, credentialId} のみ送信) で passkey rename が壊れるため、mk-go も
+	// password 必須を撤回し session 認証 + 所有権チェックに依拠する (#1952、
+	// TwoFAPasswordLess #758 と同方針)。
+	if h.securityKeyRepo == nil {
+		return c.JSON(http.StatusServiceUnavailable, apierr.Error("UNAVAILABLE", "WebAuthn is not configured.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
+	}
+	user := middleware.GetUser(c)
+	if user == nil {
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 	}
 	// upstream (update-key.ts) は key not-found (NO_SUCH_KEY) と not-owned
 	// (ACCESS_DENIED) を区別する。UpdateName は両者を ErrRecordNotFound に

--- a/internal/api/i/handler_webauthn_test.go
+++ b/internal/api/i/handler_webauthn_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -420,6 +421,51 @@ func TestTwoFAUpdateKey_Success(t *testing.T) {
 	rec := postExtra(h.TwoFAUpdateKey, `{"password":"pass","credentialId":"key1","name":"renamed"}`, user)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 	assert.Equal(t, "renamed", skRepo.keys["key1"].Name)
+}
+
+// #1952 upstream update-key.ts の paramDef は {name, credentialId} のみで password を
+// 受け付けない。standard misskey-js client は password を送らないので、password 無しで
+// 204 成功し rename されることを検証する。
+func TestTwoFAUpdateKey_NoPasswordSucceeds(t *testing.T) {
+	h, repo, skRepo := newWebAuthnHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	require.NoError(t, skRepo.Create(&model.UserSecurityKey{
+		ID: "key1", UserID: "u1", Name: "old", PublicKey: "pk",
+	}))
+	rec := postExtra(h.TwoFAUpdateKey, `{"credentialId":"key1","name":"renamed"}`, user)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, "renamed", skRepo.keys["key1"].Name)
+}
+
+// name が maxLength:30 超は INVALID_PARAM (upstream paramDef、#1952)。
+func TestTwoFAUpdateKey_NameTooLong(t *testing.T) {
+	h, repo, skRepo := newWebAuthnHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	require.NoError(t, skRepo.Create(&model.UserSecurityKey{
+		ID: "key1", UserID: "u1", Name: "old", PublicKey: "pk",
+	}))
+	long := strings.Repeat("a", 31)
+	rec := postExtra(h.TwoFAUpdateKey, `{"credentialId":"key1","name":"`+long+`"}`, user)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_PARAM")
+	// 名前は変更されない。
+	assert.Equal(t, "old", skRepo.keys["key1"].Name)
+}
+
+// securityKeyRepo 未配線 (WebAuthn 未設定) は 503 UNAVAILABLE (#1952)。
+func TestTwoFAUpdateKey_NotConfigured(t *testing.T) {
+	h, repo := newExtraHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	rec := postExtra(h.TwoFAUpdateKey, `{"credentialId":"k","name":"x"}`, user)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// session user 不在は ACCESS_DENIED (secure session 認証前提、#1952)。
+func TestTwoFAUpdateKey_NoUser(t *testing.T) {
+	h, _, _ := newWebAuthnHandler(t)
+	rec := postExtra(h.TwoFAUpdateKey, `{"credentialId":"k","name":"x"}`, nil)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "ACCESS_DENIED")
 }
 
 // #1555 他人所有の key を更新しようとすると ACCESS_DENIED (NO_SUCH_KEY ではない)。


### PR DESCRIPTION
## Summary

`i/2fa/update-key` から upstream に存在しない `password` 必須を撤回する (#1952)。

upstream `update-key.ts` は paramDef を `{name (minLength1,maxLength30), credentialId}`
required `['name','credentialId']` のみで宣言し、meta は `requireCredential + secure:true`。
handler は所有権チェック + name 更新 + meUpdated publish のみで **password を再確認しない**。

mk-go の `TwoFAUpdateKey` は `password` を必須化し `requireWebAuthn` で bcrypt 比較していた
ため、standard misskey-js client (`{name, credentialId}` のみ送信) で passkey rename が
`INVALID_PARAM` / `INCORRECT_PASSWORD` で壊れていた。

同 endpoint は router で `RequireAuth() + RequireSecure()` で gate 済み (secure session 限定、
API token 不可)。これは upstream の `secure:true` と同一の保護で、password を外しても
session 本人以外は到達できないため security regression は無い (敵対的レビューで RequireSecure
が app token を構造的に弾く invariant を repository の Preload まで遡って確認)。

## 主な変更点

- `internal/api/i/handler_2fa.go` `TwoFAUpdateKey`:
  - `password` 必須と `requireWebAuthn`/bcrypt 呼び出しを削除。`middleware.GetUser` による
    session 認証 + 所有権チェック (NO_SUCH_KEY / ACCESS_DENIED) + `UpdateName` + `publishMeUpdated`
    のみに。`securityKeyRepo == nil` は 503 UNAVAILABLE で guard (TwoFAPasswordLess #758 と同方針)。
  - upstream paramDef の `name: maxLength 30` を defense-in-depth として enforce (TwoFAKeyDone と
    同じ const `twoFAKeyNameMaxLen`、敵対的レビュー指摘)。

## テスト

`internal/api/i/handler_webauthn_test.go`:
- `TestTwoFAUpdateKey_NoPasswordSucceeds` (新規): password 無し `{name, credentialId}` で 204 成功 + rename。
- `TestTwoFAUpdateKey_NameTooLong` (新規): name 31 文字で INVALID_PARAM。
- `TestTwoFAUpdateKey_NotConfigured` (新規): securityKeyRepo 未配線で 503。
- `TestTwoFAUpdateKey_NoUser` (新規): session user 不在で ACCESS_DENIED。
- 既存 Success/MissingFields/NotFound/AccessDenied は維持 (password field は無視される)。
- `TwoFAUpdateKey` カバレッジ 82.4% → 94.7%。`make fmt` / `go vet ./...` / `make test` green。

実行方法:
```
go test ./internal/api/i/ -run TwoFAUpdateKey
```

## 補足

全 `i/2fa/*` の upstream paramDef を照合し、「upstream にない password 必須」が残る endpoint は
本件のみであることを確認 (register/unregister/register-key/key-done/remove-key は upstream も
password 必須、done は token のみ、password-less は #758 で撤回済)。

## 関連

- 親: #1948 (全面互換性 再監査フォローアップ)

Closes #1952
