### PR TITLE
Fix notifications parity (#1953): note-required drop / type-filter refetch / sinceId 昇順を upstream に揃える

### DIFF
--- a/internal/api/notifications/grouped_test.go
+++ b/internal/api/notifications/grouped_test.go
@@ -270,12 +270,13 @@ func TestGrouped_LimitSlicesAfterGrouping(t *testing.T) {
 	require.Len(t, resp, 2)
 }
 
-// renote 通知だが target note が visible map に無い (= 非可視 / 解決不能) と
-// grouping key が空になり別グループのまま残る fail-closed を確認する。
-func TestGrouped_RenoteWithUnresolvableTargetStaysSeparate(t *testing.T) {
+// renote 通知だが target note が削除済 / 非可視で pack できない場合、upstream
+// packMany は通知行ごと drop する (#1953)。grouped 経路でも note-required 通知が
+// 落ちて空になることを確認する (以前は noteId だけの行を残していた)。
+func TestGrouped_RenoteWithUnresolvableTargetDropped(t *testing.T) {
 	h, svc, userRepo, noteRepo := groupedHandler(t)
 	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob"}
-	// renote note 自体を repo に登録しない → noteByID に乗らず RenoteID 取得不能。
+	// renote note 自体を repo に登録しない → noteByID に乗らず note pack 不能。
 	_ = noteRepo
 
 	ctx := context.Background()
@@ -289,9 +290,7 @@ func TestGrouped_RenoteWithUnresolvableTargetStaysSeparate(t *testing.T) {
 	require.NoError(t, h.Grouped(c))
 
 	resp := decodeGrouped(t, rec.Body.Bytes())
-	require.Len(t, resp, 2)
-	assert.Equal(t, "renote", resp[0]["type"])
-	assert.Equal(t, "renote", resp[1]["type"])
+	require.Len(t, resp, 0, "note を pack できない note-required 通知は drop される (#1953)")
 }
 
 // grouped endpoint も markAsRead の暗黙副作用を持つ (#420 と同挙動)。

--- a/internal/api/notifications/handler.go
+++ b/internal/api/notifications/handler.go
@@ -225,24 +225,17 @@ func (h *Handler) collectNotifications(c echo.Context, user *model.User, req Lis
 	if req.IncludeTypes != nil && len(req.IncludeTypes) == 0 {
 		return nil, map[string]*model.User{}, map[string]*model.Note{}, nil
 	}
-	rows, err := h.svc.List(c.Request().Context(), user.ID, req.Limit)
+	// svc.List が upstream NotificationService.getNotifications 相当に cursor
+	// (sinceId/untilId)・向き (sinceId-only は昇順)・type filter・limit を適用して
+	// 返す (#1953)。ここではその後段で upstream packMany 側の drop (解決済み follow
+	// request / invalid notifier / 不可視 note) を適用する。
+	rows, err := h.svc.List(c.Request().Context(), user.ID, req.SinceID, req.UntilID, req.Limit, req.IncludeTypes, req.ExcludeTypes)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	// includeTypes / excludeTypes フィルタ
-	includeSet := make(map[string]bool, len(req.IncludeTypes))
-	for _, t := range req.IncludeTypes {
-		includeSet[t] = true
-	}
-	excludeSet := make(map[string]bool, len(req.ExcludeTypes))
-	for _, t := range req.ExcludeTypes {
-		excludeSet[t] = true
-	}
-
 	// 2-pass で組み立てる:
-	//   pass 1: cursor / type / followReq filter を通して残った rows と、
-	//           その notifierID / noteID を集約
+	//   pass 1: followReq filter を通して残った rows と notifierID を集約
 	//   pass 2: userRepo.FindManyByIDs / noteRepo.FindManyByIDsWithUser で
 	//           まとめて引き、map で O(1) 解決して PackNotifications に渡す
 	// (旧実装は 1 通知ごとに FindByID + FindByIDWithRelations を呼んで最大
@@ -250,20 +243,6 @@ func (h *Handler) collectNotifications(c echo.Context, user *model.User, req Lis
 	filtered := make([]*notification.Notification, 0, len(rows))
 	notifierIDSet := make(map[string]struct{})
 	for _, n := range rows {
-		// カーソルベースページネーション
-		if req.SinceID != "" && n.ID <= req.SinceID {
-			continue
-		}
-		if req.UntilID != "" && n.ID >= req.UntilID {
-			continue
-		}
-		// タイプフィルタ
-		if len(includeSet) > 0 && !includeSet[string(n.Type)] {
-			continue
-		}
-		if excludeSet[string(n.Type)] {
-			continue
-		}
 		// 既に解決された follow request (accept / reject で消えた) に対応する
 		// receiveFollowRequest 通知はユーザー視点で既に古く「残り続ける」ので
 		// 除外する (#349 コメント対応、本家 NotificationEntityService 互換)。
@@ -306,11 +285,9 @@ func (h *Handler) collectNotifications(c echo.Context, user *model.User, req Lis
 	}
 	// noteByID 構築には CanSeeNote ゲートを挟む。followers / specified note は
 	// 通知 recipient が author の follower でない / visibleUserIds に含まれない
-	// 場合に embed を nil 化する。これが無いと B の followers note への reply
-	// 通知経由で「A が B を follow していなくても」B の full note + author が
-	// 漏れる (#1444 IDOR)。通知行自体は残し、note field だけ落とすことで本家
-	// NotificationEntityService と同じ shape (noteId は残るが detail は無い) を
-	// 維持する。queryService 未配線時は fail-closed で note embed を完全 skip
+	// 場合に不可視になる。これが無いと B の followers note への reply 通知経由で
+	// 「A が B を follow していなくても」B の full note + author が漏れる
+	// (#1444 IDOR)。queryService 未配線時は fail-closed で note 解決を完全 skip
 	// する (= production router は必ず wire、test の partial setup を漏れに
 	// 繋げない)。
 	noteByID := make(map[string]*model.Note, len(noteIDSet))
@@ -325,6 +302,27 @@ func (h *Handler) collectNotifications(c echo.Context, user *model.User, req Lis
 				noteByID[nn.ID] = nn
 			}
 		}
+	}
+
+	// upstream packMany は note-required 通知 (noteId を持つ type) の note が削除済
+	// または viewer に不可視で pack できない場合、通知行ごと drop する
+	// (`validNotifications.filter(x => !('noteId' in x) || packedNotes.has(x.noteId))`、
+	// #1953)。以前は note embed だけ nil 化して行を残していたが、upstream は noteId
+	// だけの通知を返さない。noteByID は可視性 filter 済なので NoteID があるのに
+	// noteByID に無い行を落とす。repo / queryService 配線済のときだけ適用する
+	// (未配線の partial test では note 解決自体が走らず、全 note-required 通知を
+	// 誤って落とさないため)。
+	if h.noteRepo != nil && h.queryService != nil {
+		kept := filtered[:0]
+		for _, n := range filtered {
+			if n.NoteID != "" {
+				if _, ok := noteByID[n.NoteID]; !ok {
+					continue
+				}
+			}
+			kept = append(kept, n)
+		}
+		filtered = kept
 	}
 	return filtered, notifierByID, noteByID, nil
 }

--- a/internal/api/notifications/handler_test.go
+++ b/internal/api/notifications/handler_test.go
@@ -471,7 +471,7 @@ func TestFlush_Success(t *testing.T) {
 
 	// handler が Flush() を呼んでいれば stream 長 0。
 	// 以前は MarkAllAsRead() を呼んでいたため元通知が残ってしまっていた。
-	out, err := svc.List(ctx, "alice", 10)
+	out, err := svc.List(ctx, "alice", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	assert.Empty(t, out)
 }
@@ -831,11 +831,11 @@ func TestShow_FollowersReply_NonFollower_NoteHidden(t *testing.T) {
 
 	var resp []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	require.Len(t, resp, 1, "通知行自体は残ること (= IDOR 修正で通知を消すのではなく embed のみ落とす)")
-	assert.Equal(t, "reply", resp[0]["type"])
-	assert.Equal(t, "n1", resp[0]["noteId"], "noteId は echo される (本家 shape 互換)")
-	_, hasNote := resp[0]["note"]
-	assert.False(t, hasNote, "followers note の full body が非フォロワーに漏れないこと (#1444)")
+	// upstream packMany は note が不可視/削除済で pack できない note-required 通知を
+	// 行ごと drop する (`!('noteId' in x) || packedNotes.has(x.noteId)`、#1953)。以前は
+	// embed のみ nil 化して noteId だけの行を残していたが upstream 非互換だった。
+	// 非フォロワーには followers note への reply 通知自体が出ない (#1444 IDOR も更に強化)。
+	require.Len(t, resp, 0, "不可視 note の note-required 通知は行ごと drop される (#1953 / #1444)")
 }
 
 // 上記の positive counterpart: A が B を follow していれば followers reply

--- a/internal/core/notification/hooks_test.go
+++ b/internal/core/notification/hooks_test.go
@@ -44,7 +44,7 @@ func TestHook_OnNoteCreated_ReplyNotification(t *testing.T) {
 	note := &model.Note{ID: "n_reply", UserID: "bob"}
 	h.OnNoteCreated(note, &model.User{ID: "bob"}, parent, nil)
 
-	out, err := svc.List(context.Background(), "alice", 10)
+	out, err := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, TypeReply, out[0].Type)
@@ -58,7 +58,7 @@ func TestHook_OnNoteCreated_ReplyToSelfSkipped(t *testing.T) {
 	note := &model.Note{ID: "n_reply", UserID: "alice"}
 	h.OnNoteCreated(note, &model.User{ID: "alice"}, parent, nil)
 
-	out, _ := svc.List(context.Background(), "alice", 10)
+	out, _ := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	assert.Empty(t, out)
 }
 
@@ -72,7 +72,7 @@ func TestHook_OnNoteCreated_PureRenote(t *testing.T) {
 	note := &model.Note{ID: "n_renote", UserID: "bob", RenoteID: &target}
 	h.OnNoteCreated(note, &model.User{ID: "bob"}, nil, original)
 
-	out, err := svc.List(context.Background(), "alice", 10)
+	out, err := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, TypeRenote, out[0].Type)
@@ -89,7 +89,7 @@ func TestHook_OnNoteCreated_QuoteRenote(t *testing.T) {
 	note := &model.Note{ID: "n_quote", UserID: "bob", RenoteID: &target, Text: &text}
 	h.OnNoteCreated(note, &model.User{ID: "bob"}, nil, original)
 
-	out, err := svc.List(context.Background(), "alice", 10)
+	out, err := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, TypeQuote, out[0].Type)
@@ -106,7 +106,7 @@ func TestHook_OnNoteCreated_Mention(t *testing.T) {
 	}
 	h.OnNoteCreated(note, &model.User{ID: "bob"}, nil, nil)
 
-	out, err := svc.List(context.Background(), "alice", 10)
+	out, err := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, TypeMention, out[0].Type)
@@ -123,7 +123,7 @@ func TestHook_OnNoteCreated_MentionSkipsSelfAndUnknown(t *testing.T) {
 	h.OnNoteCreated(note, &model.User{ID: "bob"}, nil, nil)
 
 	// 自分自身&存在しない/空文字はスキップされる
-	out, _ := svc.List(context.Background(), "bob", 10)
+	out, _ := svc.List(context.Background(), "bob", "", "", 10, nil, nil)
 	assert.Empty(t, out)
 }
 
@@ -139,7 +139,7 @@ func TestHook_OnNoteCreated_MentionDedupedWithReply(t *testing.T) {
 	}
 	h.OnNoteCreated(note, &model.User{ID: "bob"}, parent, nil)
 
-	out, err := svc.List(context.Background(), "alice", 10)
+	out, err := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	// reply通知のみで、mentionは抑制される
 	require.Len(t, out, 1)
@@ -352,7 +352,7 @@ func TestHook_OnFollowed(t *testing.T) {
 	addLocalUser(repo, "alice", "alice")
 	h.OnFollowed("bob", "alice")
 
-	out, err := svc.List(context.Background(), "alice", 10)
+	out, err := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, TypeFollow, out[0].Type)
@@ -363,7 +363,7 @@ func TestHook_OnFollowRequested(t *testing.T) {
 	addLocalUser(repo, "alice", "alice")
 	h.OnFollowRequested("bob", "alice")
 
-	out, err := svc.List(context.Background(), "alice", 10)
+	out, err := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, TypeReceiveFollowReq, out[0].Type)
@@ -377,14 +377,14 @@ func TestHook_OnFollowRejected(t *testing.T) {
 	addLocalUser(repo, "alice", "alice")
 	// 既存の receive-follow-request 通知を alice (followee) 側に作っておく
 	h.OnFollowRequested("bob", "alice")
-	out, err := svc.List(context.Background(), "alice", 10)
+	out, err := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	require.Equal(t, TypeReceiveFollowReq, out[0].Type)
 
 	// reject されたら follower=bob 由来の receive-follow-request 通知を削除
 	h.OnFollowRejected("bob", "alice")
-	out, err = svc.List(context.Background(), "alice", 10)
+	out, err = svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	assert.Empty(t, out, "receiveFollowRequest from rejected follower should be removed")
 }
@@ -401,7 +401,7 @@ func TestHook_OnFollowAccepted(t *testing.T) {
 	addLocalUser(repo, "bob", "bob")
 	h.OnFollowAccepted("bob", "alice")
 
-	out, err := svc.List(context.Background(), "bob", 10)
+	out, err := svc.List(context.Background(), "bob", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, TypeFollowRequestAccept, out[0].Type)
@@ -412,7 +412,7 @@ func TestHook_OnPollVote(t *testing.T) {
 	addLocalUser(repo, "alice", "alice")
 	h.OnPollVote("alice", "bob", "n1", 2)
 
-	out, err := svc.List(context.Background(), "alice", 10)
+	out, err := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, TypePollVote, out[0].Type)
@@ -425,7 +425,7 @@ func TestHook_OnReactionCreated(t *testing.T) {
 	addLocalUser(repo, "alice", "alice")
 	h.OnReactionCreated("alice", "bob", "n1", "👍")
 
-	out, err := svc.List(context.Background(), "alice", 10)
+	out, err := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, TypeReaction, out[0].Type)
@@ -524,7 +524,7 @@ func TestHook_OnReactionCreated_NeverConfigSuppresses(t *testing.T) {
 	repo.Profiles["alice"] = &model.UserProfile{UserID: "alice", NotificationRecieveConfig: datatypes.JSON(`{"reaction":{"type":"never"}}`)}
 	h.OnReactionCreated("alice", "bob", "n1", "👍")
 
-	out, err := svc.List(context.Background(), "alice", 10)
+	out, err := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	assert.Empty(t, out, "reaction=never の notifiee には reaction 通知を配信しない")
 }
@@ -533,7 +533,7 @@ func TestHook_NotifyRemoteSkipped(t *testing.T) {
 	h, svc, repo := newTestHook(t)
 	addRemoteUser(repo, "alice", "alice", "remote.example")
 	h.OnFollowed("bob", "alice")
-	out, err := svc.List(context.Background(), "alice", 10)
+	out, err := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	assert.Empty(t, out)
 }
@@ -541,7 +541,7 @@ func TestHook_NotifyRemoteSkipped(t *testing.T) {
 func TestHook_NotifyMissingUserSkipped(t *testing.T) {
 	h, svc, _ := newTestHook(t)
 	h.OnFollowed("bob", "ghost")
-	out, _ := svc.List(context.Background(), "ghost", 10)
+	out, _ := svc.List(context.Background(), "ghost", "", "", 10, nil, nil)
 	assert.Empty(t, out)
 }
 
@@ -552,7 +552,7 @@ func TestHook_NotifyWithoutUserRepo(t *testing.T) {
 	h := NewHook(svc, nil)
 	h.OnFollowed("bob", "alice")
 
-	out, err := svc.List(context.Background(), "alice", 10)
+	out, err := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 }
@@ -582,7 +582,7 @@ func TestHook_NotifyMutedNotifierSkipped(t *testing.T) {
 	h.SetMuteChecker(&stubMuteChecker{muted: true})
 
 	h.OnFollowed("bob", "alice")
-	out, _ := svc.List(context.Background(), "alice", 10)
+	out, _ := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	assert.Empty(t, out)
 }
 
@@ -592,7 +592,7 @@ func TestHook_NotifyMuteCheckerErrorAllowed(t *testing.T) {
 	h.SetMuteChecker(&stubMuteChecker{err: errSentinel})
 
 	h.OnFollowed("bob", "alice")
-	out, _ := svc.List(context.Background(), "alice", 10)
+	out, _ := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	// muteチェッカーがエラーを返した場合は通知を許可する
 	assert.Len(t, out, 1)
 }
@@ -820,8 +820,8 @@ func TestHook_OnNoteCreated_VisibilityFiltersMentions(t *testing.T) {
 			}
 			h.OnNoteCreated(note, &model.User{ID: "bob"}, nil, nil)
 
-			outA, _ := svc.List(context.Background(), "alice", 10)
-			outC, _ := svc.List(context.Background(), "charlie", 10)
+			outA, _ := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
+			outC, _ := svc.List(context.Background(), "charlie", "", "", 10, nil, nil)
 			if tc.wantNotifyA {
 				require.Len(t, outA, 1, "alice should receive mention notification")
 				assert.Equal(t, TypeMention, outA[0].Type)
@@ -856,7 +856,7 @@ func TestHook_OnNoteCreated_VisibilityFiltersReplyAndRenote(t *testing.T) {
 			VisibleUserIDs: pq.StringArray{"someone_else"},
 		}
 		h.OnNoteCreated(note, &model.User{ID: "bob"}, parent, nil)
-		out, _ := svc.List(context.Background(), "alice", 10)
+		out, _ := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 		assert.Empty(t, out, "reply target が visibleUserIds 外なら通知しない")
 	})
 
@@ -874,7 +874,7 @@ func TestHook_OnNoteCreated_VisibilityFiltersReplyAndRenote(t *testing.T) {
 			VisibleUserIDs: pq.StringArray{"someone_else"},
 		}
 		h.OnNoteCreated(note, &model.User{ID: "bob"}, nil, original)
-		out, _ := svc.List(context.Background(), "alice", 10)
+		out, _ := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 		assert.Empty(t, out, "renote target が visibleUserIds 外なら通知しない")
 	})
 }

--- a/internal/core/notification/notification_service.go
+++ b/internal/core/notification/notification_service.go
@@ -320,19 +320,57 @@ func (s *Service) Create(ctx context.Context, in CreateInput) (*Notification, er
 	return n, nil
 }
 
-// List returns the notifications for the given user, newest first, capped to limit.
-func (s *Service) List(ctx context.Context, userID string, limit int) ([]*Notification, error) {
+// List returns the notifications for the given user with cursor pagination and
+// type filtering, mirroring upstream NotificationService.getNotifications.
+//
+// Direction: with sinceID set and untilID absent, results are the OLDEST `limit`
+// strictly newer than sinceID, in ascending order; otherwise the newest `limit`
+// in descending order (QueryService.makePaginationQuery と同じ向き). The type
+// filter (includeTypes else excludeTypes) is applied before the limit so that an
+// older matching notification surfaces even when the newest `limit` are all
+// filtered out (upstream の refetch loop 相当)。
+func (s *Service) List(ctx context.Context, userID, sinceID, untilID string, limit int, includeTypes, excludeTypes []string) ([]*Notification, error) {
 	if limit <= 0 {
 		limit = 10
 	}
 	if limit > 100 {
 		limit = 100
 	}
-	res, err := s.client.XRevRangeN(ctx, s.streamKey(userID), "+", "-", int64(limit)).Result()
+
+	// upstream は Redis stream id を notification id から導出して COUNT=limit の
+	// 範囲取得をループするが、mk-go の stream id は `<ms>-<redis採番seq>` で
+	// notification id とは別軸のため、id での精密な範囲指定ができない。代わりに
+	// MaxPerUser=300 cap 内で全件を向き付きで取得し、cursor(n.ID)/type で in-app
+	// filter して limit 件を取る。stream は実質 300 件上限なので、これは upstream の
+	// refetch loop と観測上等価 (返る通知集合と並び順が一致する)。なお XADD MAXLEN は
+	// approximate trim (`~`) のため stream が一時的に 300 を僅かに超えうるが、その分は
+	// 最古 tail 側であり、深い type-filter ページネーションでの取りこぼしは実害無視可能。
+	ascending := sinceID != "" && untilID == ""
+	// cursor も type filter も無ければ post-filter で行が落ちないので、newest limit
+	// 件だけ取れば足りる (= 旧実装と同コスト、first-page load の hot path)。それ以外
+	// は post-filter で limit 未満に減りうるため MaxPerUser cap まで取得してから絞る。
+	fetchN := int64(MaxPerUser)
+	if sinceID == "" && untilID == "" && len(includeTypes) == 0 && len(excludeTypes) == 0 {
+		fetchN = int64(limit)
+	}
+	key := s.streamKey(userID)
+	var (
+		res []redis.XMessage
+		err error
+	)
+	if ascending {
+		res, err = s.client.XRangeN(ctx, key, "-", "+", fetchN).Result()
+	} else {
+		res, err = s.client.XRevRangeN(ctx, key, "+", "-", fetchN).Result()
+	}
 	if err != nil {
 		return nil, err
 	}
-	out := make([]*Notification, 0, len(res))
+
+	includeSet := toTypeSet(includeTypes)
+	excludeSet := toTypeSet(excludeTypes)
+
+	out := make([]*Notification, 0, limit)
 	for _, msg := range res {
 		raw, ok := msg.Values["data"].(string)
 		if !ok {
@@ -342,9 +380,43 @@ func (s *Service) List(ctx context.Context, userID string, limit int) ([]*Notifi
 		if err := json.Unmarshal([]byte(raw), &n); err != nil {
 			continue
 		}
+		// cursor は exclusive (upstream の `(` 境界)。
+		if sinceID != "" && n.ID <= sinceID {
+			continue
+		}
+		if untilID != "" && n.ID >= untilID {
+			continue
+		}
+		// type filter。upstream は include があれば include のみ、無ければ exclude
+		// を見る (if / else if)。
+		if len(includeSet) > 0 {
+			if !includeSet[n.Type] {
+				continue
+			}
+		} else if len(excludeSet) > 0 {
+			if excludeSet[n.Type] {
+				continue
+			}
+		}
 		out = append(out, &n)
+		if len(out) >= limit {
+			break
+		}
 	}
 	return out, nil
+}
+
+// toTypeSet converts a slice of raw type strings into a set keyed by Type.
+// Empty / nil input yields a nil map (no filtering).
+func toTypeSet(types []string) map[Type]bool {
+	if len(types) == 0 {
+		return nil
+	}
+	set := make(map[Type]bool, len(types))
+	for _, t := range types {
+		set[Type(t)] = true
+	}
+	return set
 }
 
 // DeleteByTypeAndNotifier removes all notifications of the given type sent by

--- a/internal/core/notification/notification_service_test.go
+++ b/internal/core/notification/notification_service_test.go
@@ -123,7 +123,7 @@ func TestService_DeleteByTypeAndNotifier(t *testing.T) {
 	// bob からの receiveFollowRequest のみ消す。
 	require.NoError(t, svc.DeleteByTypeAndNotifier(ctx, "alice", TypeReceiveFollowReq, "bob"))
 
-	out, err := svc.List(ctx, "alice", 10)
+	out, err := svc.List(ctx, "alice", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, out, 2) // carol の receiveFollowRequest + bob の follow が残る
 	for _, n := range out {
@@ -151,11 +151,57 @@ func TestService_CreateAndList(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	out, err := svc.List(ctx, "alice", 10)
+	out, err := svc.List(ctx, "alice", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, out, 3)
 	// 新しい順
 	assert.Equal(t, TypeReaction, out[0].Type)
+}
+
+// #1953-2: type filter で新しい limit 件が全て落ちても、より古い一致通知が
+// あればそれを返す (upstream getNotifications の refetch loop 相当)。旧実装は
+// 新しい limit 件だけ取得して filter したため、空を返していた。
+func TestService_List_TypeFilterSurfacesOlderMatch(t *testing.T) {
+	svc := newTestSvc(t)
+	ctx := context.Background()
+
+	// 最古に follow を 1 件、その後 reaction を 20 件積む。
+	_, err := svc.Create(ctx, CreateInput{NotifieeID: "alice", NotifierID: "bob", Type: TypeFollow})
+	require.NoError(t, err)
+	for i := 0; i < 20; i++ {
+		_, err := svc.Create(ctx, CreateInput{NotifieeID: "alice", NotifierID: "bob", Type: TypeReaction, NoteID: "n1"})
+		require.NoError(t, err)
+	}
+
+	// excludeTypes=[reaction], limit=10: 新しい 10 件は全て reaction で除外されるが、
+	// 最古の follow を拾って返す。
+	out, err := svc.List(ctx, "alice", "", "", 10, nil, []string{"reaction"})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, TypeFollow, out[0].Type)
+}
+
+// #1953-3: sinceId のみ指定時は sinceId より新しい「最古」の limit 件を昇順で
+// 返す (upstream XRANGE 方向)。旧実装は常に新しい順で取り、新しい側 limit 件を
+// 返していた。
+func TestService_List_SinceIdReturnsOldestAscending(t *testing.T) {
+	svc := newTestSvc(t)
+	ctx := context.Background()
+
+	ids := make([]string, 0, 5)
+	for i := 0; i < 5; i++ {
+		n, err := svc.Create(ctx, CreateInput{NotifieeID: "alice", NotifierID: "bob", Type: TypeFollow})
+		require.NoError(t, err)
+		ids = append(ids, n.ID)
+	}
+
+	// ids[0] が最古。sinceId=ids[0], limit=2 -> ids[0] より新しい最古の 2 件
+	// (ids[1], ids[2]) を昇順で返す。
+	out, err := svc.List(ctx, "alice", ids[0], "", 2, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	assert.Equal(t, ids[1], out[0].ID, "oldest-after-sinceId first (ascending)")
+	assert.Equal(t, ids[2], out[1].ID)
 }
 
 // stubStreamingPublisher records every PublishNotification call.
@@ -373,12 +419,12 @@ func TestService_ListLimitClampingDefaults(t *testing.T) {
 	require.NoError(t, err)
 
 	// limit <= 0 はデフォルト10
-	out, err := svc.List(ctx, "alice", 0)
+	out, err := svc.List(ctx, "alice", "", "", 0, nil, nil)
 	require.NoError(t, err)
 	assert.Len(t, out, 1)
 
 	// limit > 100 は100にクランプ (要素は1件のみだが正常終了することを確認)
-	out, err = svc.List(ctx, "alice", 1000)
+	out, err = svc.List(ctx, "alice", "", "", 1000, nil, nil)
 	require.NoError(t, err)
 	assert.Len(t, out, 1)
 }
@@ -414,7 +460,7 @@ func TestService_Flush(t *testing.T) {
 	require.NoError(t, svc.MarkAllAsRead(ctx, "alice"))
 
 	require.NoError(t, svc.Flush(ctx, "alice"))
-	out, err := svc.List(ctx, "alice", 10)
+	out, err := svc.List(ctx, "alice", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	assert.Empty(t, out)
 
@@ -430,7 +476,7 @@ func TestService_RedisErrors(t *testing.T) {
 	_, err := svc.Create(ctx, CreateInput{NotifieeID: "u", NotifierID: "v", Type: TypeFollow})
 	assert.Error(t, err)
 
-	_, err = svc.List(ctx, "u", 10)
+	_, err = svc.List(ctx, "u", "", "", 10, nil, nil)
 	assert.Error(t, err)
 
 	err = svc.MarkAllAsRead(ctx, "u")
@@ -501,7 +547,7 @@ func TestService_List_SkipsBadEntries(t *testing.T) {
 	_, err := svc.Create(ctx, CreateInput{NotifieeID: "alice", NotifierID: "bob", Type: TypeFollow})
 	require.NoError(t, err)
 
-	out, err := svc.List(ctx, "alice", 10)
+	out, err := svc.List(ctx, "alice", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, TypeFollow, out[0].Type)

--- a/internal/core/notification/parity_1559_note_test.go
+++ b/internal/core/notification/parity_1559_note_test.go
@@ -43,7 +43,7 @@ func TestHook_OnNoteCreated_NoteNotificationToNotifyFollower(t *testing.T) {
 	note := &model.Note{ID: "n1", UserID: "alice", Visibility: model.NoteVisibilityPublic}
 	h.OnNoteCreated(note, &model.User{ID: "alice"}, nil, nil)
 
-	out, err := svc.List(context.Background(), "bob", 10)
+	out, err := svc.List(context.Background(), "bob", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, TypeNote, out[0].Type)
@@ -62,7 +62,7 @@ func TestHook_OnNoteCreated_NoteNotificationSkippedForReply(t *testing.T) {
 	note := &model.Note{ID: "n1", UserID: "alice", Visibility: model.NoteVisibilityPublic, ReplyID: &replyID}
 	h.OnNoteCreated(note, &model.User{ID: "alice"}, parent, nil)
 
-	out, _ := svc.List(context.Background(), "bob", 10)
+	out, _ := svc.List(context.Background(), "bob", "", "", 10, nil, nil)
 	assert.Empty(t, out, "reply は note 通知を発火しない")
 }
 
@@ -75,7 +75,7 @@ func TestHook_OnNoteCreated_NoteNotificationSkippedForSpecified(t *testing.T) {
 	note := &model.Note{ID: "n1", UserID: "alice", Visibility: model.NoteVisibilitySpecified}
 	h.OnNoteCreated(note, &model.User{ID: "alice"}, nil, nil)
 
-	out, _ := svc.List(context.Background(), "bob", 10)
+	out, _ := svc.List(context.Background(), "bob", "", "", 10, nil, nil)
 	assert.Empty(t, out, "specified note は note 通知を発火しない")
 }
 
@@ -92,7 +92,7 @@ func TestHook_OnNoteCreated_NoteNotificationSkipsRenoteMuted(t *testing.T) {
 	note := &model.Note{ID: "r1", UserID: "alice", Visibility: model.NoteVisibilityPublic, RenoteID: &target}
 	h.OnNoteCreated(note, &model.User{ID: "alice"}, nil, original)
 
-	out, _ := svc.List(context.Background(), "bob", 10)
+	out, _ := svc.List(context.Background(), "bob", "", "", 10, nil, nil)
 	assert.Empty(t, out, "renote-mute 済みフォロワーには pure renote の note 通知を送らない")
 }
 
@@ -109,7 +109,7 @@ func TestHook_OnNoteCreated_NoteNotificationQuoteIgnoresRenoteMute(t *testing.T)
 	note := &model.Note{ID: "q1", UserID: "alice", Visibility: model.NoteVisibilityPublic, RenoteID: &target, Text: &text}
 	h.OnNoteCreated(note, &model.User{ID: "alice"}, nil, original)
 
-	out, err := svc.List(context.Background(), "bob", 10)
+	out, err := svc.List(context.Background(), "bob", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, TypeNote, out[0].Type)
@@ -126,7 +126,7 @@ func TestHook_OnNoteCreated_NoteNotificationSkipsNonNotifyFollower(t *testing.T)
 	note := &model.Note{ID: "n1", UserID: "alice", Visibility: model.NoteVisibilityPublic}
 	h.OnNoteCreated(note, &model.User{ID: "alice"}, nil, nil)
 
-	out, _ := svc.List(context.Background(), "bob", 10)
+	out, _ := svc.List(context.Background(), "bob", "", "", 10, nil, nil)
 	assert.Empty(t, out, "notify 未設定のフォロワーには送らない")
 }
 
@@ -138,7 +138,7 @@ func TestHook_OnNoteCreated_NoteNotificationDisabledWithoutRepo(t *testing.T) {
 	note := &model.Note{ID: "n1", UserID: "alice", Visibility: model.NoteVisibilityPublic}
 	h.OnNoteCreated(note, &model.User{ID: "alice"}, nil, nil)
 
-	out, _ := svc.List(context.Background(), "alice", 10)
+	out, _ := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	assert.Empty(t, out)
 }
 
@@ -158,7 +158,7 @@ func TestHook_SelfNotifications(t *testing.T) {
 			h, svc, repo := newTestHook(t)
 			addLocalUser(repo, "alice", "alice")
 			c.fire(h, "alice")
-			out, err := svc.List(context.Background(), "alice", 10)
+			out, err := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 			require.NoError(t, err)
 			require.Len(t, out, 1)
 			assert.Equal(t, c.want, out[0].Type)
@@ -172,7 +172,7 @@ func TestHook_OnRoleAssigned(t *testing.T) {
 	h, svc, repo := newTestHook(t)
 	addLocalUser(repo, "alice", "alice")
 	h.OnRoleAssigned("alice", "role1")
-	out, err := svc.List(context.Background(), "alice", 10)
+	out, err := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, TypeRoleAssigned, out[0].Type)
@@ -185,7 +185,7 @@ func TestHook_OnRoleAssigned_RemoteSkipped(t *testing.T) {
 	h, svc, repo := newTestHook(t)
 	addRemoteUser(repo, "remote", "remote", "example.com")
 	h.OnRoleAssigned("remote", "role1")
-	out, _ := svc.List(context.Background(), "remote", 10)
+	out, _ := svc.List(context.Background(), "remote", "", "", 10, nil, nil)
 	assert.Empty(t, out)
 }
 
@@ -196,7 +196,7 @@ func TestHook_OnChatRoomInvitationReceived(t *testing.T) {
 	addLocalUser(repo, "invitee", "invitee")
 	addLocalUser(repo, "inviter", "inviter")
 	h.OnChatRoomInvitationReceived("invitee", "inviter", "inv1")
-	out, err := svc.List(context.Background(), "invitee", 10)
+	out, err := svc.List(context.Background(), "invitee", "", "", 10, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 	assert.Equal(t, TypeChatRoomInvitationReceived, out[0].Type)
@@ -209,7 +209,7 @@ func TestHook_OnChatRoomInvitationReceived_RemoteSkipped(t *testing.T) {
 	h, svc, repo := newTestHook(t)
 	addRemoteUser(repo, "remote", "remote", "example.com")
 	h.OnChatRoomInvitationReceived("remote", "inviter", "inv1")
-	out, _ := svc.List(context.Background(), "remote", 10)
+	out, _ := svc.List(context.Background(), "remote", "", "", 10, nil, nil)
 	assert.Empty(t, out)
 }
 
@@ -218,7 +218,7 @@ func TestHook_SelfNotifications_RemoteSkipped(t *testing.T) {
 	h, svc, repo := newTestHook(t)
 	addRemoteUser(repo, "remote", "remote", "example.com")
 	h.OnLogin("remote")
-	out, _ := svc.List(context.Background(), "remote", 10)
+	out, _ := svc.List(context.Background(), "remote", "", "", 10, nil, nil)
 	assert.Empty(t, out)
 }
 
@@ -232,7 +232,7 @@ func TestHook_OnNoteCreated_NoteNotificationSkipsSelfFollow(t *testing.T) {
 	note := &model.Note{ID: "n1", UserID: "alice", Visibility: model.NoteVisibilityPublic}
 	h.OnNoteCreated(note, &model.User{ID: "alice"}, nil, nil)
 
-	out, _ := svc.List(context.Background(), "alice", 10)
+	out, _ := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	assert.Empty(t, out, "自己フォロー edge には note 通知を送らない")
 }
 
@@ -257,6 +257,6 @@ func TestHook_OnNoteCreated_NoteNotificationListError(t *testing.T) {
 
 	note := &model.Note{ID: "n1", UserID: "alice", Visibility: model.NoteVisibilityPublic}
 	assert.NotPanics(t, func() { h.OnNoteCreated(note, &model.User{ID: "alice"}, nil, nil) })
-	out, _ := svc.List(context.Background(), "alice", 10)
+	out, _ := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
 	assert.Empty(t, out)
 }


### PR DESCRIPTION
## Summary

通知一覧 (`i/notifications` / `i/notifications-grouped`) の 3 つの upstream 乖離を修正する (#1953)。

upstream `NotificationService.getNotifications` と `NotificationEntityService.#packManyInternal`
に対し、mk-go は以下が乖離していた:

1. **note-required drop**: upstream packMany は noteId を持つ通知の note が削除済/不可視で
   pack できない場合、通知行ごと drop する (`!('noteId' in x) || packedNotes.has(x.noteId)`)。
   mk-go は note embed だけ nil 化して noteId だけの行を残していた。
2. **refetch loop**: upstream は type filter で newest `limit` 件が全て落ちても、より古い
   一致通知が出るまでページを進める。mk-go は newest `limit` 件だけ取得して in-memory filter
   していたため、空/過少を返していた。
3. **direction**: upstream は sinceId のみ指定時 XRANGE 昇順 (sinceId より新しい最古 `limit`
   件)、それ以外 XREVRANGE 降順。mk-go は常に降順 + post-filter で、sinceId-only でも newest
   `limit` 件を返していた。

## 主な変更点

- `internal/core/notification/notification_service.go` `List`: signature を
  `(ctx, userID, sinceID, untilID, limit, includeTypes, excludeTypes)` に拡張し、upstream
  `getNotifications` 相当に direction switch + cursor + type filter + limit を実装。
  - upstream は Redis stream id を notification id から導出して COUNT 範囲取得をループするが、
    mk-go の stream id は `<ms>-<Redis採番seq>` で notification id と別軸のため精密な範囲指定が
    できない。代わりに **MaxPerUser=300 cap 内で向き付き全件取得 → アプリ層で cursor/type
    filter → limit 件** とする (300 上限なので upstream のループと観測上等価)。
  - cursor も type filter も無い first-page は newest `limit` 件だけ取得する hot-path 最適化。
- `internal/api/notifications/handler.go` `collectNotifications`:
  - cursor/type filter を `List` に委譲 (重複削除)。
  - note-required drop を追加: noteByID (可視性 filter 済) に無い NoteID を持つ通知行を落とす
    (repo/queryService 配線時のみ)。grouped 経路も共有のため同時に修正される。

## テスト

- `internal/core/notification/notification_service_test.go`:
  - `TestService_List_TypeFilterSurfacesOlderMatch` (新規、finding 2): excludeTypes で newest
    10 件が全除外でも最古の一致通知を返す。
  - `TestService_List_SinceIdReturnsOldestAscending` (新規、finding 3): sinceId-only で最古
    `limit` 件を昇順で返す。
- `internal/api/notifications/handler_test.go` / `grouped_test.go` (finding 1):
  - `TestShow_FollowersReply_NonFollower_NoteHidden` を「行ごと drop (Len 0)」に更新 (旧:
    embed nil で行を残す)。`TestGrouped_RenoteWithUnresolvableTargetDropped` も同様に Len 0 へ。
  - positive counterpart (note 可視時は残る) は維持。
- 既存 List caller (テスト) を新 signature に移行。
- `internal/core/notification` 91.6% / `internal/api/notifications` 94.2%。`make fmt` /
  `go vet ./...` / `make test` green。

実行方法:
```
go test ./internal/core/notification/ -run List
go test ./internal/api/notifications/
```

## 補足

敵対的レビューで設計 (全件取得→アプリ層 filter) が upstream refetch loop と観測上等価である
こと、note-drop が note 非保持 type を誤って落とさないこと、signature 変更の伝播漏れが無い
ことを確認。`MAXLEN ~` の approximate trim で stream が稀に 300 を僅かに超えうる点はコメントに
明記 (実害無視可能)。obsoleteNotificationTypes (pollVote/groupInvited) の strip は pre-existing
の別 gap で本 PR スコープ外。

## 関連

- 親: #1948 (全面互換性 再監査フォローアップ)

Closes #1953
