### PR TITLE
Fix thread-mute parity (#1954): reply/mention の main-stream event と通知に thread-mute を適用する

### DIFF
--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -228,6 +228,7 @@ type CreateService struct {
 	metaRepo            repository.MetaRepository
 	channelRepo         repository.ChannelRepository
 	silencingProvider   SilencingProvider
+	threadMuteRepo      repository.NoteThreadMutingRepository
 	featuredRanking     FeaturedRanking
 	// randFn は featured ランキング更新の 30% sampling 用。テストで固定する。
 	randFn func() float64
@@ -267,6 +268,13 @@ func (s *CreateService) SetSilencingProvider(p SilencingProvider) {
 // block violations. When unset the block check is skipped (backward compat).
 func (s *CreateService) SetBlockingRepo(r repository.BlockingRepository) {
 	s.blockingRepo = r
+}
+
+// SetThreadMutingRepo attaches a NoteThreadMutingRepository so reply/mention
+// main-stream events are suppressed for recipients who thread-muted the thread,
+// matching upstream NoteCreateService (#1954). nil disables the gate.
+func (s *CreateService) SetThreadMutingRepo(r repository.NoteThreadMutingRepository) {
+	s.threadMuteRepo = r
 }
 
 // SetDriveFileRepo attaches a DriveFileRepository for validating fileIds.
@@ -897,7 +905,9 @@ func (s *CreateService) publishNoteMainEvents(note *model.Note, author *model.Us
 	// と重ねて防御。
 	if replyTarget != nil && replyTarget.UserHost == nil && replyTarget.UserID != author.ID {
 		viewer := &model.User{ID: replyTarget.UserID}
-		if CanSeeNote(viewer, note, s.followingRepo) {
+		// upstream はスレッドミュート中の reply 先には reply event を出さない
+		// (#1954)。thread は reply 先ノートの threadId (無ければ自身の id)。
+		if CanSeeNote(viewer, note, s.followingRepo) && !s.isThreadMuted(replyTarget.UserID, replyTarget) {
 			s.mainStreamPublisher.PublishMainEvent(replyTarget.UserID, "reply", packed)
 		}
 	}
@@ -935,8 +945,29 @@ func (s *CreateService) publishNoteMainEvents(note *model.Note, author *model.Us
 		if !CanSeeNote(u, note, s.followingRepo) {
 			continue
 		}
+		// mention 先がこのスレッドをミュートしていれば mention event を出さない
+		// (#1954)。thread は新規ノート自身の threadId (無ければ自身の id)。
+		if s.isThreadMuted(uid, note) {
+			continue
+		}
 		s.mainStreamPublisher.PublishMainEvent(uid, "mention", packed)
 	}
+}
+
+// isThreadMuted reports whether userID has muted the thread that threadNote
+// belongs to. The thread root is threadNote.ThreadID (falling back to its own
+// id), mirroring upstream `note.threadId ?? note.id`. Returns false when the
+// repository is not wired (gate disabled) or on lookup error (fail-open: emit).
+func (s *CreateService) isThreadMuted(userID string, threadNote *model.Note) bool {
+	if s.threadMuteRepo == nil || threadNote == nil {
+		return false
+	}
+	threadID := threadNote.ID
+	if threadNote.ThreadID != nil && *threadNote.ThreadID != "" {
+		threadID = *threadNote.ThreadID
+	}
+	muted, err := s.threadMuteRepo.Exists(userID, threadID)
+	return err == nil && muted
 }
 
 // safeGo runs fn in a new goroutine, recovering from panics.

--- a/internal/core/note/note_create_service_test.go
+++ b/internal/core/note/note_create_service_test.go
@@ -1685,6 +1685,16 @@ func TestCreateService_NoSuchFile_WrongOwner(t *testing.T) {
 
 // --- MainStreamPublisher emit (Phase 7-4b-5 / #301) ---
 
+// threadMutedFor is a NoteThreadMutingRepository stub that reports userID as
+// having muted every thread, used to assert the thread-mute gate independently
+// of the (generated) note id (#1954).
+type threadMutedFor struct{ userID string }
+
+func (m threadMutedFor) Create(*model.NoteThreadMuting) error        { return nil }
+func (m threadMutedFor) Delete(string, string) error                 { return nil }
+func (m threadMutedFor) Exists(userID, _ string) (bool, error)       { return userID == m.userID, nil }
+func (m threadMutedFor) ListMutedThreadIDs(string) ([]string, error) { return nil, nil }
+
 // stubMainStreamPublisher captures PublishMainEvent calls for test assertions.
 type stubMainStreamPublisher struct {
 	calls []mainEventCall
@@ -1742,6 +1752,73 @@ func TestCreateService_SkipsReplyToSelf(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Empty(t, pub.userIDsOf("reply"))
+}
+
+// #1954: reply 先がスレッドをミュートしていれば reply main-stream event を出さない。
+// thread は reply 先ノートの threadId (root の r1 は自身の id)。
+func TestCreateService_SkipsReplyToThreadMuted(t *testing.T) {
+	svc, noteRepo, _ := newCreateService(t)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+	muteRepo := testutil.NewMockNoteThreadMutingRepository()
+	require.NoError(t, muteRepo.Create(&model.NoteThreadMuting{UserID: "bob", ThreadID: "r1"}))
+	svc.SetThreadMutingRepo(muteRepo)
+
+	noteRepo.Notes["r1"] = &model.Note{ID: "r1", UserID: "bob", Visibility: model.NoteVisibilityPublic}
+	replyID := "r1"
+	text := "hi"
+	_, err := svc.Create(note.CreateInput{User: &model.User{ID: "alice"}, Text: &text, ReplyID: &replyID})
+	require.NoError(t, err)
+	assert.Empty(t, pub.userIDsOf("reply"), "thread-muted reply 先には reply event を出さない (#1954)")
+}
+
+// #1954: reply 先が threaded note (ThreadID 持ち) の場合、その threadId で
+// ミュート判定する (root の id ではなく)。
+func TestCreateService_ReplyThreadMuteUsesThreadID(t *testing.T) {
+	svc, noteRepo, _ := newCreateService(t)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+	muteRepo := testutil.NewMockNoteThreadMutingRepository()
+	require.NoError(t, muteRepo.Create(&model.NoteThreadMuting{UserID: "bob", ThreadID: "troot"}))
+	svc.SetThreadMutingRepo(muteRepo)
+
+	troot := "troot"
+	noteRepo.Notes["r1"] = &model.Note{ID: "r1", UserID: "bob", ThreadID: &troot, Visibility: model.NoteVisibilityPublic}
+	replyID := "r1"
+	text := "hi"
+	_, err := svc.Create(note.CreateInput{User: &model.User{ID: "alice"}, Text: &text, ReplyID: &replyID})
+	require.NoError(t, err)
+	assert.Empty(t, pub.userIDsOf("reply"), "reply 先ノートの threadId でミュート判定する (#1954)")
+}
+
+// #1954: renote はスレッドミュートで gate されない (upstream も ungated)。
+func TestCreateService_RenoteThreadMuteNotGated(t *testing.T) {
+	svc, noteRepo, _ := newCreateService(t)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+	svc.SetThreadMutingRepo(threadMutedFor{userID: "bob"})
+
+	noteRepo.Notes["r1"] = &model.Note{ID: "r1", UserID: "bob", Visibility: model.NoteVisibilityPublic}
+	renoteID := "r1"
+	_, err := svc.Create(note.CreateInput{User: &model.User{ID: "alice"}, RenoteID: &renoteID})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"bob"}, pub.userIDsOf("renote"), "renote はスレッドミュートで抑制されない (#1954)")
+}
+
+// #1954: mention 先がスレッドをミュートしていれば mention main-stream event を出さない。
+func TestCreateService_SkipsMentionToThreadMuted(t *testing.T) {
+	svc, _, _ := newCreateService(t)
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["uA"] = &model.User{ID: "uA", Username: "alice", UsernameLower: "alice"}
+	svc.SetUserRepo(userRepo)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+	svc.SetThreadMutingRepo(threadMutedFor{userID: "uA"})
+
+	text := "hi @alice"
+	_, err := svc.Create(note.CreateInput{User: &model.User{ID: "author1"}, Text: &text})
+	require.NoError(t, err)
+	assert.Empty(t, pub.userIDsOf("mention"), "thread-muted mention 先には mention event を出さない (#1954)")
 }
 
 func TestCreateService_SkipsReplyToRemoteTarget(t *testing.T) {

--- a/internal/core/notification/hooks.go
+++ b/internal/core/notification/hooks.go
@@ -57,6 +57,9 @@ type Hook struct {
 	// 指定リストの member かを確認するための optional 依存 (#1775)。未配線なら
 	// list gate は素通り (best-effort)。
 	userListRepo repository.UserListRepository
+	// threadMuteRepo は reply/mention 通知のスレッドミュート gate に使う
+	// optional 依存 (#1954)。未配線なら gate は素通り。
+	threadMuteRepo repository.NoteThreadMutingRepository
 }
 
 // NewHook constructs a Hook bound to a NotificationService and userRepo.
@@ -102,6 +105,13 @@ func (h *Hook) SetNoteNotifyRepos(following repository.FollowingRepository, reno
 	h.renoteMutingRepo = renoteMuting
 }
 
+// SetThreadMutingRepo attaches a NoteThreadMutingRepository so reply/mention
+// notifications are suppressed for recipients who thread-muted the thread,
+// matching upstream NoteCreateService (#1954). nil disables the gate.
+func (h *Hook) SetThreadMutingRepo(r repository.NoteThreadMutingRepository) {
+	h.threadMuteRepo = r
+}
+
 // SetUserListRepo attaches the user-list repository used by the
 // notificationRecieveConfig type=='list' gate (#1775)。
 func (h *Hook) SetUserListRepo(r repository.UserListRepository) {
@@ -144,9 +154,12 @@ func (h *Hook) OnNoteCreated(n *model.Note, author *model.User, replyTarget, ren
 	// #17363 で null = no filter に揃った)。default (= 不明 visibility) は
 	// 通知 fan-out 自体を停止して安全側に倒す。
 
-	// reply: 親ノートの投稿者がローカルユーザーなら通知
+	// reply: 親ノートの投稿者がローカルユーザーなら通知。ただし reply 先が
+	// スレッドをミュートしていれば通知しない (#1954)。thread は reply 先ノートの
+	// threadId (無ければ自身の id)。
 	if replyTarget != nil && replyTarget.UserID != author.ID &&
-		h.notifyVisibleToTarget(n, replyTarget.UserID) {
+		h.notifyVisibleToTarget(n, replyTarget.UserID) &&
+		!h.isThreadMuted(replyTarget.UserID, replyTarget) {
 		h.notifyLocalUser(ctx, replyTarget.UserID, CreateInput{
 			NotifieeID:     replyTarget.UserID,
 			NotifierID:     author.ID,
@@ -179,6 +192,11 @@ func (h *Hook) OnNoteCreated(n *model.Note, author *model.User, replyTarget, ren
 			continue
 		}
 		if !h.notifyVisibleToTarget(n, mentionedID) {
+			continue
+		}
+		// mention 先がこのスレッドをミュートしていれば通知しない (#1954)。
+		// thread は新規ノート自身の threadId (無ければ自身の id)。
+		if h.isThreadMuted(mentionedID, n) {
 			continue
 		}
 		h.notifyLocalUser(ctx, mentionedID, CreateInput{
@@ -301,6 +319,22 @@ func (h *Hook) OnChatRoomInvitationReceived(inviteeID, inviterID, invitationID s
 // 注: VisibleUserIDs 比較は線形探索だが、specified note の visibleUserIds 配列
 // は通常 10 件以下なので map 化のコスト (= 各通知呼び出しで毎回 map 構築) より
 // 安い。
+// isThreadMuted reports whether userID has muted the thread that threadNote
+// belongs to. The thread root is threadNote.ThreadID (falling back to its own
+// id), mirroring upstream `note.threadId ?? note.id`. Returns false when the
+// repository is not wired (gate disabled) or on lookup error (fail-open: notify).
+func (h *Hook) isThreadMuted(userID string, threadNote *model.Note) bool {
+	if h.threadMuteRepo == nil || threadNote == nil {
+		return false
+	}
+	threadID := threadNote.ID
+	if threadNote.ThreadID != nil && *threadNote.ThreadID != "" {
+		threadID = *threadNote.ThreadID
+	}
+	muted, err := h.threadMuteRepo.Exists(userID, threadID)
+	return err == nil && muted
+}
+
 func (h *Hook) notifyVisibleToTarget(n *model.Note, targetID string) bool {
 	switch n.Visibility {
 	case "", model.NoteVisibilityPublic, model.NoteVisibilityHome, model.NoteVisibilityFollowers:

--- a/internal/core/notification/hooks_test.go
+++ b/internal/core/notification/hooks_test.go
@@ -50,6 +50,83 @@ func TestHook_OnNoteCreated_ReplyNotification(t *testing.T) {
 	assert.Equal(t, TypeReply, out[0].Type)
 }
 
+// #1954: reply 先がスレッドをミュートしていれば reply 通知を出さない。
+func TestHook_OnNoteCreated_ReplyThreadMutedSkipped(t *testing.T) {
+	h, svc, repo := newTestHook(t)
+	addLocalUser(repo, "alice", "alice")
+	addLocalUser(repo, "bob", "bob")
+
+	muteRepo := testutil.NewMockNoteThreadMutingRepository()
+	// alice が thread n_parent (root) をミュート。
+	require.NoError(t, muteRepo.Create(&model.NoteThreadMuting{UserID: "alice", ThreadID: "n_parent"}))
+	h.SetThreadMutingRepo(muteRepo)
+
+	parent := &model.Note{ID: "n_parent", UserID: "alice"}
+	note := &model.Note{ID: "n_reply", UserID: "bob"}
+	h.OnNoteCreated(note, &model.User{ID: "bob"}, parent, nil)
+
+	out, _ := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
+	assert.Empty(t, out, "thread-muted reply 先には reply 通知を出さない (#1954)")
+}
+
+// #1954: reply 先が threaded note (ThreadID 持ち) の場合、その threadId で判定する。
+func TestHook_OnNoteCreated_ReplyThreadMuteUsesThreadID(t *testing.T) {
+	h, svc, repo := newTestHook(t)
+	addLocalUser(repo, "alice", "alice")
+	addLocalUser(repo, "bob", "bob")
+
+	muteRepo := testutil.NewMockNoteThreadMutingRepository()
+	require.NoError(t, muteRepo.Create(&model.NoteThreadMuting{UserID: "alice", ThreadID: "troot"}))
+	h.SetThreadMutingRepo(muteRepo)
+
+	troot := "troot"
+	parent := &model.Note{ID: "n_parent", UserID: "alice", ThreadID: &troot}
+	note := &model.Note{ID: "n_reply", UserID: "bob"}
+	h.OnNoteCreated(note, &model.User{ID: "bob"}, parent, nil)
+
+	out, _ := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
+	assert.Empty(t, out, "reply 先ノートの threadId でミュート判定する (#1954)")
+}
+
+// #1954: mention 先がスレッドをミュートしていれば mention 通知を出さない。
+func TestHook_OnNoteCreated_MentionThreadMutedSkipped(t *testing.T) {
+	h, svc, repo := newTestHook(t)
+	addLocalUser(repo, "alice", "alice")
+	addLocalUser(repo, "bob", "bob")
+
+	muteRepo := testutil.NewMockNoteThreadMutingRepository()
+	// alice が thread n_m (note 自身 = root) をミュート。
+	require.NoError(t, muteRepo.Create(&model.NoteThreadMuting{UserID: "alice", ThreadID: "n_m"}))
+	h.SetThreadMutingRepo(muteRepo)
+
+	note := &model.Note{ID: "n_m", UserID: "bob", Mentions: pq.StringArray{"alice"}}
+	h.OnNoteCreated(note, &model.User{ID: "bob"}, nil, nil)
+
+	out, _ := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
+	assert.Empty(t, out, "thread-muted mention 先には mention 通知を出さない (#1954)")
+}
+
+// #1954: renote はスレッドミュートで gate されない (upstream も ungated)。
+func TestHook_OnNoteCreated_RenoteThreadMuteNotGated(t *testing.T) {
+	h, svc, repo := newTestHook(t)
+	addLocalUser(repo, "alice", "alice")
+	addLocalUser(repo, "bob", "bob")
+
+	muteRepo := testutil.NewMockNoteThreadMutingRepository()
+	require.NoError(t, muteRepo.Create(&model.NoteThreadMuting{UserID: "alice", ThreadID: "n_target"}))
+	h.SetThreadMutingRepo(muteRepo)
+
+	target := "n_target"
+	original := &model.Note{ID: target, UserID: "alice"}
+	note := &model.Note{ID: "n_renote", UserID: "bob", RenoteID: &target}
+	h.OnNoteCreated(note, &model.User{ID: "bob"}, nil, original)
+
+	out, err := svc.List(context.Background(), "alice", "", "", 10, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, out, 1, "renote はスレッドミュートで抑制されない (#1954)")
+	assert.Equal(t, TypeRenote, out[0].Type)
+}
+
 func TestHook_OnNoteCreated_ReplyToSelfSkipped(t *testing.T) {
 	h, svc, repo := newTestHook(t)
 	addLocalUser(repo, "alice", "alice")

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -231,6 +231,8 @@ func (s *Server) setupRoutes() {
 	// canPublicNote=false の user の public note を home に降格させる
 	// silencing 機構 (#1024)。
 	noteCreateService.SetSilencingProvider(roleService)
+	// reply/mention の main-stream event をスレッドミュート済 recipient に出さない (#1954)。
+	noteCreateService.SetThreadMutingRepo(noteThreadMutingRepo)
 	noteDeleteService := corenote.NewDeleteService(noteRepo)
 	noteDeleteService.SetUserRepo(userRepo) // #1538: resolve author for moderator delete
 	noteQueryService := corenote.NewQueryService(noteRepo, followingRepo)
@@ -331,6 +333,8 @@ func (s *Server) setupRoutes() {
 	notificationHook.SetNoteNotifyRepos(followingRepo, renoteMutingRepo)
 	// notificationRecieveConfig type=='list' gate の member 確認用 (#1775)。
 	notificationHook.SetUserListRepo(userListRepo)
+	// reply/mention 通知をスレッドミュート済 recipient に出さない (#1954)。
+	notificationHook.SetThreadMutingRepo(noteThreadMutingRepo)
 	noteCreateService.SetNotificationHook(notificationHook)
 	noteCreateService.SetUserRepo(userRepo)
 	// roleAssigned 通知 (#1559): local public role 割当時に発火し、entity 側で


### PR DESCRIPTION
## Summary

スレッドミュート (`notes/thread-muting`) を reply/mention の main-stream event と通知に適用する (#1954)。

upstream `NoteCreateService` は、reply 先 / mention 先のローカルユーザーがそのスレッドを
ミュート (`noteThreadMutingsRepository.exists({userId, threadId})`) している場合、**reply/mention
の main-stream event と通知の両方を抑制**する (renote は ungated)。

mk-go は thread-muting 自体は実装済 (`NoteThreadMutingRepository` / `notes/thread-muting`
endpoint / read 経路の filter) だが、reply/mention の event 発火と通知に gate が適用されて
いなかった。結果、スレッドをミュートしたユーザーにも live `reply`/`mention` event と通知が
届いていた。

## 主な変更点

- `internal/core/note/note_create_service.go` `publishNoteMainEvents`: reply / mention の
  `PublishMainEvent` 前に `isThreadMuted(targetUserID, threadNote)` gate を追加。renote は
  ungated のまま。`SetThreadMutingRepo` + `isThreadMuted` helper を追加。
- `internal/core/notification/hooks.go` `OnNoteCreated`: reply / mention 通知前に同じ gate を
  追加。`SetThreadMutingRepo` + `isThreadMuted` helper を追加。
- `internal/server/router.go`: 両経路に `noteThreadMutingRepo` を配線。

threadId 導出は upstream と一致: reply は reply 先ノートの `threadId ?? id`、mention は新規
ノートの `threadId ?? id`。repo 未配線 / lookup error 時は fail-open (出す側に倒す)。

event 発火 (note パッケージ) と通知 (notification hook) は別 subscriber のため両方に gate が
必要 (upstream は同一 `!isThreadMuted` ブロックで両方を抑制)。

## テスト

- `internal/core/note/note_create_service_test.go`:
  - reply 抑制 / mention 抑制 / renote 非抑制 (control) / threaded reply 先での threadId 導出。
- `internal/core/notification/hooks_test.go`:
  - 同上 (reply 通知抑制 / mention 通知抑制 / renote 通知非抑制 / threadId 導出)。
- 両 `isThreadMuted` 100% カバレッジ。`internal/core/note` 94.8% / `internal/core/notification`
  91.6%。`make fmt` / `go vet ./...` / `make test` green。

実行方法:
```
go test ./internal/core/note/ ./internal/core/notification/ -run ThreadMute
```

## 補足

敵対的レビューで、event / 通知の 2 経路に加えて **user webhook の reply/mention 配信**も
upstream は同一ブロックで thread-mute するが mk-go は未対応であることを発見し、#1954 スコープ外
として別 issue 化した (#1965)。

## 関連

- 親: #1948 (全面互換性 再監査フォローアップ)

Closes #1954
