### PR TITLE
Fix announcements parity (#1955): show/list の isRead を read 状態反映 + 匿名 key 省略に揃える

### DIFF
--- a/internal/api/announcements/handler.go
+++ b/internal/api/announcements/handler.go
@@ -139,6 +139,11 @@ func (h *Handler) List(c echo.Context) error {
 		if user != nil {
 			read, _ := h.repo.IsRead(user.ID, a.ID)
 			item["isRead"] = read
+		} else {
+			// 匿名 (requireCredential:false) では upstream pack() が isRead を
+			// undefined にし key ごと省略する。mk-go の packAnnouncement は常に
+			// false を入れるため、ここで削除して shape を揃える (#1955)。
+			delete(item, "isRead")
 		}
 		result = append(result, item)
 	}

--- a/internal/api/announcements/handler_show.go
+++ b/internal/api/announcements/handler_show.go
@@ -34,11 +34,21 @@ func (h *Handler) Show(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "b57b5e1d-4f49-404a-9edb-46b00268f121"))
 	}
+	me := middleware.GetUser(c)
 	if a.UserID != nil {
-		me := middleware.GetUser(c)
 		if me == nil || *a.UserID != me.ID {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "b57b5e1d-4f49-404a-9edb-46b00268f121"))
 		}
 	}
-	return c.JSON(http.StatusOK, packAnnouncement(a, h.idGen))
+	item := packAnnouncement(a, h.idGen)
+	// upstream getAnnouncement は announcement_reads を引いて isRead=(read!==null)
+	// を pack する。匿名では isRead を undefined にし key を省略する。mk-go は read
+	// 状態を見ずに常に false を返していた (#1955)。
+	if me != nil {
+		read, _ := h.repo.IsRead(me.ID, a.ID)
+		item["isRead"] = read
+	} else {
+		delete(item, "isRead")
+	}
+	return c.JSON(http.StatusOK, item)
 }

--- a/internal/api/announcements/handler_show_test.go
+++ b/internal/api/announcements/handler_show_test.go
@@ -36,6 +36,45 @@ func TestShow_Success(t *testing.T) {
 	shapetest.Assert(t, "Announcement", resp) // L3 (#1318)
 }
 
+// #1955: 匿名 caller には isRead key を出さない (upstream pack() は me==null で
+// isRead を undefined にする)。
+func TestShow_AnonymousOmitsIsRead(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Items["a1"] = &model.Announcement{ID: "a1", Title: "hi", Text: "hello", IsActive: true}
+	rec := doPost(h.Show, `{"announcementId":"a1"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	_, hasIsRead := resp["isRead"]
+	assert.False(t, hasIsRead, "匿名には isRead key を出さない (#1955)")
+}
+
+// #1955: 既読のログインユーザーには isRead:true を返す (旧実装は常に false)。
+func TestShow_AuthenticatedReflectsReadState(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Items["a1"] = &model.Announcement{ID: "a1", Title: "hi", Text: "hello", IsActive: true}
+	require.NoError(t, repo.MarkRead(&model.AnnouncementRead{UserID: "u1", AnnouncementID: "a1"}))
+
+	rec := doPost(h.Show, `{"announcementId":"a1"}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["isRead"], "既読ユーザーには isRead:true (#1955)")
+}
+
+// 未読のログインユーザーには isRead:false。
+func TestShow_AuthenticatedUnreadIsReadFalse(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Items["a1"] = &model.Announcement{ID: "a1", Title: "hi", Text: "hello", IsActive: true}
+
+	rec := doPost(h.Show, `{"announcementId":"a1"}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["isRead"], "未読ユーザーには isRead:false (#1955)")
+}
+
 // upstream Misskey TS 2026.5.4 fix: userId-targeted announcement に対して
 // 非ログイン user (me == nil) は 404 を返す。旧 mk-go では Show 経路に権限
 // check が一切なく、admin が特定 user に向けた通知が漏れる drop-in regression
@@ -70,4 +109,18 @@ func TestShow_UserTargeted_OwnerReturnsOK(t *testing.T) {
 	alice := &model.User{ID: "alice"}
 	rec := doPost(h.Show, `{"announcementId":"a1"}`, alice)
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// #1955: user-targeted announcement の owner でも isRead が read 状態を反映する。
+func TestShow_UserTargeted_OwnerReflectsReadState(t *testing.T) {
+	h, repo := newTestHandler(t)
+	uid := "alice"
+	repo.Items["a1"] = &model.Announcement{ID: "a1", Title: "private", Text: "to alice", IsActive: true, UserID: &uid}
+	require.NoError(t, repo.MarkRead(&model.AnnouncementRead{UserID: "alice", AnnouncementID: "a1"}))
+
+	rec := doPost(h.Show, `{"announcementId":"a1"}`, &model.User{ID: "alice"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["isRead"], "owner-targeted でも既読は isRead:true (#1955)")
 }

--- a/internal/api/announcements/handler_test.go
+++ b/internal/api/announcements/handler_test.go
@@ -66,6 +66,40 @@ func java_time() time.Time {
 	return time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
 }
 
+// #1955: 匿名 (requireCredential:false) の List では isRead key を省略する。
+func TestList_AnonymousOmitsIsRead(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Items["a1"] = &model.Announcement{ID: "a1", Title: "Hi", Text: "Hello", IsActive: true}
+	rec := doPost(h.List, `{}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	_, hasIsRead := resp[0]["isRead"]
+	assert.False(t, hasIsRead, "匿名 List には isRead key を出さない (#1955)")
+}
+
+// #1955: authed List は item ごとに実 read 状態を isRead に反映する。
+func TestList_AuthenticatedReflectsReadState(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Items["a_read"] = &model.Announcement{ID: "a_read", Title: "R", Text: "read", IsActive: true}
+	repo.Items["a_unread"] = &model.Announcement{ID: "a_unread", Title: "U", Text: "unread", IsActive: true}
+	require.NoError(t, repo.MarkRead(&model.AnnouncementRead{UserID: "u1", AnnouncementID: "a_read"}))
+
+	rec := doPost(h.List, `{}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	byID := map[string]map[string]any{}
+	for _, it := range resp {
+		byID[it["id"].(string)] = it
+	}
+	require.Contains(t, byID, "a_read")
+	require.Contains(t, byID, "a_unread")
+	assert.Equal(t, true, byID["a_read"]["isRead"], "既読 item は isRead:true (#1955)")
+	assert.Equal(t, false, byID["a_unread"]["isRead"], "未読 item は isRead:false (#1955)")
+}
+
 func TestList_InvalidJSON(t *testing.T) {
 	h, _ := newTestHandler(t)
 	rec := doPost(h.List, `invalid`, nil)


### PR DESCRIPTION
## Summary

`/api/announcements` (List) と `/api/announcements/show` の `isRead` を upstream に揃える (#1955)。

upstream `AnnouncementService.getAnnouncement` / `AnnouncementEntityService.pack` は:
- ログイン viewer があれば `announcement_reads` を引いて `isRead = (read !== null)` を pack。
- 匿名 (me==null) では `isRead` を undefined にし JSON から key ごと省略 (misskey-js も
  `isRead?: boolean` で optional)。

mk-go の乖離:
1. `/api/announcements/show` (requireCredential:false) が read 状態を一切見ず、ログイン
   ユーザーにも常に `isRead:false` を返していた (既読ユーザーで read-state tracking が壊れる)。
2. show / list が匿名 caller にも `isRead:false` を出していた (upstream は key 省略)。

## 主な変更点

- `internal/api/announcements/handler_show.go` `Show`: `me` を取得し、`me!=nil` なら
  `repo.IsRead(me.ID, a.ID)` を反映、`me==nil` なら `isRead` key を削除。user-targeted
  announcement の owner 経路でも read 状態を反映。
- `internal/api/announcements/handler.go` `List`: 匿名 (`user==nil`) で `isRead` key を削除
  (authed は既存どおり実 read 反映)。
- `entity.PackAnnouncement` の signature は変えず call-site で対応 (announcementCreated event
  body / AdminCreate / AdminList の `isRead` 挙動は不変)。

`isRead` は misskey-js / golden schema ともに optional なので、匿名で省略しても L3 shape
check (`shapetest.Assert("Announcement")`) は通る。

## テスト

- `handler_show_test.go`: 匿名で isRead 省略 / 既読ユーザーで isRead:true / 未読で false /
  user-targeted owner で read 反映。
- `handler_test.go`: 匿名 List で isRead 省略 / authed List で item ごとの read 反映。
- `internal/api/announcements` 96.8%、List/Show ともに 100%。`make fmt` / `go vet` /
  `make test` green。

実行方法:
```
go test ./internal/api/announcements/ -run 'Show|List'
```

## 補足

敵対的レビューで、同じ packer の隣接 field `forYou` が upstream の `userId === me?.id` ではなく
`userId != nil` で計算されている乖離を発見した。これは List/Show では他人宛て per-user が
返らないため顕在化せず、**AdminList で他人宛て announcement に forYou:true が付く**形でのみ
表面化する (= 監査の「admin/announcements/list が非 upstream の forYou/isRead を返す」LOW
finding と同根)。#1955 (public isRead) のスコープ外として別 issue 化した。

## 関連

- 親: #1948 (全面互換性 再監査フォローアップ)

Closes #1955
