### PR TITLE
Fix AP actor parity (#1956): system actor を Application 型で render する

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -188,10 +188,16 @@ type PollResolver interface {
 	FindByNoteID(noteID string) (*model.Poll, error)
 }
 
-// actorTypeForUser returns the AP actor `type` to emit for a local user.
-// 現状: IsBot=true なら Service、それ以外は Person。Application (system actor)
-// 出力は将来のシステムアカウント機能で別経路を追加する想定。
+// actorTypeForUser returns the AP actor `type` to emit for a local user,
+// mirroring upstream ApRendererService.renderPerson: a system account
+// (username が '.' を含む、例 relay.actor / instance.actor / proxy.actor) は
+// 'Application' を最優先で返す。それ以外は IsBot なら 'Service'、通常は 'Person'
+// (#1956)。Mastodon/Misskey の relay ロジックや actor-type ベースの UI は
+// Application を特別扱いするため、wire 上一致させる必要がある。
 func actorTypeForUser(u *model.User) string {
+	if strings.Contains(u.Username, ".") {
+		return "Application"
+	}
 	if u.IsBot {
 		return "Service"
 	}

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -234,6 +234,26 @@ func TestRenderer_RenderPerson_NoOptionalFields(t *testing.T) {
 	assert.False(t, p.ManuallyApproves)
 }
 
+// #1956: system actor (username に '.' を含む relay.actor / instance.actor /
+// proxy.actor 等) は AS actor type 'Application' で render する。isSystem は
+// IsBot より優先される (upstream renderPerson)。
+func TestRenderer_RenderPerson_SystemActorIsApplication(t *testing.T) {
+	r := newRenderer()
+	// relay.actor は system account として作成され IsBot=true。それでも
+	// Application が優先されること (isSystem > isBot) を確認する。
+	u := &model.User{ID: "u_relay", Username: "relay.actor", IsBot: true}
+	p := r.RenderPerson(u, nil, "PUBKEY", nil)
+	assert.Equal(t, "Application", p.Type)
+}
+
+// 通常の bot (username に '.' 無し) は Service のまま。
+func TestRenderer_RenderPerson_BotIsService(t *testing.T) {
+	r := newRenderer()
+	u := &model.User{ID: "u_bot", Username: "botuser", IsBot: true}
+	p := r.RenderPerson(u, nil, "PUBKEY", nil)
+	assert.Equal(t, "Service", p.Type)
+}
+
 func TestRenderer_RenderPerson_AssertionMethodOmittedWhenNoEd25519(t *testing.T) {
 	r := newRenderer()
 	u := &model.User{ID: "u1", Username: "alice"}


### PR DESCRIPTION
## Summary

system actor (relay.actor / instance.actor / proxy.actor) を AS actor type `Application` で
render する (#1956)。

upstream `ApRendererService.renderPerson` は `isSystem = user.username.includes('.')` を計算し、
actor type を `isSystem ? 'Application' : user.isBot ? 'Service' : 'Person'` で出力する
(isSystem が isBot より優先)。username に `.` を含む system account は `Application` になる。

mk-go の `actorTypeForUser` は `IsBot ? "Service" : "Person"` のみで `Application` を出さなかった。
mk-go は system account を `.actor` suffix の username + `IsBot=true` で作成し、同じ `RenderPerson`
経路 (`/users/:id` / `/@:acct`) で配信するため、連合 peer (relay 購読側 / authorized-fetch で
instance.actor を取得する側) は `Application` であるべき所で `Service` を観測していた。

## 主な変更点

- `internal/activitypub/renderer.go` `actorTypeForUser`: `strings.Contains(u.Username, ".")` なら
  `"Application"` を最優先で返す。else `IsBot → "Service"`、else `"Person"`。

通常ユーザーの username は signup validation (`^[a-zA-Z0-9_]{1,20}$`) で `.` を許可しないため、
`Application` 化されるのは system account のみ。誤分類は起きない (upstream も同じ invariant に依拠)。
`RenderPerson` の全呼び出し元はローカル actor をガード済みで、リモート actor には影響しない。

## テスト

- `internal/activitypub/renderer_test.go`:
  - `TestRenderer_RenderPerson_SystemActorIsApplication`: `relay.actor` + `IsBot=true` → `Application`
    (isSystem > isBot を検証)。
  - `TestRenderer_RenderPerson_BotIsService`: 通常 bot (`.` 無し) → `Service`。
- `go vet` / `go test ./internal/activitypub/` green。`make test` green。

実行方法:
```
go test ./internal/activitypub/ -run RenderPerson
```

## 補足

敵対的レビューで、upstream renderPerson が avatar/banner 未設定時に icon(identicon)/image
(systemAvatar/systemBanner) を付ける一方 mk-go は nil 時に省略する隣接差分を発見し、別 issue
化した (#1969)。本 PR (type 判定) のスコープ外。

## 関連

- 親: #1948 (全面互換性 再監査フォローアップ)

Closes #1956
