### PR TITLE
Fix relation packing parity (#1957-a): user-list endpoint の embed user に viewer-relation を付ける

### DIFF
--- a/internal/api/blocking/handler.go
+++ b/internal/api/blocking/handler.go
@@ -148,7 +148,7 @@ func (h *Handler) List(c echo.Context) error {
 	}
 	// upstream frontend が item.blockee で MkUserCardMini を描画するので
 	// batch fetch で N+1 を回避しつつ user object を embed する。
-	blockeeMap := h.fetchBlockeeMap(rows)
+	blockeeMap := h.fetchBlockeeMap(user.ID, rows)
 	const tsFormat = "2006-01-02T15:04:05.000Z"
 	out := make([]map[string]any, 0, len(rows))
 	for _, b := range rows {
@@ -173,7 +173,11 @@ func (h *Handler) List(c echo.Context) error {
 
 // fetchBlockeeMap batches user + profile lookups for the blockee IDs in
 // rows so the response build loop performs zero per-row DB queries.
-func (h *Handler) fetchBlockeeMap(rows []*model.Blocking) map[string]entity.UserDetailed {
+// viewerID は embed する blockee に viewer->blockee の relation block
+// (isBlocking=true 等) を付与するために使う。mute/list / renote-mute/list と
+// 揃える (upstream BlockingEntityService.packMany が UserDetailedNotMe + me で
+// pack するため、#1957-a)。
+func (h *Handler) fetchBlockeeMap(viewerID string, rows []*model.Blocking) map[string]entity.UserDetailed {
 	if h.userRepo == nil || len(rows) == 0 {
 		return nil
 	}
@@ -201,7 +205,11 @@ func (h *Handler) fetchBlockeeMap(rows []*model.Blocking) map[string]entity.User
 	}
 	out := make(map[string]entity.UserDetailed, len(users))
 	for _, u := range users {
-		out[u.ID] = entity.PackUserDetailed(u, profileByUser[u.ID], h.idGen)
+		d := entity.PackUserDetailed(u, profileByUser[u.ID], h.idGen)
+		// viewer->blockee の relation block を付与 (isBlocking=true 等)。Apply は
+		// viewerID 空 / self では no-op。relation 未配線 (test stub) でも安全。
+		h.relation.Apply(&d, viewerID, u, profileByUser[u.ID])
+		out[u.ID] = d
 	}
 	return out
 }

--- a/internal/api/blocking/handler_test.go
+++ b/internal/api/blocking/handler_test.go
@@ -89,6 +89,37 @@ func TestCreateDelete_ReturnsIsBlockingRelation(t *testing.T) {
 	assert.Equal(t, false, resp["isBlocking"], "unblock 後は isBlocking=false")
 }
 
+// #1957-a: blocking/list の embed blockee に viewer->blockee の relation block が
+// 乗る (isBlocking=true)。upstream BlockingEntityService.packMany が
+// UserDetailedNotMe + me で pack するのと一致。mute/list と同様。
+func TestList_BlockeeCarriesIsBlocking(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	blockingRepo := testutil.NewMockBlockingRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := coreblocking.NewService(userRepo, blockingRepo, nil, idGen)
+	h := NewHandler(svc, userRepo, idGen)
+	// relation の Blocking は service と同一インスタンスで block 状態を反映。
+	h.SetRelationRepos(userrelation.Repos{Blocking: blockingRepo})
+	addUser(userRepo, "alice")
+	addUser(userRepo, "bob")
+
+	c1, _ := newReq(t, `{"userId":"bob"}`)
+	setUser(c1, "alice")
+	require.NoError(t, h.Create(c1))
+
+	c, rec := newReq(t, `{}`)
+	setUser(c, "alice")
+	require.NoError(t, h.List(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	blockee, ok := resp[0]["blockee"].(map[string]any)
+	require.True(t, ok, "blockee が embed される")
+	assert.Equal(t, true, blockee["isBlocking"], "embed blockee に isBlocking=true が乗る (#1957-a)")
+}
+
 func TestCreate_InvalidParam(t *testing.T) {
 	h, _ := newHandler(t)
 	c, rec := newReq(t, `{}`)

--- a/internal/api/federation/handler.go
+++ b/internal/api/federation/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
+	"github.com/shiroha-a/mk/internal/api/userrelation"
 	corefederation "github.com/shiroha-a/mk/internal/core/federation"
 	coreinstance "github.com/shiroha-a/mk/internal/core/instance"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -43,6 +44,9 @@ type Handler struct {
 	// で createdAt を aidx ID から導出するために使う。nil の場合 createdAt は
 	// 空文字列になる (= 互換性は維持しつつ degrade)。
 	idGen id.Generator
+	// relation は embed する user/followee に viewer 視点の relation block を
+	// 付与する (upstream packMany(users, me))。未配線 / 匿名では no-op (#1957-a)。
+	relation userrelation.Repos
 }
 
 // NewHandler creates a new federation Handler.
@@ -69,6 +73,12 @@ func (h *Handler) SetIDGen(g id.Generator) {
 // SetResolver attaches an ActorResolver for update-remote-user.
 func (h *Handler) SetResolver(r ActorResolver) {
 	h.resolver = r
+}
+
+// SetRelationRepos wires the repositories used to populate viewer-relative
+// relation fields on embedded users/followees (#1957-a). Unset = relations omitted.
+func (h *Handler) SetRelationRepos(r userrelation.Repos) {
+	h.relation = r
 }
 
 // SetModeratorChecker attaches a ModeratorChecker so moderationNote is only

--- a/internal/api/federation/handler_test.go
+++ b/internal/api/federation/handler_test.go
@@ -66,6 +66,19 @@ func postStub(handler func(echo.Context) error) *httptest.ResponseRecorder {
 	return postBody(handler, `{}`)
 }
 
+// postBodyAs is postBody with an authenticated viewer set in the context, used
+// to exercise viewer-relative relation packing (#1957-a).
+func postBodyAs(handler func(echo.Context) error, body, viewerID string) *httptest.ResponseRecorder {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), &model.User{ID: viewerID})
+	_ = handler(c)
+	return rec
+}
+
 func seedInstance(t *testing.T, repo *testutil.MockInstanceRepository, host string) *model.Instance {
 	t.Helper()
 	inst := &model.Instance{

--- a/internal/api/federation/host_listings.go
+++ b/internal/api/federation/host_listings.go
@@ -9,6 +9,7 @@ import (
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
 // hostPageRequest is the common request body for the three per-host listing
@@ -43,7 +44,7 @@ func (h *Handler) Followers(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, h.packFollowings(rows))
+	return c.JSON(http.StatusOK, h.packFollowings(viewerIDOf(c), rows))
 }
 
 // Following handles POST /api/federation/following.
@@ -62,7 +63,7 @@ func (h *Handler) Following(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
-	return c.JSON(http.StatusOK, h.packFollowings(rows))
+	return c.JSON(http.StatusOK, h.packFollowings(viewerIDOf(c), rows))
 }
 
 // Users handles POST /api/federation/users.
@@ -92,12 +93,25 @@ func (h *Handler) Users(c echo.Context) error {
 	// createdAt/notesCount/followersCount/description/fields/roles 等が欠落して
 	// いた (#1544)。UserDetailed で pack して shape を揃える。user_profile は
 	// 1 batch で解決して N+1 を回避。
+	viewerID := viewerIDOf(c)
 	profByID := h.userProfiles(users)
 	out := make([]entity.UserDetailed, 0, len(users))
 	for _, u := range users {
-		out = append(out, entity.PackUserDetailed(u, profByID[u.ID], h.idGen))
+		d := entity.PackUserDetailed(u, profByID[u.ID], h.idGen)
+		// 認証 caller には viewer->user の relation block を付与 (匿名/self は no-op、#1957-a)。
+		h.relation.Apply(&d, viewerID, u, profByID[u.ID])
+		out = append(out, d)
 	}
 	return c.JSON(http.StatusOK, out)
+}
+
+// viewerIDOf returns the authenticated viewer's ID, or "" for anonymous callers.
+// federation/* は requireCredential:false なので nil viewer を許容する。
+func viewerIDOf(c echo.Context) string {
+	if u := middleware.GetUser(c); u != nil {
+		return u.ID
+	}
+	return ""
 }
 
 // userProfiles batch-loads the user_profile rows for the given users keyed by
@@ -146,12 +160,19 @@ func parseHostPage(c echo.Context) (hostPageRequest, bool) {
 // true}) を呼ぶため followee (UserDetailedNotMe) を必ず embed する。followee の
 // User+UserProfile は ID をまとめて 1 度引いて N+1 を避ける。userRepo が nil の
 // 場合 (= test 等で未配線) は followee を埋めずに id 系フィールドだけ返す。
-func (h *Handler) packFollowings(rows []*model.Following) []entity.Following {
+func (h *Handler) packFollowings(viewerID string, rows []*model.Following) []entity.Following {
 	lookup := h.followeeLookup(rows)
 	out := make([]entity.Following, 0, len(rows))
 	for _, f := range rows {
 		// populateFollowee=true / populateFollower=false (本家と同じ)。
-		out = append(out, entity.PackFollowing(f, true, false, lookup, h.idGen))
+		pf := entity.PackFollowing(f, true, false, lookup, h.idGen)
+		// embed followee に viewer 視点の relation block を付与 (#1957-a)。
+		if pf.Followee != nil {
+			if u, p := lookup(f.FolloweeID); u != nil {
+				h.relation.Apply(pf.Followee, viewerID, u, p)
+			}
+		}
+		out = append(out, pf)
 	}
 	return out
 }

--- a/internal/api/federation/host_listings_test.go
+++ b/internal/api/federation/host_listings_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shiroha-a/mk/internal/api/userrelation"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
@@ -215,6 +216,81 @@ func TestUsers_CursorUntilID(t *testing.T) {
 	require.Len(t, rows, 2)
 	assert.Equal(t, "u2", rows[0]["id"])
 	assert.Equal(t, "u1", rows[1]["id"])
+}
+
+// #1957-a: federation/users の embed user に viewer 視点の relation block が乗る。
+// 認証 viewer が remote user を follow していれば isFollowing=true、匿名なら省略。
+func TestUsers_EmbedsViewerRelation(t *testing.T) {
+	h, _ := newHandler(t)
+	userRepo := testutil.NewMockUserRepository()
+	remote := "remote.example"
+	userRepo.Users["r1"] = &model.User{ID: "r1", Username: "r1", Host: &remote}
+	h.SetUserRepo(userRepo)
+	idGen, _ := id.NewGenerator("aidx")
+	h.SetIDGen(idGen)
+	followingRepo := testutil.NewMockFollowingRepository()
+	followingRepo.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "local1", FolloweeID: "r1"}
+	h.SetFollowingRepo(followingRepo)
+	h.SetRelationRepos(userrelation.Repos{Following: followingRepo})
+
+	// 認証 viewer local1: r1 を follow しているので isFollowing=true。
+	rec := postBodyAs(h.Users, `{"host":"remote.example","limit":10}`, "local1")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, true, rows[0]["isFollowing"], "認証 viewer の embed user に isFollowing=true (#1957-a)")
+
+	// 匿名 caller: relation は省略される (key 不在)。fresh な slice に unmarshal する
+	// (既存 slice 再利用だと json が map をマージし前回の isFollowing が残るため)。
+	rec = postBody(h.Users, `{"host":"remote.example","limit":10}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var anonRows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &anonRows))
+	require.Len(t, anonRows, 1)
+	_, hasIsFollowing := anonRows[0]["isFollowing"]
+	assert.False(t, hasIsFollowing, "匿名 caller には relation を出さない (#1957-a)")
+}
+
+// #1957-a: federation/followers の embed followee に viewer 視点の relation block が
+// 乗る。viewer が followee を follow していれば followee.isFollowing=true、匿名なら省略。
+// packFollowings の二重 lookup + pf.Followee ポインタ経路の回帰ガード。
+func TestFollowers_FolloweeCarriesViewerRelation(t *testing.T) {
+	h, _ := newHandler(t)
+	idGen, _ := id.NewGenerator("aidx")
+	h.SetIDGen(idGen)
+	userRepo := testutil.NewMockUserRepository()
+	remote := "remote.example"
+	userRepo.Users["rf1"] = &model.User{ID: "rf1", Username: "rf1", Host: &remote}
+	h.SetUserRepo(userRepo)
+
+	followingRepo := testutil.NewMockFollowingRepository()
+	// Followers が返す行 (followeeHost=remote)。
+	followingRepo.Followings["f_listed"] = &model.Following{ID: "f_listed", FollowerID: "someone", FolloweeID: "rf1", FolloweeHost: &remote}
+	// viewer1 -> rf1 の follow (isFollowing 検出用)。
+	followingRepo.Followings["f_viewer"] = &model.Following{ID: "f_viewer", FollowerID: "viewer1", FolloweeID: "rf1"}
+	h.SetFollowingRepo(followingRepo)
+	h.SetRelationRepos(userrelation.Repos{Following: followingRepo})
+
+	// 認証 viewer: embed followee に isFollowing=true。
+	rec := postBodyAs(h.Followers, `{"host":"remote.example","limit":10}`, "viewer1")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	followee, ok := rows[0]["followee"].(map[string]any)
+	require.True(t, ok, "followee が embed される")
+	assert.Equal(t, true, followee["isFollowing"], "embed followee に viewer の isFollowing=true (#1957-a)")
+
+	// 匿名: relation 省略。
+	rec = postBody(h.Followers, `{"host":"remote.example","limit":10}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var anon []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &anon))
+	require.Len(t, anon, 1)
+	anonFollowee, _ := anon[0]["followee"].(map[string]any)
+	_, has := anonFollowee["isFollowing"]
+	assert.False(t, has, "匿名には followee relation を出さない (#1957-a)")
 }
 
 func TestUsers_FiltersByHost(t *testing.T) {

--- a/internal/api/hashtags/handler.go
+++ b/internal/api/hashtags/handler.go
@@ -10,21 +10,32 @@ import (
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
+	"github.com/shiroha-a/mk/internal/api/userrelation"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/misc/searchnorm"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/server/middleware"
 	"gorm.io/gorm"
 )
 
 // Handler handles hashtag-related API endpoints.
 type Handler struct {
 	db *gorm.DB
+	// relation は hashtags/users の embed user に viewer 視点の relation block を
+	// 付与する (upstream packMany(users, me))。未配線 / 匿名では no-op (#1957-a)。
+	relation userrelation.Repos
 }
 
 // NewHandler creates a new hashtags Handler.
 func NewHandler(db *gorm.DB) *Handler {
 	return &Handler{db: db}
+}
+
+// SetRelationRepos wires the repositories used to populate viewer-relative
+// relation fields on hashtags/users (#1957-a). Unset = relations omitted.
+func (h *Handler) SetRelationRepos(r userrelation.Repos) {
+	h.relation = r
 }
 
 // listSortOrders は upstream Misskey TS hashtags/list paramDef enum を、
@@ -400,9 +411,16 @@ func (h *Handler) Users(c echo.Context) error {
 	if err != nil {
 		return apierr.JSONInternalError(c)
 	}
+	viewerID := ""
+	if v := middleware.GetUser(c); v != nil {
+		viewerID = v.ID
+	}
 	out := make([]entity.UserDetailed, 0, len(users))
 	for _, u := range users {
-		out = append(out, entity.PackUserDetailed(u, profByID[u.ID], gen))
+		d := entity.PackUserDetailed(u, profByID[u.ID], gen)
+		// 認証 caller には viewer->user の relation block を付与 (匿名/self は no-op、#1957-a)。
+		h.relation.Apply(&d, viewerID, u, profByID[u.ID])
+		out = append(out, d)
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/hashtags/handler_test.go
+++ b/internal/api/hashtags/handler_test.go
@@ -11,9 +11,12 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/api/hashtags"
+	"github.com/shiroha-a/mk/internal/api/userrelation"
 	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+	"github.com/shiroha-a/mk/internal/server/middleware"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -45,6 +48,18 @@ func doPost(h func(echo.Context) error, body string) *httptest.ResponseRecorder 
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
+	_ = h(c)
+	return rec
+}
+
+// doPostAs is doPost with an authenticated viewer set in the context (#1957-a).
+func doPostAs(h func(echo.Context) error, body, viewerID string) *httptest.ResponseRecorder {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), &model.User{ID: viewerID})
 	_ = h(c)
 	return rec
 }
@@ -447,6 +462,40 @@ func TestUsers_ContainmentAndShape(t *testing.T) {
 	assert.Equal(t, "htua", list[0]["username"])
 	assert.Contains(t, list[0], "followersCount")
 	assert.Contains(t, list[0], "notesCount")
+}
+
+// #1957-a: hashtags/users の embed user に viewer 視点の relation block が乗る。
+// viewer が tag user を follow していれば isFollowing=true、匿名なら省略。
+func TestUsers_EmbedsViewerRelation(t *testing.T) {
+	now := time.Now()
+	seedTagUser(t, "u_htu_rel", "hturel", []string{"reltag"}, nil, false, 1, now)
+	// viewer 自身も user 行が要る (following の FK 制約)。tag 無しなので結果には出ない。
+	seedTagUser(t, "viewer1", "htuviewer", nil, nil, false, 0, now)
+	// viewer1 -> u_htu_rel の following 行を作る。
+	require.NoError(t, repository.NewFollowingRepository(testDB).Create(&model.Following{
+		ID: "f_htu_rel", FollowerID: "viewer1", FolloweeID: "u_htu_rel",
+	}))
+	t.Cleanup(func() { testDB.Exec(`DELETE FROM "following" WHERE id = ?`, "f_htu_rel") })
+
+	h := hashtags.NewHandler(testDB)
+	h.SetRelationRepos(userrelation.Repos{Following: repository.NewFollowingRepository(testDB)})
+
+	// 認証 viewer: isFollowing=true。
+	rec := doPostAs(h.Users, `{"tag":"reltag","sort":"+follower"}`, "viewer1")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, true, rows[0]["isFollowing"], "認証 viewer の embed user に isFollowing=true (#1957-a)")
+
+	// 匿名: relation 省略。
+	rec = doPost(h.Users, `{"tag":"reltag","sort":"+follower"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var anon []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &anon))
+	require.Len(t, anon, 1)
+	_, has := anon[0]["isFollowing"]
+	assert.False(t, has, "匿名には relation を出さない (#1957-a)")
 }
 
 // suspended user は除外される (isSuspended = FALSE)。

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1044,6 +1044,19 @@ func (s *Server) setupRoutes() {
 		})
 	})
 
+	// listRelationRepos は embed user に viewer 視点の relation block を付与する
+	// 共有 Repos。/users・/pinned-users の inline handler と mute/renote-mute/
+	// following/federation/hashtags handler が共有する (#1957-a)。Apply は
+	// 匿名 / self / 未配線で no-op。
+	listRelationRepos := userrelation.Repos{
+		Following:     followingRepo,
+		Blocking:      blockingRepo,
+		Muting:        mutingRepo,
+		RenoteMuting:  renoteMutingRepo,
+		FollowRequest: followRequestRepo,
+		Memo:          repository.NewUserMemoRepository(s.db),
+	}
+
 	// Users endpoint (public) — ユーザー一覧
 	api.POST("/users", func(c echo.Context) error {
 		var req struct {
@@ -1069,12 +1082,19 @@ func (s *Server) setupRoutes() {
 		if err != nil {
 			return c.JSON(http.StatusOK, []any{})
 		}
+		viewerID := ""
+		if v := middleware.GetUser(c); v != nil {
+			viewerID = v.ID
+		}
 		result := make([]entity.UserDetailed, 0, len(users))
 		for _, u := range users {
 			profile, _ := userRepo.FindProfileByUserID(u.ID)
 			// idGen を渡して createdAt を有効にする。未配線だと createdAt="" で
 			// misskey_dart の DateTimeConverter が FormatException で落ちる (#1251)。
-			result = append(result, entity.PackUserDetailed(u, profile, idGen))
+			d := entity.PackUserDetailed(u, profile, idGen)
+			// 認証 caller には viewer->user の relation block を付与 (#1957-a)。
+			listRelationRepos.Apply(&d, viewerID, u, profile)
+			result = append(result, d)
 		}
 		return c.JSON(http.StatusOK, result)
 	})
@@ -1089,6 +1109,10 @@ func (s *Server) setupRoutes() {
 		if err != nil || len(m.PinnedUsers) == 0 {
 			return c.JSON(http.StatusOK, []any{})
 		}
+		pinnedViewerID := ""
+		if v := middleware.GetUser(c); v != nil {
+			pinnedViewerID = v.ID
+		}
 		result := make([]entity.UserDetailed, 0, len(m.PinnedUsers))
 		for _, acct := range m.PinnedUsers {
 			username, host := parseAcct(acct, localHost)
@@ -1100,7 +1124,10 @@ func (s *Server) setupRoutes() {
 				continue
 			}
 			profile, _ := userRepo.FindProfileByUserID(u.ID)
-			result = append(result, entity.PackUserDetailed(u, profile, idGen))
+			d := entity.PackUserDetailed(u, profile, idGen)
+			// 認証 caller には viewer->user の relation block を付与 (#1957-a)。
+			listRelationRepos.Apply(&d, pinnedViewerID, u, profile)
+			result = append(result, d)
 		}
 		return c.JSON(http.StatusOK, result)
 	})
@@ -1651,6 +1678,7 @@ func (s *Server) setupRoutes() {
 
 	// Hashtags endpoints (Phase 6)
 	hashtagsHandler := apihashtags.NewHandler(s.db)
+	hashtagsHandler.SetRelationRepos(listRelationRepos) // #1957-a: hashtags/users の embed user に relation
 	api.POST("/hashtags/list", hashtagsHandler.List)
 	api.POST("/hashtags/search", hashtagsHandler.Search)
 	api.POST("/hashtags/show", hashtagsHandler.Show)
@@ -1690,17 +1718,6 @@ func (s *Server) setupRoutes() {
 	api.POST("/blocking/create", blockingHandler.Create, middleware.RequireAuth(), middleware.RequireScope("write:blocks"))
 	api.POST("/blocking/delete", blockingHandler.Delete, middleware.RequireAuth(), middleware.RequireScope("write:blocks"))
 	api.POST("/blocking/list", blockingHandler.List, middleware.RequireAuth(), middleware.RequireScope("read:blocks"))
-
-	// following/list・mute/list・renote-mute/list の埋め込み user に viewer-relation
-	// flag (isFollowing/isMuted 等) を付与するための共有 repo 束 (#1912)。
-	listRelationRepos := userrelation.Repos{
-		Following:     followingRepo,
-		Blocking:      blockingRepo,
-		Muting:        mutingRepo,
-		RenoteMuting:  renoteMutingRepo,
-		FollowRequest: followRequestRepo,
-		Memo:          repository.NewUserMemoRepository(s.db),
-	}
 
 	// Mute endpoints
 	muteHandler := mute.NewHandler(mutingService, userRepo, idGen)
@@ -1882,6 +1899,7 @@ func (s *Server) setupRoutes() {
 	federationHandler.SetUserRepo(userRepo)
 	federationHandler.SetIDGen(idGen)
 	federationHandler.SetResolver(federationResolver)
+	federationHandler.SetRelationRepos(listRelationRepos) // #1957-a: followers/following/users の embed user に relation
 	// moderationNote は公開エンドポイントで moderator にのみ返す (情報漏洩対策)。
 	federationHandler.SetModeratorChecker(roleService)
 	api.POST("/federation/instances", federationHandler.Instances)


### PR DESCRIPTION
## Summary

user-list 系 endpoint が embed する UserDetailed に、viewer 視点の relation block を付与する
(#1957-a / 親 #1957)。

upstream は `packMany(users, me, {schema:'UserDetailedNotMe'|'UserDetailed'})` のように me を
渡すため、authenticated caller には embed user/followee に relation フラグ
(isFollowing/isFollowed/isBlocking/isBlocked/isMuted/isRenoteMuted/hasPendingFollowRequest*/
notify/withReplies/followedMessage) が乗る。mk-go は viewer を渡さず常に省略していた。
**additive な parity 改善で result-set は変えない** (/users の hostname/mute-block/isExplorable
filter は behavioral なので #1957-b に分離)。

## 主な変更点

各 endpoint で viewer を解決し `userrelation.Repos.Apply(&detailed, viewerID, target, profile)`
を呼ぶ。Apply は viewerID 空 (匿名) / self / 未配線で no-op。

- `internal/api/blocking/handler.go` `fetchBlockeeMap`: viewerID を thread し Apply
  (mute/list・renote-mute/list と同じ。blocking だけ漏れていた)。
- `internal/api/federation/host_listings.go`: `Users` の embed user、`packFollowings` の embed
  followee に Apply。`viewerIDOf` ヘルパー追加。`handler.go` に relation field + `SetRelationRepos`。
- `internal/api/hashtags/handler.go` `Users`: relation field + setter + Apply。
- `internal/server/router.go`: 共有 `listRelationRepos` を /users handler 前に移動し、inline
  `/users` `/pinned-users` で viewer 解決 + Apply。federation/hashtags handler に SetRelationRepos 配線。

## テスト

- `blocking/handler_test.go` `TestList_BlockeeCarriesIsBlocking`: blockee.isBlocking=true。
- `federation/host_listings_test.go` `TestUsers_EmbedsViewerRelation` (authed isFollowing=true /
  匿名省略) + `TestFollowers_FolloweeCarriesViewerRelation` (packFollowings の followee relation)。
- `hashtags/handler_test.go` `TestUsers_EmbedsViewerRelation` (testDB-backed)。
- gate package coverage: blocking 92.4% / federation 92.0% / hashtags 91.3% / userrelation 100%。
  router inline (/users・/pinned-users) は coverage 対象外だが同一 Apply パターンで担保。
- `make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで、同種 parity gap が残る隣接 endpoint (roles/users・users/recommendation・
get-frequently-replied-users) を発見し別 issue 化した (#1973)。本 PR スコープ外。
N+1: Apply は per-user で relation repo を引くが匿名は no-op、認証時のみのコストで limit≤100
clamp 済 (#1912 mute/list と同パターン)。

## 関連

- 親: #1957 / #1948