### PR TITLE
Fix /users parity (#1957-b): public /users に explorable/hostname/mute-block filter を追加

### DIFF
--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -85,4 +85,11 @@ type UserListFilter struct {
 	// id ASC、それ以外は id DESC。
 	SinceID string
 	UntilID string
+	// ExplorableOnly は public /users endpoint 用の base filter。true のとき
+	// isExplorable = TRUE AND isSuspended = FALSE で絞る (upstream users.ts、#1957-b)。
+	ExplorableOnly bool
+	// ExcludeRelatedTo が非空のとき、その viewer が mute / block している user、
+	// および viewer を block している user を除外する (upstream
+	// generateMutedUserQueryForUsers / generateBlockQueryForUsers、#1957-b)。
+	ExcludeRelatedTo string
 }

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -451,6 +451,19 @@ func (r *userRepository) ListUsers(filter model.UserListFilter) ([]*model.User, 
 		// 突合する。host は lowercase 保存なので大文字混在でも match させる。
 		q = q.Where("host = ?", strings.ToLower(filter.Hostname))
 	}
+	// public /users endpoint の base filter (upstream users.ts:58-59、#1957-b)。
+	if filter.ExplorableOnly {
+		q = q.Where(`"isExplorable" = true`).Where(`"isSuspended" = false`)
+	}
+	// 認証 caller が mute / block している user、および caller を block している
+	// user を除外する (upstream generateMutedUserQueryForUsers /
+	// generateBlockQueryForUsers、#1957-b)。block は双方向、mute は片方向。
+	if filter.ExcludeRelatedTo != "" {
+		vid := filter.ExcludeRelatedTo
+		q = q.Where(`id NOT IN (SELECT "muteeId" FROM muting WHERE "muterId" = ?)`, vid).
+			Where(`id NOT IN (SELECT "blockeeId" FROM blocking WHERE "blockerId" = ?)`, vid).
+			Where(`id NOT IN (SELECT "blockerId" FROM blocking WHERE "blockeeId" = ?)`, vid)
+	}
 	// username prefix フィルタ (upstream show-users.ts:92-94 の
 	// usernameLower LIKE sqlLikeEscape(lower)+'%')。LIKE メタ文字を escape し
 	// ESCAPE '\' を明示して prefix match させる (sibling query と統一)。

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -762,6 +762,59 @@ func TestUserRepository_ListUsers_Default(t *testing.T) {
 	assert.GreaterOrEqual(t, len(users), 2)
 }
 
+// #1957-b: public /users の base filter (isExplorable=TRUE AND isSuspended=FALSE) と
+// 認証 viewer の mute/block 除外 (双方向 block) を検証する。
+func TestUserRepository_ListUsers_ExplorableAndMuteBlockFilter(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	viewer := insertTestUser(t, "lub_v", "lubviewer")
+	defer cleanupUser(t, viewer.ID)
+	visible := insertTestUser(t, "lub_vis", "lubvisible")
+	defer cleanupUser(t, visible.ID)
+	hidden := insertTestUser(t, "lub_hid", "lubhidden")
+	defer cleanupUser(t, hidden.ID)
+	require.NoError(t, repo.UpdateUser(hidden.ID, map[string]any{"isExplorable": false}))
+	susp := insertTestUser(t, "lub_sus", "lubsusp")
+	defer cleanupUser(t, susp.ID)
+	require.NoError(t, repo.UpdateUser(susp.ID, map[string]any{"isSuspended": true}))
+	muted := insertTestUser(t, "lub_mut", "lubmuted")
+	defer cleanupUser(t, muted.ID)
+	blocked := insertTestUser(t, "lub_blk", "lubblocked")
+	defer cleanupUser(t, blocked.ID)
+	blocker := insertTestUser(t, "lub_blkr", "lubblocker")
+	defer cleanupUser(t, blocker.ID)
+
+	require.NoError(t, testDB.Create(&model.Muting{ID: "mut_lub", MuterID: viewer.ID, MuteeID: muted.ID}).Error)
+	defer testDB.Exec(`DELETE FROM "muting" WHERE id = ?`, "mut_lub")
+	require.NoError(t, testDB.Create(&model.Blocking{ID: "blk_lub", BlockerID: viewer.ID, BlockeeID: blocked.ID}).Error)
+	defer testDB.Exec(`DELETE FROM "blocking" WHERE id = ?`, "blk_lub")
+	// blocker が viewer を block (逆方向)。
+	require.NoError(t, testDB.Create(&model.Blocking{ID: "blk_rev_lub", BlockerID: blocker.ID, BlockeeID: viewer.ID}).Error)
+	defer testDB.Exec(`DELETE FROM "blocking" WHERE id = ?`, "blk_rev_lub")
+
+	idSet := func(filter model.UserListFilter) map[string]bool {
+		us, err := repo.ListUsers(filter)
+		require.NoError(t, err)
+		m := make(map[string]bool, len(us))
+		for _, u := range us {
+			m[u.ID] = true
+		}
+		return m
+	}
+
+	// ExplorableOnly: non-explorable / suspended を除外。
+	got := idSet(model.UserListFilter{ExplorableOnly: true, Limit: 1000})
+	assert.True(t, got[visible.ID], "explorable user は残る")
+	assert.False(t, got[hidden.ID], "non-explorable は除外 (#1957-b)")
+	assert.False(t, got[susp.ID], "suspended は除外 (#1957-b)")
+
+	// + ExcludeRelatedTo=viewer: mute / block (双方向) を除外。
+	got = idSet(model.UserListFilter{ExplorableOnly: true, ExcludeRelatedTo: viewer.ID, Limit: 1000})
+	assert.True(t, got[visible.ID])
+	assert.False(t, got[muted.ID], "viewer が mute した user は除外 (#1957-b)")
+	assert.False(t, got[blocked.ID], "viewer が block した user は除外 (#1957-b)")
+	assert.False(t, got[blocker.ID], "viewer を block した user も除外 (双方向、#1957-b)")
+}
+
 func TestUserRepository_ListUsers_LocalOnly(t *testing.T) {
 	repo := NewUserRepository(testDB)
 	u := insertTestUser(t, "lu_loc", "localonly")

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1060,11 +1060,12 @@ func (s *Server) setupRoutes() {
 	// Users endpoint (public) — ユーザー一覧
 	api.POST("/users", func(c echo.Context) error {
 		var req struct {
-			Limit  int    `json:"limit"`
-			Offset int    `json:"offset"`
-			Sort   string `json:"sort"`
-			State  string `json:"state"`
-			Origin string `json:"origin"`
+			Limit    int    `json:"limit"`
+			Offset   int    `json:"offset"`
+			Sort     string `json:"sort"`
+			State    string `json:"state"`
+			Origin   string `json:"origin"`
+			Hostname string `json:"hostname"`
 		}
 		if err := c.Bind(&req); err != nil {
 			return c.JSON(http.StatusOK, []any{})
@@ -1075,16 +1076,21 @@ func (s *Server) setupRoutes() {
 		if req.Origin == "" {
 			req.Origin = "local"
 		}
-		users, err := userRepo.ListUsers(model.UserListFilter{
-			State: req.State, Origin: req.Origin, Sort: req.Sort,
-			Limit: req.Limit, Offset: req.Offset,
-		})
-		if err != nil {
-			return c.JSON(http.StatusOK, []any{})
-		}
 		viewerID := ""
 		if v := middleware.GetUser(c); v != nil {
 			viewerID = v.ID
+		}
+		// upstream users.ts: base filter isExplorable=TRUE AND isSuspended=FALSE、
+		// hostname 絞り込み、認証時は mute/block 除外 (#1957-b)。
+		users, err := userRepo.ListUsers(model.UserListFilter{
+			State: req.State, Origin: req.Origin, Sort: req.Sort,
+			Limit: req.Limit, Offset: req.Offset,
+			Hostname:         req.Hostname,
+			ExplorableOnly:   true,
+			ExcludeRelatedTo: viewerID,
+		})
+		if err != nil {
+			return c.JSON(http.StatusOK, []any{})
 		}
 		result := make([]entity.UserDetailed, 0, len(users))
 		for _, u := range users {


### PR DESCRIPTION
## Summary

public `/api/users` に upstream の base filter / hostname / mute・block 除外を追加する
(#1957-b / 親 #1957)。

upstream `users.ts` は public /users で:
- base filter `isExplorable = TRUE AND isSuspended = FALSE`。
- `hostname` param で `host = hostname.toLowerCase()` 絞り込み。
- 認証時 `generateMutedUserQueryForUsers` (mute 片方向) + `generateBlockQueryForUsers`
  (block 双方向) で muted/blocked user を除外。

mk-go の inline /users handler はこれらを欠き、result-set が upstream と乖離していた。

## 主な変更点

- `internal/model/user.go` `UserListFilter`: `ExplorableOnly bool` / `ExcludeRelatedTo string`
  (viewerID) を追加。
- `internal/repository/user.go` `ListUsers`:
  - `ExplorableOnly` で `isExplorable=true AND isSuspended=false`。
  - `ExcludeRelatedTo` で `id NOT IN (SELECT "muteeId" FROM muting WHERE "muterId"=?)` (mute 片方向)
    と blocking 双方向 (`blockeeId WHERE blockerId=?` + `blockerId WHERE blockeeId=?`) を除外。
- `internal/server/router.go` inline /users: `hostname` param を bind、viewer を解決し
  `ExplorableOnly=true` + `ExcludeRelatedTo=viewerID` を渡す。

新 field はデフォルト false/"" なので、`ListUsers` の他 caller (admin/show-users・
federation/users) の挙動は不変。匿名 caller は `ExcludeRelatedTo=""` で mute/block 除外を
skip (upstream の `if (me)` ガードと一致)。

## テスト

- `internal/repository/user_test.go` `TestUserRepository_ListUsers_ExplorableAndMuteBlockFilter`:
  non-explorable / suspended 除外、mute 除外、block 双方向除外 (viewer→blocked と blocker→viewer)。
- `ListUsers` 100% カバレッジ。`make fmt` / `go vet ./...` / `make test` green。

## スコープ外 (本 PR では未対応、別途追従)

- **`state=alive` の updatedAt 窓**: upstream public users.ts は `state=alive` を
  `updatedAt > now-5d` で扱うが、mk-go の `ListUsers` は `state=alive` を `isSuspended=false` に
  マップする (admin/show-users と共有)。public /users 側の alive 窓は admin show-users state
  finding (別 candidate) と併せて別途対応する。
- **`+updatedAt`/`-updatedAt` sort の `updatedAt IS NOT NULL` 除外**: upstream は updatedAt sort 時
  に NULL updatedAt user を除外するが mk-go は NULLS LAST/FIRST で含める。隣接 finding として
  別 issue 化 (#1975)。

## 関連

- 親: #1957 / #1948
