### PR TITLE
Fix admin announcements parity (#1967): admin/list を upstream の生 row 形に揃える

### DIFF
--- a/internal/api/announcements/handler.go
+++ b/internal/api/announcements/handler.go
@@ -442,12 +442,40 @@ func (h *Handler) AdminList(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
+	// upstream admin/announcements/list.ts は生 row を返す: public list 用の
+	// forYou / isRead は持たず、imageUrl は media-proxy せず raw を返す (#1967)。
+	// public 用 packAnnouncement を流用すると非 upstream な forYou/isRead が混入し、
+	// forYou の意味 (userId === me.id) とも乖離するため、ここでは明示的に組み立てる。
+	const tsFormat = "2006-01-02T15:04:05.000Z"
 	out := make([]map[string]any, 0, len(items))
 	for _, a := range items {
-		row := packAnnouncement(a, h.idGen)
-		row["userId"] = a.UserID
-		row["reads"] = reads[a.ID]
-		out = append(out, row)
+		createdAt := ""
+		if h.idGen != nil {
+			if t, err := h.idGen.ParseTime(a.ID); err == nil {
+				createdAt = t.UTC().Format(tsFormat)
+			}
+		}
+		var updatedAt *string
+		if a.UpdatedAt != nil {
+			s := a.UpdatedAt.UTC().Format(tsFormat)
+			updatedAt = &s
+		}
+		out = append(out, map[string]any{
+			"id":                     a.ID,
+			"createdAt":              createdAt,
+			"updatedAt":              updatedAt,
+			"title":                  a.Title,
+			"text":                   a.Text,
+			"imageUrl":               a.ImageURL, // raw (*string, nullable) — proxy しない
+			"icon":                   a.Icon,
+			"display":                a.Display,
+			"isActive":               a.IsActive,
+			"forExistingUsers":       a.ForExistingUsers,
+			"silence":                a.Silence,
+			"needConfirmationToRead": a.NeedConfirmationToRead,
+			"userId":                 a.UserID,
+			"reads":                  reads[a.ID],
+		})
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/api/announcements/handler_test.go
+++ b/internal/api/announcements/handler_test.go
@@ -489,6 +489,36 @@ func TestAdminList_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// #1967: admin/announcements/list は upstream の生 row 形 (forYou/isRead 無し、
+// imageUrl は raw)。public list 用の packAnnouncement を流用しない。
+func TestAdminList_ShapeMatchesUpstream(t *testing.T) {
+	h, repo := newTestHandler(t)
+	remoteImg := "https://remote.example/img.png"
+	updated := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	// global announcement (userId IS NULL) — mock ListForAdmin は userId 無し要求で
+	// global のみ返す。updatedAt non-null で .000Z 形式の経路も踏む。
+	repo.Items["a1"] = &model.Announcement{ID: "a1", Title: "t", Text: "x", IsActive: true, ImageURL: &remoteImg, UpdatedAt: &updated}
+	rec := doPost(h.AdminList, `{}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	row := resp[0]
+	assert.Equal(t, "2026-01-02T03:04:05.000Z", row["updatedAt"], "updatedAt は toISOString 互換 .000Z 形式 (#1967)")
+	_, hasForYou := row["forYou"]
+	assert.False(t, hasForYou, "admin/list に forYou key は出さない (#1967)")
+	_, hasIsRead := row["isRead"]
+	assert.False(t, hasIsRead, "admin/list に isRead key は出さない (#1967)")
+	// imageUrl は proxy せず raw を返す。
+	assert.Equal(t, remoteImg, row["imageUrl"], "imageUrl は raw (proxy しない、#1967)")
+	// upstream の生 row フィールドは揃う (userId は global なので null)。
+	assert.Contains(t, row, "userId")
+	assert.Nil(t, row["userId"])
+	assert.Contains(t, row, "reads")
+	assert.Contains(t, row, "forExistingUsers")
+}
+
 // /admin/user/<id> のお知らせタブが userId で narrow したときに、対象
 // ユーザー宛 announcement のみ返り、サーバー全体 announcement (userId
 // IS NULL) が混ざらないこと (#472)。


### PR DESCRIPTION
## Summary

`admin/announcements/list` のレスポンスを upstream の生 row 形に揃える (#1967)。

upstream `admin/announcements/list.ts` は生 row を map して返す:
`id / createdAt / updatedAt / title / text / imageUrl(raw) / icon / display / isActive /
forExistingUsers / silence / needConfirmationToRead / userId / reads` の 14 フィールドのみで、
**forYou / isRead は持たず、imageUrl は media-proxy せず raw**。

mk-go の `AdminList` は public list 用の `packAnnouncement` (= entity.PackAnnouncement) を流用して
いたため、(1) 非 upstream の `forYou`/`isRead` が混入し、(2) `forYou` の意味も `userId != nil` で
upstream `userId === me.id` と乖離、(3) `imageUrl` が media-proxy 書き換えされていた。

## 主な変更点

- `internal/api/announcements/handler.go` `AdminList`: `packAnnouncement` 流用をやめ、upstream と
  同じ 14 フィールドを明示的に組み立てる。`imageUrl` は raw `a.ImageURL`、createdAt/updatedAt は
  `2006-01-02T15:04:05.000Z` (toISOString 互換)、forYou/isRead は出さない。

`packAnnouncement` は List (public、#1955) と AdminCreate が引き続き使用 (影響なし)。frontend の
admin UI (`admin/announcements.vue` 等) は forYou/isRead を読まず reads/userId/imageUrl 等のみ
参照するため壊れない。

## テスト

- `internal/api/announcements/handler_test.go` `TestAdminList_ShapeMatchesUpstream`: forYou/isRead
  不在、imageUrl raw (remote URL がそのまま)、updatedAt の `.000Z` 形式、userId(null)/reads/
  forExistingUsers 存在を検証。
- `internal/api/announcements` coverage 95.3%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで、`AdminCreate` のレスポンスも同種 drift (forYou/isRead 等の余剰 + imageUrl
proxy、upstream create res は 6 フィールド raw) を持つことを発見し別 issue 化した (#1977)。
本 PR スコープ外。

## 関連

- 親: #1948
- 発見元: #1955 の敵対的レビュー

Closes #1967
