### PR TITLE
Fix AP renderPerson parity (#1969): avatar/banner 未設定時の icon(identicon)/image fallback

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -213,6 +213,10 @@ type Renderer struct {
 	noteResolver    NoteResolver
 	pollResolver    PollResolver
 	host            string // ローカルホスト名 (MFM変換用)
+	// instanceImages は system actor の icon/banner fallback に使う meta.iconUrl /
+	// meta.bannerUrl を実行時に解決する lookup (#1969)。meta は admin が変更しうる
+	// ため static でなく lookup で都度取得する。nil なら system fallback 無し。
+	instanceImages func() (iconURL, bannerURL string)
 }
 
 // NewRenderer constructs a Renderer.
@@ -225,6 +229,12 @@ func NewRenderer(urls *URLBuilder) *Renderer {
 // builder (#1876)。
 func (r *Renderer) URLs() *URLBuilder {
 	return r.urls
+}
+
+// SetInstanceImageLookup wires a lookup for meta.iconUrl / meta.bannerUrl used
+// as the icon/image fallback for system actors in RenderPerson (#1969).
+func (r *Renderer) SetInstanceImageLookup(fn func() (iconURL, bannerURL string)) {
+	r.instanceImages = fn
 }
 
 // RenderOrderedCollection builds an AS OrderedCollection (#1876)。upstream
@@ -348,11 +358,31 @@ func (r *Renderer) RenderPerson(u *model.User, profile *model.UserProfile, publi
 				"userID", u.ID, "error", err)
 		}
 	}
-	if u.AvatarURL != nil {
-		p.Icon = &Image{Type: "Image", URL: *u.AvatarURL}
+	// upstream renderPerson の icon/image fallback (#1969):
+	//   icon  = avatar ? renderImage(avatar) : isSystem ? renderSystemAvatar : renderIdenticon
+	//   image = banner ? renderImage(banner) : isSystem ? renderSystemBanner  : null
+	// avatar/banner 未設定の全ローカル actor に icon (identicon) を必ず付ける。
+	// system actor (username に '.') は meta.iconUrl / bannerUrl を優先する。
+	var instanceIcon, instanceBanner string
+	if r.instanceImages != nil {
+		instanceIcon, instanceBanner = r.instanceImages()
 	}
-	if u.BannerURL != nil {
+	isSystem := strings.Contains(u.Username, ".")
+	switch {
+	case u.AvatarURL != nil && *u.AvatarURL != "":
+		p.Icon = &Image{Type: "Image", URL: *u.AvatarURL}
+	case isSystem && instanceIcon != "":
+		p.Icon = &Image{Type: "Image", URL: instanceIcon}
+	default:
+		// identicon URL は mk-go の /identicon/<username> route 規則に合わせる
+		// (entity.IdenticonURL と同一 seed なので REST avatarUrl と同じ画像)。
+		p.Icon = &Image{Type: "Image", URL: r.urls.baseURL + "/identicon/" + u.Username}
+	}
+	switch {
+	case u.BannerURL != nil && *u.BannerURL != "":
 		p.Image = &Image{Type: "Image", URL: *u.BannerURL}
+	case isSystem && instanceBanner != "":
+		p.Image = &Image{Type: "Image", URL: instanceBanner}
 	}
 	if u.MovedToURI != nil && *u.MovedToURI != "" {
 		p.MovedTo = *u.MovedToURI

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -230,8 +230,71 @@ func TestRenderer_RenderPerson_NoOptionalFields(t *testing.T) {
 	u := &model.User{ID: "u1", Username: "alice"}
 	p := r.RenderPerson(u, nil, "PUBKEY", nil)
 	assert.Empty(t, p.Name)
-	assert.Nil(t, p.Icon)
+	// #1969: avatar 未設定でも upstream は identicon を icon に必ず付ける。
+	require.NotNil(t, p.Icon)
+	assert.Equal(t, "https://example.com/identicon/alice", p.Icon.URL)
+	// 通常 user で banner 未設定なら image は付かない (upstream null)。
+	assert.Nil(t, p.Image)
 	assert.False(t, p.ManuallyApproves)
+}
+
+// #1969: avatar 未設定でも全ローカル actor に icon=identicon が付く (upstream renderPerson)。
+func TestRenderer_RenderPerson_IdenticonFallback(t *testing.T) {
+	r := newRenderer()
+	u := &model.User{ID: "u1", Username: "alice"}
+	p := r.RenderPerson(u, nil, "PUBKEY", nil)
+	require.NotNil(t, p.Icon)
+	assert.Equal(t, "https://example.com/identicon/alice", p.Icon.URL)
+}
+
+// #1969: system actor は meta.iconUrl / bannerUrl を icon/image に使う。
+// instance image 未設定 (lookup 空) なら system でも identicon にフォールバック。
+func TestRenderer_RenderPerson_SystemActorUsesInstanceImages(t *testing.T) {
+	r := newRenderer()
+	r.SetInstanceImageLookup(func() (string, string) {
+		return "https://example.com/files/icon.png", "https://example.com/files/banner.png"
+	})
+	u := &model.User{ID: "u_sys", Username: "relay.actor"}
+	p := r.RenderPerson(u, nil, "PUBKEY", nil)
+	require.NotNil(t, p.Icon)
+	assert.Equal(t, "https://example.com/files/icon.png", p.Icon.URL, "system actor の icon は meta.iconUrl")
+	require.NotNil(t, p.Image)
+	assert.Equal(t, "https://example.com/files/banner.png", p.Image.URL, "system actor の image は meta.bannerUrl")
+
+	// instance image 未設定なら system でも icon=identicon、image は付かない。
+	r2 := newRenderer()
+	p2 := r2.RenderPerson(u, nil, "PUBKEY", nil)
+	require.NotNil(t, p2.Icon)
+	assert.Equal(t, "https://example.com/identicon/relay.actor", p2.Icon.URL)
+	assert.Nil(t, p2.Image)
+}
+
+// #1969: instance image が配線済みでも、通常 user (username に '.' 無し) には
+// instance icon/banner を漏らさず identicon / 省略にフォールバックする (isSystem gate)。
+func TestRenderer_RenderPerson_NormalUserDoesNotLeakInstanceImages(t *testing.T) {
+	r := newRenderer()
+	r.SetInstanceImageLookup(func() (string, string) {
+		return "https://example.com/files/icon.png", "https://example.com/files/banner.png"
+	})
+	u := &model.User{ID: "u1", Username: "alice"} // 通常 user
+	p := r.RenderPerson(u, nil, "PUBKEY", nil)
+	require.NotNil(t, p.Icon)
+	assert.Equal(t, "https://example.com/identicon/alice", p.Icon.URL, "通常 user は instance icon でなく identicon")
+	assert.Nil(t, p.Image, "通常 user は banner 未設定で image 省略 (instance banner を漏らさない)")
+}
+
+// avatar/banner 設定済みなら raw URL を使う (identicon/instance image にしない)。
+func TestRenderer_RenderPerson_AvatarBannerRaw(t *testing.T) {
+	r := newRenderer()
+	r.SetInstanceImageLookup(func() (string, string) { return "https://i/icon.png", "https://i/banner.png" })
+	avatar := "https://example.com/files/a.png"
+	banner := "https://example.com/files/b.png"
+	u := &model.User{ID: "u1", Username: "relay.actor", AvatarURL: &avatar, BannerURL: &banner}
+	p := r.RenderPerson(u, nil, "PUBKEY", nil)
+	require.NotNil(t, p.Icon)
+	assert.Equal(t, avatar, p.Icon.URL, "avatar 設定済みなら raw avatar (instance icon でない)")
+	require.NotNil(t, p.Image)
+	assert.Equal(t, banner, p.Image.URL)
 }
 
 // #1956: system actor (username に '.' を含む relay.actor / instance.actor /

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -528,6 +528,21 @@ func (s *Server) setupRoutes() {
 	apRenderer.SetEmojiResolver(emojiRepo)
 	apRenderer.SetNoteResolver(noteRepo)
 	apRenderer.SetPollResolver(pollRepo)
+	// system actor の icon/banner fallback 用に meta.iconUrl / bannerUrl を都度解決する (#1969)。
+	apRenderer.SetInstanceImageLookup(func() (string, string) {
+		m, err := metaRepo.Fetch()
+		if err != nil {
+			return "", ""
+		}
+		icon, banner := "", ""
+		if m.IconURL != nil {
+			icon = *m.IconURL
+		}
+		if m.BannerURL != nil {
+			banner = *m.BannerURL
+		}
+		return icon, banner
+	})
 	// config.URL は "https://example.com" 形式。ホスト部分だけ抽出して
 	// apRenderer と webfinger 側で共有する (下の resolver 設定でも再利用)。
 	localHost := ""


### PR DESCRIPTION
## Summary

AP `renderPerson` が avatar/banner 未設定時に icon/image を省略していた問題を修正する (#1969)。

upstream `ApRendererService.renderPerson` は:
- `icon = avatar ? renderImage(avatar) : isSystem ? renderSystemAvatar : renderIdenticon`
  — avatar 未設定でも**全ローカル actor に icon を必ず付ける** (system は meta.iconUrl→なければ
  identicon、通常は identicon)。
- `image = banner ? renderImage(banner) : isSystem ? renderSystemBanner : null`
  — banner 未設定の system actor は meta.bannerUrl、通常 actor は null (省略)。
- `isSystem = username.includes('.')`。

mk-go の `RenderPerson` は `AvatarURL`/`BannerURL` が nil のとき icon/image を**完全省略**して
いたため、連合 peer が mk-go ユーザー (自前 avatar 未設定) の avatar を identicon すら表示でき
なかった。

## 主な変更点

- `internal/activitypub/renderer.go` `RenderPerson`: icon/image を upstream の fallback に揃える。
  - icon: avatar → raw / system+instanceIcon → meta.iconUrl / それ以外 → identicon。
  - image: banner → raw / system+instanceBanner → meta.bannerUrl / それ以外 → 省略。
  - identicon URL は `baseURL + "/identicon/" + username` (mk-go の /identicon route 規則、
    `entity.IdenticonURL` と同一 seed なので REST avatarUrl と同じ画像)。
- `SetInstanceImageLookup(fn func()(icon,banner string))` を追加。meta.iconUrl/bannerUrl を実行時に
  解決 (admin が変更しても反映)。`router.go` で metaRepo から配線。

## テスト

- `internal/activitypub/renderer_test.go`: identicon fallback / system actor の instance image /
  instance image 未配線時の identicon フォールバック / avatar・banner raw / 通常 user に instance
  image を漏らさない (isSystem gate) / NoOptionalFields を icon=identicon・image=nil に更新。
- `RenderPerson` 100% / activitypub 91.1%。`make fmt` / `go vet ./...` / `make test` green。

## 既知の軽微な乖離 (本 PR スコープ外)

- identicon URL の seed は upstream が `lower(username)@host` だが mk-go は `username` (REST の
  `entity.IdenticonURL` と一致)。route は任意 seed を hash するので画像は返り federation 上無害。
- AP `Image` struct が upstream の `sensitive: false` / `name: null` を持たない (Type/URL のみ)。
  これは #1948 の MEDIUM 候補「AP outbound wire-shape (Image struct field 追加)」で別途追従。

## 関連

- 親: #1948
- 発見元: #1956 の敵対的レビュー

Closes #1969
