### PR TITLE
Fix relation packing parity (#1973): roles/users・users/recommendation・get-frequently-replied に viewer-relation を付ける

### DIFF
--- a/internal/api/roles/handler.go
+++ b/internal/api/roles/handler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/notehide"
+	"github.com/shiroha-a/mk/internal/api/userrelation"
 	"github.com/shiroha-a/mk/internal/core/notesfilter"
 	"github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/entity"
@@ -39,6 +40,15 @@ type Handler struct {
 	mutingRepo        repository.MutingRepository
 	blockingRepo      repository.BlockingRepository
 	channelMutingRepo repository.ChannelMutingRepository
+	// relation は roles/users の embed user に viewer 視点の relation block を
+	// 付与する (upstream packMany(users, me))。未配線 / 匿名では no-op (#1973)。
+	relation userrelation.Repos
+}
+
+// SetRelationRepos wires the repositories used to populate viewer-relative
+// relation fields on roles/users embedded users (#1973). Unset = relations omitted.
+func (h *Handler) SetRelationRepos(r userrelation.Repos) {
+	h.relation = r
 }
 
 // SetUserRepo wires a UserRepository so roles/notes filters out notes that
@@ -194,6 +204,10 @@ func (h *Handler) Users(c echo.Context) error {
 
 	// reporter/assignee と同様に user_profile を 1 batch で解決して UserDetailed を
 	// pack する (N+1 回避)。userRepo 未配線時は profile なしで pack する。
+	viewerID := ""
+	if v := middleware.GetUser(c); v != nil {
+		viewerID = v.ID
+	}
 	profByID := h.assignmentProfiles(assigns)
 	out := make([]any, 0, len(assigns))
 	for _, a := range assigns {
@@ -202,9 +216,12 @@ func (h *Handler) Users(c echo.Context) error {
 			// UserDetailed を組めないため skip する (defensive)。
 			continue
 		}
+		d := entity.PackUserDetailed(a.User, profByID[a.UserID], h.idGen)
+		// 認証 viewer には viewer->user の relation block を付与 (匿名/self は no-op、#1973)。
+		h.relation.Apply(&d, viewerID, a.User, profByID[a.UserID])
 		out = append(out, map[string]any{
 			"id":   a.ID,
-			"user": entity.PackUserDetailed(a.User, profByID[a.UserID], h.idGen),
+			"user": d,
 		})
 	}
 	return c.JSON(http.StatusOK, out)

--- a/internal/api/roles/handler_test.go
+++ b/internal/api/roles/handler_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/roles"
+	"github.com/shiroha-a/mk/internal/api/userrelation"
 	corerole "github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -240,6 +241,38 @@ func TestUsers_ReturnsAssignedUsers(t *testing.T) {
 	user, ok := resp[0]["user"].(map[string]any)
 	require.True(t, ok, "user は UserDetailed object")
 	assert.Equal(t, "alice", user["id"])
+}
+
+// #1973: roles/users の embed user に viewer 視点の relation block が乗る。
+// viewer が assigned user を follow していれば isFollowing=true、匿名なら省略。
+func TestUsers_EmbedsViewerRelation(t *testing.T) {
+	h, roleRepo, assignRepo, userRepo := newUsersTestHandler(t)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", IsPublic: true, IsExplorable: true}
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	require.NoError(t, assignRepo.Create(&model.RoleAssignment{ID: "ra1", RoleID: "r1", UserID: "alice"}))
+	followingRepo := testutil.NewMockFollowingRepository()
+	followingRepo.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "viewer1", FolloweeID: "alice"}
+	h.SetRelationRepos(userrelation.Repos{Following: followingRepo})
+
+	// 認証 viewer: isFollowing=true。
+	vc := newCtxWithViewer(`{"roleId":"r1"}`, "viewer1")
+	require.NoError(t, h.Users(vc.ctx))
+	require.Equal(t, http.StatusOK, vc.rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(vc.rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	user := resp[0]["user"].(map[string]any)
+	assert.Equal(t, true, user["isFollowing"], "viewer の embed user に isFollowing=true (#1973)")
+
+	// 匿名: relation 省略。
+	rec := doPost(h.Users, `{"roleId":"r1"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var anon []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &anon))
+	require.Len(t, anon, 1)
+	anonUser := anon[0]["user"].(map[string]any)
+	_, has := anonUser["isFollowing"]
+	assert.False(t, has, "匿名には relation を出さない (#1973)")
 }
 
 // 期限切れの割当 (expiresAt <= now) はユーザー一覧に現れない (#1544)。

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -242,6 +242,20 @@ func (h *Handler) SetMemoRepo(r repository.UserMemoRepository) {
 	h.memoRepo = r
 }
 
+// viewerRelationRepos returns the Repos bundle used to populate viewer->target
+// relation fields on packed users (users/show, users/recommendation,
+// get-frequently-replied-users)。二重実装を避けるため抽出 (#1802 / #1973)。
+func (h *Handler) viewerRelationRepos() userrelation.Repos {
+	return userrelation.Repos{
+		Following:     h.followingRepo,
+		Blocking:      h.blockingRepo,
+		Muting:        h.mutingRepo,
+		RenoteMuting:  h.renoteMutingRepo,
+		FollowRequest: h.followRequestRepo,
+		Memo:          h.memoRepo,
+	}
+}
+
 // SetFollowingRepo attaches a FollowingRepository for follow relation queries.
 func (h *Handler) SetFollowingRepo(r repository.FollowingRepository) {
 	h.followingRepo = r
@@ -565,14 +579,7 @@ func (h *Handler) Show(c echo.Context) error {
 	if viewer != nil {
 		viewerID = viewer.ID
 	}
-	viewerIsFollowing := userrelation.Repos{
-		Following:     h.followingRepo,
-		Blocking:      h.blockingRepo,
-		Muting:        h.mutingRepo,
-		RenoteMuting:  h.renoteMutingRepo,
-		FollowRequest: h.followRequestRepo,
-		Memo:          h.memoRepo,
-	}.Apply(&detailed, viewerID, bundle.User, bundle.Profile)
+	viewerIsFollowing := h.viewerRelationRepos().Apply(&detailed, viewerID, bundle.User, bundle.Profile)
 
 	// viewer===target の self-view では upstream `pack(user, me)` 互換で
 	// MeDetailed 拡張 field (isExplorable / noCrawle 等 11 個 + #985 で

--- a/internal/api/users/recommendation.go
+++ b/internal/api/users/recommendation.go
@@ -54,8 +54,11 @@ func (h *Handler) GetFrequentlyRepliedUsers(c echo.Context) error {
 		if peak > 0 {
 			weight = float64(r.Count) / float64(peak)
 		}
+		d := entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen)
+		// 認証 viewer には viewer->user の relation block を付与 (upstream packMany(users, me)、#1973)。
+		h.viewerRelationRepos().Apply(&d, viewerID, bundle.User, bundle.Profile)
 		out = append(out, map[string]any{
-			"user":   entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen),
+			"user":   d,
 			"weight": weight,
 		})
 	}
@@ -180,7 +183,10 @@ func (h *Handler) UserRecommendation(c echo.Context) error {
 	out := make([]entity.UserDetailed, 0, len(users))
 	for _, u := range users {
 		profile := h.userService.GetProfile(u.ID)
-		out = append(out, entity.PackUserDetailed(u, profile, h.idGen))
+		d := entity.PackUserDetailed(u, profile, h.idGen)
+		// 認証 viewer には viewer->user の relation block を付与 (upstream packMany(users, me)、#1973)。
+		h.viewerRelationRepos().Apply(&d, viewer.ID, u, profile)
+		out = append(out, d)
 	}
 	return c.JSON(http.StatusOK, out)
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2302,6 +2302,7 @@ func (s *Server) setupRoutes() {
 	rolesHandler.SetNoteFieldResolver(noteFieldResolver)
 	rolesHandler.SetUserRepo(userRepo)
 	rolesHandler.SetMuteBlockRepos(mutingRepo, blockingRepo, channelMutingRepo) // #1544: Notes の mute/block/channel-mute filter
+	rolesHandler.SetRelationRepos(listRelationRepos)                            // #1973: roles/users の embed user に viewer-relation
 	api.POST("/roles/list", rolesHandler.List, middleware.RequireAuth(), middleware.RequireScope("read:account"))
 	api.POST("/roles/show", rolesHandler.Show)
 	api.POST("/roles/users", rolesHandler.Users)


### PR DESCRIPTION
## Summary

#1957-a と同じ class の viewer-relative relation packing 漏れを、embed user を返す 3 endpoint で
塞ぐ (#1973)。

upstream は `packMany(users, me, {schema:'UserDetailed'})` で me を渡すため、authenticated
caller には embed user に relation block (isFollowing/isBlocking/isMuted/hasPendingFollowRequest*/
notify/withReplies/followedMessage) が乗る。mk-go は viewer を渡さず常に省略していた:
- `roles/users` (`roles/users.ts:98`)
- `users/recommendation`
- `users/get-frequently-replied-users`

## 主な変更点

- `internal/api/users/handler.go`: `viewerRelationRepos()` ヘルパーを抽出 (users/show の inline
  Repos から、二重実装解消)。
- `internal/api/users/recommendation.go`: `GetFrequentlyRepliedUsers` / `UserRecommendation` で
  pack 後に `h.viewerRelationRepos().Apply(&d, viewerID, user, profile)`。
- `internal/api/roles/handler.go`: Handler に `relation userrelation.Repos` + `SetRelationRepos`、
  `Users` で viewer 解決 + Apply。
- `internal/server/router.go`: `rolesHandler.SetRelationRepos(listRelationRepos)` を配線。

Apply は viewerID 空 (匿名) / self / 未配線で no-op なので匿名応答は従来と一致。

## テスト

- `internal/api/roles/handler_test.go` `TestUsers_EmbedsViewerRelation`: 認証 viewer で
  isFollowing=true / 匿名で relation 省略。
- users recommendation の 2 handler は relation-setting を直接 assert しないが、共有ヘルパー
  `viewerRelationRepos` は users/show のテストで検証済、Apply call line も既存の recommendation
  テストでカバー (92.9% / 86.7%)。
- gate package coverage: roles 94.2% / users 90.2% / userrelation 100%。`make fmt` / `go vet ./...`
  / `make test` green。

## 補足

敵対的レビューで、同 class の漏れが `users/search` / `users/search-by-username-and-host` の
Detail 経路にも残ることを発見し別 issue 化した (#1980)。本 PR スコープ外。

## 関連

- 親: #1948
- 発見元: #1957-a の敵対的レビュー

Closes #1973
