### PR TITLE
Fix /users parity (#1975): public /users の updatedAt sort で IS NOT NULL を強制する

### DIFF
--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -92,4 +92,8 @@ type UserListFilter struct {
 	// および viewer を block している user を除外する (upstream
 	// generateMutedUserQueryForUsers / generateBlockQueryForUsers、#1957-b)。
 	ExcludeRelatedTo string
+	// UpdatedAtSortNonNull が true のとき、+updatedAt/-updatedAt sort で
+	// updatedAt IS NOT NULL を強制する (upstream public users.ts、#1975)。
+	// admin/show-users は NULLS LAST/FIRST で NULL を保持するため false のまま。
+	UpdatedAtSortNonNull bool
 }

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -530,8 +530,17 @@ func (r *userRepository) ListUsers(filter model.UserListFilter) ([]*model.User, 
 	case "-createdAt":
 		q = q.Order("id ASC")
 	case "+updatedAt":
+		// public users.ts は updatedAt sort 時 IS NOT NULL を andWhere して NULL
+		// updatedAt user を除外する (#1975)。admin/show-users は NULLS LAST で
+		// 保持するため UpdatedAtSortNonNull は public /users のみ true。
+		if filter.UpdatedAtSortNonNull {
+			q = q.Where(`"updatedAt" IS NOT NULL`)
+		}
 		q = q.Order(`"updatedAt" DESC NULLS LAST`)
 	case "-updatedAt":
+		if filter.UpdatedAtSortNonNull {
+			q = q.Where(`"updatedAt" IS NOT NULL`)
+		}
 		q = q.Order(`"updatedAt" ASC NULLS FIRST`)
 	case "+lastActiveDate":
 		q = q.Order(`"lastActiveDate" DESC NULLS LAST`)

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -815,6 +815,46 @@ func TestUserRepository_ListUsers_ExplorableAndMuteBlockFilter(t *testing.T) {
 	assert.False(t, got[blocker.ID], "viewer を block した user も除外 (双方向、#1957-b)")
 }
 
+// #1975: public /users は +updatedAt/-updatedAt sort で updatedAt IS NOT NULL を
+// 強制 (UpdatedAtSortNonNull=true)。admin/show-users (flag false) は NULL を保持する。
+func TestUserRepository_ListUsers_UpdatedAtSortNonNull(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	withUpd := insertTestUser(t, "lu_upd_y", "luupdy")
+	defer cleanupUser(t, withUpd.ID)
+	noUpd := insertTestUser(t, "lu_upd_n", "luupdn")
+	defer cleanupUser(t, noUpd.ID)
+	// GORM は UpdatedAt を Create 時に自動設定するため、NULL updatedAt は明示的に
+	// 落として作る (upstream TypeORM では未更新 user の updatedAt が NULL になりうる)。
+	require.NoError(t, testDB.Exec(`UPDATE "user" SET "updatedAt" = NULL WHERE id = ?`, noUpd.ID).Error)
+
+	idSet := func(filter model.UserListFilter) map[string]bool {
+		us, err := repo.ListUsers(filter)
+		require.NoError(t, err)
+		m := make(map[string]bool, len(us))
+		for _, u := range us {
+			m[u.ID] = true
+		}
+		return m
+	}
+
+	// public /users mode: NULL updatedAt を除外。
+	got := idSet(model.UserListFilter{Sort: "+updatedAt", UpdatedAtSortNonNull: true, Limit: 1000})
+	assert.True(t, got[withUpd.ID], "updatedAt 有 user は残る")
+	assert.False(t, got[noUpd.ID], "public /users は updatedAt NULL を除外 (#1975)")
+
+	// admin/show-users mode (flag false): NULL を保持 (NULLS LAST)。
+	got = idSet(model.UserListFilter{Sort: "+updatedAt", Limit: 1000})
+	assert.True(t, got[withUpd.ID])
+	assert.True(t, got[noUpd.ID], "admin/show-users は updatedAt NULL を保持 (NULLS LAST)")
+
+	// -updatedAt sort でも同じ (public は NULL 除外、admin は保持)。
+	got = idSet(model.UserListFilter{Sort: "-updatedAt", UpdatedAtSortNonNull: true, Limit: 1000})
+	assert.True(t, got[withUpd.ID])
+	assert.False(t, got[noUpd.ID], "public /users は -updatedAt でも NULL を除外 (#1975)")
+	got = idSet(model.UserListFilter{Sort: "-updatedAt", Limit: 1000})
+	assert.True(t, got[noUpd.ID], "admin/show-users は -updatedAt でも NULL を保持")
+}
+
 func TestUserRepository_ListUsers_LocalOnly(t *testing.T) {
 	repo := NewUserRepository(testDB)
 	u := insertTestUser(t, "lu_loc", "localonly")

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1100,9 +1100,10 @@ func (s *Server) setupRoutes() {
 		users, err := userRepo.ListUsers(model.UserListFilter{
 			State: req.State, Origin: req.Origin, Sort: req.Sort,
 			Limit: req.Limit, Offset: req.Offset,
-			Hostname:         req.Hostname,
-			ExplorableOnly:   true,
-			ExcludeRelatedTo: viewerID,
+			Hostname:             req.Hostname,
+			ExplorableOnly:       true,
+			ExcludeRelatedTo:     viewerID,
+			UpdatedAtSortNonNull: true, // #1975: public /users は updatedAt sort で NULL updatedAt を除外
 		})
 		if err != nil {
 			return c.JSON(http.StatusOK, []any{})


### PR DESCRIPTION
## Summary

public `/api/users` の `+updatedAt`/`-updatedAt` sort で `updatedAt IS NOT NULL` を強制し、
upstream に揃える (#1975)。

upstream は caller で挙動が異なる:
- public `users.ts`: `+updatedAt`/`-updatedAt` 両方で `andWhere('user.updatedAt IS NOT NULL')` →
  NULL updatedAt user を除外。
- `admin/show-users.ts`: `orderBy(..., 'NULLS LAST'/'NULLS FIRST')` のみで **NULL を保持**。

mk-go の共有 `ListUsers` は updatedAt sort を常に `NULLS LAST/FIRST` で扱い NULL を保持していた
(= admin 相当、public と乖離)。

## 主な変更点

- `internal/model/user.go` `UserListFilter`: `UpdatedAtSortNonNull bool` を追加。
- `internal/repository/user.go` `ListUsers`: `+updatedAt`/`-updatedAt` branch で flag が true の
  ときだけ `"updatedAt" IS NOT NULL` を付与。flag false (admin/show-users・federation/users) は
  従来通り NULL 保持。
- `internal/server/router.go` inline `/users`: `UpdatedAtSortNonNull: true` を渡す。

flag デフォルト false なので admin/show-users・federation/users の挙動は不変。

## テスト

- `internal/repository/user_test.go` `TestUserRepository_ListUsers_UpdatedAtSortNonNull`:
  public mode (flag true) で NULL updatedAt 除外 / admin mode (flag false) で NULL 保持を
  `+updatedAt`・`-updatedAt` の両方で検証。
- `ListUsers` 98.4% / repository 90.0%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

mk-go は GORM が `UpdatedAt` を Create 時に自動設定するため、updatedAt は実質常に非 NULL
(upstream TypeORM では未更新 user の updatedAt が NULL になりうる)。本 fix は SQL を upstream に
揃える **parity / 防御目的**で、通常運用では除外対象は 0 件 (テストは生 SQL で NULL を強制して
filter 動作を検証)。

## 関連

- 親: #1948
- 発見元: #1957-b の敵対的レビュー

Closes #1975
