### PR TITLE
Fix webhook thread-mute parity (#1965): reply/mention の user webhook も thread-mute で抑制する

### DIFF
--- a/internal/core/webhook/hooks.go
+++ b/internal/core/webhook/hooks.go
@@ -6,6 +6,7 @@ import (
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
 )
 
 // NoteCreateHook wraps Service to implement the WebhookHook interface
@@ -20,11 +21,36 @@ import (
 type NoteCreateHook struct {
 	svc   *Service
 	idGen id.Generator
+	// threadMuteRepo は reply/mention webhook のスレッドミュート gate に使う
+	// optional 依存 (#1965)。未配線なら gate は素通り。
+	threadMuteRepo repository.NoteThreadMutingRepository
 }
 
 // NewNoteCreateHook constructs a NoteCreateHook.
 func NewNoteCreateHook(svc *Service, idGen id.Generator) *NoteCreateHook {
 	return &NoteCreateHook{svc: svc, idGen: idGen}
+}
+
+// SetThreadMutingRepo attaches a NoteThreadMutingRepository so reply/mention
+// webhook events are suppressed for recipients who thread-muted the thread,
+// matching upstream NoteCreateService (#1965). nil disables the gate.
+func (h *NoteCreateHook) SetThreadMutingRepo(r repository.NoteThreadMutingRepository) {
+	h.threadMuteRepo = r
+}
+
+// isThreadMuted reports whether userID has muted the thread that threadNote
+// belongs to (threadNote.ThreadID ?? threadNote.ID)。repo 未配線 / lookup error
+// では false (fail-open: 配信)。#1954 / notification.Hook.isThreadMuted と同一規則。
+func (h *NoteCreateHook) isThreadMuted(userID string, threadNote *model.Note) bool {
+	if h.threadMuteRepo == nil || threadNote == nil {
+		return false
+	}
+	threadID := threadNote.ID
+	if threadNote.ThreadID != nil && *threadNote.ThreadID != "" {
+		threadID = *threadNote.ThreadID
+	}
+	muted, err := h.threadMuteRepo.Exists(userID, threadID)
+	return err == nil && muted
 }
 
 // OnNoteCreated fires note / reply / renote / mention webhook events. 失敗は
@@ -38,17 +64,22 @@ func (h *NoteCreateHook) OnNoteCreated(note *model.Note, author *model.User, rep
 	// 作者本人のwebhook
 	h.svc.DispatchUser(author.ID, EventNote, body)
 
-	// reply: 親ノート投稿者
-	if replyTarget != nil && replyTarget.UserID != author.ID {
+	// reply: 親ノート投稿者。upstream はスレッドミュート中の reply 先には reply
+	// webhook を出さない (#1965)。thread は reply 先ノートの threadId。
+	if replyTarget != nil && replyTarget.UserID != author.ID && !h.isThreadMuted(replyTarget.UserID, replyTarget) {
 		h.svc.DispatchUser(replyTarget.UserID, EventReply, body)
 	}
-	// renote: 対象ノート投稿者
+	// renote: 対象ノート投稿者 (renote はスレッドミュートで gate しない、upstream 同様)。
 	if renoteTarget != nil && renoteTarget.UserID != author.ID {
 		h.svc.DispatchUser(renoteTarget.UserID, EventRenote, body)
 	}
-	// mention: 本文から抽出されたユーザー ID ごとに配信
+	// mention: 本文から抽出されたユーザー ID ごとに配信。スレッドミュート中の
+	// mention 先には mention webhook を出さない (#1965)。thread は新規ノートの threadId。
 	for _, mentionID := range note.Mentions {
 		if mentionID == "" || mentionID == author.ID {
+			continue
+		}
+		if h.isThreadMuted(mentionID, note) {
 			continue
 		}
 		h.svc.DispatchUser(mentionID, EventMention, body)

--- a/internal/core/webhook/hooks_test.go
+++ b/internal/core/webhook/hooks_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/shiroha-a/mk/internal/core/webhook"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -55,6 +56,85 @@ func TestNoteCreateHook_FiresReplyEventOnParentAuthor(t *testing.T) {
 	)
 	require.Len(t, enq.userCalls, 1)
 	assert.Equal(t, "reply", enq.userCalls[0].EventType)
+}
+
+// #1965: reply 先がスレッドをミュートしていれば reply webhook を出さない。
+func TestNoteCreateHook_ReplyThreadMutedSkipped(t *testing.T) {
+	svc, enq, userRepo, _ := newTestService(t)
+	userRepo.hooks["h_reply"] = &model.Webhook{ID: "h_reply", UserID: "bob", Active: true, On: pq.StringArray{"reply"}}
+	idGen, _ := id.NewGenerator("aidx")
+	h := webhook.NewNoteCreateHook(svc, idGen)
+	muteRepo := testutil.NewMockNoteThreadMutingRepository()
+	require.NoError(t, muteRepo.Create(&model.NoteThreadMuting{UserID: "bob", ThreadID: "np"}))
+	h.SetThreadMutingRepo(muteRepo)
+
+	text := "reply body"
+	h.OnNoteCreated(
+		&model.Note{ID: "n2", UserID: "alice", Text: &text, Visibility: model.NoteVisibilityPublic},
+		&model.User{ID: "alice", Username: "alice", UsernameLower: "alice"},
+		&model.Note{ID: "np", UserID: "bob"},
+		nil,
+	)
+	assert.Empty(t, enq.userCalls, "thread-muted reply 先には reply webhook を出さない (#1965)")
+}
+
+// #1965: reply 先が threaded note (ThreadID 持ち) の場合、その threadId で判定する。
+func TestNoteCreateHook_ReplyThreadMuteUsesThreadID(t *testing.T) {
+	svc, enq, userRepo, _ := newTestService(t)
+	userRepo.hooks["h_reply"] = &model.Webhook{ID: "h_reply", UserID: "bob", Active: true, On: pq.StringArray{"reply"}}
+	idGen, _ := id.NewGenerator("aidx")
+	h := webhook.NewNoteCreateHook(svc, idGen)
+	muteRepo := testutil.NewMockNoteThreadMutingRepository()
+	require.NoError(t, muteRepo.Create(&model.NoteThreadMuting{UserID: "bob", ThreadID: "troot"}))
+	h.SetThreadMutingRepo(muteRepo)
+
+	troot := "troot"
+	text := "reply body"
+	h.OnNoteCreated(
+		&model.Note{ID: "n2", UserID: "alice", Text: &text, Visibility: model.NoteVisibilityPublic},
+		&model.User{ID: "alice", Username: "alice", UsernameLower: "alice"},
+		&model.Note{ID: "np", UserID: "bob", ThreadID: &troot},
+		nil,
+	)
+	assert.Empty(t, enq.userCalls, "reply 先ノートの threadId でミュート判定する (#1965)")
+}
+
+// #1965: mention 先がスレッドをミュートしていれば mention webhook を出さない。
+func TestNoteCreateHook_MentionThreadMutedSkipped(t *testing.T) {
+	svc, enq, userRepo, _ := newTestService(t)
+	userRepo.hooks["h_m"] = &model.Webhook{ID: "h_m", UserID: "bob", Active: true, On: pq.StringArray{"mention"}}
+	idGen, _ := id.NewGenerator("aidx")
+	h := webhook.NewNoteCreateHook(svc, idGen)
+	muteRepo := testutil.NewMockNoteThreadMutingRepository()
+	require.NoError(t, muteRepo.Create(&model.NoteThreadMuting{UserID: "bob", ThreadID: "n_m"}))
+	h.SetThreadMutingRepo(muteRepo)
+
+	text := "hi @bob"
+	h.OnNoteCreated(
+		&model.Note{ID: "n_m", UserID: "alice", Text: &text, Visibility: model.NoteVisibilityPublic, Mentions: pq.StringArray{"bob"}},
+		&model.User{ID: "alice", Username: "alice", UsernameLower: "alice"},
+		nil, nil,
+	)
+	assert.Empty(t, enq.userCalls, "thread-muted mention 先には mention webhook を出さない (#1965)")
+}
+
+// #1965: renote はスレッドミュートで gate されない (upstream も ungated)。
+func TestNoteCreateHook_RenoteThreadMuteNotGated(t *testing.T) {
+	svc, enq, userRepo, _ := newTestService(t)
+	userRepo.hooks["h_rn"] = &model.Webhook{ID: "h_rn", UserID: "bob", Active: true, On: pq.StringArray{"renote"}}
+	idGen, _ := id.NewGenerator("aidx")
+	h := webhook.NewNoteCreateHook(svc, idGen)
+	muteRepo := testutil.NewMockNoteThreadMutingRepository()
+	require.NoError(t, muteRepo.Create(&model.NoteThreadMuting{UserID: "bob", ThreadID: "nr"}))
+	h.SetThreadMutingRepo(muteRepo)
+
+	h.OnNoteCreated(
+		&model.Note{ID: "n_rn", UserID: "alice", Visibility: model.NoteVisibilityPublic},
+		&model.User{ID: "alice", Username: "alice", UsernameLower: "alice"},
+		nil, &model.Note{ID: "nr", UserID: "bob"},
+	)
+	require.Len(t, enq.userCalls, 1, "renote はスレッドミュートで抑制されない (#1965)")
+	assert.Equal(t, "renote", enq.userCalls[0].EventType)
 }
 
 func TestNoteCreateHook_FiresRenoteEventOnRenoteAuthor(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -369,7 +369,10 @@ func (s *Server) setupRoutes() {
 
 	// Webhook (Phase 9.5): ユーザー/システムwebhookの配信を非同期処理する。
 	webhookService := corewebhook.NewService(s.queueClient, webhookRepo, systemWebhookRepo, s.config.URL)
-	noteCreateService.SetWebhookHook(corewebhook.NewNoteCreateHook(webhookService, idGen))
+	webhookNoteHook := corewebhook.NewNoteCreateHook(webhookService, idGen)
+	// reply/mention webhook をスレッドミュート済 recipient に出さない (#1965)。
+	webhookNoteHook.SetThreadMutingRepo(noteThreadMutingRepo)
+	noteCreateService.SetWebhookHook(webhookNoteHook)
 	reactionService.SetWebhookHook(corewebhook.NewReactionCreateHook(webhookService, idGen))
 	followingService.SetWebhookHook(corewebhook.NewFollowingHook(webhookService))
 	signupService.SetWebhookHook(corewebhook.NewSignupHook(webhookService))


### PR DESCRIPTION
## Summary

reply/mention の **user webhook 配信**もスレッドミュートで抑制する (#1965)。

upstream `NoteCreateService` は reply 先 / mention 先がスレッドをミュートしている場合、
event / 通知に加えて **user webhook (`enqueueUserWebhook`)** も同じ `!isThreadMuted` ブロックで
抑制する (`NoteCreateService.ts:837` reply / `:980` mention)。#1954 で event/通知には gate を
入れたが、webhook `NoteCreateHook` には gate が漏れていた。

## 主な変更点

- `internal/core/webhook/hooks.go` `NoteCreateHook`: `threadMuteRepo` + `SetThreadMutingRepo` +
  `isThreadMuted` を追加し、`OnNoteCreated` の reply/mention dispatch を gate。renote は ungated
  (upstream + #1954 と同じ)。threadId 導出 (reply: replyTarget.ThreadID ?? ID、mention:
  note.ThreadID ?? ID) は `note_create_service.go` / `notification/hooks.go` の `isThreadMuted` と
  同一規則。
- `internal/server/router.go`: `webhookNoteHook.SetThreadMutingRepo(noteThreadMutingRepo)` を配線。

fail-open (repo nil / lookup error) は配信側に倒す。author への `note` webhook は無条件 (upstream 同様)。

## テスト

- `internal/core/webhook/hooks_test.go`: reply 抑制 / mention 抑制 / renote 非抑制 (control) /
  threaded reply 先での threadId 導出。
- webhook package 92.7%。`make fmt` / `go vet ./...` / `make test` green。

## 関連

- 親: #1948
- 発見元: #1954 の敵対的レビュー

Closes #1965
