### PR TITLE
Fix admin announcements parity (#1977): admin/create の imageUrl を raw で返す

### DIFF
--- a/internal/api/announcements/handler.go
+++ b/internal/api/announcements/handler.go
@@ -268,9 +268,15 @@ func (h *Handler) AdminCreate(c echo.Context) error {
 		"announcementId": a.ID,
 		"announcement":   a,
 	})
-	// upstream create.ts は packed (createdAt 等を含む) を返す。raw model は
-	// createdAt 列を持たない (ID 由来) ため packer を通す (#1545)。
-	return c.JSON(http.StatusOK, entity.PackAnnouncement(a, h.idGen, false))
+	// upstream admin/announcements/create.ts は `packed` (= AnnouncementEntityService
+	// .pack の full object) をそのまま返す。`meta.res` の 6 フィールドは型契約/doc 用で、
+	// ランタイムでは strip されない (Ajv は paramDef のみ検証)。よって wire 実体は
+	// forYou/isRead/icon 等を含む full shape。唯一 imageUrl だけ upstream は raw を返す
+	// (admin/list #1967 と同じく proxy しない)。public 用 PackAnnouncement は #1529 で
+	// imageUrl を proxy 化するため、その field だけ raw に上書きする (#1977)。
+	resp := entity.PackAnnouncement(a, h.idGen, false)
+	resp["imageUrl"] = a.ImageURL // upstream wire は raw imageUrl
+	return c.JSON(http.StatusOK, resp)
 }
 
 // isValidAnnouncementIcon reports whether v matches upstream's

--- a/internal/api/announcements/handler_test.go
+++ b/internal/api/announcements/handler_test.go
@@ -224,6 +224,26 @@ func TestAdminCreate_Success(t *testing.T) {
 	assert.NotEmpty(t, createdAt)
 }
 
+// #1977: admin/announcements/create のレスポンスは upstream の wire 実体 (= pack の
+// full object) と一致し、imageUrl だけ raw を返す。upstream は `packed` をそのまま返し
+// res schema (6 フィールド) では strip されないため、forYou/isRead 等は wire に含まれる。
+// 唯一 imageUrl は upstream が raw を返すので mk-go も proxy しない。
+func TestAdminCreate_ResponseImageURLRaw(t *testing.T) {
+	h, _ := newTestHandler(t)
+	rec := doPost(h.AdminCreate, `{"title":"News","text":"x","imageUrl":"https://remote.example/i.png"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	// imageUrl は raw (proxy しない)。これが #1977 の本質的な修正点。
+	assert.Equal(t, "https://remote.example/i.png", resp["imageUrl"], "imageUrl は raw (proxy しない、#1977)")
+	// upstream wire は full pack なので forYou/isRead 等は含まれる (strip しない)。
+	assert.Contains(t, resp, "forYou", "upstream wire は full pack (forYou を含む、#1977)")
+	assert.Contains(t, resp, "isRead")
+	for _, k := range []string{"id", "createdAt", "updatedAt", "title", "text", "imageUrl"} {
+		assert.Contains(t, resp, k, "create response に %s が必要", k)
+	}
+}
+
 func TestAdminCreate_InvalidParam(t *testing.T) {
 	h, _ := newTestHandler(t)
 	rec := doPost(h.AdminCreate, `{}`, nil)


### PR DESCRIPTION
## Summary

`admin/announcements/create` のレスポンス `imageUrl` を raw に揃える (#1977)。

upstream `admin/announcements/create.ts` は `packed` (= `AnnouncementEntityService.pack` の full
object) をそのまま返す。`meta.res` の 6 フィールド宣言は型契約 / OpenAPI doc 用で、ランタイムでは
strip されない (Ajv は paramDef のみ検証、Fastify response serializer 未指定)。よって **wire 実体は
forYou/isRead/icon 等を含む full shape**で、`imageUrl` のみ raw (proxy しない)。

mk-go の `AdminCreate` は public 用 `entity.PackAnnouncement` を返しており、full shape 自体は
upstream wire と一致していたが、`imageUrl` を #1529 hardening で media-proxy 書き換えしていた点
だけが乖離していた。

## 主な変更点

- `internal/api/announcements/handler.go` `AdminCreate`: HTTP レスポンスの `imageUrl` を raw
  (`a.ImageURL`) に上書き。full pack (forYou/isRead 等を含む) は upstream wire と一致するため維持。
  announcementCreated イベント body は従来通り full pack (frontend $i 反映用)。

## 当初の誤りと訂正

当初は「upstream create res は 6 フィールドのみ」という `meta.res` 宣言を根拠にレスポンスを 6
フィールドに絞ったが、敵対的レビューで **upstream の実 wire は full pack (12 フィールド) で `res` は
strip されない**ことが判明。6 フィールド化は upstream wire より狭める新たな乖離だった。
wire parity 最優先の方針に従い、full pack を維持し imageUrl のみ raw 化する形に訂正した
(メモリ `feedback_verify_misskey_ts_before_drift_fix` の罠: schema 宣言でなく wire 実体を確認)。

## テスト

- `internal/api/announcements/handler_test.go` `TestAdminCreate_ResponseImageURLRaw`: imageUrl が
  raw (remote URL そのまま)、full pack (forYou/isRead 含む) であることを検証。
- 既存 `TestAdminCreate_PerUserPublishesAnnouncementCreated` (event body の forYou/isRead) は維持。
- `internal/api/announcements` 96.4%。`make fmt` / `go vet ./...` / `make test` green。

## 関連

- 親: #1948
- 発見元: #1967 の敵対的レビュー

Closes #1977
