### PR TITLE
Fix relation packing parity (#1980): users/search・search-by-username-and-host に viewer-relation を付ける

### DIFF
--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -670,6 +670,10 @@ func (h *Handler) Search(c echo.Context) error {
 	}
 	profiles := h.userService.GetProfilesByUserIDs(ids)
 
+	viewerID := ""
+	if viewer != nil {
+		viewerID = viewer.ID
+	}
 	out := make([]entity.UserDetailed, 0, len(users))
 	for _, u := range users {
 		d := entity.PackUserDetailed(u, profiles[u.ID], h.idGen)
@@ -678,10 +682,12 @@ func (h *Handler) Search(c echo.Context) error {
 		// moderator viewer には moderationNote を出す (#1558、users/show と対称)。
 		h.applyModerationNote(&d, iAmModerator, profiles[u.ID])
 		entity.ApplyModeratorSecurityFields(&d, iAmModerator, profiles[u.ID])
-		// count visibility gate (#1558)。search は per-user の follow 関係を
-		// 解決しないため isFollowing=false。self / moderator は count を保持。
+		// upstream search.ts は packMany(users, me, {schema}) で embed user に viewer
+		// 視点の relation block を付ける (#1980)。Apply は匿名/self で no-op。戻り値の
+		// isFollowing を count visibility gate (#1558) に渡す (以前は hardcode false)。
+		viewerIsFollowing := h.viewerRelationRepos().Apply(&d, viewerID, u, profiles[u.ID])
 		isMe := viewer != nil && viewer.ID == u.ID
-		entity.GateCountVisibility(&d, isMe, iAmModerator, false)
+		entity.GateCountVisibility(&d, isMe, iAmModerator, viewerIsFollowing)
 		out = append(out, d)
 	}
 	return c.JSON(http.StatusOK, out)

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -615,6 +615,12 @@ func (h *Handler) SearchByUsernameAndHost(c echo.Context) error {
 		return c.JSON(http.StatusOK, result)
 	}
 
+	viewer := middleware.GetUser(c)
+	viewerID := ""
+	if viewer != nil {
+		viewerID = viewer.ID
+	}
+	iAmModerator := viewer != nil && h.moderatorChecker != nil && h.moderatorChecker.IsModerator(viewer.ID)
 	ids := make([]string, 0, len(users))
 	for _, u := range users {
 		ids = append(ids, u.ID)
@@ -625,6 +631,13 @@ func (h *Handler) SearchByUsernameAndHost(c echo.Context) error {
 		d := entity.PackUserDetailed(u, profiles[u.ID], h.idGen)
 		resolver.FillUserLite(&d.UserLite)
 		h.populateUserEmojis(u, &d.UserLite)
+		// upstream search-by-username-and-host は packMany(users, me, {schema:'UserDetailed'})
+		// で embed user に viewer 視点の relation block を付ける (#1980)。匿名/self で no-op。
+		viewerIsFollowing := h.viewerRelationRepos().Apply(&d, viewerID, u, profiles[u.ID])
+		// upstream pack は count gate (followersVisibility=followers 等) を isFollowing で
+		// 解く。これが無いと followers-only count が非フォロワーに leak する (#1980、users/search と対称)。
+		isMe := viewer != nil && viewer.ID == u.ID
+		entity.GateCountVisibility(&d, isMe, iAmModerator, viewerIsFollowing)
 		result = append(result, d)
 	}
 	return c.JSON(http.StatusOK, result)

--- a/internal/api/users/handler_parity1547_test.go
+++ b/internal/api/users/handler_parity1547_test.go
@@ -129,6 +129,76 @@ func TestSearchByUsernameAndHost_DetailFalseUserLite(t *testing.T) {
 	assert.False(t, hasDetailedField(out[0]), "detail=false は UserLite (#1547)")
 }
 
+// #1980: users/search の Detail (default) 経路の embed user に viewer 視点の relation
+// block が乗る。viewer が結果 user を follow していれば isFollowing=true、匿名なら省略。
+func TestSearch_DetailEmbedsViewerRelation(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addTestUser(repo) // user1 / testuser
+	fRepo := testutil.NewMockFollowingRepository()
+	require.NoError(t, fRepo.Create(&model.Following{ID: "f1", FollowerID: "viewer1", FolloweeID: "user1"}))
+	h.SetFollowingRepo(fRepo)
+
+	rec := postStub(h.Search, `{"query":"test"}`, &model.User{ID: "viewer1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	assert.Equal(t, true, out[0]["isFollowing"], "search detail の embed user に isFollowing=true (#1980)")
+
+	rec = post(h.Search, `{"query":"test"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var anon []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &anon))
+	require.Len(t, anon, 1)
+	_, has := anon[0]["isFollowing"]
+	assert.False(t, has, "匿名 search には relation を出さない (#1980)")
+}
+
+// #1980: search-by-username-and-host の Detail (default) 経路にも relation block。
+func TestSearchByUsernameAndHost_EmbedsViewerRelation(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addTestUser(repo)
+	fRepo := testutil.NewMockFollowingRepository()
+	require.NoError(t, fRepo.Create(&model.Following{ID: "f1", FollowerID: "viewer1", FolloweeID: "user1"}))
+	h.SetFollowingRepo(fRepo)
+
+	rec := postStub(h.SearchByUsernameAndHost, `{"username":"testuser"}`, &model.User{ID: "viewer1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	assert.Equal(t, true, out[0]["isFollowing"], "search-by-username-and-host の embed user に isFollowing=true (#1980)")
+
+	rec = postStub(h.SearchByUsernameAndHost, `{"username":"testuser"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var anon []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &anon))
+	require.Len(t, anon, 1)
+	_, has := anon[0]["isFollowing"]
+	assert.False(t, has, "匿名には relation を出さない (#1980)")
+}
+
+// #1980: search-by-username-and-host は followers-visibility の count を非フォロワーに
+// leak させない (count gate を users/search と対称に追加した)。
+func TestSearchByUsernameAndHost_GatesFollowersCount(t *testing.T) {
+	h, repo := newTestHandler(t)
+	u := addTestUser(repo) // user1 / testuser
+	u.FollowersCount = 7
+	repo.Profiles["user1"] = &model.UserProfile{
+		UserID:              "user1",
+		FollowersVisibility: model.FollowingVisibilityFollowers,
+		FollowingVisibility: model.FollowingVisibilityPublic,
+	}
+
+	// 非フォロワー viewer: followersVisibility=followers の count は 0 に潰される。
+	rec := postStub(h.SearchByUsernameAndHost, `{"username":"testuser"}`, &model.User{ID: "stranger"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	assert.EqualValues(t, 0, out[0]["followersCount"], "followers-only count は非フォロワーに leak しない (#1980)")
+}
+
 // --- S5: moderator viewer sees moderationNote ---
 
 type modStub struct{}


### PR DESCRIPTION
## Summary

#1973 と同じ class の viewer-relative relation packing 漏れを、`users/search` と
`users/search-by-username-and-host` の Detail (default) 経路で塞ぐ (#1980)。

upstream は両 endpoint で `packMany(users, me, {schema:'UserDetailed'})` で me を渡すため、
embed user に relation block (isFollowing/isBlocking/isMuted 等) が乗り、count visibility gate
(followersVisibility=followers 等を isFollowing で解く) も走る。mk-go は viewer を渡さず relation
を省略し、search-by-username-and-host は count gate も持たず followers-only count を leak していた。

## 主な変更点

- `internal/api/users/handler.go` `Search` (Detail 経路): `h.viewerRelationRepos().Apply(...)` を
  追加し、戻り値 `viewerIsFollowing` を**既存の `GateCountVisibility`** に渡す (以前は hardcode
  `false`。フォロワーには count を見せる upstream 挙動に改善)。
- `internal/api/users/handler_extra.go` `SearchByUsernameAndHost` (Detail 経路): viewer 解決 +
  Apply (relation block) + `GateCountVisibility` を追加 (count gate 欠如による followers-only
  count leak も修正、users/search と対称化)。

両者とも `viewerRelationRepos()` (#1973 のヘルパー) を再利用。Apply / GateCountVisibility は
匿名 / self で no-op (relation 省略、self は count 保持)。

## テスト

- `internal/api/users/handler_parity1547_test.go`:
  - `TestSearch_DetailEmbedsViewerRelation` / `TestSearchByUsernameAndHost_EmbedsViewerRelation`:
    authed viewer で isFollowing=true、匿名で relation 省略。
  - `TestSearchByUsernameAndHost_GatesFollowersCount`: followers-visibility の count が非フォロワー
    に 0 で返る (leak 修正の回帰)。
- users package 90.3%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで、search-by-username-and-host の count gate 欠落 (followers-only count leak) を
発見し本 PR に取り込んだ。さらに同種の count-gate 欠如が他の list endpoint
(users/recommendation・mute/list・renote-mute/list・blocking/list) にも残ることを発見し、横断 issue
として切り出した (#1985)。

## 関連

- 親: #1948
- 発見元: #1973 の敵対的レビュー

Closes #1980
