### PR TITLE
Fix count visibility parity (#1985): embed user list endpoint の count gate を横断的に揃える

### DIFF
--- a/internal/api/blocking/handler.go
+++ b/internal/api/blocking/handler.go
@@ -18,12 +18,22 @@ import (
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
+// ModeratorChecker reports whether a user holds moderator privileges. Used to
+// let moderator viewers see follower/following counts that would otherwise be
+// gated by visibility (mirrors upstream UserEntityService iAmModerator, #1985)。
+type ModeratorChecker interface {
+	IsModerator(userID string) bool
+}
+
 // Handler handles blocking-related API endpoints.
 type Handler struct {
 	svc      *coreblocking.Service
 	userRepo repository.UserRepository
 	idGen    id.Generator
 	relation userrelation.Repos
+	// moderator は blocking/list の埋め込み blockee の count gate で moderator
+	// viewer を判定する (#1985)。未配線なら non-moderator 扱い。
+	moderator ModeratorChecker
 }
 
 // NewHandler creates a new blocking Handler.
@@ -39,6 +49,12 @@ func NewHandler(svc *coreblocking.Service, userRepo repository.UserRepository, i
 // test fixtures).
 func (h *Handler) SetRelationRepos(r userrelation.Repos) {
 	h.relation = r
+}
+
+// SetModeratorChecker wires the moderator check used by blocking/list's count
+// gate so a moderator viewer keeps seeing follower/following counts (#1985)。
+func (h *Handler) SetModeratorChecker(m ModeratorChecker) {
+	h.moderator = m
 }
 
 // PairRequest is the request body for blocking/create and blocking/delete.
@@ -114,7 +130,12 @@ func (h *Handler) respondPackedUser(c echo.Context, viewer *model.User, userID s
 	profile, _ := h.userRepo.FindProfileByUserID(userID)
 	detailed := entity.PackUserDetailed(target, profile, h.idGen)
 	if viewer != nil {
-		h.relation.Apply(&detailed, viewer.ID, target, profile)
+		viewerIsFollowing := h.relation.Apply(&detailed, viewer.ID, target, profile)
+		// followers-only count を非フォロワーに leak させない (upstream blocking/create・delete も
+		// pack(blockee, blocker, UserDetailedNotMe) で count gate を通す、#1985)。block 自己不可
+		// なので isMe は常に false。
+		iAmModerator := h.moderator != nil && h.moderator.IsModerator(viewer.ID)
+		entity.GateCountVisibility(&detailed, false, iAmModerator, viewerIsFollowing)
 	}
 	return c.JSON(http.StatusOK, detailed)
 }
@@ -203,12 +224,16 @@ func (h *Handler) fetchBlockeeMap(viewerID string, rows []*model.Blocking) map[s
 	for _, p := range profiles {
 		profileByUser[p.UserID] = p
 	}
+	iAmModerator := h.moderator != nil && viewerID != "" && h.moderator.IsModerator(viewerID)
 	out := make(map[string]entity.UserDetailed, len(users))
 	for _, u := range users {
 		d := entity.PackUserDetailed(u, profileByUser[u.ID], h.idGen)
 		// viewer->blockee の relation block を付与 (isBlocking=true 等)。Apply は
 		// viewerID 空 / self では no-op。relation 未配線 (test stub) でも安全。
-		h.relation.Apply(&d, viewerID, u, profileByUser[u.ID])
+		viewerIsFollowing := h.relation.Apply(&d, viewerID, u, profileByUser[u.ID])
+		// followers-only count を非フォロワーに leak させない (upstream packMany(_, me) の
+		// count gate、#1985)。blockee は viewer 自身ではないため isMe は常に false。
+		entity.GateCountVisibility(&d, u.ID == viewerID, iAmModerator, viewerIsFollowing)
 		out[u.ID] = d
 	}
 	return out

--- a/internal/api/blocking/handler_test.go
+++ b/internal/api/blocking/handler_test.go
@@ -120,6 +120,102 @@ func TestList_BlockeeCarriesIsBlocking(t *testing.T) {
 	assert.Equal(t, true, blockee["isBlocking"], "embed blockee に isBlocking=true が乗る (#1957-a)")
 }
 
+// modStub implements ModeratorChecker for the count-gate tests.
+type modStub struct{ mods map[string]bool }
+
+func (m modStub) IsModerator(id string) bool { return m.mods[id] }
+
+// newGatedHandler wires relation + moderator repos and blocks "bob" whose
+// followersVisibility=followers and followersCount=7.
+func newGatedHandler(t *testing.T, mod ModeratorChecker) (*Handler, *httptest.ResponseRecorder, echo.Context) {
+	t.Helper()
+	userRepo := testutil.NewMockUserRepository()
+	blockingRepo := testutil.NewMockBlockingRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := coreblocking.NewService(userRepo, blockingRepo, nil, idGen)
+	h := NewHandler(svc, userRepo, idGen)
+	h.SetRelationRepos(userrelation.Repos{
+		Following: testutil.NewMockFollowingRepository(),
+		Blocking:  blockingRepo,
+	})
+	if mod != nil {
+		h.SetModeratorChecker(mod)
+	}
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", FollowersCount: 7}
+	userRepo.Profiles["bob"] = &model.UserProfile{
+		UserID:              "bob",
+		FollowersVisibility: model.FollowingVisibilityFollowers,
+		FollowingVisibility: model.FollowingVisibilityPublic,
+	}
+	c1, _ := newReq(t, `{"userId":"bob"}`)
+	setUser(c1, "alice")
+	require.NoError(t, h.Create(c1))
+	c, rec := newReq(t, `{}`)
+	setUser(c, "alice")
+	return h, rec, c
+}
+
+// TestCreate_GatesFollowersCount: blocking/create のレスポンス (UserDetailedNotMe)
+// でも followers-only count を非フォロワーに leak させない (upstream は
+// pack(blockee, blocker) で gate を通す、#1985)。
+func TestCreate_GatesFollowersCount(t *testing.T) {
+	h, _, _ := newGatedHandler(t, nil)
+	// 別途 Create を直接叩いてレスポンスを検証する (newGatedHandler は List 用の
+	// context を返すため)。alice は bob を既に block 済みなので unblock してから。
+	c, rec := newReq(t, `{"userId":"bob"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Delete(c)) // 既存 block を解除
+	c, rec = newReq(t, `{"userId":"bob"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.EqualValues(t, 0, resp["followersCount"], "create レスポンスでも followers-only count は leak しない (#1985)")
+}
+
+// TestCreate_ModeratorSeesFollowersCount: moderator viewer の create レスポンスは
+// gate しない。
+func TestCreate_ModeratorSeesFollowersCount(t *testing.T) {
+	h, _, _ := newGatedHandler(t, modStub{mods: map[string]bool{"alice": true}})
+	c, rec := newReq(t, `{"userId":"bob"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Delete(c))
+	c, rec = newReq(t, `{"userId":"bob"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.EqualValues(t, 7, resp["followersCount"], "moderator viewer には count を見せる (#1985)")
+}
+
+// TestList_GatesFollowersCount: followers-only count を非フォロワー viewer に
+// leak させない (#1985)。
+func TestList_GatesFollowersCount(t *testing.T) {
+	h, rec, c := newGatedHandler(t, nil)
+	require.NoError(t, h.List(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	blockee := resp[0]["blockee"].(map[string]any)
+	assert.EqualValues(t, 0, blockee["followersCount"], "followers-only count は非フォロワーに leak しない (#1985)")
+}
+
+// TestList_ModeratorSeesFollowersCount: moderator viewer には gate をかけない。
+func TestList_ModeratorSeesFollowersCount(t *testing.T) {
+	h, rec, c := newGatedHandler(t, modStub{mods: map[string]bool{"alice": true}})
+	require.NoError(t, h.List(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	blockee := resp[0]["blockee"].(map[string]any)
+	assert.EqualValues(t, 7, blockee["followersCount"], "moderator viewer には count を見せる (#1985)")
+}
+
 func TestCreate_InvalidParam(t *testing.T) {
 	h, _ := newHandler(t)
 	c, rec := newReq(t, `{}`)

--- a/internal/api/mute/handler.go
+++ b/internal/api/mute/handler.go
@@ -19,6 +19,13 @@ import (
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
+// ModeratorChecker reports whether a user holds moderator privileges. Used to
+// let moderator viewers see follower/following counts that would otherwise be
+// gated by visibility (mirrors upstream UserEntityService iAmModerator, #1985)。
+type ModeratorChecker interface {
+	IsModerator(userID string) bool
+}
+
 // Handler handles mute-related API endpoints.
 type Handler struct {
 	svc      *coremuting.Service
@@ -27,12 +34,21 @@ type Handler struct {
 	// relation は mute/list の埋め込み mutee に viewer-relation flag (isMuted 等)
 	// を付与する repo 束 (#1912)。未配線なら flag は omit (= legacy 挙動)。
 	relation userrelation.Repos
+	// moderator は mute/list の埋め込み mutee の count gate で moderator viewer を
+	// 判定する (#1985)。未配線なら non-moderator 扱い。
+	moderator ModeratorChecker
 }
 
 // SetRelationRepos wires the repositories used to populate viewer-relation flags
 // on the embedded mutee in mute/list (#1912)。
 func (h *Handler) SetRelationRepos(r userrelation.Repos) {
 	h.relation = r
+}
+
+// SetModeratorChecker wires the moderator check used by mute/list's count gate
+// so a moderator viewer keeps seeing follower/following counts (#1985)。
+func (h *Handler) SetModeratorChecker(m ModeratorChecker) {
+	h.moderator = m
 }
 
 // NewHandler creates a new mute Handler.
@@ -189,11 +205,15 @@ func (h *Handler) fetchMuteeMap(viewerID string, rows []*model.Muting) map[strin
 	for _, p := range profiles {
 		profileByUser[p.UserID] = p
 	}
+	iAmModerator := h.moderator != nil && viewerID != "" && h.moderator.IsModerator(viewerID)
 	out := make(map[string]entity.UserDetailed, len(users))
 	for _, u := range users {
 		d := entity.PackUserDetailed(u, profileByUser[u.ID], h.idGen)
 		// viewer-relation flag を付与 (#1912)。mute 一覧なので isMuted=true が出る。
-		h.relation.Apply(&d, viewerID, u, profileByUser[u.ID])
+		viewerIsFollowing := h.relation.Apply(&d, viewerID, u, profileByUser[u.ID])
+		// followers-only count を非フォロワーに leak させない (upstream packMany(_, me) の
+		// count gate、#1985)。mutee は viewer 自身ではないため isMe は常に false。
+		entity.GateCountVisibility(&d, u.ID == viewerID, iAmModerator, viewerIsFollowing)
 		out[u.ID] = d
 	}
 	return out

--- a/internal/api/mute/handler_test.go
+++ b/internal/api/mute/handler_test.go
@@ -253,6 +253,68 @@ func TestList_EmbedsRelationFlags(t *testing.T) {
 	assert.Equal(t, false, mutee["isBlocking"])
 }
 
+// modStub implements ModeratorChecker for the count-gate tests.
+type modStub struct{ mods map[string]bool }
+
+func (m modStub) IsModerator(id string) bool { return m.mods[id] }
+
+// newGatedHandler wires relation + moderator repos and returns a handler with a
+// muted "bob" whose followersVisibility=followers and followersCount=7.
+func newGatedHandler(t *testing.T, mod ModeratorChecker) (*Handler, *httptest.ResponseRecorder, echo.Context) {
+	t.Helper()
+	userRepo := testutil.NewMockUserRepository()
+	mutingRepo := testutil.NewMockMutingRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := coremuting.NewService(userRepo, mutingRepo, idGen)
+	h := NewHandler(svc, userRepo, idGen)
+	h.SetRelationRepos(userrelation.Repos{
+		Following: testutil.NewMockFollowingRepository(),
+		Muting:    mutingRepo,
+	})
+	if mod != nil {
+		h.SetModeratorChecker(mod)
+	}
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", FollowersCount: 7}
+	userRepo.Profiles["bob"] = &model.UserProfile{
+		UserID:              "bob",
+		FollowersVisibility: model.FollowingVisibilityFollowers,
+		FollowingVisibility: model.FollowingVisibilityPublic,
+	}
+	c1, _ := newReq(t, `{"userId":"bob"}`)
+	setUser(c1, "alice")
+	require.NoError(t, h.Create(c1))
+	c, rec := newReq(t, `{}`)
+	setUser(c, "alice")
+	return h, rec, c
+}
+
+// TestList_GatesFollowersCount: followers-only count を非フォロワー viewer に
+// leak させない (#1985)。
+func TestList_GatesFollowersCount(t *testing.T) {
+	h, rec, c := newGatedHandler(t, nil)
+	require.NoError(t, h.List(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	mutee := resp[0]["mutee"].(map[string]any)
+	assert.EqualValues(t, 0, mutee["followersCount"], "followers-only count は非フォロワーに leak しない (#1985)")
+}
+
+// TestList_ModeratorSeesFollowersCount: moderator viewer には gate をかけず
+// count をそのまま見せる (upstream iAmModerator、#1985)。
+func TestList_ModeratorSeesFollowersCount(t *testing.T) {
+	h, rec, c := newGatedHandler(t, modStub{mods: map[string]bool{"alice": true}})
+	require.NoError(t, h.List(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	mutee := resp[0]["mutee"].(map[string]any)
+	assert.EqualValues(t, 7, mutee["followersCount"], "moderator viewer には count を見せる (#1985)")
+}
+
 func TestList_LimitClamping(t *testing.T) {
 	h, _ := newHandler(t)
 	c, rec := newReq(t, `{"limit":1000}`)

--- a/internal/api/renotemute/handler.go
+++ b/internal/api/renotemute/handler.go
@@ -18,6 +18,13 @@ import (
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
+// ModeratorChecker reports whether a user holds moderator privileges. Used to
+// let moderator viewers see follower/following counts that would otherwise be
+// gated by visibility (mirrors upstream UserEntityService iAmModerator, #1985)。
+type ModeratorChecker interface {
+	IsModerator(userID string) bool
+}
+
 // Handler handles renote-mute endpoints.
 type Handler struct {
 	svc      *coremuting.RenoteService
@@ -26,12 +33,21 @@ type Handler struct {
 	// relation は renote-mute/list の埋め込み mutee に viewer-relation flag
 	// (isRenoteMuted 等) を付与する repo 束 (#1912)。未配線なら flag は omit。
 	relation userrelation.Repos
+	// moderator は renote-mute/list の埋め込み mutee の count gate で moderator
+	// viewer を判定する (#1985)。未配線なら non-moderator 扱い。
+	moderator ModeratorChecker
 }
 
 // SetRelationRepos wires the repositories used to populate viewer-relation flags
 // on the embedded mutee in renote-mute/list (#1912)。
 func (h *Handler) SetRelationRepos(r userrelation.Repos) {
 	h.relation = r
+}
+
+// SetModeratorChecker wires the moderator check used by renote-mute/list's count
+// gate so a moderator viewer keeps seeing follower/following counts (#1985)。
+func (h *Handler) SetModeratorChecker(m ModeratorChecker) {
+	h.moderator = m
 }
 
 // NewHandler creates a new Handler.
@@ -163,12 +179,16 @@ func (h *Handler) fetchMuteeMap(viewerID string, rows []*model.RenoteMuting) map
 	for _, p := range profiles {
 		profileByUser[p.UserID] = p
 	}
+	iAmModerator := h.moderator != nil && viewerID != "" && h.moderator.IsModerator(viewerID)
 	out := make(map[string]entity.UserDetailed, len(users))
 	for _, u := range users {
 		d := entity.PackUserDetailed(u, profileByUser[u.ID], h.idGen)
 		// viewer-relation flag を付与 (#1912)。renote-mute 一覧なので
 		// isRenoteMuted=true が出る。
-		h.relation.Apply(&d, viewerID, u, profileByUser[u.ID])
+		viewerIsFollowing := h.relation.Apply(&d, viewerID, u, profileByUser[u.ID])
+		// followers-only count を非フォロワーに leak させない (upstream packMany(_, me) の
+		// count gate、#1985)。mutee は viewer 自身ではないため isMe は常に false。
+		entity.GateCountVisibility(&d, u.ID == viewerID, iAmModerator, viewerIsFollowing)
 		out[u.ID] = d
 	}
 	return out

--- a/internal/api/renotemute/handler_test.go
+++ b/internal/api/renotemute/handler_test.go
@@ -243,6 +243,67 @@ func TestList_EmbedsRelationFlags(t *testing.T) {
 	assert.Equal(t, false, mutee["isFollowing"])
 }
 
+// modStub implements ModeratorChecker for the count-gate tests.
+type modStub struct{ mods map[string]bool }
+
+func (m modStub) IsModerator(id string) bool { return m.mods[id] }
+
+// newGatedHandler wires relation + moderator repos and renote-mutes "bob" whose
+// followersVisibility=followers and followersCount=7.
+func newGatedHandler(t *testing.T, mod ModeratorChecker) (*Handler, *httptest.ResponseRecorder, echo.Context) {
+	t.Helper()
+	userRepo := testutil.NewMockUserRepository()
+	rmRepo := testutil.NewMockRenoteMutingRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := coremuting.NewRenoteService(userRepo, rmRepo, idGen)
+	h := NewHandler(svc, userRepo, idGen)
+	h.SetRelationRepos(userrelation.Repos{
+		Following:    testutil.NewMockFollowingRepository(),
+		RenoteMuting: rmRepo,
+	})
+	if mod != nil {
+		h.SetModeratorChecker(mod)
+	}
+	userRepo.Users["alice"] = &model.User{ID: "alice", Username: "alice"}
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", FollowersCount: 7}
+	userRepo.Profiles["bob"] = &model.UserProfile{
+		UserID:              "bob",
+		FollowersVisibility: model.FollowingVisibilityFollowers,
+		FollowingVisibility: model.FollowingVisibilityPublic,
+	}
+	c1, _ := newReq(t, `{"userId":"bob"}`)
+	setUser(c1, "alice")
+	require.NoError(t, h.Create(c1))
+	c, rec := newReq(t, `{}`)
+	setUser(c, "alice")
+	return h, rec, c
+}
+
+// TestList_GatesFollowersCount: followers-only count を非フォロワー viewer に
+// leak させない (#1985)。
+func TestList_GatesFollowersCount(t *testing.T) {
+	h, rec, c := newGatedHandler(t, nil)
+	require.NoError(t, h.List(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	mutee := resp[0]["mutee"].(map[string]any)
+	assert.EqualValues(t, 0, mutee["followersCount"], "followers-only count は非フォロワーに leak しない (#1985)")
+}
+
+// TestList_ModeratorSeesFollowersCount: moderator viewer には gate をかけない。
+func TestList_ModeratorSeesFollowersCount(t *testing.T) {
+	h, rec, c := newGatedHandler(t, modStub{mods: map[string]bool{"alice": true}})
+	require.NoError(t, h.List(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	mutee := resp[0]["mutee"].(map[string]any)
+	assert.EqualValues(t, 7, mutee["followersCount"], "moderator viewer には count を見せる (#1985)")
+}
+
 func TestList_LimitClamping(t *testing.T) {
 	h, _ := newHandler(t)
 	c, rec := newReq(t, `{"limit":1000}`)

--- a/internal/api/users/handler_p189_test.go
+++ b/internal/api/users/handler_p189_test.go
@@ -156,6 +156,90 @@ func TestGetFrequentlyRepliedUsers_VisibilityIDOR(t *testing.T) {
 	assert.Equal(t, target1.ID, u["id"])
 }
 
+// p189ModStub implements users.ModeratorChecker for the count-gate tests.
+type p189ModStub struct{ mods map[string]bool }
+
+func (m p189ModStub) IsModerator(id string) bool     { return m.mods[id] }
+func (m p189ModStub) IsAdministrator(id string) bool { return m.mods[id] }
+
+// seedFollowersOnly registers a user with followersVisibility=followers and
+// followersCount=7 so the count-gate behavior can be observed.
+func seedFollowersOnly(k *p189Kit, id string) {
+	k.userRepo.Users[id] = &model.User{ID: id, Username: id, FollowersCount: 7}
+	k.userRepo.Profiles[id] = &model.UserProfile{
+		UserID:              id,
+		FollowersVisibility: model.FollowingVisibilityFollowers,
+		FollowingVisibility: model.FollowingVisibilityPublic,
+	}
+}
+
+// #1985: get-frequently-replied-users の embed user の followers-only count は
+// 非フォロワー viewer に leak しない。
+func TestGetFrequentlyRepliedUsers_GatesFollowersCount(t *testing.T) {
+	k := newP189Kit(t)
+	k.userRepo.Users["auth"] = &model.User{ID: "auth", Username: "auth"}
+	seedFollowersOnly(k, "bob")
+	replyDummy, bobID := "src", "bob"
+	k.noteRepo.Notes["np"] = &model.Note{ID: "np", UserID: "auth", ReplyID: &replyDummy, ReplyUserID: &bobID, Visibility: model.NoteVisibilityPublic}
+
+	// 非フォロワー viewer: count は 0 に潰される。
+	rec := postP189(k.h.GetFrequentlyRepliedUsers, `{"userId":"auth","limit":10}`, &model.User{ID: "stranger"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	u := out[0]["user"].(map[string]any)
+	assert.EqualValues(t, 0, u["followersCount"], "followers-only count は非フォロワーに leak しない (#1985)")
+}
+
+// #1985: moderator viewer には count をそのまま見せる。
+func TestGetFrequentlyRepliedUsers_ModeratorSeesFollowersCount(t *testing.T) {
+	k := newP189Kit(t)
+	k.h.SetModeratorChecker(p189ModStub{mods: map[string]bool{"mod": true}})
+	k.userRepo.Users["auth"] = &model.User{ID: "auth", Username: "auth"}
+	seedFollowersOnly(k, "bob")
+	replyDummy, bobID := "src", "bob"
+	k.noteRepo.Notes["np"] = &model.Note{ID: "np", UserID: "auth", ReplyID: &replyDummy, ReplyUserID: &bobID, Visibility: model.NoteVisibilityPublic}
+
+	rec := postP189(k.h.GetFrequentlyRepliedUsers, `{"userId":"auth","limit":10}`, &model.User{ID: "mod"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	u := out[0]["user"].(map[string]any)
+	assert.EqualValues(t, 7, u["followersCount"], "moderator viewer には count を見せる (#1985)")
+}
+
+// #1985: users/recommendation の embed user の followers-only count も gate する。
+func TestUserRecommendation_GatesFollowersCount(t *testing.T) {
+	k := newP189Kit(t)
+	now := time.Now()
+	k.userRepo.Users["me"] = &model.User{ID: "me"}
+	// recommend 対象 r1 は followers-only の count。me は r1 を follow していない。
+	k.userRepo.Users["r1"] = &model.User{ID: "r1", Username: "r1", IsExplorable: true, UpdatedAt: &now, FollowersCount: 7}
+	k.userRepo.Profiles["r1"] = &model.UserProfile{
+		UserID:              "r1",
+		FollowersVisibility: model.FollowingVisibilityFollowers,
+		FollowingVisibility: model.FollowingVisibilityPublic,
+	}
+
+	rec := postP189(k.h.UserRecommendation, `{"limit":10}`, &model.User{ID: "me"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	assert.EqualValues(t, 0, out[0]["followersCount"], "followers-only count は非フォロワーに leak しない (#1985)")
+
+	// moderator viewer には count を見せる。
+	k.h.SetModeratorChecker(p189ModStub{mods: map[string]bool{"me": true}})
+	rec = postP189(k.h.UserRecommendation, `{"limit":10}`, &model.User{ID: "me"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	out = out[:0]
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	assert.EqualValues(t, 7, out[0]["followersCount"], "moderator viewer には count を見せる (#1985)")
+}
+
 // --- GetFollowingUsersByBirthday ---
 
 func TestGetFollowingUsersByBirthday_SingleDayMatch(t *testing.T) {

--- a/internal/api/users/recommendation.go
+++ b/internal/api/users/recommendation.go
@@ -29,10 +29,12 @@ func (h *Handler) GetFrequentlyRepliedUsers(c echo.Context) error {
 	if _, err := h.userService.ShowByID(req.UserID); err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "e6965129-7b2a-40a4-bae2-cd84cd434822"))
 	}
+	viewer := middleware.GetUser(c)
 	var viewerID string
-	if viewer := middleware.GetUser(c); viewer != nil {
+	if viewer != nil {
 		viewerID = viewer.ID
 	}
+	iAmModerator := viewer != nil && h.moderatorChecker != nil && h.moderatorChecker.IsModerator(viewer.ID)
 	rows, err := h.noteRepo.CountReplyTargets(req.UserID, viewerID, req.Limit)
 	if err != nil {
 		return apierr.JSONInternalError(c)
@@ -56,7 +58,11 @@ func (h *Handler) GetFrequentlyRepliedUsers(c echo.Context) error {
 		}
 		d := entity.PackUserDetailed(bundle.User, bundle.Profile, h.idGen)
 		// 認証 viewer には viewer->user の relation block を付与 (upstream packMany(users, me)、#1973)。
-		h.viewerRelationRepos().Apply(&d, viewerID, bundle.User, bundle.Profile)
+		viewerIsFollowing := h.viewerRelationRepos().Apply(&d, viewerID, bundle.User, bundle.Profile)
+		// followers-only count を非フォロワーに leak させない (upstream UserEntityService の
+		// count gate、#1985)。
+		isMe := viewer != nil && viewer.ID == bundle.User.ID
+		entity.GateCountVisibility(&d, isMe, iAmModerator, viewerIsFollowing)
 		out = append(out, map[string]any{
 			"user":   d,
 			"weight": weight,
@@ -176,6 +182,7 @@ func (h *Handler) UserRecommendation(c echo.Context) error {
 		return apierr.JSONInvalidParam(c)
 	}
 	clampListLimit(&req.Limit)
+	iAmModerator := viewer != nil && h.moderatorChecker != nil && h.moderatorChecker.IsModerator(viewer.ID)
 	users, err := h.userService.ListRecommendations(viewer.ID, time.Now().AddDate(0, 0, -7), req.Limit, req.Offset)
 	if err != nil {
 		return apierr.JSONInternalError(c)
@@ -185,7 +192,12 @@ func (h *Handler) UserRecommendation(c echo.Context) error {
 		profile := h.userService.GetProfile(u.ID)
 		d := entity.PackUserDetailed(u, profile, h.idGen)
 		// 認証 viewer には viewer->user の relation block を付与 (upstream packMany(users, me)、#1973)。
-		h.viewerRelationRepos().Apply(&d, viewer.ID, u, profile)
+		viewerIsFollowing := h.viewerRelationRepos().Apply(&d, viewer.ID, u, profile)
+		// followers-only count を非フォロワーに leak させない (upstream UserEntityService の
+		// count gate、#1985)。recommendation は未フォロー/非 self のみ返すため通常 isMe/isFollowing
+		// は false だが、moderator viewer には count を見せる upstream 挙動に揃える。
+		isMe := viewer != nil && viewer.ID == u.ID
+		entity.GateCountVisibility(&d, isMe, iAmModerator, viewerIsFollowing)
 		out = append(out, d)
 	}
 	return c.JSON(http.StatusOK, out)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1740,6 +1740,7 @@ func (s *Server) setupRoutes() {
 		FollowRequest: followRequestRepo,
 		Memo:          repository.NewUserMemoRepository(s.db),
 	})
+	blockingHandler.SetModeratorChecker(roleService) // #1985: blocking/list の count gate で moderator viewer 判定
 	api.POST("/blocking/create", blockingHandler.Create, middleware.RequireAuth(), middleware.RequireScope("write:blocks"))
 	api.POST("/blocking/delete", blockingHandler.Delete, middleware.RequireAuth(), middleware.RequireScope("write:blocks"))
 	api.POST("/blocking/list", blockingHandler.List, middleware.RequireAuth(), middleware.RequireScope("read:blocks"))
@@ -1747,6 +1748,7 @@ func (s *Server) setupRoutes() {
 	// Mute endpoints
 	muteHandler := mute.NewHandler(mutingService, userRepo, idGen)
 	muteHandler.SetRelationRepos(listRelationRepos)
+	muteHandler.SetModeratorChecker(roleService) // #1985: mute/list の count gate で moderator viewer 判定
 	api.POST("/mute/create", muteHandler.Create, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:mutes"))
 	api.POST("/mute/delete", muteHandler.Delete, middleware.RequireAuth(), middleware.RequireScope("write:mutes"))
 	api.POST("/mute/list", muteHandler.List, middleware.RequireAuth(), middleware.RequireScope("read:mutes"))
@@ -1754,6 +1756,7 @@ func (s *Server) setupRoutes() {
 	// Renote mute endpoints
 	renoteMuteHandler := renotemute.NewHandler(renoteMutingService, userRepo, idGen)
 	renoteMuteHandler.SetRelationRepos(listRelationRepos)
+	renoteMuteHandler.SetModeratorChecker(roleService) // #1985: renote-mute/list の count gate で moderator viewer 判定
 	api.POST("/renote-mute/create", renoteMuteHandler.Create, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:mutes"))
 	api.POST("/renote-mute/delete", renoteMuteHandler.Delete, middleware.RequireAuth(), middleware.RequireScope("write:mutes"))
 	api.POST("/renote-mute/list", renoteMuteHandler.List, middleware.RequireAuth(), middleware.RequireScope("read:mutes"))


### PR DESCRIPTION
## Summary

embed UserDetailed を返す list endpoint の count visibility gate を upstream Misskey と
横断的に揃える (#1985)。#1980 (search の viewer-relation) の敵対的レビューで発見した、
followers-only の `followersCount`/`followingCount` が非フォロワー viewer に leak する
parity gap を塞ぐ。

upstream は authed viewer 向けの UserDetailed list を `packMany(_, me, ...)` で返し、
`UserEntityService` の count gate (`isMe || iAmModerator || (visibility==='followers' &&
isFollowing)`) が走る。mk-go では `entity.GateCountVisibility` を呼ぶ endpoint と呼ばない
endpoint が混在し、以下で count が leak していた。

## 主な変更点

- `internal/api/users/recommendation.go` `GetFrequentlyRepliedUsers` / `UserRecommendation`:
  `Apply` の戻り値 `viewerIsFollowing` と `iAmModerator` を `GateCountVisibility` に渡す。
- `internal/api/mute/handler.go` `fetchMuteeMap` (mute/list): 同上 + `ModeratorChecker` を
  追加配線。
- `internal/api/renotemute/handler.go` `fetchMuteeMap` (renote-mute/list): 同上。
- `internal/api/blocking/handler.go` `fetchBlockeeMap` (blocking/list): 同上。
- `internal/api/blocking/handler.go` `respondPackedUser` (blocking/create・delete のレスポンス):
  敵対的レビューで発見した同一 class の leak。upstream `blocking/create.ts:104` /
  `delete.ts:105` は `pack(blockee, blocker, UserDetailedNotMe)` で gate を通すため、
  本 PR に取り込んだ。
- `internal/server/router.go`: mute/renote-mute/blocking の各ハンドラに
  `SetModeratorChecker(roleService)` を配線。

`isMe` は mute/blocking/renote-mute では mutee/blockee が viewer 自身になり得ないため常に
false。匿名 viewer (`viewerID==""`) では `iAmModerator` が false に短絡し fail-closed。

## テスト

- `internal/api/{mute,renotemute,blocking}/handler_test.go`:
  `TestList_GatesFollowersCount` (非フォロワーで count=0) / `TestList_ModeratorSeesFollowersCount`
  (moderator で count 保持)。blocking はさらに `TestCreate_GatesFollowersCount` /
  `TestCreate_ModeratorSeesFollowersCount`。
- `internal/api/users/handler_p189_test.go`: `TestGetFrequentlyRepliedUsers_GatesFollowersCount`
  / `..._ModeratorSeesFollowersCount` / `TestUserRecommendation_GatesFollowersCount` (gate +
  moderator)。
- 各 package カバレッジ: mute 96.2% / renotemute 95.8% / blocking 94.0% / users 90.4%。
  `make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで、federation の `federation/users`・`federation/followers`・`federation/following`
にも同種の count gate 欠如 (匿名到達可能なため誰にでも leak) が残ることを発見した。別 package
(federation) のため本 PR スコープ外とし、別 issue として切り出す。

## 関連

- 親: #1948
- 発見元: #1980 の敵対的レビュー

Closes #1985
