### PR TITLE
Fix count visibility parity (#1988): federation/{users,followers,following} の embed user に count gate を適用

### DIFF
--- a/internal/api/federation/host_listings.go
+++ b/internal/api/federation/host_listings.go
@@ -94,12 +94,16 @@ func (h *Handler) Users(c echo.Context) error {
 	// いた (#1544)。UserDetailed で pack して shape を揃える。user_profile は
 	// 1 batch で解決して N+1 を回避。
 	viewerID := viewerIDOf(c)
+	iAmModerator := h.moderator != nil && viewerID != "" && h.moderator.IsModerator(viewerID)
 	profByID := h.userProfiles(users)
 	out := make([]entity.UserDetailed, 0, len(users))
 	for _, u := range users {
 		d := entity.PackUserDetailed(u, profByID[u.ID], h.idGen)
 		// 認証 caller には viewer->user の relation block を付与 (匿名/self は no-op、#1957-a)。
-		h.relation.Apply(&d, viewerID, u, profByID[u.ID])
+		viewerIsFollowing := h.relation.Apply(&d, viewerID, u, profByID[u.ID])
+		// followers-only count を非フォロワー (federation/* は requireCredential:false なので
+		// 匿名含む) に leak させない (upstream packMany(users, me) の count gate、#1988)。
+		entity.GateCountVisibility(&d, u.ID == viewerID, iAmModerator, viewerIsFollowing)
 		out = append(out, d)
 	}
 	return c.JSON(http.StatusOK, out)
@@ -162,6 +166,7 @@ func parseHostPage(c echo.Context) (hostPageRequest, bool) {
 // 場合 (= test 等で未配線) は followee を埋めずに id 系フィールドだけ返す。
 func (h *Handler) packFollowings(viewerID string, rows []*model.Following) []entity.Following {
 	lookup := h.followeeLookup(rows)
+	iAmModerator := h.moderator != nil && viewerID != "" && h.moderator.IsModerator(viewerID)
 	out := make([]entity.Following, 0, len(rows))
 	for _, f := range rows {
 		// populateFollowee=true / populateFollower=false (本家と同じ)。
@@ -169,7 +174,10 @@ func (h *Handler) packFollowings(viewerID string, rows []*model.Following) []ent
 		// embed followee に viewer 視点の relation block を付与 (#1957-a)。
 		if pf.Followee != nil {
 			if u, p := lookup(f.FolloweeID); u != nil {
-				h.relation.Apply(pf.Followee, viewerID, u, p)
+				viewerIsFollowing := h.relation.Apply(pf.Followee, viewerID, u, p)
+				// followers-only count を非フォロワー (匿名含む) に leak させない
+				// (upstream FollowingEntityService が followee を pack(_, me) で gate、#1988)。
+				entity.GateCountVisibility(pf.Followee, u.ID == viewerID, iAmModerator, viewerIsFollowing)
 			}
 		}
 		out = append(out, pf)

--- a/internal/api/federation/host_listings_test.go
+++ b/internal/api/federation/host_listings_test.go
@@ -293,6 +293,101 @@ func TestFollowers_FolloweeCarriesViewerRelation(t *testing.T) {
 	assert.False(t, has, "匿名には followee relation を出さない (#1957-a)")
 }
 
+// #1988: federation/users の embed user の followers-only count は非フォロワー
+// (federation/* は requireCredential:false なので匿名含む) に leak しない。
+func TestUsers_GatesFollowersCount(t *testing.T) {
+	h, _ := newHandler(t)
+	idGen, _ := id.NewGenerator("aidx")
+	h.SetIDGen(idGen)
+	userRepo := testutil.NewMockUserRepository()
+	remote := "remote.example"
+	userRepo.Users["r1"] = &model.User{ID: "r1", Username: "r1", Host: &remote, FollowersCount: 7}
+	userRepo.Profiles["r1"] = &model.UserProfile{
+		UserID:              "r1",
+		FollowersVisibility: model.FollowingVisibilityFollowers,
+		FollowingVisibility: model.FollowingVisibilityPublic,
+	}
+	h.SetUserRepo(userRepo)
+	h.SetRelationRepos(userrelation.Repos{Following: testutil.NewMockFollowingRepository()})
+
+	// 匿名 caller: followers-only count は 0 に潰される。
+	rec := postBody(h.Users, `{"host":"remote.example","limit":10}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.EqualValues(t, 0, rows[0]["followersCount"], "followers-only count は匿名に leak しない (#1988)")
+
+	// moderator caller: count をそのまま見せる。
+	h.SetModeratorChecker(fakeModerator{ids: map[string]bool{"mod1": true}})
+	rec = postBodyAs(h.Users, `{"host":"remote.example","limit":10}`, "mod1")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var modRows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &modRows))
+	require.Len(t, modRows, 1)
+	assert.EqualValues(t, 7, modRows[0]["followersCount"], "moderator には count を見せる (#1988)")
+}
+
+// #1988: federation/followers の embed followee の followers-only count も非フォロワー
+// (匿名含む) に leak しない。
+func TestFollowers_FolloweeGatesFollowersCount(t *testing.T) {
+	h, _ := newHandler(t)
+	idGen, _ := id.NewGenerator("aidx")
+	h.SetIDGen(idGen)
+	userRepo := testutil.NewMockUserRepository()
+	remote := "remote.example"
+	userRepo.Users["rf1"] = &model.User{ID: "rf1", Username: "rf1", Host: &remote, FollowersCount: 7}
+	userRepo.Profiles["rf1"] = &model.UserProfile{
+		UserID:              "rf1",
+		FollowersVisibility: model.FollowingVisibilityFollowers,
+		FollowingVisibility: model.FollowingVisibilityPublic,
+	}
+	h.SetUserRepo(userRepo)
+	followingRepo := testutil.NewMockFollowingRepository()
+	followingRepo.Followings["f_listed"] = &model.Following{ID: "f_listed", FollowerID: "someone", FolloweeID: "rf1", FolloweeHost: &remote}
+	h.SetFollowingRepo(followingRepo)
+	h.SetRelationRepos(userrelation.Repos{Following: followingRepo})
+
+	// 匿名: embed followee の followers-only count は 0。
+	rec := postBody(h.Followers, `{"host":"remote.example","limit":10}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	followee := rows[0]["followee"].(map[string]any)
+	assert.EqualValues(t, 0, followee["followersCount"], "followee の followers-only count は匿名に leak しない (#1988)")
+}
+
+// #1988: federation/following も同じ packFollowings 経路を通るため、embed followee の
+// followers-only count が非フォロワー (匿名含む) に leak しないことを明示的に確認する。
+func TestFollowing_FolloweeGatesFollowersCount(t *testing.T) {
+	h, _ := newHandler(t)
+	idGen, _ := id.NewGenerator("aidx")
+	h.SetIDGen(idGen)
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["lf1"] = &model.User{ID: "lf1", Username: "lf1", FollowersCount: 7}
+	userRepo.Profiles["lf1"] = &model.UserProfile{
+		UserID:              "lf1",
+		FollowersVisibility: model.FollowingVisibilityFollowers,
+		FollowingVisibility: model.FollowingVisibilityPublic,
+	}
+	h.SetUserRepo(userRepo)
+	followingRepo := testutil.NewMockFollowingRepository()
+	remote := "remote.example"
+	// federation/following は followerHost=remote の行が対象 (embed されるのは followee=lf1)。
+	followingRepo.Followings["f_listed"] = &model.Following{ID: "f_listed", FollowerID: "someone", FollowerHost: &remote, FolloweeID: "lf1"}
+	h.SetFollowingRepo(followingRepo)
+	h.SetRelationRepos(userrelation.Repos{Following: followingRepo})
+
+	rec := postBody(h.Following, `{"host":"remote.example","limit":10}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	followee := rows[0]["followee"].(map[string]any)
+	assert.EqualValues(t, 0, followee["followersCount"], "followee の followers-only count は匿名に leak しない (#1988)")
+}
+
 func TestUsers_FiltersByHost(t *testing.T) {
 	h, _ := newHandler(t)
 	userRepo := testutil.NewMockUserRepository()


### PR DESCRIPTION
## Summary

federation の list endpoint の embed user に count visibility gate を追加する (#1988)。
#1985 の敵対的レビューで発見した、federation package 側の同種 parity gap。

`federation/users`・`federation/followers`・`federation/following` は embed UserDetailed を
upstream の `packMany(_, me, {schema:'UserDetailedNotMe'})` (followers/following は
`FollowingEntityService` 経由) で返し、`UserEntityService` の count gate
(`isMe || iAmModerator || (visibility==='followers' && isFollowing)`) が走る。mk-go は
`relation.Apply` で relation block は付与していたが `entity.GateCountVisibility` を呼んでおらず、
followers-only 可視性ユーザーの `followersCount`/`followingCount` が leak していた。さらにこれら
3 endpoint は `requireCredential:false` のため**匿名 viewer にも leak**していた (#1985 が塞いだ
mute/block list は authed-only だったのに対し影響範囲が広い)。

## 主な変更点

- `internal/api/federation/host_listings.go` `Users` (federation/users): `Apply` の戻り値
  `viewerIsFollowing` と `iAmModerator` を `GateCountVisibility` に渡す。
- `internal/api/federation/host_listings.go` `packFollowings` (federation/followers・following 共用):
  embed followee に同 gate を適用。

federation handler は既に `viewerIDOf` / `h.relation` / `SetModeratorChecker`(`h.moderator`)を
持つため追加配線は不要。`iAmModerator` は `h.moderator != nil && viewerID != "" &&
IsModerator(viewerID)` で匿名は fail-closed (mute/blocking/renote-mute と同一パターン)。

## テスト

- `internal/api/federation/host_listings_test.go`:
  - `TestUsers_GatesFollowersCount`: 匿名で count=0、moderator で count=7。
  - `TestFollowers_FolloweeGatesFollowersCount` / `TestFollowing_FolloweeGatesFollowersCount`:
    embed followee の followers-only count が匿名に leak しない。
- federation package カバレッジ 93.1%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで upstream の `following.ts:59` / `followers.ts:59` が**両方とも**
`packMany(_, me, {populateFollowee:true})` で followee を pack することを確認し、mk-go が両者で
`PackFollowing(_, true, false, ...)` を使い回す実装が parity 一致であることを照合した。

## 関連

- 親: #1948
- 発見元: #1985 の敵対的レビュー

Closes #1988
