### PR TITLE
Fix datetime parity (#1948-10): time.Time packer を toISOString() の .000Z 形式に揃える

### DIFF
--- a/internal/api/admin/abuse_report_notification.go
+++ b/internal/api/admin/abuse_report_notification.go
@@ -22,16 +22,19 @@ type packedRecipient struct {
 	// RFC3339Nano (秒ちょうどは .000 を落とし、非 UTC は +09:00 表記) になり、
 	// upstream の Date.toISOString() (常に 3 桁ミリ秒 + Z) と乖離する。entity 層と
 	// 同じ canonical layout で文字列化し、embedded 側の updatedAt を shadow する。
-	UpdatedAt     string               `json:"updatedAt"`
-	User          *entity.UserLite     `json:"user,omitempty"`
-	SystemWebhook *model.SystemWebhook `json:"systemWebhook,omitempty"`
+	UpdatedAt string           `json:"updatedAt"`
+	User      *entity.UserLite `json:"user,omitempty"`
+	// systemWebhook は upstream SystemWebhookEntityService.pack shape で返す。
+	// model 直埋め込みだと updatedAt/latestSentAt が RFC3339Nano になるため
+	// packSystemWebhook 経由で .000Z に揃える (#1948-10)。
+	SystemWebhook map[string]any `json:"systemWebhook,omitempty"`
 }
 
 // packRecipient resolves the recipient's user / systemWebhook for the response
 // (upstream AbuseReportNotificationRecipientEntityService.pack).
 func (h *Handler) packRecipient(r *model.AbuseReportNotificationRecipient) packedRecipient {
 	p := packedRecipient{AbuseReportNotificationRecipient: r}
-	p.UpdatedAt = r.UpdatedAt.UTC().Format("2006-01-02T15:04:05.000Z")
+	p.UpdatedAt = entity.ISOMillis(r.UpdatedAt)
 	if r.UserID != nil && *r.UserID != "" && h.userRepo != nil {
 		if u, err := h.userRepo.FindByID(*r.UserID); err == nil && u != nil {
 			lite := entity.PackUserLite(u)
@@ -40,7 +43,7 @@ func (h *Handler) packRecipient(r *model.AbuseReportNotificationRecipient) packe
 	}
 	if r.SystemWebhookID != nil && *r.SystemWebhookID != "" && h.systemWebhookRepo != nil {
 		if w, err := h.systemWebhookRepo.FindByID(*r.SystemWebhookID); err == nil && w != nil {
-			p.SystemWebhook = w
+			p.SystemWebhook = packSystemWebhook(w)
 		}
 	}
 	return p

--- a/internal/api/admin/drive_emoji_test.go
+++ b/internal/api/admin/drive_emoji_test.go
@@ -793,6 +793,27 @@ func TestEmojiListV2_RoleObjectsAndShape(t *testing.T) {
 	shapetest.Assert(t, "EmojiDetailedAdmin", em) // L3 (#1300)
 }
 
+// #1948-10: EmojiDetailedAdmin の updatedAt は upstream toISOString() (.000Z / null)。
+// raw *time.Time の RFC3339Nano だと wire-byte が乖離する。
+func TestEmojiListV2_UpdatedAtFormat(t *testing.T) {
+	upd := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	h, _ := setupEmojiHandler(t,
+		&model.Emoji{ID: "e1", Name: "smile", PublicURL: "https://example.com/s.png", UpdatedAt: &upd},
+		&model.Emoji{ID: "e2", Name: "wave", PublicURL: "https://example.com/w.png"}, // updatedAt nil
+	)
+	rec := doPost(h.EmojiListV2, `{}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	byID := map[string]map[string]any{}
+	for _, raw := range resp["emojis"].([]any) {
+		em := raw.(map[string]any)
+		byID[em["id"].(string)] = em
+	}
+	assert.Equal(t, "2026-01-02T03:04:05.000Z", byID["e1"]["updatedAt"], "updatedAt は .000Z (#1948-10)")
+	assert.Nil(t, byID["e2"]["updatedAt"], "nil updatedAt は null (#1948-10)")
+}
+
 func TestEmojiListV2_NilRepo(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	rec := doPost(h.EmojiListV2, `{}`, adminUser)

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -2745,8 +2745,10 @@ func packEmojiDetailedAdmin(e *model.Emoji, roleNames map[string]string) map[str
 		aliases = []string{}
 	}
 	return map[string]any{
-		"id":          e.ID,
-		"updatedAt":   e.UpdatedAt,
+		"id": e.ID,
+		// upstream EmojiEntityService.ts:112 は updatedAt?.toISOString() ?? null。
+		// raw *time.Time だと RFC3339Nano になるため .000Z/null に揃える (#1948-10)。
+		"updatedAt":   entity.ISOMillisPtr(e.UpdatedAt),
 		"name":        e.Name,
 		"host":        e.Host,
 		"publicUrl":   e.PublicURL,

--- a/internal/api/admin/system_webhook.go
+++ b/internal/api/admin/system_webhook.go
@@ -9,8 +9,35 @@ import (
 
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/core/moderationlog"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/model"
 )
+
+// packSystemWebhook serializes a SystemWebhook into the upstream
+// SystemWebhookEntityService.pack shape (SystemWebhookEntityService.ts:33-43):
+// the same 9 fields the model carries, but with updatedAt / latestSentAt
+// rendered via Date.toISOString() (.000Z) rather than the model's raw time.Time
+// (which encoding/json would emit as RFC3339Nano). Returning the model directly
+// diverged on those two timestamp fields (#1948-10).
+func packSystemWebhook(w *model.SystemWebhook) map[string]any {
+	// on は string[] 必須 (non-null)。nil pq.StringArray は null になるため
+	// [] へ coalesce する (model 直返し時の pq.StringArray と同じ array 表現を維持)。
+	on := []string(w.On)
+	if on == nil {
+		on = []string{}
+	}
+	return map[string]any{
+		"id":           w.ID,
+		"isActive":     w.IsActive,
+		"updatedAt":    entity.ISOMillis(w.UpdatedAt),
+		"latestSentAt": entity.ISOMillisPtr(w.LatestSentAt),
+		"latestStatus": w.LatestStatus,
+		"name":         w.Name,
+		"on":           on,
+		"url":          w.URL,
+		"secret":       w.Secret,
+	}
+}
 
 // systemWebhookEventTypes is the allow-list of system webhook `on` event types,
 // mirroring upstream models/SystemWebhook.ts systemWebhookEventTypes (#1542)。
@@ -98,7 +125,7 @@ func (h *Handler) SystemWebhookCreate(c echo.Context) error {
 		"systemWebhookId": sw.ID,
 		"webhook":         sw,
 	})
-	return c.JSON(http.StatusOK, sw)
+	return c.JSON(http.StatusOK, packSystemWebhook(sw))
 }
 
 // SystemWebhookDelete handles POST /api/admin/system-webhook/delete.
@@ -135,7 +162,11 @@ func (h *Handler) SystemWebhookList(c echo.Context) error {
 	if rows == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
-	return c.JSON(http.StatusOK, rows)
+	out := make([]map[string]any, 0, len(rows))
+	for _, w := range rows {
+		out = append(out, packSystemWebhook(w))
+	}
+	return c.JSON(http.StatusOK, out)
 }
 
 // SystemWebhookShow handles POST /api/admin/system-webhook/show.
@@ -151,7 +182,7 @@ func (h *Handler) SystemWebhookShow(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.NotFound())
 	}
-	return c.JSON(http.StatusOK, sw)
+	return c.JSON(http.StatusOK, packSystemWebhook(sw))
 }
 
 // SystemWebhookTest handles POST /api/admin/system-webhook/test.
@@ -253,5 +284,5 @@ func (h *Handler) SystemWebhookUpdate(c echo.Context) error {
 		"before":          before,
 		"after":           sw,
 	})
-	return c.JSON(http.StatusOK, sw)
+	return c.JSON(http.StatusOK, packSystemWebhook(sw))
 }

--- a/internal/api/admin/system_webhook_test.go
+++ b/internal/api/admin/system_webhook_test.go
@@ -101,6 +101,39 @@ func TestSystemWebhookList_ReturnsRows(t *testing.T) {
 	assert.Equal(t, "w1", rows[1].ID)
 }
 
+// #1948-10: SystemWebhook の updatedAt / latestSentAt は upstream toISOString()
+// (.000Z / null) で返す。raw time.Time の RFC3339Nano だと wire-byte が乖離する。
+func TestSystemWebhookShow_DateFormat(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	repo := testutil.NewMockSystemWebhookRepository()
+	sent := time.Date(2026, 6, 21, 1, 2, 3, 456_000_000, time.UTC)
+	// w1: 秒ちょうど (RFC3339Nano なら .000 を落とす) updatedAt + latestSentAt set。
+	require.NoError(t, repo.Create(&model.SystemWebhook{
+		ID: "w1", Name: "hook", URL: "u", IsActive: true,
+		UpdatedAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC), LatestSentAt: &sent,
+	}))
+	// w2: latestSentAt nil。
+	require.NoError(t, repo.Create(&model.SystemWebhook{
+		ID: "w2", Name: "hook2", URL: "u", IsActive: true,
+		UpdatedAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+	}))
+	h.SetSystemWebhookRepo(repo)
+
+	rec := doPost(h.SystemWebhookShow, `{"id":"w1"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "2026-01-02T03:04:05.000Z", got["updatedAt"], "updatedAt は .000Z 形式 (#1948-10)")
+	assert.Equal(t, "2026-06-21T01:02:03.456Z", got["latestSentAt"], "latestSentAt は .000Z 形式 (#1948-10)")
+	// createdAt は upstream SystemWebhook pack に無い (model にも無い) → 露出しない。
+	_, hasCreatedAt := got["createdAt"]
+	assert.False(t, hasCreatedAt, "createdAt は SystemWebhook shape に含まれない")
+
+	rec = doPost(h.SystemWebhookShow, `{"id":"w2"}`, adminUser)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Nil(t, got["latestSentAt"], "latestSentAt nil は null (#1948-10)")
+}
+
 func TestSystemWebhookShow_FoundAndNotFound(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	repo := testutil.NewMockSystemWebhookRepository()

--- a/internal/api/federation/handler.go
+++ b/internal/api/federation/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/userrelation"
 	corefederation "github.com/shiroha-a/mk/internal/core/federation"
 	coreinstance "github.com/shiroha-a/mk/internal/core/instance"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -229,7 +230,7 @@ func instanceToMap(inst *model.Instance, hosts coreinstance.FederationHostSets, 
 	}
 	return map[string]any{
 		"id":                      inst.ID,
-		"firstRetrievedAt":        inst.FirstRetrievedAt,
+		"firstRetrievedAt":        entity.ISOMillis(inst.FirstRetrievedAt),
 		"host":                    inst.Host,
 		"usersCount":              inst.UsersCount,
 		"notesCount":              inst.NotesCount,
@@ -238,7 +239,7 @@ func instanceToMap(inst *model.Instance, hosts coreinstance.FederationHostSets, 
 		"federating":              inst.FollowingCount > 0 || inst.FollowersCount > 0,
 		"subscribing":             inst.FollowersCount > 0,
 		"publishing":              inst.FollowingCount > 0,
-		"latestRequestReceivedAt": inst.LatestRequestReceivedAt,
+		"latestRequestReceivedAt": entity.ISOMillisPtr(inst.LatestRequestReceivedAt),
 		"isNotResponding":         inst.IsNotResponding,
 		"notRespondingSince":      inst.NotRespondingSince,
 		"isSuspended":             isSuspended,
@@ -256,7 +257,7 @@ func instanceToMap(inst *model.Instance, hosts coreinstance.FederationHostSets, 
 		"iconUrl":                 inst.IconURL,
 		"faviconUrl":              inst.FaviconURL,
 		"themeColor":              inst.ThemeColor,
-		"infoUpdatedAt":           inst.InfoUpdatedAt,
+		"infoUpdatedAt":           entity.ISOMillisPtr(inst.InfoUpdatedAt),
 		"moderationNote":          moderationNote,
 	}
 }

--- a/internal/api/federation/handler_test.go
+++ b/internal/api/federation/handler_test.go
@@ -98,6 +98,26 @@ func TestInstances_Empty(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// #1948-10: instance の firstRetrievedAt / infoUpdatedAt / latestRequestReceivedAt
+// は upstream toISOString() (.000Z / null)。raw time.Time の RFC3339Nano だと乖離。
+func TestShowInstance_DateFormat(t *testing.T) {
+	h, repo := newHandler(t)
+	inst := seedInstance(t, repo, "alpha.example")
+	inst.FirstRetrievedAt = time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	infoUpdated := time.Date(2026, 6, 21, 1, 2, 3, 456_000_000, time.UTC)
+	inst.InfoUpdatedAt = &infoUpdated
+	// latestRequestReceivedAt は nil のまま → null。
+
+	c, rec := newReq(t, `{"host":"alpha.example"}`)
+	require.NoError(t, h.ShowInstance(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "2026-01-02T03:04:05.000Z", resp["firstRetrievedAt"], "firstRetrievedAt は .000Z (#1948-10)")
+	assert.Equal(t, "2026-06-21T01:02:03.456Z", resp["infoUpdatedAt"], "infoUpdatedAt は .000Z (#1948-10)")
+	assert.Nil(t, resp["latestRequestReceivedAt"], "nil は null (#1948-10)")
+}
+
 // fakeModerator implements ModeratorChecker for the moderationNote gate tests.
 type fakeModerator struct{ ids map[string]bool }
 

--- a/internal/api/i/registry.go
+++ b/internal/api/i/registry.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 )
 
@@ -80,7 +81,8 @@ func (h *Handler) RegistryGetDetail(c echo.Context) error {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_KEY", "No such key.", "97a1e8e7-c0f7-47d2-957a-92e61256e01a"))
 	}
 	return c.JSON(http.StatusOK, map[string]any{
-		"updatedAt": item.UpdatedAt,
+		// upstream i/registry/get-detail.ts:62 は updatedAt.toISOString()。
+		"updatedAt": entity.ISOMillis(item.UpdatedAt),
 		"value":     item.Value,
 		"scope":     []string(item.Scope),
 		"domain":    item.Domain,

--- a/internal/api/i/registry_test.go
+++ b/internal/api/i/registry_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/lib/pq"
@@ -168,6 +169,23 @@ func TestRegistryGetDetail_Found(t *testing.T) {
 	h.SetRegistryRepo(reg)
 	rec := postExtra(h.RegistryGetDetail, `{"key":"theme"}`, stubUser)
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// #1948-10: get-detail の updatedAt は upstream toISOString() (.000Z)。
+// raw time.Time の RFC3339Nano だと wire-byte が乖離する。
+func TestRegistryGetDetail_UpdatedAtFormat(t *testing.T) {
+	h, _ := newExtraHandler(t)
+	reg := testutil.NewMockRegistryRepository()
+	require.NoError(t, reg.Set(&model.RegistryItem{
+		ID: "r1", UserID: stubUser.ID, Key: "theme", Value: datatypes.JSON(`"dark"`),
+		UpdatedAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+	}))
+	h.SetRegistryRepo(reg)
+	rec := postExtra(h.RegistryGetDetail, `{"key":"theme"}`, stubUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "2026-01-02T03:04:05.000Z", got["updatedAt"], "updatedAt は .000Z 形式 (#1948-10)")
 }
 
 func TestRegistryGetDetail_NotFound(t *testing.T) {

--- a/internal/api/invite/handler.go
+++ b/internal/api/invite/handler.go
@@ -98,9 +98,10 @@ func (h *Handler) Create(c echo.Context) error {
 	}
 
 	resp := map[string]any{
-		"id":        ticket.ID,
-		"code":      ticket.Code,
-		"expiresAt": ticket.ExpiresAt,
+		"id":   ticket.ID,
+		"code": ticket.Code,
+		// upstream InviteCodeEntityService.ts:47 は expiresAt ? toISOString() : null (#1948-10)。
+		"expiresAt": entity.ISOMillisPtr(ticket.ExpiresAt),
 		"createdBy": entity.PackUserLite(user),
 		"usedBy":    nil,
 		"usedAt":    nil,
@@ -173,12 +174,13 @@ func (h *Handler) List(c echo.Context) error {
 			}
 		}
 		entry := map[string]any{
-			"id":        t.ID,
-			"code":      t.Code,
-			"expiresAt": t.ExpiresAt,
+			"id":   t.ID,
+			"code": t.Code,
+			// upstream InviteCodeEntityService.ts:47,51 は expiresAt/usedAt ? toISOString() : null (#1948-10)。
+			"expiresAt": entity.ISOMillisPtr(t.ExpiresAt),
 			"createdBy": createdByLite,
 			"usedBy":    usedBy,
-			"usedAt":    t.UsedAt,
+			"usedAt":    entity.ISOMillisPtr(t.UsedAt),
 			"used":      t.UsedByID != nil,
 		}
 		if ts, err := h.idGen.ParseTime(t.ID); err == nil {

--- a/internal/api/invite/handler_test.go
+++ b/internal/api/invite/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
@@ -201,6 +202,30 @@ func TestList_ResolvesCreatedByAndUsedBy(t *testing.T) {
 	ub, ok := byID["z_a2"]["usedBy"].(map[string]any)
 	require.True(t, ok, "used ticket must resolve usedBy UserLite")
 	assert.Equal(t, "bob", ub["username"])
+}
+
+// #1948-10: List の expiresAt / usedAt は upstream toISOString() (.000Z / null)。
+// raw *time.Time の RFC3339Nano だと wire-byte が乖離する。
+func TestList_DateFormat(t *testing.T) {
+	h, repo := newTestHandler(t)
+	me := "u1"
+	exp := time.Date(2026, 6, 21, 1, 2, 3, 456_000_000, time.UTC)
+	used := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	repo.Tickets["t1"] = &model.RegistrationTicket{ID: "z_a1", Code: "c1", CreatedByID: &me, ExpiresAt: &exp, UsedAt: &used}
+	repo.Tickets["t2"] = &model.RegistrationTicket{ID: "z_a2", Code: "c2", CreatedByID: &me}
+
+	rec := post(h.List, `{"limit":50}`, &model.User{ID: me})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	byID := map[string]map[string]any{}
+	for _, e := range out {
+		byID[e["id"].(string)] = e
+	}
+	assert.Equal(t, "2026-06-21T01:02:03.456Z", byID["z_a1"]["expiresAt"], "expiresAt は .000Z (#1948-10)")
+	assert.Equal(t, "2026-01-02T03:04:05.000Z", byID["z_a1"]["usedAt"], "usedAt は .000Z (#1948-10)")
+	assert.Nil(t, byID["z_a2"]["expiresAt"], "nil expiresAt は null (#1948-10)")
+	assert.Nil(t, byID["z_a2"]["usedAt"], "nil usedAt は null (#1948-10)")
 }
 
 // listErrRepo は ListByCreator だけ error を返す stub。

--- a/internal/api/webhooks/handler.go
+++ b/internal/api/webhooks/handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -84,14 +85,16 @@ func (h *Handler) SetRolePolicyProvider(p RolePolicyProvider) {
 
 func packWebhook(w *model.Webhook) map[string]any {
 	return map[string]any{
-		"id":           w.ID,
-		"userId":       w.UserID,
-		"name":         w.Name,
-		"on":           w.On,
-		"url":          w.URL,
-		"secret":       w.Secret,
-		"active":       w.Active,
-		"latestSentAt": w.LatestSentAt,
+		"id":     w.ID,
+		"userId": w.UserID,
+		"name":   w.Name,
+		"on":     w.On,
+		"url":    w.URL,
+		"secret": w.Secret,
+		"active": w.Active,
+		// upstream i/webhooks/list.ts:54 は latestSentAt ? toISOString() : null。
+		// raw *time.Time だと RFC3339Nano になるため .000Z/null に揃える (#1948-10)。
+		"latestSentAt": entity.ISOMillisPtr(w.LatestSentAt),
 		"latestStatus": w.LatestStatus,
 	}
 }

--- a/internal/api/webhooks/handler_test.go
+++ b/internal/api/webhooks/handler_test.go
@@ -245,6 +245,25 @@ func TestList_Empty(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// #1948-10: packWebhook の latestSentAt は upstream toISOString() (.000Z / null)。
+// raw *time.Time の RFC3339Nano だと wire-byte が乖離する。
+func TestList_LatestSentAtFormat(t *testing.T) {
+	h, repo := newTestHandler()
+	sent := time.Date(2026, 6, 21, 1, 2, 3, 456_000_000, time.UTC)
+	repo.webhooks["w1"] = &model.Webhook{ID: "w1", UserID: "u1", Name: "hook1", On: pq.StringArray{"note"}, LatestSentAt: &sent}
+	repo.webhooks["w2"] = &model.Webhook{ID: "w2", UserID: "u1", Name: "hook2", On: pq.StringArray{}}
+	rec := post(h.List, `{}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	byID := map[string]map[string]any{}
+	for _, e := range resp {
+		byID[e["id"].(string)] = e
+	}
+	assert.Equal(t, "2026-06-21T01:02:03.456Z", byID["w1"]["latestSentAt"], "latestSentAt は .000Z (#1948-10)")
+	assert.Nil(t, byID["w2"]["latestSentAt"], "nil latestSentAt は null (#1948-10)")
+}
+
 type failListRepo struct{ *mockWebhookRepo }
 
 func (f *failListRepo) ListByUserID(_ string) ([]*model.Webhook, error) { return nil, errMock }

--- a/internal/entity/time.go
+++ b/internal/entity/time.go
@@ -1,0 +1,26 @@
+package entity
+
+import "time"
+
+// isoMillisLayout is the fixed millisecond ISO8601 layout produced by
+// JavaScript's Date.toISOString() (always 3 fractional digits, trailing Z, UTC).
+// Upstream Misskey serializes every timestamp through toISOString(), so mk-go
+// must match this exact layout rather than stdlib RFC3339Nano (variable
+// fractional digits, numeric offset for non-UTC locations).
+const isoMillisLayout = "2006-01-02T15:04:05.000Z"
+
+// ISOMillis formats t as a Misskey-compatible ISO8601 millisecond timestamp,
+// mirroring upstream's Date.toISOString(). The value is normalized to UTC first.
+func ISOMillis(t time.Time) string {
+	return t.UTC().Format(isoMillisLayout)
+}
+
+// ISOMillisPtr returns nil for a nil pointer, otherwise the ISOMillis string,
+// mirroring upstream's `x ? x.toISOString() : null`. The return type is `any`
+// so callers can drop it straight into a map[string]any response.
+func ISOMillisPtr(t *time.Time) any {
+	if t == nil {
+		return nil
+	}
+	return ISOMillis(*t)
+}

--- a/internal/entity/time_test.go
+++ b/internal/entity/time_test.go
@@ -1,0 +1,30 @@
+package entity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestISOMillis(t *testing.T) {
+	// 非 UTC location + ナノ秒を含む時刻でも、固定 3 桁ミリ秒 + Z (UTC) に揃う。
+	jst := time.FixedZone("JST", 9*60*60)
+	in := time.Date(2026, 6, 21, 12, 34, 56, 789_000_000, jst)
+	assert.Equal(t, "2026-06-21T03:34:56.789Z", ISOMillis(in))
+
+	// 秒ちょうど (ナノ秒 0) でも .000 を保持する (RFC3339Nano は落とす)。
+	exact := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	assert.Equal(t, "2026-01-02T03:04:05.000Z", ISOMillis(exact))
+}
+
+func TestISOMillisPtr(t *testing.T) {
+	assert.Nil(t, ISOMillisPtr(nil), "nil ポインタは null")
+
+	v := time.Date(2026, 1, 2, 3, 4, 5, 123_000_000, time.UTC)
+	assert.Equal(t, "2026-01-02T03:04:05.123Z", ISOMillisPtr(&v))
+
+	// ゼロ値ポインタは null ではなく epoch を整形する (upstream の truthy Date と同じ)。
+	var zero time.Time
+	assert.Equal(t, "0001-01-01T00:00:00.000Z", ISOMillisPtr(&zero))
+}


### PR DESCRIPTION
## Summary

#1948 全面互換性再監査の MEDIUM 候補 [10]。一部の admin / webhook / federation / registry /
invite packer が `time.Time` / `*time.Time` を素のまま `encoding/json` に渡しており、Go 既定の
RFC3339Nano (秒ちょうどは `.000` を落とし、非 UTC location は数値オフセット表記) で直列化されて
いた。upstream は全て `Date.toISOString()` (固定3桁ミリ秒 + `Z`、null は `null`) で返すため
wire-byte が乖離する。

共有ヘルパー `entity.ISOMillis` / `entity.ISOMillisPtr` を追加し、affected packer を経由させて
upstream と byte 一致させる。

## 主な変更点

- `internal/entity/time.go` (新規): `ISOMillis(time.Time) string` (non-null) /
  `ISOMillisPtr(*time.Time) any` (nil→null)。JS `toISOString()` と同じ UTC 変換 + 3桁ミリ切り捨て。
- `internal/api/admin/system_webhook.go`: SystemWebhook を model 直返ししていたのを
  `packSystemWebhook` (upstream `SystemWebhookEntityService.ts:33-43` の 9 フィールド shape) 経由化。
  `updatedAt` (non-null) / `latestSentAt` (nullable) を .000Z 化。Create/List/Show/Update の 4 経路。
- `internal/api/admin/abuse_report_notification.go`: 埋め込み `systemWebhook` も `packSystemWebhook`
  経由化 (model 直埋め込みの RFC3339Nano leak を排除)。recipient 自身の updatedAt 整形も
  `entity.ISOMillis` に寄せて canonical layout を単一管理化。
- `internal/api/admin/handler.go` `packEmojiDetailedAdmin`: `updatedAt` (nullable, `EmojiEntityService.ts:112`)。
- `internal/api/federation/handler.go` `instanceToMap`: `firstRetrievedAt` (non-null) /
  `latestRequestReceivedAt` / `infoUpdatedAt` (nullable) (`InstanceEntityService.ts:38,60,61`)。
- `internal/api/i/registry.go` get-detail: `updatedAt` (non-null, `i/registry/get-detail.ts:62`)。
- `internal/api/invite/handler.go` Create/List: `expiresAt` / `usedAt` (nullable,
  `InviteCodeEntityService.ts:47,51`)。
- `internal/api/webhooks/handler.go` `packWebhook`: `latestSentAt` (nullable, `i/webhooks/list.ts:54`)。

## テスト

- `internal/entity/time_test.go`: 非 UTC + ナノ秒 / 秒ちょうど (.000 保持) / nil→null / ゼロ値を検証。
- 各 packer の serialized date を `.000Z` / null で検証する回帰テストを追加
  (admin SystemWebhook・emoji / federation instance / registry / invite / webhooks)。
  いずれも「秒ちょうど (.000 脱落ケース)・ミリ秒あり・nil→null」を確認。
- 各 package カバレッジ: entity 96.3% / webhooks 99.0% / federation 93.1% / i 90.6% /
  invite 96.1% / admin 89.6% (admin は緩和閾値 80%)。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで、federation `instanceToMap` の `notRespondingSince` (raw time) と
`federating`/`subscribing`/`publishing` が upstream `InstanceEntityService` / federation-instance
json-schema に存在しない余剰フィールドであることを発見した。本候補 (date-format) のスコープ外
かつ field-presence の調査を要するため別 issue (#1991) に切り出した。

## 関連

- 親: #1948

Closes #1990
