### PR TITLE
Fix AP wire-shape parity (#1948-11): outbound activity を upstream ApRendererService に揃える

### DIFF
--- a/internal/activitypub/parity_1948_11_render_test.go
+++ b/internal/activitypub/parity_1948_11_render_test.go
@@ -1,0 +1,170 @@
+package activitypub
+
+import (
+	"encoding/json"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// millisZ matches the upstream Date.toISOString() shape (fixed 3-digit ms + Z).
+var millisZ = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$`)
+
+func marshalMap(t *testing.T, v any) map[string]any {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(b, &m))
+	return m
+}
+
+// #1948-11: RenderVote の object Note は最小フィールド (id/type/attributedTo/to/
+// inReplyTo/name) のみ。content/published/sensitive は upstream renderVote が出さない。
+func TestRenderVote_MinimalNote(t *testing.T) {
+	r := newRenderer()
+	voter := &model.User{ID: "voter1"}
+	target := &model.Note{ID: "poll1"}
+	c := r.RenderVote(voter, target, "https://remote.example/notes/poll1", "https://remote.example/users/author", "choiceA")
+	m := marshalMap(t, c)
+	note := m["object"].(map[string]any)
+	assert.Equal(t, "Note", note["type"])
+	assert.Equal(t, "choiceA", note["name"])
+	assert.Equal(t, "https://remote.example/notes/poll1", note["inReplyTo"])
+	_, hasContent := note["content"]
+	_, hasPublished := note["published"]
+	_, hasSensitive := note["sensitive"]
+	assert.False(t, hasContent, "vote note に content は出さない (#1948-11)")
+	assert.False(t, hasPublished, "vote note に published は出さない (#1948-11)")
+	assert.False(t, hasSensitive, "vote note に sensitive は出さない (#1948-11)")
+	// Create activity 側の published は .000Z。
+	assert.Regexp(t, millisZ, m["published"], "Create.published は .000Z (#1948-11)")
+}
+
+// #1948-11: Delete / UndoLike / UndoAnnounce に published(.000Z) が常に乗る。
+func TestRenderDeleteAndUndo_HavePublished(t *testing.T) {
+	r := newRenderer()
+	author := &model.User{ID: "u1"}
+
+	d := marshalMap(t, r.RenderDelete(author, "https://example.com/notes/n1"))
+	assert.Regexp(t, millisZ, d["published"], "Delete.published は .000Z (#1948-11)")
+
+	da := marshalMap(t, r.RenderDeleteActor(author))
+	assert.Regexp(t, millisZ, da["published"], "DeleteActor.published は .000Z (#1948-11)")
+
+	ul := marshalMap(t, r.RenderUndoLike(author, &Like{Activity: Activity{Object: Object{ID: "https://example.com/likes/l1"}}}))
+	assert.Regexp(t, millisZ, ul["published"], "UndoLike.published は .000Z (#1948-11)")
+
+	ua := marshalMap(t, r.RenderUndoAnnounce(author, &Announce{Activity: Activity{Object: Object{ID: "https://example.com/notes/n1/activity"}}}))
+	assert.Regexp(t, millisZ, ua["published"], "UndoAnnounce.published は .000Z (#1948-11)")
+
+	ub := marshalMap(t, r.RenderUndoBlock("u1", "https://remote.example/users/b"))
+	assert.Regexp(t, millisZ, ub["published"], "UndoBlock.published は .000Z (#1948-11)")
+
+	uda := marshalMap(t, r.RenderUndoDeleteActor(author))
+	assert.Regexp(t, millisZ, uda["published"], "UndoDeleteActor.published は .000Z (#1948-11)")
+}
+
+// #1948-11: RenderQuestionUpdate の published は .000Z だが、Activity ID は
+// 同一秒内の連続投票でも衝突しないよう nano 精度を維持する。
+func TestRenderQuestionUpdate_PublishedMillisIDNano(t *testing.T) {
+	r := newRenderer()
+	idGen := newIDGen(t)
+	n := &model.Note{ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: model.NoteVisibilityPublic, HasPoll: true}
+	m := marshalMap(t, r.RenderQuestionUpdate(n, idGen))
+	assert.Regexp(t, millisZ, m["published"], "QuestionUpdate.published は .000Z (#1948-11)")
+	// ID は #updates/<nano> 形式 (ミリ秒超の精度を含むため millisZ には一致しない)。
+	assert.Contains(t, m["id"], "#updates/", "QuestionUpdate.id は #updates/<nano> 形式")
+}
+
+// #1948-11: actor の manuallyApprovesFollowers/discoverable/isCat/
+// _misskey_requireSigninToViewContents は false でも常に key として present。
+func TestRenderPerson_BoolFlagsAlwaysPresent(t *testing.T) {
+	r := newRenderer()
+	// 全 bool が false になる素のユーザー。
+	u := &model.User{ID: "u1", Username: "alice"}
+	m := marshalMap(t, r.RenderPerson(u, nil, "PUBKEY", nil))
+	for _, k := range []string{"manuallyApprovesFollowers", "discoverable", "isCat", "_misskey_requireSigninToViewContents"} {
+		v, ok := m[k]
+		assert.True(t, ok, k+" は false でも present (#1948-11)")
+		assert.Equal(t, false, v, k+" は false")
+	}
+
+	// 値が user 状態を反映することも確認 (explorable/cat/locked = true)。
+	u2 := &model.User{ID: "u2", Username: "bob", IsExplorable: true, IsCat: true, IsLocked: true}
+	m2 := marshalMap(t, r.RenderPerson(u2, nil, "PUBKEY", nil))
+	assert.Equal(t, true, m2["discoverable"])
+	assert.Equal(t, true, m2["isCat"])
+	assert.Equal(t, true, m2["manuallyApprovesFollowers"])
+}
+
+// #1948-11: local custom emoji tag は id(=baseURL/emojis/name) / updated(.000Z) /
+// icon.mediaType を必ず持ち、publicUrl 空時は originalUrl にフォールバックする。
+func TestAddEmojiTags_LocalIDUpdatedMediaType(t *testing.T) {
+	r := newRenderer()
+	upd := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	typ := "image/webp"
+	r.SetEmojiResolver(&stubEmojiResolver{emojis: map[string]*model.Emoji{
+		"smile": {Name: "smile", PublicURL: "https://example.com/files/smile.webp", UpdatedAt: &upd, Type: &typ},
+	}})
+	l := r.RenderLike(&model.User{ID: "alice"}, "https://remote.example/notes/n1", ":smile@.:", "https://example.com/likes/l1")
+	require.Len(t, l.Tag, 1)
+	et := l.Tag[0].(EmojiTag)
+	assert.Equal(t, "https://example.com/emojis/smile", et.ID, "local emoji tag は local id を持つ (#1948-11)")
+	assert.Equal(t, "2026-01-02T03:04:05.000Z", et.Updated, "updated は .000Z (#1948-11)")
+	assert.Equal(t, "image/webp", et.Icon.MediaType, "icon.mediaType (#1948-11)")
+
+	// publicUrl 空 → originalUrl fallback、Type nil → image/png default、UpdatedAt nil → now。
+	r.SetEmojiResolver(&stubEmojiResolver{emojis: map[string]*model.Emoji{
+		"foo": {Name: "foo", PublicURL: "", OriginalURL: "https://example.com/files/foo-orig.png"},
+	}})
+	l2 := r.RenderLike(&model.User{ID: "alice"}, "https://remote.example/notes/n1", ":foo@.:", "https://example.com/likes/l2")
+	require.Len(t, l2.Tag, 1)
+	et2 := l2.Tag[0].(EmojiTag)
+	assert.Equal(t, "https://example.com/files/foo-orig.png", et2.Icon.URL, "publicUrl 空は originalUrl fallback (#1948-11)")
+	assert.Equal(t, "image/png", et2.Icon.MediaType, "Type nil は image/png default (#1948-11)")
+	assert.Regexp(t, millisZ, et2.Updated, "UpdatedAt nil は now(.000Z) (#1948-11)")
+}
+
+// stubNoteResolver1948 returns a fixed quote URI.
+type stubNoteResolver1948 struct{ uri string }
+
+func (s stubNoteResolver1948) FindByID(string) (*model.Note, error) {
+	return &model.Note{URI: &s.uri}, nil
+}
+
+// #1948-11: simple text の quote renote でも _misskey_content / source を必ず出す
+// (upstream extraHtml!=null で noMisskeyContent=false 強制)。
+func TestRenderNote_SimpleQuoteEmitsSource(t *testing.T) {
+	r := newRenderer()
+	r.SetNoteResolver(stubNoteResolver1948{uri: "https://remote.example/notes/orig"})
+	idGen := newIDGen(t)
+	text := "hi" // mfm.IsSimple が true になる素の本文
+	renoteID := "renote-target"
+	n := &model.Note{ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: model.NoteVisibilityPublic, Text: &text, RenoteID: &renoteID}
+	out := r.RenderNote(n, idGen)
+	assert.Equal(t, "hi", out.MisskeyContent, "simple quote renote でも _misskey_content を出す (#1948-11)")
+	require.NotNil(t, out.Source, "simple quote renote でも source を出す (#1948-11)")
+	assert.Equal(t, "text/x.misskeymarkdown", out.Source.MediaType)
+	assert.Equal(t, "https://remote.example/notes/orig", out.QuoteURL)
+
+	// 対照: quote なしの simple text は従来どおり source/_misskey_content を省略。
+	n2 := &model.Note{ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: model.NoteVisibilityPublic, Text: &text}
+	out2 := r.RenderNote(n2, idGen)
+	assert.Empty(t, out2.MisskeyContent, "quote なし simple text は _misskey_content を出さない")
+	assert.Nil(t, out2.Source, "quote なし simple text は source を出さない")
+}
+
+// #1948-11: RenderNote の published が .000Z (parseNoteTime 経由)。
+func TestRenderNote_PublishedMillis(t *testing.T) {
+	r := newRenderer()
+	idGen := newIDGen(t)
+	text := "hello"
+	n := &model.Note{ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: model.NoteVisibilityPublic, Text: &text}
+	out := r.RenderNote(n, idGen)
+	assert.Regexp(t, millisZ, out.Published, "Note.published は .000Z (#1948-11)")
+}

--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -17,6 +17,13 @@ import (
 	"github.com/shiroha-a/mk/internal/model"
 )
 
+// publishedLayout is the millisecond ISO8601 layout (JS Date.toISOString()) used
+// for every AP `published` / `updated` timestamp, matching upstream
+// ApRendererService which formats all of them via toISOString() (#1948-11).
+// stdlib time.RFC3339 produces second precision (no `.000`), diverging on the
+// wire from Misskey's millisecond form.
+const publishedLayout = "2006-01-02T15:04:05.000Z"
+
 // URLBuilder constructs canonical URLs for the local instance.
 // 同じデータでも複数の場所から参照されるので、ヘルパとして集約しておく。
 type URLBuilder struct {
@@ -500,8 +507,18 @@ func (r *Renderer) RenderNote(n *model.Note, idGen id.Generator) *Note {
 		Sensitive: n.CW != nil,
 	}
 
-	// _misskey_content / source: 標準ノードのみなら省略 (TS版 noMisskeyContent)
-	if text != "" && !mfm.IsSimple(nodes) {
+	// quote renote の URI を先に解決する (gate と quote-inline span の両方で使う)。
+	var quoteURI string
+	if n.RenoteID != nil && text != "" {
+		quoteURI = r.resolveNoteURI(*n.RenoteID)
+	}
+
+	// _misskey_content / source: 標準ノードのみなら省略 (TS版 noMisskeyContent)。
+	// ただし quote renote は upstream getNoteHtml が extraHtml(!=null) を渡して
+	// noMisskeyContent=false を強制するため、simple text でも必ず source/
+	// _misskey_content を出す (受信 Misskey が raw markdown を失わないように、#1948-11)。
+	hasExtraHtml := quoteURI != ""
+	if text != "" && (hasExtraHtml || !mfm.IsSimple(nodes)) {
 		out.MisskeyContent = text
 		out.Source = &Source{
 			Content:   text,
@@ -528,17 +545,14 @@ func (r *Renderer) RenderNote(n *model.Note, idGen id.Generator) *Note {
 	}
 
 	// Quote renote: text付きrenoteは_misskey_quote + quoteUrlを付ける
-	if n.RenoteID != nil && text != "" {
-		quoteURI := r.resolveNoteURI(*n.RenoteID)
-		if quoteURI != "" {
-			out.MisskeyQuote = quoteURI
-			out.QuoteURL = quoteURI
-			// 非 Misskey クライアント向けに content 末尾へ quote-inline span を
-			// 付ける (#1560、upstream ApRendererService.ts:436-441)。class名
-			// `quote-inline` は非 Misskey クライアントの quote 表示に使われる。
-			esc := html.EscapeString(quoteURI)
-			out.Content += `<br><br><span class="quote-inline">RE: <a href="` + esc + `">` + esc + `</a></span>`
-		}
+	if quoteURI != "" {
+		out.MisskeyQuote = quoteURI
+		out.QuoteURL = quoteURI
+		// 非 Misskey クライアント向けに content 末尾へ quote-inline span を
+		// 付ける (#1560、upstream ApRendererService.ts:436-441)。class名
+		// `quote-inline` は非 Misskey クライアントの quote 表示に使われる。
+		esc := html.EscapeString(quoteURI)
+		out.Content += `<br><br><span class="quote-inline">RE: <a href="` + esc + `">` + esc + `</a></span>`
 	}
 
 	// 添付ファイル
@@ -723,13 +737,36 @@ func (r *Renderer) addEmojiTags(tags *[]any, emojiNames []string, host *string) 
 		if emoji.LocalOnly {
 			continue
 		}
+		// upstream renderEmoji の icon: mediaType = emoji.type ?? 'image/png'、
+		// url = publicUrl || originalUrl (publicUrl 空時の後方互換 fallback) (#1948-11)。
+		iconURL := emoji.PublicURL
+		if iconURL == "" {
+			iconURL = emoji.OriginalURL
+		}
+		mediaType := "image/png"
+		if emoji.Type != nil && *emoji.Type != "" {
+			mediaType = *emoji.Type
+		}
 		tag := EmojiTag{
 			Type: "Emoji",
 			Name: ":" + emoji.Name + ":",
-			Icon: Image{Type: "Image", URL: emoji.PublicURL},
+			Icon: Image{Type: "Image", MediaType: mediaType, URL: iconURL},
 		}
+		// id: remote emoji は元 URI を保持、local emoji は自ドメインの
+		// /emojis/<name> (upstream renderEmoji は常に local URL を出すが、remote
+		// emoji の参照同一性を壊さないため URI を優先する保守的方針、#1948-11)。
 		if emoji.URI != nil {
 			tag.ID = *emoji.URI
+		} else {
+			tag.ID = r.urls.baseURL + "/emojis/" + emoji.Name
+		}
+		// updated: upstream renderEmoji は updatedAt?.toISOString() ?? now を常に
+		// 出力する。受信側 instance が cache 済 emoji を再取得するか判定するため、
+		// local emoji でも必ず付与する (#1948-11)。
+		if emoji.UpdatedAt != nil {
+			tag.Updated = emoji.UpdatedAt.UTC().Format(publishedLayout)
+		} else {
+			tag.Updated = time.Now().UTC().Format(publishedLayout)
 		}
 		// #731: upstream Misskey TS の renderEmoji と同じく `_misskey_license`
 		// を出力する。受信側 mk-go / Misskey TS は wrapper を見て license を
@@ -753,15 +790,17 @@ func (r *Renderer) addEmojiTags(tags *[]any, emojiNames []string, host *string) 
 // drop されて count が古いまま固定される (#690 review)。
 func (r *Renderer) RenderQuestionUpdate(n *model.Note, idGen id.Generator) *Update {
 	question := r.RenderNote(n, idGen)
-	now := time.Now().UTC().Format(time.RFC3339Nano)
+	// Activity ID は同一秒内の連続投票でも衝突しないよう nano 精度を保つが、
+	// published は upstream toISOString() の .000Z 形式に揃える (#1948-11)。
+	t := time.Now().UTC()
 	u := &Update{
 		Activity: Activity{
 			Object: Object{
-				ID:   r.urls.NoteURI(n.ID) + "#updates/" + now,
+				ID:   r.urls.NoteURI(n.ID) + "#updates/" + t.Format(time.RFC3339Nano),
 				Type: "Update",
 			},
 			Actor:     r.urls.UserURI(n.UserID),
-			Published: now,
+			Published: t.Format(publishedLayout),
 			To:        question.To,
 			CC:        question.CC,
 		},
@@ -778,16 +817,15 @@ func (r *Renderer) RenderQuestionUpdate(n *model.Note, idGen id.Generator) *Upda
 // はリモート側の note.URI を使う (local URL で render すると相手が解決でき
 // ない)。authorURI は target.UserID から URLBuilder 経由で組み立てる。
 func (r *Renderer) RenderVote(voter *model.User, target *model.Note, targetURI, authorURI, choiceName string) *Create {
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := time.Now().UTC().Format(publishedLayout)
 	noteID := r.urls.VoteActivityURI(voter.ID, target.ID)
-	note := &Note{
-		Object: Object{
-			ID:   noteID,
-			Type: "Note",
-		},
+	// upstream renderVote の object Note は {id, type, attributedTo, to, inReplyTo, name}
+	// のみ。汎用 Note 構造体は content/published(omitempty 無し) を必ず出力してしまい
+	// upstream が送らない余剰フィールドが乗るため、最小 struct で組む (#1948-11)。
+	note := &voteNote{
+		ID:           noteID,
+		Type:         "Note",
 		AttributedTo: r.urls.UserURI(voter.ID),
-		Content:      "",
-		Published:    now,
 		To:           []string{authorURI},
 		InReplyTo:    targetURI,
 		Name:         choiceName,
@@ -806,6 +844,18 @@ func (r *Renderer) RenderVote(voter *model.User, target *model.Note, targetURI, 
 	}
 	AddContext(c)
 	return c
+}
+
+// voteNote is the minimal AP Note shape upstream renderVote emits for a poll
+// vote: exactly {id, type, attributedTo, to, inReplyTo, name} with no content /
+// published / sensitive (#1948-11).
+type voteNote struct {
+	ID           string   `json:"id"`
+	Type         string   `json:"type"`
+	AttributedTo string   `json:"attributedTo"`
+	To           []string `json:"to"`
+	InReplyTo    string   `json:"inReplyTo"`
+	Name         string   `json:"name"`
 }
 
 // RenderCreate wraps a Note into a Create activity addressed to the same audience.
@@ -859,7 +909,7 @@ func (r *Renderer) RenderUpdate(person *Person) *Update {
 			},
 			Actor:     actor,
 			To:        []string{Public},
-			Published: time.Now().UTC().Format(time.RFC3339),
+			Published: time.Now().UTC().Format(publishedLayout),
 		},
 		Object: person,
 	}
@@ -897,7 +947,7 @@ func (r *Renderer) RenderUndoBlock(blockerID, blockeeURI string) *Undo {
 				Type: "Undo",
 			},
 			Actor:     r.urls.UserURI(blockerID),
-			Published: time.Now().UTC().Format(time.RFC3339),
+			Published: time.Now().UTC().Format(publishedLayout),
 		},
 		Object: inner,
 	}
@@ -1120,6 +1170,8 @@ func (r *Renderer) RenderUndoLike(reactor *model.User, like *Like) *Undo {
 				Type: "Undo",
 			},
 			Actor: r.urls.UserURI(reactor.ID),
+			// upstream renderUndo は published を常に付与する (#1948-11)。
+			Published: time.Now().UTC().Format(publishedLayout),
 		},
 		Object: like,
 	}
@@ -1171,6 +1223,8 @@ func (r *Renderer) RenderUndoAnnounce(renoter *model.User, announce *Announce) *
 				Type: "Undo",
 			},
 			Actor: r.urls.UserURI(renoter.ID),
+			// upstream renderUndo は published を常に付与する (#1948-11)。
+			Published: time.Now().UTC().Format(publishedLayout),
 		},
 		Object: announce,
 	}
@@ -1189,6 +1243,8 @@ func (r *Renderer) RenderDelete(author *model.User, noteURI string) *Delete {
 			},
 			Actor: r.urls.UserURI(author.ID),
 			To:    []string{Public},
+			// upstream renderDelete は published を常に付与する (#1948-11)。
+			Published: time.Now().UTC().Format(publishedLayout),
 		},
 		Object: Tombstone{
 			ID:   noteURI,
@@ -1214,6 +1270,8 @@ func (r *Renderer) RenderDeleteActor(user *model.User) *Delete {
 			},
 			Actor: uri,
 			To:    []string{Public},
+			// upstream renderDelete は published を常に付与する (#1948-11)。
+			Published: time.Now().UTC().Format(publishedLayout),
 		},
 		Object: uri,
 	}
@@ -1236,6 +1294,8 @@ func (r *Renderer) RenderUndoDeleteActor(user *model.User) *Undo {
 			},
 			Actor: uri,
 			To:    []string{Public},
+			// upstream renderUndo は published を常に付与する (#1948-11)。
+			Published: time.Now().UTC().Format(publishedLayout),
 		},
 		Object: inner,
 	}
@@ -1408,7 +1468,7 @@ func parseNoteTime(noteID string, idGen id.Generator) string {
 	t, err := idGen.ParseTime(noteID)
 	if err != nil {
 		slog.Warn("renderer: failed to parse note ID for timestamp, using time.Now()", "noteId", noteID, "err", err)
-		return time.Now().UTC().Format(time.RFC3339)
+		return time.Now().UTC().Format(publishedLayout)
 	}
-	return t.UTC().Format(time.RFC3339)
+	return t.UTC().Format(publishedLayout)
 }

--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -164,6 +164,12 @@ type Endpoints struct {
 type Image struct {
 	Type string `json:"type"`
 	URL  string `json:"url"`
+	// MediaType / Sensitive / Name は upstream renderImage / renderEmoji icon の
+	// 追加プロパティ (ApRendererService.ts:186-191,253-260)。omitempty なので
+	// 未設定時は従来どおり {type,url} のみ出力し後方互換を保つ (#1948-11)。
+	MediaType string `json:"mediaType,omitempty"`
+	Sensitive *bool  `json:"sensitive,omitempty"`
+	Name      string `json:"name,omitempty"`
 }
 
 // UnmarshalJSON accepts both forms allowed by ActivityStreams 2.0 for
@@ -238,24 +244,28 @@ type Person struct {
 	// SharedInbox は upstream renderPerson が endpoints.sharedInbox とは別に
 	// top-level にも出す (#1560、ApRendererService.ts:551)。古い実装/一部の
 	// 受信側は top-level を見るため両方出す。
-	SharedInbox                         string    `json:"sharedInbox,omitempty"`
-	Endpoints                           Endpoints `json:"endpoints,omitzero"`
-	PublicKey                           PublicKey `json:"publicKey"`
-	Icon                                *Image    `json:"icon,omitempty"`
-	Image                               *Image    `json:"image,omitempty"`
-	Attachment                          []any     `json:"attachment,omitempty"`
-	Tag                                 []any     `json:"tag,omitempty"`
-	Featured                            string    `json:"featured,omitempty"`
-	ManuallyApproves                    bool      `json:"manuallyApprovesFollowers,omitempty"`
-	Discoverable                        bool      `json:"discoverable,omitempty"`
-	IsCat                               bool      `json:"isCat,omitempty"`
-	VcardBday                           string    `json:"vcard:bday,omitempty"`
-	VcardAddress                        string    `json:"vcard:Address,omitempty"`
-	MisskeySummary                      string    `json:"_misskey_summary,omitempty"`
-	MisskeyFollowedMessage              string    `json:"_misskey_followedMessage,omitempty"`
-	MisskeyRequireSigninToViewContents  bool      `json:"_misskey_requireSigninToViewContents,omitempty"`
-	MisskeyMakeNotesFollowersOnlyBefore *int      `json:"_misskey_makeNotesFollowersOnlyBefore,omitempty"`
-	MisskeyMakeNotesHiddenBefore        *int      `json:"_misskey_makeNotesHiddenBefore,omitempty"`
+	SharedInbox string    `json:"sharedInbox,omitempty"`
+	Endpoints   Endpoints `json:"endpoints,omitzero"`
+	PublicKey   PublicKey `json:"publicKey"`
+	Icon        *Image    `json:"icon,omitempty"`
+	Image       *Image    `json:"image,omitempty"`
+	Attachment  []any     `json:"attachment,omitempty"`
+	Tag         []any     `json:"tag,omitempty"`
+	Featured    string    `json:"featured,omitempty"`
+	// upstream renderPerson は manuallyApprovesFollowers/discoverable/isCat/
+	// _misskey_requireSigninToViewContents を常に boolean で出力する。omitempty だと
+	// false で key 自体が消えて wire-shape が乖離するため omitempty を外す (#1948-11)。
+	// 値は RenderPerson で user 状態から populate 済み。
+	ManuallyApproves                    bool   `json:"manuallyApprovesFollowers"`
+	Discoverable                        bool   `json:"discoverable"`
+	IsCat                               bool   `json:"isCat"`
+	VcardBday                           string `json:"vcard:bday,omitempty"`
+	VcardAddress                        string `json:"vcard:Address,omitempty"`
+	MisskeySummary                      string `json:"_misskey_summary,omitempty"`
+	MisskeyFollowedMessage              string `json:"_misskey_followedMessage,omitempty"`
+	MisskeyRequireSigninToViewContents  bool   `json:"_misskey_requireSigninToViewContents"`
+	MisskeyMakeNotesFollowersOnlyBefore *int   `json:"_misskey_makeNotesFollowersOnlyBefore,omitempty"`
+	MisskeyMakeNotesHiddenBefore        *int   `json:"_misskey_makeNotesHiddenBefore,omitempty"`
 	// MisskeyCanChat は CherryPick の chat 連合 capability flag (#692)。
 	// 受信側 instance が DM を受け付けるか (false なら拒絶) を表す boolean。
 	// pointer で持つことで「未指定 (= 旧実装 / 互換) → 許可」を区別する。


### PR DESCRIPTION
## Summary

#1948 全面互換性再監査の MEDIUM 候補 [11]。AP outbound activity の wire-shape が upstream
`ApRendererService` と複数箇所で乖離していたのを揃える。

## 主な変更点 (internal/activitypub/renderer.go, types.go)

- **published/updated を .000Z 統一**: const `publishedLayout` を導入し `time.RFC3339` (秒精度)
  を排除。parseNoteTime / RenderVote / RenderUndoBlock / RenderUpdate / RenderQuestionUpdate
  (published のみ、Activity ID は連続投票衝突回避のため nano 維持)。
- **Delete / Undo に published 付与**: RenderDelete / RenderDeleteActor / RenderUndoLike /
  RenderUndoAnnounce / RenderUndoDeleteActor (upstream renderDelete / renderUndo は常に付与)。
- **RenderVote の object Note 最小化**: 専用 `voteNote` struct ({id,type,attributedTo,to,
  inReplyTo,name}) で content/published/sensitive の余剰出力を排除。
- **Image struct 拡張**: mediaType/sensitive/name (omitempty)。
- **emoji tag**: local emoji に id(=baseURL/emojis/name)、updated(updatedAt?.000Z:now) を常時付与、
  icon.mediaType(=Type ?? image/png) と url の publicUrl||originalUrl fallback。remote emoji の
  URI は保持 (参照同一性のため保守的方針)。
- **actor bool flags 常時出力**: manuallyApprovesFollowers/discoverable/isCat/
  _misskey_requireSigninToViewContents の omitempty を除去 (値は user 状態から populate 済み)。
- **simple-text quote renote の _misskey_content/source**: quote URI を gate 前に解決し、quote
  renote では simple text でも source を出力 (upstream getNoteHtml の extraHtml!=null 強制)。

## テスト

- `internal/activitypub/parity_1948_11_render_test.go`: vote 最小 note / Delete・全 Undo の
  published(.000Z) / actor bool flags 常時 present / emoji tag id+updated+mediaType+fallback /
  simple quote source 強制 / Note published .000Z / QuestionUpdate published-millis+ID-nano。
- activitypub package カバレッジ 92.0%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで同一ファイル内の `RenderUndoDeleteActor` published 欠落 (M-1) を発見し本 PR に
取り込んだ。renderer 外で直接組む Undo(Follow) の published 欠落と actor icon の sensitive/name
未対応は別 issue (#1993) に分離。

## 関連

- 親: #1948

Closes #1994
