### PR TITLE
Fix admin/show-users state parity (#1948-12): ListUsers の state フィルタを upstream に揃える

### DIFF
--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -474,51 +474,40 @@ func (r *userRepository) ListUsers(filter model.UserListFilter) ([]*model.User, 
 	switch filter.State {
 	case "suspended":
 		q = q.Where("\"isSuspended\" = true")
-	case "alive", "available":
-		// `available` は本家 admin/show-users で `alive` と同義 (suspended で
-		// ない = アクティブ)。`alive` だけ受け付けると admin UI が空返却に
-		// なるので両方カバーする。
+	case "available":
+		// upstream show-users.ts:64 — available = isSuspended = FALSE (#1948-12)。
 		q = q.Where("\"isSuspended\" = false")
+	case "alive":
+		// upstream show-users.ts:65 — alive は updatedAt > now-5d の「直近アクティブ」
+		// window で、available (= 未 suspend) とは別 filter。以前は alive を available
+		// の synonym 扱いにしていたが upstream と乖離していた (#1948-12)。
+		q = q.Where(`"updatedAt" > ?`, time.Now().Add(-5*24*time.Hour))
 	case "admin", "moderator", "adminOrModerator":
-		// 本家 RoleService.getModeratorIds と等価な条件を SQL に落とす。
-		// expiresAt が過ぎている assignment は除外、role の
-		// isAdministrator / isModerator フラグで絞る。host は問わない方が
-		// 上位表示で柔軟だが、admin/overview の moderator カードはローカル
-		// だけを期待するので host IS NULL も付ける (#421)。
+		// upstream show-users.ts は getAdministratorIds / getModeratorIds で role 由来の
+		// id 集合に絞る。これらは (1) host を問わない (origin param が別途 host を filter
+		// する)、(2) expiresAt を filter しない (getModeratorIds の excludeExpire は既定
+		// false、getAdministratorIds は expiry 非考慮)、(3) root を含めない
+		// (getAdministratorIds は TODO で未対応 / getModeratorIds の includeRoot 既定
+		// false) — の 3 点を満たす。以前の mk-go は host IS NULL / expiresAt filter /
+		// root union を付けており upstream と乖離していた (#1948-12)。
 		//
-		// root user (meta.rootUserId) は role_assignment 行を持たない
-		// 暗黙の administrator なので admin / adminOrModerator では OR 条件
-		// で必ず含める。本家 getModeratorIds の rootUserIds union と同じ
-		// (#421 Devin review)。pure moderator フィルタは root を含まない。
+		// upstream #17334 の「複数 admin role を持つ user の id 重複」は、本 SQL の
+		// `id IN (SELECT ra."userId" ...)` が PostgreSQL の IN semantics で自動 dedup
+		// するため等価に解消される。
 		var roleCond string
-		includeRoot := false
 		switch filter.State {
 		case "admin":
 			roleCond = `r."isAdministrator" = true`
-			includeRoot = true
 		case "moderator":
 			roleCond = `r."isModerator" = true`
 		default: // adminOrModerator
 			roleCond = `(r."isAdministrator" = true OR r."isModerator" = true)`
-			includeRoot = true
 		}
-		// upstream Misskey #17334 (= 2026.5.0 fix / triage #1007): RoleService.
-		// getAdministratorIds で「複数 admin role を持つ user の ID が重複する」bug。
-		// mk-go では admin user 解決を method ベースの map+slice ではなく、本 SQL
-		// の `id IN (SELECT ra."userId" ...)` 構造で実装しているため、PostgreSQL の
-		// IN subquery semantics で自動的に dedup される (= 内部行が複数あっても
-		// 外側 id は 1 度しか match しない)。よって upstream の Set 経由 dedup と
-		// 等価な挙動が SQL レベルで保証されている。
-		idCond := `id IN (
+		q = q.Where(`id IN (
 			SELECT ra."userId" FROM role_assignment ra
 			JOIN role r ON ra."roleId" = r.id
 			WHERE ` + roleCond + `
-			  AND (ra."expiresAt" IS NULL OR ra."expiresAt" > now())
-		)`
-		if includeRoot {
-			idCond = "(" + idCond + ` OR id = (SELECT "rootUserId" FROM meta WHERE "rootUserId" IS NOT NULL LIMIT 1))`
-		}
-		q = q.Where("host IS NULL").Where(idCond)
+		)`)
 	}
 
 	// sort 方向は upstream admin/show-users.ts:99-110 に一致させる。'+' は

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -880,10 +880,10 @@ func TestUserRepository_ListUsers_Suspended(t *testing.T) {
 	}
 }
 
-// adminOrModerator filter joins role_assignment + role and returns only
-// users with isAdministrator/isModerator role and host IS NULL (#421)。
-// 旧実装は state=adminOrModerator を黙って無視していたので admin/overview
-// の moderator 一覧に観測した全リモートユーザーが流れ込んでいた。
+// adminOrModerator filter joins role_assignment + role and returns users with
+// isAdministrator/isModerator role. upstream show-users は role state に host
+// filter をかけず、host は origin param で別途絞る (#1948-12)。以前は role state
+// 自体に host IS NULL を付けていたが upstream と乖離していた。
 func TestUserRepository_ListUsers_AdminOrModerator(t *testing.T) {
 	repo := NewUserRepository(testDB)
 	host := "remote.example"
@@ -908,7 +908,7 @@ func TestUserRepository_ListUsers_AdminOrModerator(t *testing.T) {
 	require.NoError(t, testDB.Create(role).Error)
 	defer testDB.Exec(`DELETE FROM "role" WHERE id = ?`, role.ID)
 
-	// local mod + remote (incorrectly) get the moderator role
+	// local mod + remote both get the moderator role
 	for _, uid := range []string{mod.ID, remote.ID} {
 		ra := &model.RoleAssignment{ID: "ra_" + uid, UserID: uid, RoleID: role.ID}
 		require.NoError(t, testDB.Create(ra).Error)
@@ -923,23 +923,28 @@ func TestUserRepository_ListUsers_AdminOrModerator(t *testing.T) {
 	}
 	assert.Contains(t, ids, mod.ID, "local moderator must be listed")
 	assert.NotContains(t, ids, plain.ID, "non-moderator local user must be excluded")
-	assert.NotContains(t, ids, remote.ID, "remote user must be excluded even if assigned the role")
+	// upstream parity: role state は host を問わない。remote の role 保持者も含まれる。
+	assert.Contains(t, ids, remote.ID, "remote moderator is included (host is filtered by origin, not state)")
+
+	// origin=local を併用すると remote は除外される (upstream の origin filter)。
+	localUsers, err := repo.ListUsers(model.UserListFilter{State: "adminOrModerator", Origin: "local", Limit: 100})
+	require.NoError(t, err)
+	localIDs := make(map[string]struct{}, len(localUsers))
+	for _, u := range localUsers {
+		localIDs[u.ID] = struct{}{}
+	}
+	assert.Contains(t, localIDs, mod.ID)
+	assert.NotContains(t, localIDs, remote.ID, "origin=local excludes the remote moderator")
 }
 
-// admin / adminOrModerator フィルタは meta.rootUserId を暗黙の admin として
-// 含める必要がある。本家 RoleService.getModeratorIds の rootUserIds union と
-// 同じ挙動で、これが無いと「初期 root のみ」のインスタンスでは moderator
-// カードが空になる (#421 Devin review)。
-func TestUserRepository_ListUsers_AdminIncludesRootUser(t *testing.T) {
+// #1948-12: admin / adminOrModerator は root user を暗黙 admin として含めない
+// (upstream getAdministratorIds は TODO で未対応 / getModeratorIds の includeRoot
+// 既定 false)。以前の mk-go は root を OR union で含めており乖離していた。
+func TestUserRepository_ListUsers_AdminDoesNotIncludeRootUser(t *testing.T) {
 	repo := NewUserRepository(testDB)
 	root := insertTestUser(t, "lu_root", "rootuser")
 	defer cleanupUser(t, root.ID)
-	other := insertTestUser(t, "lu_other", "otheruser")
-	defer cleanupUser(t, other.ID)
 
-	// root を meta.rootUserId に設定する。テスト終了時に元の値へ戻す。
-	// migration には meta シードが無いので、行が無ければ INSERT でブート
-	// ストラップする。
 	var rowCount int64
 	require.NoError(t, testDB.Raw(`SELECT COUNT(*) FROM meta`).Scan(&rowCount).Error)
 	if rowCount == 0 {
@@ -958,23 +963,66 @@ func TestUserRepository_ListUsers_AdminIncludesRootUser(t *testing.T) {
 		})
 	}
 
-	for _, state := range []string{"admin", "adminOrModerator"} {
+	// root は role_assignment を持たないので、どの role state にも現れない。
+	for _, state := range []string{"admin", "adminOrModerator", "moderator"} {
 		users, err := repo.ListUsers(model.UserListFilter{State: state, Limit: 100})
 		require.NoError(t, err)
-		ids := make(map[string]struct{}, len(users))
 		for _, u := range users {
-			ids[u.ID] = struct{}{}
+			assert.NotEqual(t, root.ID, u.ID, "root must NOT be in state=%s (upstream parity, #1948-12)", state)
 		}
-		assert.Contains(t, ids, root.ID, "root user must be in state=%s results", state)
-		assert.NotContains(t, ids, other.ID, "non-admin local user must not be in state=%s results", state)
 	}
+}
 
-	// pure moderator フィルタは root (admin) を含まない。
-	users, err := repo.ListUsers(model.UserListFilter{State: "moderator", Limit: 100})
+// #1948-12: state=alive は updatedAt > now-5d、state=available は isSuspended=false
+// の別 filter。expired role assignment も role state に含まれる (excludeExpire 既定 false)。
+func TestUserRepository_ListUsers_AliveAvailableAndExpiry(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	// recent: updatedAt = now、stale: updatedAt = now-10d、suspended。
+	recent := insertTestUser(t, "lu_recent", "recentuser")
+	defer cleanupUser(t, recent.ID)
+	stale := insertTestUser(t, "lu_stale", "staleuser")
+	defer cleanupUser(t, stale.ID)
+	susp := insertTestUser(t, "lu_susp", "suspuser")
+	defer cleanupUser(t, susp.ID)
+	require.NoError(t, testDB.Exec(`UPDATE "user" SET "updatedAt" = ? WHERE id = ?`, time.Now(), recent.ID).Error)
+	require.NoError(t, testDB.Exec(`UPDATE "user" SET "updatedAt" = ? WHERE id = ?`, time.Now().Add(-10*24*time.Hour), stale.ID).Error)
+	require.NoError(t, testDB.Exec(`UPDATE "user" SET "isSuspended" = true WHERE id = ?`, susp.ID).Error)
+
+	// state=alive: recent のみ (stale は 5 日窓外、susp は updatedAt=now でも... 別途)。
+	aliveUsers, err := repo.ListUsers(model.UserListFilter{State: "alive", Limit: 100})
 	require.NoError(t, err)
+	aliveIDs := userIDSet(aliveUsers)
+	assert.Contains(t, aliveIDs, recent.ID, "alive は直近 5 日の user を含む")
+	assert.NotContains(t, aliveIDs, stale.ID, "alive は 5 日より古い user を除外する (#1948-12)")
+
+	// state=available: suspended でない user (recent/stale)、susp は除外。
+	availUsers, err := repo.ListUsers(model.UserListFilter{State: "available", Limit: 100})
+	require.NoError(t, err)
+	availIDs := userIDSet(availUsers)
+	assert.Contains(t, availIDs, stale.ID, "available は updatedAt に依らず未 suspend を含む")
+	assert.NotContains(t, availIDs, susp.ID, "available は suspended を除外する")
+
+	// expired role assignment も role state に含まれる (upstream excludeExpire 既定 false)。
+	now := time.Now()
+	role := &model.Role{ID: "role_lu_exp", Name: "exp-mod", IsModerator: true, UpdatedAt: now, LastUsedAt: now}
+	require.NoError(t, testDB.Create(role).Error)
+	defer testDB.Exec(`DELETE FROM "role" WHERE id = ?`, role.ID)
+	past := now.Add(-1 * time.Hour)
+	ra := &model.RoleAssignment{ID: "ra_exp", UserID: recent.ID, RoleID: role.ID, ExpiresAt: &past}
+	require.NoError(t, testDB.Create(ra).Error)
+	defer testDB.Exec(`DELETE FROM "role_assignment" WHERE id = ?`, ra.ID)
+
+	modUsers, err := repo.ListUsers(model.UserListFilter{State: "moderator", Limit: 100})
+	require.NoError(t, err)
+	assert.Contains(t, userIDSet(modUsers), recent.ID, "expired assignment も moderator state に含まれる (#1948-12)")
+}
+
+func userIDSet(users []*model.User) map[string]struct{} {
+	ids := make(map[string]struct{}, len(users))
 	for _, u := range users {
-		assert.NotEqual(t, root.ID, u.ID, "root must NOT be in state=moderator (admin-only)")
+		ids[u.ID] = struct{}{}
 	}
+	return ids
 }
 
 func TestUserRepository_ListUsers_SortAndPagination(t *testing.T) {


### PR DESCRIPTION
## Summary

#1948 全面互換性再監査の MEDIUM 候補 [12]。`internal/repository/user.go` の `ListUsers` の state
フィルタが upstream admin/show-users と乖離していたのを揃える。

## 主な変更点

- **alive / available の分離**: upstream show-users.ts:64-65 は `available` = `isSuspended=FALSE`、
  `alive` = `updatedAt > now-5d` の別 filter。mk-go は両方を `isSuspended=false` に merge し
  「alive は available の synonym」という誤ったコメントを付けていた。
- **role state の過剰 filter 除去**: admin/moderator/adminOrModerator から `host IS NULL` /
  `expiresAt` filter / root user の OR union を除去。upstream `getAdministratorIds`
  (root は TODO で非対応・expiry 非考慮) / `getModeratorIds` (`includeRoot` 既定 false・
  `excludeExpire` 既定 false) は host も expiry も root も付けず、host は `origin` param で別途
  filter する。#421 で入れた 3 つの追加 filter は upstream に無い過剰実装だった。

ListUsers を role state で呼ぶ caller は admin/show-users のみ (federation/users は origin 固定、
public /users は state enum に role を含まない)。admin/overview の moderator 判定は別経路
(RoleService.IsModerator) で ListUsers role state に依存しないため regression なし。

## テスト

- `internal/repository/user_test.go`:
  - `AdminOrModerator`: remote moderator が含まれる + `Origin:"local"` で remote 除外 (host は
    origin が担う)。
  - `AdminDoesNotIncludeRootUser`: root が admin/adminOrModerator/moderator いずれにも現れない。
  - `AliveAvailableAndExpiry`: alive の 5 日窓 (recent 含む / stale 除外)、available の suspend 除外、
    expired assignment の moderator state 包含。
- repository 90.0% / admin 89.6% (admin 緩和閾値 80%)。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで public `/users` の state enum 未検証 (本 PR 以前からの軽微な乖離) を発見し
別 issue (#1996) に分離した。

## 関連

- 親: #1948

Closes #1997
