### PR TITLE
Fix admin emoji write parity (#1948-13): updatedAt bump / null-clear / 正規化 / role-sort

### DIFF
--- a/internal/api/admin/drive_emoji_test.go
+++ b/internal/api/admin/drive_emoji_test.go
@@ -793,6 +793,76 @@ func TestEmojiListV2_RoleObjectsAndShape(t *testing.T) {
 	shapetest.Assert(t, "EmojiDetailedAdmin", em) // L3 (#1300)
 }
 
+// #1948-13: roleIdsThatCanBeUsedThisEmojiAsReaction は displayOrder DESC, id ASC
+// で sort される (upstream packDetailedAdmin)。
+func TestEmojiListV2_RoleSortByDisplayOrder(t *testing.T) {
+	h, _, _, roleRepo := newTestHandler(t)
+	// displayOrder: rB=10, rA=5, rC=5 (同 displayOrder は id ASC)。
+	require.NoError(t, roleRepo.Create(&model.Role{ID: "rB", Name: "B", DisplayOrder: 10}))
+	require.NoError(t, roleRepo.Create(&model.Role{ID: "rA", Name: "A", DisplayOrder: 5}))
+	require.NoError(t, roleRepo.Create(&model.Role{ID: "rC", Name: "C", DisplayOrder: 5}))
+	repo := testutil.NewMockEmojiRepository()
+	require.NoError(t, repo.Create(&model.Emoji{
+		ID: "e1", Name: "smile", PublicURL: "https://example.com/s.png",
+		// 格納順は意図的にバラバラ。
+		RoleIDsThatCanBeUsedThisEmojiAsReaction: pq.StringArray{"rA", "rC", "rB"},
+	}))
+	h.SetEmojiRepo(repo)
+
+	rec := doPost(h.EmojiListV2, `{}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	em := resp["emojis"].([]any)[0].(map[string]any)
+	roles := em["roleIdsThatCanBeUsedThisEmojiAsReaction"].([]any)
+	require.Len(t, roles, 3)
+	// 期待順: rB(displayOrder10) → rA(5,id A) → rC(5,id C)。
+	assert.Equal(t, "rB", roles[0].(map[string]any)["id"], "displayOrder DESC で rB が先頭 (#1948-13)")
+	assert.Equal(t, "rA", roles[1].(map[string]any)["id"], "同 displayOrder は id ASC で rA (#1948-13)")
+	assert.Equal(t, "rC", roles[2].(map[string]any)["id"])
+}
+
+// #1948-13: set-category-bulk / set-license-bulk に null を送ると SQL NULL に
+// reset される (旧 non-pointer string では "" になっていた)。
+func TestEmojiSetCategoryLicenseBulk_NullClears(t *testing.T) {
+	cat, lic := "anime", "MIT"
+	h, repo := setupEmojiHandler(t,
+		&model.Emoji{ID: "e1", Name: "a", Category: &cat, License: &lic},
+	)
+	get := func() *model.Emoji {
+		e, err := repo.FindByID("e1")
+		require.NoError(t, err)
+		return e
+	}
+	rec := doPost(h.EmojiSetCategoryBulk, `{"ids":["e1"],"category":null}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Nil(t, get().Category, "category null は NULL reset (#1948-13)")
+
+	rec = doPost(h.EmojiSetLicenseBulk, `{"ids":["e1"],"license":null}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Nil(t, get().License, "license null は NULL reset (#1948-13)")
+
+	// 非 null は値設定 (回帰防止)。
+	rec = doPost(h.EmojiSetCategoryBulk, `{"ids":["e1"],"category":"manga"}`, adminUser)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.NotNil(t, get().Category)
+	assert.Equal(t, "manga", *get().Category)
+}
+
+// #1948-13: list-remote の host は toPuny (lowercase + IDN punycode) 正規化される。
+func TestEmojiListRemote_HostToPuny(t *testing.T) {
+	punyHost := "xn--eckwd4c7c.example" // "ドメイン.example" の punycode
+	h, _ := setupEmojiHandler(t,
+		&model.Emoji{ID: "e1", Name: "remote1", Host: &punyHost},
+	)
+	// Unicode IDN を query → handler が toPunyHost で正規化して match。
+	rec := doPost(h.EmojiListRemote, `{"host":"ドメイン.example"}`, adminUser)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp, 1, "IDN host が punycode 正規化されて match する (#1948-13)")
+}
+
 // #1948-10: EmojiDetailedAdmin の updatedAt は upstream toISOString() (.000Z / null)。
 // raw *time.Time の RFC3339Nano だと wire-byte が乖離する。
 func TestEmojiListV2_UpdatedAtFormat(t *testing.T) {

--- a/internal/api/admin/emoji.go
+++ b/internal/api/admin/emoji.go
@@ -251,7 +251,14 @@ func (h *Handler) EmojiListRemote(c echo.Context) error {
 	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 	// sinceDate / untilDate を aidx prefix に正規化 (#1173)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
-	emojis, err := h.emojiRepo.ListRemoteWithFilter(req.Query, req.Host, sinceID, untilID, req.Limit, req.Offset)
+	// upstream list-remote.ts:69 は host を toPuny (lowercase + IDN punycode) して
+	// から equality 突合する。host は punycode 正規化して保存されているため、IDN /
+	// 大文字混在の host param を正規化しないと match しない (#1948-13)。
+	host := req.Host
+	if host != "" {
+		host = toPunyHost(host)
+	}
+	emojis, err := h.emojiRepo.ListRemoteWithFilter(req.Query, host, sinceID, untilID, req.Limit, req.Offset)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 	}
@@ -333,7 +340,7 @@ func (h *Handler) EmojiSetAliasesBulk(c echo.Context) error {
 func (h *Handler) EmojiSetCategoryBulk(c echo.Context) error {
 	var req struct {
 		IDs      []string `json:"ids"`
-		Category string   `json:"category"`
+		Category *string  `json:"category"`
 	}
 	if err := c.Bind(&req); err != nil || len(req.IDs) == 0 {
 		return c.NoContent(http.StatusNoContent)
@@ -341,17 +348,30 @@ func (h *Handler) EmojiSetCategoryBulk(c echo.Context) error {
 	if h.emojiRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
-	if err := h.emojiRepo.UpdateFieldsMany(req.IDs, map[string]any{"category": req.Category}); err != nil {
+	// upstream set-category-bulk は category nullable ('Use null to reset') で
+	// ps.category ?? null を書く。*string にして JSON null を SQL NULL に落とす
+	// (旧 non-pointer string だと null が "" になっていた、#1948-13)。
+	if err := h.emojiRepo.UpdateFieldsMany(req.IDs, map[string]any{"category": nullableString(req.Category)}); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 	}
 	return c.NoContent(http.StatusNoContent)
+}
+
+// nullableString returns the dereferenced string for a non-nil pointer, else nil
+// so a GORM map Updates writes SQL NULL (matching upstream's `?? null` reset
+// semantics for nullable emoji fields, #1948-13).
+func nullableString(p *string) any {
+	if p == nil {
+		return nil
+	}
+	return *p
 }
 
 // EmojiSetLicenseBulk handles POST /api/admin/emoji/set-license-bulk.
 func (h *Handler) EmojiSetLicenseBulk(c echo.Context) error {
 	var req struct {
 		IDs     []string `json:"ids"`
-		License string   `json:"license"`
+		License *string  `json:"license"`
 	}
 	if err := c.Bind(&req); err != nil || len(req.IDs) == 0 {
 		return c.NoContent(http.StatusNoContent)
@@ -359,7 +379,8 @@ func (h *Handler) EmojiSetLicenseBulk(c echo.Context) error {
 	if h.emojiRepo == nil {
 		return c.NoContent(http.StatusNoContent)
 	}
-	if err := h.emojiRepo.UpdateFieldsMany(req.IDs, map[string]any{"license": req.License}); err != nil {
+	// upstream set-license-bulk も license nullable で ps.license ?? null を書く (#1948-13)。
+	if err := h.emojiRepo.UpdateFieldsMany(req.IDs, map[string]any{"license": nullableString(req.License)}); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 	}
 	return c.NoContent(http.StatusNoContent)

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -2665,10 +2665,10 @@ func (h *Handler) EmojiListV2(c echo.Context) error {
 		allPages = int((allCount + int64(limit) - 1) / int64(limit))
 	}
 
-	roleNames := h.emojiRoleNameMap()
+	roleByID := h.emojiRoleByID()
 	packed := make([]map[string]any, 0, len(emojis))
 	for _, e := range emojis {
-		packed = append(packed, packEmojiDetailedAdmin(e, roleNames))
+		packed = append(packed, packEmojiDetailedAdmin(e, roleByID))
 	}
 
 	return c.JSON(http.StatusOK, emojiListV2Response{
@@ -2708,12 +2708,12 @@ type emojiListV2Response struct {
 	AllPages int              `json:"allPages"`
 }
 
-// emojiRoleNameMap resolves all role ids to their names once, so the v2 emoji
-// packer can embed {id, name} for roleIdsThatCanBeUsedThisEmojiAsReaction
-// without an N+1 lookup per emoji (#1300)。roleService 未配線 / 取得失敗時は
-// 空 map を返し、未知 role 同様 roleIds から省かれる。
-func (h *Handler) emojiRoleNameMap() map[string]string {
-	out := map[string]string{}
+// emojiRoleByID resolves all roles by id once, so the v2 emoji packer can embed
+// {id, name} for roleIdsThatCanBeUsedThisEmojiAsReaction without an N+1 lookup
+// per emoji (#1300), and sort them by displayOrder/id like upstream (#1948-13)。
+// roleService 未配線 / 取得失敗時は空 map を返し、未知 role 同様 roleIds から省かれる。
+func (h *Handler) emojiRoleByID() map[string]*model.Role {
+	out := map[string]*model.Role{}
 	if h.roleService == nil {
 		return out
 	}
@@ -2722,7 +2722,7 @@ func (h *Handler) emojiRoleNameMap() map[string]string {
 		return out
 	}
 	for _, r := range roles {
-		out[r.ID] = r.Name
+		out[r.ID] = r
 	}
 	return out
 }
@@ -2731,12 +2731,24 @@ func (h *Handler) emojiRoleNameMap() map[string]string {
 // admin emoji list. upstream packDetailedAdmin と同じく roleIds を {id, name}
 // に解決する (golden は object array、生の string[] ではない)。未知 role は
 // 省く (#1300)。scalar field は model.Emoji の json tag と一致する。
-func packEmojiDetailedAdmin(e *model.Emoji, roleNames map[string]string) map[string]any {
-	roles := make([]map[string]any, 0, len(e.RoleIDsThatCanBeUsedThisEmojiAsReaction))
+func packEmojiDetailedAdmin(e *model.Emoji, roleByID map[string]*model.Role) map[string]any {
+	// upstream packDetailedAdmin は解決した role を displayOrder DESC, id ASC で
+	// sort してから {id, name} に map する (EmojiEntityService、#1948-13)。
+	resolved := make([]*model.Role, 0, len(e.RoleIDsThatCanBeUsedThisEmojiAsReaction))
 	for _, rid := range e.RoleIDsThatCanBeUsedThisEmojiAsReaction {
-		if name, ok := roleNames[rid]; ok {
-			roles = append(roles, map[string]any{"id": rid, "name": name})
+		if r, ok := roleByID[rid]; ok {
+			resolved = append(resolved, r)
 		}
+	}
+	sort.SliceStable(resolved, func(i, j int) bool {
+		if resolved[i].DisplayOrder != resolved[j].DisplayOrder {
+			return resolved[i].DisplayOrder > resolved[j].DisplayOrder // displayOrder DESC
+		}
+		return resolved[i].ID < resolved[j].ID // id ASC
+	})
+	roles := make([]map[string]any, 0, len(resolved))
+	for _, r := range resolved {
+		roles = append(roles, map[string]any{"id": r.ID, "name": r.Name})
 	}
 	// golden aliases は string[] 必須 (non-null)。nil pq.StringArray は null に
 	// なるため [] へ coalesce する。

--- a/internal/repository/emoji.go
+++ b/internal/repository/emoji.go
@@ -3,10 +3,21 @@ package repository
 import (
 	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/gorm"
 )
+
+// bumpEmojiUpdatedAt injects updatedAt=now into an emoji write field map when the
+// caller did not set it. upstream CustomEmojiService は update / 各 bulk op で
+// 必ず updatedAt = new Date() を書くため、map-based GORM Updates でも同等に bump
+// する (model.Emoji.UpdatedAt は autoUpdateTime tag を持たない、#1948-13)。
+func bumpEmojiUpdatedAt(fields map[string]any) {
+	if _, ok := fields["updatedAt"]; !ok {
+		fields["updatedAt"] = time.Now()
+	}
+}
 
 // emojiNameTokenRe extracts `:name:` tokens from an admin/emoji/list query,
 // mirroring upstream list.ts の `/\:([a-z0-9_]*)\:/g` (#1543)。
@@ -90,6 +101,7 @@ func (r *emojiRepository) FindByID(id string) (*model.Emoji, error) {
 }
 
 func (r *emojiRepository) UpdateFields(id string, fields map[string]any) error {
+	bumpEmojiUpdatedAt(fields)
 	res := r.db.Model(&model.Emoji{}).Where("id = ?", id).Updates(fields)
 	if res.Error != nil {
 		return res.Error
@@ -118,6 +130,7 @@ func (r *emojiRepository) UpdateFieldsMany(ids []string, fields map[string]any) 
 	if len(ids) == 0 || len(fields) == 0 {
 		return nil
 	}
+	bumpEmojiUpdatedAt(fields)
 	return r.db.Model(&model.Emoji{}).Where("id IN ?", ids).Updates(fields).Error
 }
 
@@ -152,7 +165,10 @@ func (r *emojiRepository) FindManyByNamesAndHost(names []string, host *string) (
 func (r *emojiRepository) ListRemoteWithFilter(query, host, sinceID, untilID string, limit, offset int) ([]*model.Emoji, error) {
 	q := r.db.Where("host IS NOT NULL").Order("id DESC")
 	if query != "" {
-		q = q.Where("name ILIKE ?", "%"+query+"%")
+		// upstream list-remote.ts:72 は `name LIKE :query` (Postgres LIKE は
+		// case-sensitive) かつ sqlLikeEscape で %/_ を literal 化する。mk-go も
+		// case-sensitive LIKE + escapeLike + ESCAPE '\' に揃える (#1948-13)。
+		q = q.Where(`name LIKE ? ESCAPE '\'`, "%"+escapeLike(query)+"%")
 	}
 	if host != "" {
 		q = q.Where("host = ?", host)
@@ -194,8 +210,10 @@ func (r *emojiRepository) ListWithFilter(query, category string, local bool, sin
 		if names := extractEmojiNameTokens(query); len(names) > 0 {
 			q = q.Where("name IN ?", names)
 		} else {
+			// upstream list.ts は JS String.includes (case-sensitive 部分一致) で
+			// in-memory filter する。mk-go も case-sensitive LIKE に揃える (#1948-13)。
 			like := "%" + escapeLike(query) + "%"
-			q = q.Where(`name ILIKE ? ESCAPE '\' OR array_to_string(aliases, ',') ILIKE ? ESCAPE '\' OR category ILIKE ? ESCAPE '\'`, like, like, like)
+			q = q.Where(`name LIKE ? ESCAPE '\' OR array_to_string(aliases, ',') LIKE ? ESCAPE '\' OR category LIKE ? ESCAPE '\'`, like, like, like)
 		}
 	}
 	if category != "" {

--- a/internal/repository/emoji_test.go
+++ b/internal/repository/emoji_test.go
@@ -62,6 +62,64 @@ func TestEmojiRepository_UpdateFields_RoleIdsAndType(t *testing.T) {
 	assert.Empty(t, []string(got.RoleIDsThatCanBeUsedThisEmojiAsReaction))
 }
 
+// #1948-13: UpdateFields / UpdateFieldsMany は updatedAt を bump する
+// (upstream CustomEmojiService は全 mutation で updatedAt=now を書く)。
+func TestEmojiRepository_UpdateFieldsBumpsUpdatedAt(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+	e := &model.Emoji{ID: "e_bump", Name: "bumpx", OriginalURL: "https://example.com/x.png"}
+	require.NoError(t, testDB.Create(e).Error)
+	defer cleanupEmoji(t, e.ID)
+	// updatedAt を明示的に NULL にしておく。
+	require.NoError(t, testDB.Exec(`UPDATE emoji SET "updatedAt" = NULL WHERE id = ?`, e.ID).Error)
+
+	require.NoError(t, repo.UpdateFields(e.ID, map[string]any{"name": "bumped"}))
+	got, err := repo.FindByID(e.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.UpdatedAt, "UpdateFields は updatedAt を bump する (#1948-13)")
+
+	// UpdateFieldsMany も bump する。
+	require.NoError(t, testDB.Exec(`UPDATE emoji SET "updatedAt" = NULL WHERE id = ?`, e.ID).Error)
+	require.NoError(t, repo.UpdateFieldsMany([]string{e.ID}, map[string]any{"category": "x"}))
+	got, err = repo.FindByID(e.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.UpdatedAt, "UpdateFieldsMany は updatedAt を bump する (#1948-13)")
+}
+
+// #1948-13: list-remote の query は case-sensitive LIKE かつ %/_ を escape する。
+func TestEmojiRepository_ListRemoteCaseSensitiveAndEscape(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+	host := "remote.example"
+	lower := &model.Emoji{ID: "e_lr_lower", Name: "catface", Host: &host, OriginalURL: "https://r/x.png"}
+	upper := &model.Emoji{ID: "e_lr_upper", Name: "CATFACE", Host: &host, OriginalURL: "https://r/y.png"}
+	pct := &model.Emoji{ID: "e_lr_pct", Name: "a%b", Host: &host, OriginalURL: "https://r/z.png"}
+	for _, e := range []*model.Emoji{lower, upper, pct} {
+		require.NoError(t, testDB.Create(e).Error)
+		defer cleanupEmoji(t, e.ID)
+	}
+
+	// query "cat" は case-sensitive で "catface" のみ match (CATFACE は除外)。
+	got, err := repo.ListRemoteWithFilter("cat", host, "", "", 100, 0)
+	require.NoError(t, err)
+	ids := emojiIDSet(got)
+	assert.Contains(t, ids, lower.ID, "case-sensitive LIKE で catface が match (#1948-13)")
+	assert.NotContains(t, ids, upper.ID, "case-sensitive LIKE で CATFACE は除外 (#1948-13)")
+
+	// query "a%b" の % は escape され literal match ("a%b" 名のみ)。
+	got, err = repo.ListRemoteWithFilter("a%b", host, "", "", 100, 0)
+	require.NoError(t, err)
+	ids = emojiIDSet(got)
+	assert.Contains(t, ids, pct.ID, "% は escape され literal match する (#1948-13)")
+	assert.NotContains(t, ids, lower.ID, "% は wildcard として解釈されない")
+}
+
+func emojiIDSet(emojis []*model.Emoji) map[string]struct{} {
+	ids := make(map[string]struct{}, len(emojis))
+	for _, e := range emojis {
+		ids[e.ID] = struct{}{}
+	}
+	return ids
+}
+
 func TestEmojiRepository_FindByNameAndHost_Remote(t *testing.T) {
 	repo := NewEmojiRepository(testDB)
 

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -2173,11 +2173,16 @@ func (m *MockEmojiRepository) UpdateFieldsMany(ids []string, fields map[string]a
 		for k, v := range fields {
 			switch k {
 			case "category":
-				if s, ok := v.(string); ok {
+				// nil (any) は null reset (#1948-13)。string は値設定。
+				if v == nil {
+					e.Category = nil
+				} else if s, ok := v.(string); ok {
 					e.Category = &s
 				}
 			case "license":
-				if s, ok := v.(string); ok {
+				if v == nil {
+					e.License = nil
+				} else if s, ok := v.(string); ok {
 					e.License = &s
 				}
 			case "aliases":
@@ -2229,7 +2234,9 @@ func (m *MockEmojiRepository) ListRemoteWithFilter(query, host, sinceID, untilID
 		if host != "" && *e.Host != host {
 			continue
 		}
-		if query != "" && !strings.Contains(strings.ToLower(e.Name), strings.ToLower(query)) {
+		// production ListRemoteWithFilter は case-sensitive LIKE (#1948-13) なので
+		// mock も case-sensitive Contains に揃える。
+		if query != "" && !strings.Contains(e.Name, query) {
 			continue
 		}
 		if sinceID != "" && e.ID <= sinceID {


### PR DESCRIPTION
## Summary

#1948 全面互換性再監査の MEDIUM 候補 [13]。admin emoji write の複数の取りこぼしを upstream
CustomEmojiService に揃える。

## 主な変更点

- **updatedAt bump** (`internal/repository/emoji.go`): `UpdateFields`/`UpdateFieldsMany` に
  `bumpEmojiUpdatedAt` を挿入。upstream は update / 各 bulk op で `updatedAt = new Date()` を書くが、
  mk-go の map-based GORM Updates は bump せず `model.Emoji.UpdatedAt` に autoUpdateTime tag も無かった。
- **set-category/license-bulk の null-clear** (`internal/api/admin/emoji.go`): `req.Category`/`License`
  を `*string` 化し `nullableString()` で JSON null を SQL NULL に reset (paramDef は nullable
  'Use null to reset')。旧 non-pointer string では null が "" になっていた。
- **list-remote host toPuny**: `EmojiListRemote` で `toPunyHost(req.Host)` 正規化 (upstream
  list-remote.ts:69)。
- **list-remote / list の query**: list-remote を case-sensitive LIKE + `escapeLike` + `ESCAPE '\'`、
  list を ILIKE→LIKE (upstream は String.includes / SQL LIKE で case-sensitive、list-remote は
  sqlLikeEscape)。
- **role array sort** (`internal/api/admin/handler.go`): `emojiRoleByID` が Role を返すようにし、
  `packEmojiDetailedAdmin` で displayOrder DESC, id ASC に sort (upstream packDetailedAdmin)。

## テスト

- `drive_emoji_test.go`: role displayOrder DESC/id ASC sort / set-category・license-bulk の null-clear /
  list-remote host toPuny。
- `emoji_test.go` (統合): UpdateFields・UpdateFieldsMany の updatedAt bump / list-remote の
  case-sensitive + escape。
- mock `ListRemoteWithFilter` も case-sensitive に追従。
- admin 89.6% (緩和閾値 80%) / repository 90.0%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで、v2 `buildV2Query` の ILIKE 残置 (最高トラフィックの主クエリ) / legacy list の
limit+1 / emoji broadcast stream 未実装 / import-zip 同期 reject を別 issue (#1999) に分離した。

## 関連

- 親: #1948

Closes #2000
