### PR TITLE
Fix drive parity (#1948-14): getPublicProperties (orientation 正規化) を非 self pack に実装

### DIFF
--- a/internal/api/admin/drive.go
+++ b/internal/api/admin/drive.go
@@ -202,7 +202,9 @@ func (h *Handler) packDriveFileAdmin(f *model.DriveFile) entity.DriveFileEntity 
 			user = u
 		}
 	}
-	return entity.PackDriveFileWithRelations(f, h.idGen, nil, user)
+	// admin moderation view は upstream pack({self:true}) 相当で raw properties を
+	// 保持する (orientation を strip しない、#1948-14)。
+	return entity.PackDriveFileWithRelationsSelf(f, h.idGen, nil, user)
 }
 
 // DriveShowFile handles POST /api/admin/drive/show-file.
@@ -257,7 +259,10 @@ func (h *Handler) packAdminDriveShowFile(f *model.DriveFile, viewer *model.User)
 	// browser が img src として取得するこれら 3 つは、通常の drive pack と同じ
 	// media proxy 書き換え (image 限定・thumbnail は static mode・remote のみ) を
 	// 通すことで一貫させる。uri/accessKey 等は moderation 用の raw メタなのでそのまま。
-	packed := entity.PackDriveFile(f, h.idGen)
+	// admin moderation view は self:true 相当。ここでは packed から url/thumbnailUrl/
+	// webpublicUrl のみ使い、properties は後段の driveFileProperties が raw 返却するため
+	// self の有無は実効的に URL のみに影響する。一貫性のため Self 変種を使う (#1948-14)。
+	packed := entity.PackDriveFileSelf(f, h.idGen)
 	fileURL := packed.URL
 	thumbURL := packed.ThumbnailURL
 	webpublicURL := packed.WebpublicURL

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -141,7 +141,7 @@ var driveTypePatternRe = regexp.MustCompile(`^[a-zA-Z/\-*]+$`)
 // self list path とは異なり userId も **null にする** 点に注意 (= pack は
 // detail=false で userId を返さない、packNullable とは別経路)。
 func packDriveFileSelfSingle(f *model.DriveFile, idGen id.Generator) entity.DriveFileEntity {
-	e := entity.PackDriveFile(f, idGen)
+	e := entity.PackDriveFileSelf(f, idGen)
 	e.UserID = nil
 	return e
 }
@@ -159,7 +159,7 @@ func packDriveFileSelfSingle(f *model.DriveFile, idGen id.Generator) entity.Driv
 // self single path (#812) とは異なり userId は **owner ID を維持** する
 // (= packNullable は userId を常時返す)。
 func (h *Handler) packDriveFileSelfList(f *model.DriveFile) entity.DriveFileEntity {
-	return entity.PackDriveFile(f, h.idGen)
+	return entity.PackDriveFileSelf(f, h.idGen)
 }
 
 // readMultipartFile extracts the uploaded file's bytes and original filename.
@@ -303,7 +303,7 @@ func (h *Handler) FilesShow(c echo.Context) error {
 // (#1564)。folder / user は各 1 回だけ fetch する (full pack 経由の二重
 // fetch を解消、#1564 review)。
 func (h *Handler) packDriveFileShow(f *model.DriveFile) entity.DriveFileEntity {
-	e := entity.PackDriveFile(f, h.idGen)
+	e := entity.PackDriveFileSelf(f, h.idGen)
 	if h.folderRepo != nil && f.FolderID != nil {
 		if fo, err := h.folderRepo.FindByID(*f.FolderID); err == nil {
 			d := h.packDriveFolderDetail(fo)

--- a/internal/core/drive/drive_service.go
+++ b/internal/core/drive/drive_service.go
@@ -446,7 +446,7 @@ func (s *Service) Upload(ctx context.Context, in UploadInput) (*model.DriveFile,
 		// driveFileCreatedをemitしてUploader自身のUI(ドロップアップロード等)
 		// を即時反映させる(TS: DriveService.ts:665)。
 		if s.mainStreamPublisher != nil {
-			s.mainStreamPublisher.PublishMainEvent(in.User.ID, "driveFileCreated", entity.PackDriveFile(f, s.idGen))
+			s.mainStreamPublisher.PublishMainEvent(in.User.ID, "driveFileCreated", entity.PackDriveFileSelf(f, s.idGen))
 		}
 	}
 	// chartHook は user nil でも発火させる: bytes / count は instance-wide

--- a/internal/entity/drive.go
+++ b/internal/entity/drive.go
@@ -46,11 +46,45 @@ type DriveFileEntity struct {
 	User *UserLite `json:"user"`
 }
 
-// PackDriveFile converts a model.DriveFile to a DriveFileEntity. The Folder
-// and User fields are left nil; callers that need the nested objects should
-// fetch them via DriveFolderRepository / UserRepository and assign
-// &PackDriveFolder(...) / &PackUserLite(...) to the returned entity.
+// applyPublicProperties mirrors upstream DriveFileEntityService.getPublicProperties
+// (DriveFileEntityService.ts:67-78): when the stored properties carry an EXIF
+// orientation, the public (non-self) view reports the visually-correct dimensions
+// (width/height swapped for orientation >= 5) and strips the orientation key
+// entirely. The raw stored properties (including orientation) are returned only
+// for the self path (owner / admin drive listings) (#1948-14)。
+//
+// 注: mk-go ネイティブのデータは orientation を properties に保存しない (local は
+// image_processor が pixel を auto-orient して補正済 width/height のみ、remote は
+// {width,height} のみ格納) ため、この変換は native データでは no-op。real Misskey
+// DB を drop-in した legacy データ (orientation を持つ) でのみ作用する。
+func applyPublicProperties(props DriveFileProperties) DriveFileProperties {
+	if props.Orientation == nil {
+		return props
+	}
+	if *props.Orientation >= 5 {
+		props.Width, props.Height = props.Height, props.Width
+	}
+	props.Orientation = nil
+	return props
+}
+
+// PackDriveFile converts a model.DriveFile to a DriveFileEntity for the public
+// (non-self) view: EXIF orientation is normalized via applyPublicProperties. The
+// Folder and User fields are left nil; callers that need the nested objects should
+// fetch them and assign &PackDriveFolder(...) / &PackUserLite(...). Owner/admin
+// (self) listings must use PackDriveFileSelf to keep raw properties.
 func PackDriveFile(f *model.DriveFile, idGen id.Generator) DriveFileEntity {
+	return packDriveFile(f, idGen, false)
+}
+
+// PackDriveFileSelf is PackDriveFile for the self path (owner-owned drive
+// listings and admin moderation views): the raw stored properties are kept,
+// matching upstream pack({self: true}) (#1948-14)。
+func PackDriveFileSelf(f *model.DriveFile, idGen id.Generator) DriveFileEntity {
+	return packDriveFile(f, idGen, true)
+}
+
+func packDriveFile(f *model.DriveFile, idGen id.Generator, self bool) DriveFileEntity {
 	createdAt := ""
 	if t, err := idGen.ParseTime(f.ID); err == nil {
 		createdAt = t.UTC().Format("2006-01-02T15:04:05.000Z")
@@ -61,10 +95,16 @@ func PackDriveFile(f *model.DriveFile, idGen id.Generator) DriveFileEntity {
 	if len(f.Properties) > 0 {
 		_ = json.Unmarshal(f.Properties, &props)
 	}
+	// 非 self (公開) view は orientation を normalize する (upstream getPublicProperties)。
+	if !self {
+		props = applyPublicProperties(props)
+	}
 	// remote (link 形式) file の url/thumbnailUrl/webpublicUrl は remote origin
 	// をそのまま指すため、pack 時に media proxy 経由 URL へ書き換えて閲覧者の
 	// IP 漏洩を防ぐ (#1529)。context 未配線 (= nil) の場合は raw を返し従来
-	// 挙動を維持する (メソッドは nil-safe)。
+	// 挙動を維持する (メソッドは nil-safe)。admin/drive も同 proxy を通すのは
+	// upstream の self:true raw-url 契約からの意図的 deviation (moderator IP 保護、
+	// #1529 / #1948-14 で文書化済)。
 	ctx := currentMediaURLContext()
 	return DriveFileEntity{
 		ID:           f.ID,
@@ -124,12 +164,22 @@ func isImageMime(t string) bool {
 	return t[:6] == "image/"
 }
 
-// PackDriveFileWithRelations is PackDriveFile + optional folder/user
+// PackDriveFileWithRelations is PackDriveFile (non-self) + optional folder/user
 // embedding. The caller is responsible for fetching the related rows (so
 // batch/cached access is possible). Pass nil for fields you do not want to
 // expose — JSON 上は `null` として出る (#812 で omitempty を外した)。
 func PackDriveFileWithRelations(f *model.DriveFile, idGen id.Generator, folder *model.DriveFolder, user *model.User) DriveFileEntity {
-	out := PackDriveFile(f, idGen)
+	return packDriveFileWithRelations(f, idGen, folder, user, false)
+}
+
+// PackDriveFileWithRelationsSelf is PackDriveFileWithRelations for the self path
+// (admin moderation drive views): raw properties are kept (#1948-14)。
+func PackDriveFileWithRelationsSelf(f *model.DriveFile, idGen id.Generator, folder *model.DriveFolder, user *model.User) DriveFileEntity {
+	return packDriveFileWithRelations(f, idGen, folder, user, true)
+}
+
+func packDriveFileWithRelations(f *model.DriveFile, idGen id.Generator, folder *model.DriveFolder, user *model.User, self bool) DriveFileEntity {
+	out := packDriveFile(f, idGen, self)
 	if folder != nil {
 		packed := PackDriveFolder(folder, idGen)
 		out.Folder = &packed

--- a/internal/entity/drive_test.go
+++ b/internal/entity/drive_test.go
@@ -145,15 +145,35 @@ func TestPackDriveFile_AllPropertyFields(t *testing.T) {
 		URL:        "https://example.com/p.jpg",
 		Properties: datatypes.JSON(props),
 	}
+	// #1948-14: PackDriveFile は非 self (公開) view なので getPublicProperties を
+	// 適用する。orientation=8 (>=5) なので width/height が swap され、orientation は
+	// strip される (upstream getPublicProperties)。
 	out := PackDriveFile(f, idGen)
 	require.NotNil(t, out.Properties.Width)
-	assert.Equal(t, 1280, *out.Properties.Width)
+	assert.Equal(t, 720, *out.Properties.Width, "orientation>=5 で width/height が swap (#1948-14)")
 	require.NotNil(t, out.Properties.Height)
-	assert.Equal(t, 720, *out.Properties.Height)
-	require.NotNil(t, out.Properties.Orientation)
-	assert.Equal(t, 8, *out.Properties.Orientation)
+	assert.Equal(t, 1280, *out.Properties.Height)
+	assert.Nil(t, out.Properties.Orientation, "非 self view は orientation を strip (#1948-14)")
 	require.NotNil(t, out.Properties.AvgColor)
 	assert.Equal(t, "rgb(40,65,87)", *out.Properties.AvgColor)
+
+	// #1948-14: self path (PackDriveFileSelf) は raw properties を保持する。
+	self := PackDriveFileSelf(f, idGen)
+	assert.Equal(t, 1280, *self.Properties.Width, "self view は raw width を保持")
+	assert.Equal(t, 720, *self.Properties.Height)
+	require.NotNil(t, self.Properties.Orientation, "self view は orientation を保持 (#1948-14)")
+	assert.Equal(t, 8, *self.Properties.Orientation)
+}
+
+// #1948-14: orientation < 5 は width/height を swap せず orientation だけ strip する。
+func TestPackDriveFile_PublicPropertiesNoSwapBelowFive(t *testing.T) {
+	idGen := newTestIDGen(t)
+	props, _ := json.Marshal(map[string]any{"width": 1280, "height": 720, "orientation": 3})
+	f := &model.DriveFile{ID: idGen.Generate(time.Now()), Name: "p.jpg", URL: "https://e/p.jpg", Properties: datatypes.JSON(props)}
+	out := PackDriveFile(f, idGen)
+	assert.Equal(t, 1280, *out.Properties.Width, "orientation<5 は swap しない")
+	assert.Equal(t, 720, *out.Properties.Height)
+	assert.Nil(t, out.Properties.Orientation, "orientation は strip される")
 }
 
 func TestPackDriveFile_InvalidPropertiesJSON_Defaults(t *testing.T) {


### PR DESCRIPTION
## Summary

#1948 全面互換性再監査の MEDIUM 候補 [14]。drive file pack の EXIF orientation 正規化
(getPublicProperties) を upstream に揃え、admin/drive の URL proxy deviation を文書化する。

## 主な変更点

- **getPublicProperties** (`internal/entity/drive.go`): `applyPublicProperties` を追加し、非 self
  (公開) view で orientation>=5 のとき width/height を swap し orientation を strip する (upstream
  `DriveFileEntityService.getPublicProperties`)。`PackDriveFile` を非 self 化、self path 用に
  `PackDriveFileSelf` / `PackDriveFileWithRelationsSelf` を追加して raw properties を保持。
- **self path 配線**: owner-owned drive endpoints (`packDriveFileSelfSingle`/`List`/`Show`)、
  `driveFileCreated` main-stream event、admin/drive (`packDriveFileAdmin` / `DriveShowFile`) を
  Self 変種に切替 (upstream の `self:true` 経路と一致)。note 添付・gallery・page・chat・draft は
  非 self のまま。
- **admin URL proxy**: upstream admin/drive/files・show-file は self:true で raw url を返すが、
  mk-go は #1529 (moderator IP leak 防止) で remote url を media-proxy する。revert は IP-leak
  再発のため、意図的 deviation として code comment で文書化 (動作維持)。

注: mk-go ネイティブデータは orientation を properties に保存しない (local は image_processor が
pixel auto-orient 済 / remote は {width,height} のみ) ため、本変換は native では no-op。real
Misskey DB を drop-in した legacy データでのみ作用する。

## テスト

- `internal/entity/drive_test.go`: orientation=8 で width/height swap + strip / orientation<5 で
  非 swap + strip / PackDriveFileSelf が raw 保持。
- entity 96.2% / drive 90.1% / admin 89.6% / core/drive 97.7%。`make fmt` / `go vet ./...` /
  `make test` green。

## 補足

敵対的レビューで、drive **channel** の fileCreated/fileUpdated が raw model を serialize する既存の
shape drift (本 PR の main-stream 経路とは別) を発見し #2002 に分離した。

## 関連

- 親: #1948

Closes #2003
