### PR TITLE
Fix null-clear/forPublic parity (#1948-15): users/lists/* と channels/update の absent/null 区別

### DIFF
--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/notehide"
+	"github.com/shiroha-a/mk/internal/api/optional"
 	"github.com/shiroha-a/mk/internal/api/pagination"
 	corechannel "github.com/shiroha-a/mk/internal/core/channel"
 	"github.com/shiroha-a/mk/internal/core/notesfilter"
@@ -257,15 +258,15 @@ func (h *Handler) packPinnedNotes(ctx context.Context, ch *model.Channel, viewer
 
 // UpdateRequest is the request body for channels/update.
 type UpdateRequest struct {
-	ChannelID             string    `json:"channelId"`
-	Name                  *string   `json:"name"`
-	Description           *string   `json:"description"`
-	Color                 *string   `json:"color"`
-	IsArchived            *bool     `json:"isArchived"`
-	IsSensitive           *bool     `json:"isSensitive"`
-	BannerID              *string   `json:"bannerId"`
-	PinnedNoteIDs         *[]string `json:"pinnedNoteIds"`
-	AllowRenoteToExternal *bool     `json:"allowRenoteToExternal"`
+	ChannelID             string                    `json:"channelId"`
+	Name                  *string                   `json:"name"`
+	Description           optional.Nullable[string] `json:"description"`
+	Color                 *string                   `json:"color"`
+	IsArchived            *bool                     `json:"isArchived"`
+	IsSensitive           *bool                     `json:"isSensitive"`
+	BannerID              *string                   `json:"bannerId"`
+	PinnedNoteIDs         *[]string                 `json:"pinnedNoteIds"`
+	AllowRenoteToExternal *bool                     `json:"allowRenoteToExternal"`
 }
 
 // Update handles POST /api/channels/update.
@@ -284,8 +285,11 @@ func (h *Handler) Update(c echo.Context) error {
 		PinnedNoteIDs:         req.PinnedNoteIDs,
 		AllowRenoteToExternal: req.AllowRenoteToExternal,
 	}
-	if req.Description != nil {
-		desc := req.Description
+	// upstream channels/update.ts は description を `!== undefined` で spread するため、
+	// explicit null も書き込んで NULL clear する。absent は維持 (#1948-15)。
+	// in.Description は **string: nil=未変更 / *が nil=NULL clear / 値=設定。
+	if req.Description.Present {
+		desc := req.Description.Value // *string (nil for explicit null)
 		in.Description = &desc
 	}
 	// bannerId 設定時 (空文字 = 解除は検証不要) は所有権を検証する

--- a/internal/api/channels/handler_test.go
+++ b/internal/api/channels/handler_test.go
@@ -246,6 +246,39 @@ func TestUpdate_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// #1948-15: description の absent/null/value を区別する。
+//
+//	absent → 維持 / null → NULL clear / "x" → 設定 (upstream は !== undefined で spread)。
+func TestUpdate_DescriptionNullAbsentValue(t *testing.T) {
+	h, repo, _, _ := newHandler(t)
+	owner := "alice"
+	old := "old desc"
+	repo.Channels["c1"] = &model.Channel{ID: "c1", Name: "alpha", UserID: &owner, Description: &old}
+
+	// absent → 維持。
+	c, rec := newReq(t, `{"channelId":"c1","name":"a2"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Update(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, repo.Channels["c1"].Description, "description 省略は維持 (#1948-15)")
+	assert.Equal(t, "old desc", *repo.Channels["c1"].Description)
+
+	// null → NULL clear。
+	c, rec = newReq(t, `{"channelId":"c1","description":null}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Update(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Nil(t, repo.Channels["c1"].Description, "description:null は NULL clear (#1948-15)")
+
+	// "new" → 設定。
+	c, rec = newReq(t, `{"channelId":"c1","description":"new"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Update(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, repo.Channels["c1"].Description)
+	assert.Equal(t, "new", *repo.Channels["c1"].Description)
+}
+
 func TestUpdate_BadJSON(t *testing.T) {
 	h, _, _, _ := newHandler(t)
 	c, rec := newReq(t, `{not`)

--- a/internal/api/optional/nullable.go
+++ b/internal/api/optional/nullable.go
@@ -1,0 +1,37 @@
+// Package optional provides a JSON wrapper that distinguishes an absent field
+// from an explicit null, which Go's encoding/json cannot express with a plain
+// pointer (both decode to nil).
+package optional
+
+import "encoding/json"
+
+// Nullable distinguishes three states of a JSON field: absent (Present=false),
+// explicit null (Present=true, Value=nil), and a concrete value (Present=true,
+// Value=&v). Upstream Misskey endpoints frequently branch on `ps.x !== undefined`
+// (present) vs `ps.x === null` (explicit null) — e.g. channels/update clears
+// description on null and i/webhooks/update resets secret to "" on null — which a
+// plain *T cannot represent. encoding/json only calls UnmarshalJSON when the key
+// is present, so an omitted key leaves the zero value (Present=false).
+type Nullable[T any] struct {
+	Present bool
+	Value   *T
+}
+
+// UnmarshalJSON records that the key was present and decodes its value (nil for
+// an explicit JSON null).
+func (n *Nullable[T]) UnmarshalJSON(data []byte) error {
+	n.Present = true
+	if string(data) == "null" {
+		n.Value = nil
+		return nil
+	}
+	var v T
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	n.Value = &v
+	return nil
+}
+
+// IsNull reports whether the field was present and explicitly null.
+func (n Nullable[T]) IsNull() bool { return n.Present && n.Value == nil }

--- a/internal/api/optional/nullable_test.go
+++ b/internal/api/optional/nullable_test.go
@@ -1,0 +1,44 @@
+package optional
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNullable_AbsentNullValue(t *testing.T) {
+	type body struct {
+		Secret Nullable[string] `json:"secret"`
+	}
+
+	// absent: Present=false。
+	var absent body
+	require.NoError(t, json.Unmarshal([]byte(`{}`), &absent))
+	assert.False(t, absent.Secret.Present, "absent key は Present=false")
+	assert.False(t, absent.Secret.IsNull())
+
+	// explicit null: Present=true, Value=nil。
+	var null body
+	require.NoError(t, json.Unmarshal([]byte(`{"secret":null}`), &null))
+	assert.True(t, null.Secret.Present)
+	assert.Nil(t, null.Secret.Value)
+	assert.True(t, null.Secret.IsNull(), "explicit null は IsNull=true")
+
+	// value: Present=true, Value=&v。
+	var val body
+	require.NoError(t, json.Unmarshal([]byte(`{"secret":"x"}`), &val))
+	assert.True(t, val.Secret.Present)
+	require.NotNil(t, val.Secret.Value)
+	assert.Equal(t, "x", *val.Secret.Value)
+	assert.False(t, val.Secret.IsNull())
+}
+
+func TestNullable_InvalidValueErrors(t *testing.T) {
+	type body struct {
+		N Nullable[int] `json:"n"`
+	}
+	var b body
+	assert.Error(t, json.Unmarshal([]byte(`{"n":"notint"}`), &b))
+}

--- a/internal/api/userlists/handler.go
+++ b/internal/api/userlists/handler.go
@@ -217,11 +217,20 @@ func (h *Handler) Show(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7bc05c21-1d7a-41ae-88f1-66820f4dc686"))
 	}
-	// upstream users/lists/show: 非公開リストは所有者のみ閲覧可。public リスト
-	// は誰でも閲覧可。所有者でも public でもない場合は存在を隠す (NO_SUCH_LIST)。
-	// これが無いと任意の認証ユーザーが他人の私的リスト (とメンバー) を読めてしまう。
+	// upstream show.ts は forPublic で selection を切り替える (#1948-15):
+	//   !forPublic && me != null  → {id, userId: me.id}  (= 自分の list のみ。private 可)
+	//   それ以外 (forPublic / 匿名) → {id, isPublic: true} (= public list のみ)
+	// 以前の mk-go は「private は所有者のみ / public は誰でも」と緩く、(a) 認証
+	// 非所有者が他人の public list を forPublic 無しで読め、(b) forPublic=true で
+	// 自分の private list が 404 にならない、という乖離があった。
 	viewer := middleware.GetUser(c)
-	if !list.IsPublic && (viewer == nil || list.UserID != viewer.ID) {
+	var visible bool
+	if !req.ForPublic && viewer != nil {
+		visible = list.UserID == viewer.ID
+	} else {
+		visible = list.IsPublic
+	}
+	if !visible {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7bc05c21-1d7a-41ae-88f1-66820f4dc686"))
 	}
 	packed := entity.PackUserList(list, h.memberIDs(list.ID), h.idGen)

--- a/internal/api/userlists/handler_test.go
+++ b/internal/api/userlists/handler_test.go
@@ -642,11 +642,16 @@ func TestShow_PrivateListNonOwnerHidden(t *testing.T) {
 	assert.Contains(t, rec.Body.String(), "NO_SUCH_LIST")
 }
 
-// public リストは非所有者でも閲覧可 (upstream: isPublic なら誰でも閲覧)。
-func TestShow_PublicListNonOwnerVisible(t *testing.T) {
+// #1948-15: 非所有者が他人の public list を閲覧するには forPublic=true が必要。
+// default (forPublic=false) は {id, userId:me} selection なので 404 (upstream 一致)。
+func TestShow_PublicListNonOwnerNeedsForPublic(t *testing.T) {
 	h, repo := newTestHandler(t)
 	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "u1", Name: "Public", IsPublic: true}
+	// default forPublic=false → 404。
 	rec := doPost(h.Show, `{"listId":"l1"}`, &model.User{ID: "u2"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	// forPublic=true → 200。
+	rec = doPost(h.Show, `{"listId":"l1","forPublic":true}`, &model.User{ID: "u2"})
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
@@ -696,16 +701,45 @@ func TestShow_NoForPublicNoLikedFields(t *testing.T) {
 	assert.NotContains(t, resp, "isLiked")
 }
 
-// forPublic=true でも private list (owner 閲覧) には likedCount/isLiked を付けない。
-func TestShow_ForPublicPrivateNoLikedFields(t *testing.T) {
+// #1948-15: forPublic=true は {id, isPublic:true} selection なので、自分の private
+// list でも 404 (NO_SUCH_LIST) になる (upstream show.ts と一致)。
+func TestShow_ForPublicOwnPrivateNotFound(t *testing.T) {
 	h, repo := newTestHandler(t)
 	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "owner", Name: "priv", IsPublic: false}
 	h.SetFavoriteRepo(testutil.NewMockUserListFavoriteRepository())
 	rec := doPost(h.Show, `{"listId":"l1","forPublic":true}`, &model.User{ID: "owner"})
-	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_LIST")
+}
+
+// #1948-15: default (forPublic=false) で認証非所有者は他人の public list を読めない
+// ({id, userId:me} selection)。
+func TestShow_NonOwnerPublicListNotFound(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "owner", Name: "pub", IsPublic: true}
+	rec := doPost(h.Show, `{"listId":"l1"}`, &model.User{ID: "other"})
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_LIST")
+}
+
+// #1948-15: default で所有者は自分の private list を読める ({id, userId:me})。
+func TestShow_OwnerPrivateListVisible(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "owner", Name: "priv", IsPublic: false}
+	rec := doPost(h.Show, `{"listId":"l1"}`, &model.User{ID: "owner"})
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// #1948-15: forPublic=true で他人の public list は読める ({id, isPublic:true})。
+func TestShow_ForPublicOtherPublicVisible(t *testing.T) {
+	h, repo := newTestHandler(t)
+	repo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "owner", Name: "pub", IsPublic: true}
+	h.SetFavoriteRepo(testutil.NewMockUserListFavoriteRepository())
+	rec := doPost(h.Show, `{"listId":"l1","forPublic":true}`, &model.User{ID: "other"})
+	assert.Equal(t, http.StatusOK, rec.Code)
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	assert.NotContains(t, resp, "likedCount")
+	assert.Contains(t, resp, "likedCount", "forPublic && public は likedCount を付与")
 }
 
 // 他人 list への push が「存在しない」扱いで弾かれること。viewer が list owner

--- a/internal/api/users/lists.go
+++ b/internal/api/users/lists.go
@@ -291,9 +291,15 @@ func (h *Handler) listMemberIDs(listID string) []string {
 func (h *Handler) ListsUpdateMembership(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req struct {
-		ListID      string `json:"listId"`
-		UserID      string `json:"userId"`
-		WithReplies bool   `json:"withReplies"`
+		ListID string `json:"listId"`
+		UserID string `json:"userId"`
+		// upstream update-membership.ts は withReplies を optional param とする。
+		// 旧 mk-go は non-pointer bool で「省略時に false へ clobber」していたが、
+		// これは partial update で既存 withReplies を意図せず潰す bug だった。*bool に
+		// して absent(nil)=維持、明示値=更新と区別する (#1948-15)。なお upstream は
+		// withReplies 省略時に TypeORM の空 SET で 500 を投げる挙動だが、mk-go は
+		// 既存値維持の方が合理的なのでそちらを採る (#2005 で方針追跡)。
+		WithReplies *bool `json:"withReplies"`
 	}
 	if err := c.Bind(&req); err != nil || req.ListID == "" || req.UserID == "" {
 		return apierr.JSONInvalidParam(c)

--- a/internal/api/users/lists_test.go
+++ b/internal/api/users/lists_test.go
@@ -552,6 +552,27 @@ func TestListsUpdateMembership_Success(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 }
 
+// #1948-15: withReplies を省略すると既存値を維持する (upstream は undefined カラムを
+// skip)。明示値は更新する。
+func TestListsUpdateMembership_WithRepliesOmittedPreserves(t *testing.T) {
+	h, _ := newTestHandler(t)
+	listRepo := testutil.NewMockUserListRepository()
+	listRepo.Lists["l1"] = &model.UserList{ID: "l1", UserID: "u1", Name: "test"}
+	mem := &model.UserListMembership{ID: "m1", UserListID: "l1", UserID: "u2", WithReplies: true}
+	listRepo.Members = append(listRepo.Members, mem)
+	h.SetUserListRepo(listRepo)
+
+	// withReplies 省略 → 既存 true を維持。
+	rec := postStub(h.ListsUpdateMembership, `{"listId":"l1","userId":"u2"}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.True(t, mem.WithReplies, "withReplies 省略時は既存値を維持 (#1948-15)")
+
+	// withReplies:false → 明示更新。
+	rec = postStub(h.ListsUpdateMembership, `{"listId":"l1","userId":"u2","withReplies":false}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.False(t, mem.WithReplies, "明示 false は更新する (#1948-15)")
+}
+
 func TestListsUpdateMembership_NotFound(t *testing.T) {
 	h, _ := newTestHandler(t)
 	listRepo := testutil.NewMockUserListRepository()

--- a/internal/api/webhooks/handler.go
+++ b/internal/api/webhooks/handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/api/optional"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -181,12 +182,12 @@ func (h *Handler) Show(c echo.Context) error {
 func (h *Handler) Update(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req struct {
-		WebhookID string   `json:"webhookId"`
-		Name      string   `json:"name"`
-		URL       string   `json:"url"`
-		Secret    *string  `json:"secret"`
-		On        []string `json:"on"`
-		Active    *bool    `json:"active"`
+		WebhookID string                    `json:"webhookId"`
+		Name      string                    `json:"name"`
+		URL       string                    `json:"url"`
+		Secret    optional.Nullable[string] `json:"secret"`
+		On        []string                  `json:"on"`
+		Active    *bool                     `json:"active"`
 	}
 	if err := c.Bind(&req); err != nil || req.WebhookID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "webhookId is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
@@ -206,8 +207,14 @@ func (h *Handler) Update(c echo.Context) error {
 	if req.URL != "" {
 		w.URL = req.URL
 	}
-	if req.Secret != nil {
-		w.Secret = *req.Secret
+	// upstream i/webhooks/update.ts: secret===null ? '' : secret。absent は維持、
+	// explicit null は空文字 reset、値は設定 (#1948-15)。
+	if req.Secret.Present {
+		if req.Secret.Value == nil {
+			w.Secret = ""
+		} else {
+			w.Secret = *req.Secret.Value
+		}
 	}
 	if req.On != nil {
 		w.On = req.On

--- a/internal/api/webhooks/handler_test.go
+++ b/internal/api/webhooks/handler_test.go
@@ -325,6 +325,31 @@ func TestUpdate_Partial(t *testing.T) {
 	assert.Equal(t, newSecret, repo.webhooks["w1"].Secret)
 }
 
+// #1948-15: secret の absent/null/value を区別する。
+//
+//	absent  → 維持
+//	null    → "" reset (upstream: secret===null ? '')
+//	"x"     → 設定
+func TestUpdate_SecretNullAbsentValue(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.webhooks["w1"] = &model.Webhook{ID: "w1", UserID: "u1", Name: "n", URL: "https://e", Secret: "old", On: pq.StringArray{}}
+
+	// absent → 維持。
+	rec := post(h.Update, `{"webhookId":"w1","name":"x"}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, "old", repo.webhooks["w1"].Secret, "secret 省略は維持 (#1948-15)")
+
+	// null → "" reset。
+	rec = post(h.Update, `{"webhookId":"w1","secret":null}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, "", repo.webhooks["w1"].Secret, "secret:null は空文字 reset (#1948-15)")
+
+	// "v" → 設定。
+	rec = post(h.Update, `{"webhookId":"w1","secret":"v"}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, "v", repo.webhooks["w1"].Secret)
+}
+
 func TestUpdate_NotFound(t *testing.T) {
 	h, _ := newTestHandler()
 	rec := post(h.Update, `{"webhookId":"ghost"}`, &model.User{ID: "u1"})

--- a/internal/core/antenna/antenna_service_test.go
+++ b/internal/core/antenna/antenna_service_test.go
@@ -995,7 +995,7 @@ func (r *failingUserListRepo) ListMembersByListIDs(_ []string) (map[string][]str
 	return nil, errors.New("list members by ids error")
 }
 func (r *failingUserListRepo) UpdateList(_ string, _ map[string]any) error { return nil }
-func (r *failingUserListRepo) UpdateMembership(_, _ string, _ bool) error  { return nil }
+func (r *failingUserListRepo) UpdateMembership(_, _ string, _ *bool) error { return nil }
 func (r *failingUserListRepo) ListIDsByMember(_ string) ([]string, error)  { return nil, nil }
 func (r *failingUserListRepo) ListIDsAndOwnersByMember(_ string) (map[string]string, error) {
 	return nil, nil

--- a/internal/repository/coverage_batch_test.go
+++ b/internal/repository/coverage_batch_test.go
@@ -327,7 +327,8 @@ func TestUserListRepository_UpdateList_UpdateMembership_ListsContainingMember(t 
 	).Error)
 	defer testDB.Exec(`DELETE FROM "user_list_membership" WHERE id = ?`, "ul_cov_mem1")
 
-	require.NoError(t, repo.UpdateMembership("ul_cov_l1", member.ID, true))
+	wrTrue := true
+	require.NoError(t, repo.UpdateMembership("ul_cov_l1", member.ID, &wrTrue))
 
 	// ListsContainingMember (owner視点でmemberを含むリスト一覧)
 	lists, err := repo.ListsContainingMember(owner.ID, member.ID)

--- a/internal/repository/coverage_complete_test.go
+++ b/internal/repository/coverage_complete_test.go
@@ -278,7 +278,8 @@ func TestErrorPaths_CancelledContext(t *testing.T) {
 	// 追加のerror paths
 	_, err = cr.FindMessageByURI("x")
 	assert.Error(t, err)
-	err = NewUserListRepository(db).UpdateMembership("x", "y", true)
+	wrTrue := true
+	err = NewUserListRepository(db).UpdateMembership("x", "y", &wrTrue)
 	assert.Error(t, err)
 	_, err = NewUserListRepository(db).ListsContainingMember("x", "y")
 	assert.Error(t, err)

--- a/internal/repository/coverage_final_test.go
+++ b/internal/repository/coverage_final_test.go
@@ -76,8 +76,34 @@ func TestReversiRepository_Extras(t *testing.T) {
 
 func TestUserListRepository_UpdateMembership_NotFound(t *testing.T) {
 	r := NewUserListRepository(testDB)
-	err := r.UpdateMembership("nonexistent_list", "nonexistent_user", true)
+	wrTrue := true
+	err := r.UpdateMembership("nonexistent_list", "nonexistent_user", &wrTrue)
 	assert.ErrorIs(t, err, gorm.ErrRecordNotFound)
+}
+
+// #1948-15: withReplies=nil (= request 省略) は既存値を維持し、membership 存在のみ確認する。
+func TestUserListRepository_UpdateMembership_NilPreservesAndExistence(t *testing.T) {
+	r := NewUserListRepository(testDB)
+	owner := insertTestUser(t, "ulnowner", "ulnilowner")
+	defer cleanupUser(t, owner.ID)
+	member := insertTestUser(t, "ulnmember", "ulnilmember")
+	defer cleanupUser(t, member.ID)
+	list := &model.UserList{ID: "ul_nil_l1", UserID: owner.ID, Name: "nil-test"}
+	require.NoError(t, r.Create(list))
+	defer testDB.Exec(`DELETE FROM "user_list" WHERE id = ?`, list.ID)
+	mem := &model.UserListMembership{ID: "ul_nil_m1", UserListID: list.ID, UserID: member.ID, WithReplies: true}
+	require.NoError(t, r.AddMember(mem))
+	defer testDB.Exec(`DELETE FROM "user_list_membership" WHERE id = ?`, mem.ID)
+
+	// nil + 存在: 既存 withReplies=true を維持 (no-op)。
+	require.NoError(t, r.UpdateMembership(list.ID, member.ID, nil))
+	var got model.UserListMembership
+	require.NoError(t, testDB.Where("id = ?", mem.ID).First(&got).Error)
+	assert.True(t, got.WithReplies, "nil 渡しは既存値を維持 (#1948-15)")
+
+	// nil + 不在: NO_SUCH_USER 判定のため ErrRecordNotFound を返す。
+	err := r.UpdateMembership(list.ID, "ghost_member", nil)
+	assert.ErrorIs(t, err, gorm.ErrRecordNotFound, "nil + membership 不在は ErrRecordNotFound (#1948-15)")
 }
 
 // --- page: ListPublicByUser limit defaults ---

--- a/internal/repository/user_list.go
+++ b/internal/repository/user_list.go
@@ -36,7 +36,7 @@ type UserListRepository interface {
 	// (= users/lists/list の N+1 を消す batch fetch、#876)。
 	ListMembersByListIDs(listIDs []string) (map[string][]string, error)
 	UpdateList(id string, fields map[string]any) error
-	UpdateMembership(listID, userID string, withReplies bool) error
+	UpdateMembership(listID, userID string, withReplies *bool) error
 	// ListsContainingMember returns lists owned by ownerID that include
 	// memberUserID as a member. Used by users/lists/get-memberships.
 	ListsContainingMember(ownerID, memberUserID string) ([]*model.UserList, error)
@@ -152,10 +152,25 @@ func (r *userListRepository) UpdateList(id string, fields map[string]any) error 
 	return r.db.Model(&model.UserList{}).Where("id = ?", id).Updates(fields).Error
 }
 
-func (r *userListRepository) UpdateMembership(listID, userID string, withReplies bool) error {
+func (r *userListRepository) UpdateMembership(listID, userID string, withReplies *bool) error {
+	// withReplies が nil (= request で省略) の場合は既存値を維持する (旧 false
+	// clobber bug の修正、#1948-15)。membership 不在時は handler の NO_SUCH_USER
+	// 判定のため ErrRecordNotFound を返す必要があるので存在確認を行う。
+	if withReplies == nil {
+		var count int64
+		if err := r.db.Model(&model.UserListMembership{}).
+			Where("\"userListId\" = ? AND \"userId\" = ?", listID, userID).
+			Count(&count).Error; err != nil {
+			return err
+		}
+		if count == 0 {
+			return gorm.ErrRecordNotFound
+		}
+		return nil
+	}
 	result := r.db.Model(&model.UserListMembership{}).
 		Where("\"userListId\" = ? AND \"userId\" = ?", listID, userID).
-		Update("withReplies", withReplies)
+		Update("withReplies", *withReplies)
 	if result.Error != nil {
 		return result.Error
 	}

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -5840,10 +5840,13 @@ func (m *MockUserListRepository) UpdateList(id string, fields map[string]any) er
 	return nil
 }
 
-func (m *MockUserListRepository) UpdateMembership(listID, userID string, withReplies bool) error {
+func (m *MockUserListRepository) UpdateMembership(listID, userID string, withReplies *bool) error {
 	for _, mem := range m.Members {
 		if mem.UserListID == listID && mem.UserID == userID {
-			mem.WithReplies = withReplies
+			// nil (= 省略) は既存値を維持 (#1948-15)。
+			if withReplies != nil {
+				mem.WithReplies = *withReplies
+			}
 			return nil
 		}
 	}


### PR DESCRIPTION
## Summary

#1948 全面互換性再監査の MEDIUM 候補 [15]。Go の `*T` が「absent」と「explicit null」を区別できない
ことに起因する null-clear / clobber 系の乖離と、users/lists/show の forPublic 可視性を upstream に
揃える。

## 主な変更点

- **`internal/api/optional/nullable.go`** (新規): `Nullable[T]` — JSON の absent (Present=false) /
  explicit null (Present=true, Value=nil) / value を区別する wrapper。
- **users/lists/show** (`userlists/handler.go`): upstream show.ts の
  `!forPublic && me ? {id, userId:me} : {id, isPublic:true}` selection に揃える。旧 mk-go は
  「private は所有者のみ / public は誰でも」と緩く、(a) 認証非所有者が他人の public list を
  forPublic 無しで読め、(b) forPublic=true で自分の private list が 404 にならなかった。
- **users/lists/update-membership** (`users/lists.go` + `repository/user_list.go`): `WithReplies` を
  `*bool` 化し repo signature も `bool`→`*bool`。省略時に false へ clobber する bug を修正
  (absent=既存値維持)。
- **channels/update description** (`channels/handler.go`): `optional.Nullable[string]` で explicit
  null を NULL clear、absent は維持。
- **i/webhooks/update secret** (`webhooks/handler.go`): explicit null を空文字 reset
  (upstream `secret===null ? ''`)、absent は維持。

## テスト

- `optional` 100% / lists/show 4 ケース (forPublic own-private 404 / 非所有者 public 404 /
  owner private 200 / forPublic 他者 public 200) / update-membership 省略維持 + 明示更新 (handler +
  repo nil-path 統合) / channels description null-clear / webhooks secret null/absent/value。
- optional 100% / userlists 96.9% / webhooks 99.0% / channels 93.3% / repository 90.0%。
  `make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで、upstream の update-membership は withReplies 省略時に TypeORM 空 SET で 500 を
投げる挙動 (当初 finding の「no-op 維持」前提は誤り) と判明。mk-go は維持の方が合理的なのでそちらを
採り、NO_SUCH_USER の発火条件差と併せて #2005 に方針追跡を分離した。

## 関連

- 親: #1948

Closes #2006
