### PR TITLE
Fix drive param parity (#1948-16): move-bulk 検証 + folders/create name + moderator bypass 文書化

### DIFF
--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -424,7 +424,10 @@ func (h *Handler) FilesFindByHash(c echo.Context) error {
 
 // FoldersCreateRequest is the body for drive/folders/create.
 type FoldersCreateRequest struct {
-	Name     string  `json:"name"`
+	// upstream paramDef は name に default:'Untitled' を持つ。default は key 省略時
+	// のみ適用され、明示的な空文字 "" はそのまま保持される (minLength 無し)。absent と
+	// explicit "" を区別するため *string にする (#1948-16)。
+	Name     *string `json:"name"`
 	ParentID *string `json:"parentId"`
 }
 
@@ -435,14 +438,17 @@ func (h *Handler) FoldersCreate(c echo.Context) error {
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
+	// name 省略 (nil) のときだけ default 'Untitled' を適用する。explicit "" は
+	// upstream paramDef (minLength 無し) と同じくそのまま保持する (#1948-16)。
+	name := "Untitled"
+	if req.Name != nil {
+		name = *req.Name
+	}
 	// upstream folders/create paramDef は name maxLength=200 (#1564)。
-	if utf8.RuneCountInString(req.Name) > maxDriveFolderNameLength {
+	if utf8.RuneCountInString(name) > maxDriveFolderNameLength {
 		return apierr.JSONInvalidParam(c)
 	}
-	if req.Name == "" {
-		req.Name = "Untitled"
-	}
-	f, err := h.svc.CreateFolder(user, req.Name, req.ParentID)
+	f, err := h.svc.CreateFolder(user, name, req.ParentID)
 	if err != nil {
 		return mapFolderError(c, err, folderEndpointCreate)
 	}
@@ -931,6 +937,18 @@ func (h *Handler) FilesMoveBulk(c echo.Context) error {
 	}
 	if err := c.Bind(&req); err != nil || len(req.FileIDs) == 0 {
 		return apierr.JSONInvalidParam(c)
+	}
+	// upstream move-bulk.ts paramDef は fileIds に minItems:1 / maxItems:100 /
+	// uniqueItems:true を課す。100 超過・重複は INVALID_PARAM で reject する (#1948-16)。
+	if len(req.FileIDs) > 100 {
+		return apierr.JSONInvalidParam(c)
+	}
+	seen := make(map[string]struct{}, len(req.FileIDs))
+	for _, id := range req.FileIDs {
+		if _, dup := seen[id]; dup {
+			return apierr.JSONInvalidParam(c)
+		}
+		seen[id] = struct{}{}
 	}
 	// 空文字 folderId は root(null) と同義に正規化する (upstream の
 	// `folderId ?? null` 相当、#parity review DRV-2)。

--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	coredrive "github.com/shiroha-a/mk/internal/core/drive"
@@ -564,6 +565,44 @@ func TestFoldersCreate_DefaultName(t *testing.T) {
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Equal(t, "Untitled", resp["name"])
+}
+
+// #1948-16: explicit な空文字 name は 'Untitled' に置換せずそのまま保持する
+// (upstream paramDef は default を absent 時のみ適用、minLength 無し)。
+func TestFoldersCreate_ExplicitEmptyNameKept(t *testing.T) {
+	h, _, _ := newHandler(t)
+	c, rec := newJSONReq(t, `{"name":""}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FoldersCreate(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "", resp["name"], "explicit \"\" は Untitled に置換しない (#1948-16)")
+}
+
+// #1948-16: move-bulk は fileIds の maxItems:100 / uniqueItems を強制する。
+func TestFilesMoveBulk_TooManyAndDuplicate(t *testing.T) {
+	h, _, _ := newHandler(t)
+	// 101 件 → 400。
+	ids := make([]string, 101)
+	for i := range ids {
+		ids[i] = "f" + timeSuffixDrive(i)
+	}
+	body, _ := json.Marshal(map[string]any{"fileIds": ids})
+	c, rec := newJSONReq(t, string(body))
+	setUser(c, "u1")
+	require.NoError(t, h.FilesMoveBulk(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "maxItems:100 超過は 400 (#1948-16)")
+
+	// 重複 → 400。
+	c, rec = newJSONReq(t, `{"fileIds":["a","a"]}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesMoveBulk(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "uniqueItems 違反は 400 (#1948-16)")
+}
+
+func timeSuffixDrive(i int) string {
+	return time.Date(2025, 1, 1, 0, 0, i, 0, time.UTC).Format("20060102150405")
 }
 
 func TestFoldersCreate_InvalidJSON(t *testing.T) {

--- a/internal/core/drive/drive_service.go
+++ b/internal/core/drive/drive_service.go
@@ -657,6 +657,13 @@ type UpdateInput struct {
 // Update applies the non-nil fields to a drive file owned by the user.
 // Owner-only: moderator が他ユーザーの file を編集できないよう
 // findOwnedFile() を使う (#499)。
+//
+// upstream drive/files/update.ts は `!isModerator && file.userId !== me.id` の
+// ときのみ ACCESS_DENIED とし、moderator は他人の file を編集できる (markSensitive
+// の moderationLog も残す)。mk-go はこの moderator write bypass を**意図的に
+// 排除**している (#499 で privilege-escalation として hardening 済)。moderator が
+// 他ユーザーの file を moderation する正規経路は /admin/drive/* で、本 endpoint は
+// owner-only を維持する。これは upstream からの deliberate deviation (#1948-16)。
 func (s *Service) Update(user *model.User, id string, in UpdateInput) (*model.DriveFile, error) {
 	f, err := s.findOwnedFile(user, id)
 	if err != nil {


### PR DESCRIPTION
## Summary

#1948 全面互換性再監査の MEDIUM 候補 [16]。drive endpoint の param 検証取りこぼしを upstream に
揃え、moderator bypass の deliberate deviation を文書化する。

## 主な変更点

- **drive/files/move-bulk** (`handler.go`): upstream paramDef の fileIds (minItems:1 / maxItems:100 /
  uniqueItems:true) に合わせ、100 超過・重複を `INVALID_PARAM` (400) で reject (minItems:1 は既存の
  `len==0` check)。
- **drive/folders/create name** (`handler.go`): `Name` を `*string` 化。upstream paramDef は
  `default:'Untitled'` を absent 時のみ適用し explicit "" は保持する (minLength 無し) ため、absent→
  'Untitled' / explicit ""→"" 保持 / "x"→"x" に揃える。
- **drive/files/update・delete の moderator bypass** (`drive_service.go` docstring): upstream は
  moderator が他人の file を編集/削除できるが、mk-go は #499 で privilege-escalation hardening として
  owner-only に固めた**意図的 deviation**。moderation 正規経路は /admin/drive/*。reverse せず
  docstring で文書化のみ (#1529 と同種の deliberate deviation)。

## テスト

- `TestFoldersCreate_ExplicitEmptyNameKept` (explicit ""→"" 保持) / `TestFilesMoveBulk_TooManyAndDuplicate`
  (101件→400 / 重複→400)。既存 `TestFoldersCreate_DefaultName` ({}→Untitled) は維持。
- drive 90.3%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで、move-bulk の宛先 folder 不在エラー (mk-go 404 NO_SUCH_FOLDER vs upstream 偶発的
500) は本 PR 範囲外の既存 LOW deviation で、mk-go の 404 が clean なので keep が妥当と確認した。

## 関連

- 親: #1948

Closes #2008
