### PR TITLE
Fix notes parity (#1948-17): conversation 順序+可視性 / notes/state / translate

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -887,7 +887,24 @@ func (h *Handler) Conversation(c echo.Context) error {
 		// 現状QueryService.ConversationはErrNoteNotFound以外を返さない
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "e1035875-9551-45ec-afa8-1ded1fcb53c8"))
 	}
-	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))
+	// Conversation は非可視な祖先も raw に返すので、ここで CanSee 判定して
+	// 非可視 note を hideNote stub する (upstream packMany(_, me) の hideNote 挙動、
+	// #1948-17)。index ずれ (ApplyHardMute の drop) に強いよう note ID で突合する。
+	hidden := make(map[string]struct{})
+	for _, n := range notes {
+		if !h.queryService.CanSee(viewer, n) {
+			hidden[n.ID] = struct{}{}
+		}
+	}
+	packed := h.packMany(c.Request().Context(), notes, viewer)
+	if len(hidden) > 0 {
+		for i := range packed {
+			if _, ok := hidden[packed[i].ID]; ok {
+				entity.HideNoteEntity(&packed[i])
+			}
+		}
+	}
+	return c.JSON(http.StatusOK, packed)
 }
 
 // BulkShow handles POST /api/notes — bulk note lookup by noteIds.

--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -487,10 +487,10 @@ func (h *Handler) Translate(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "noteId and targetLang are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
-	if h.translator == nil {
-		return c.JSON(http.StatusServiceUnavailable, apierr.Error("UNAVAILABLE", "Translator is not configured.", "50a70314-2d8a-431b-b433-efa5cc56444c"))
-	}
-
+	// upstream translate.ts の順序に合わせる (#1948-17): note fetch → visibility →
+	// text==null で 204 → unavailable → translate。translator-nil(unavailable) を
+	// note/text check より前に置くと、null-text note が upstream の 204 ではなく
+	// UNAVAILABLE を返してしまうため後ろに移動する。
 	n, err := h.noteRepo.FindByID(req.NoteID)
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "bea9b03f-36e0-49c5-a4db-627a029f8971"))
@@ -507,8 +507,15 @@ func (h *Handler) Translate(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, apierr.Error("CANNOT_TRANSLATE_INVISIBLE_NOTE", "Cannot translate invisible note.", "ea29f2ca-c368-43b3-aaf1-5ac3e74bbe5d"))
 	}
 
-	if n.Text == nil || *n.Text == "" {
-		return c.JSON(http.StatusBadRequest, apierr.Error("CANNOT_TRANSLATE", "Nothing to translate.", "bef6e895-c05f-4572-96ab-58f5ae1e2e28"))
+	// upstream translate.ts:86-88: note.text == null は return; (res optional → 204
+	// No Content)。空文字は upstream が DeepL へ POST するので素通しする。mk-go の
+	// 旧 CANNOT_TRANSLATE は upstream に無い独自 error だったので廃止 (#1948-17)。
+	if n.Text == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+
+	if h.translator == nil {
+		return c.JSON(http.StatusServiceUnavailable, apierr.Error("UNAVAILABLE", "Translator is not configured.", "50a70314-2d8a-431b-b433-efa5cc56444c"))
 	}
 
 	result, err := h.translator.Translate(c.Request().Context(), *n.Text, req.TargetLang)

--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -882,9 +882,25 @@ func TestClips_Success(t *testing.T) {
 // --- Translate ---
 
 func TestTranslate_NoTranslator(t *testing.T) {
-	h, _, _ := newExtraHandler(t)
+	// #1948-17: translator-nil(unavailable) check は note fetch / text check の後に
+	// 移動したので、可視 + text 有りの note を seed して 503 path を踏ませる。
+	h, noteRepo, _ := newExtraHandler(t)
+	txt := "hello"
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic, Text: &txt}
 	rec := postExtra(h.Translate, `{"noteId":"n1","targetLang":"en"}`, nil)
 	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+// #1948-17: text == null の note は upstream translate.ts:86-88 と同じく 204
+// (res optional, return;)。mk-go の旧 400 CANNOT_TRANSLATE は廃止。translator
+// unavailable でも null-text は 204 が先に返る。
+func TestTranslate_NullText_204(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	// text=nil (file/poll only note)。public で可視。translator は未配線。
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic, Text: nil}
+	rec := postExtra(h.Translate, `{"noteId":"n1","targetLang":"en"}`, nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code, "null-text は 204 no-op (#1948-17)")
+	assert.Empty(t, rec.Body.String(), "body は空")
 }
 
 func TestTranslate_InvalidParam(t *testing.T) {
@@ -946,20 +962,19 @@ func TestTranslate_SpecifiedNote_NotInList_Invisible(t *testing.T) {
 }
 
 // follower / visibleUserIds 対象 / author は visibility gate を通過する。
-// Text を空にして text-empty 経路 (CANNOT_TRANSLATE) で止め、DeepL を呼ばずに
-// 「gate を通った」ことを検証する (invisible エラーでないことを確認)。
+// #1948-17: text=nil の note を使い null-text 経路 (204) で止め、DeepL を呼ばずに
+// 「gate を通った」ことを検証する (invisible なら手前で 400 になる)。
 func TestTranslate_VisibleViewers_PassVisibilityGate(t *testing.T) {
-	empty := ""
 	cases := []struct {
 		name   string
 		note   *model.Note
 		viewer *model.User
 		follow bool
 	}{
-		{"follower", &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityFollowers, Text: &empty}, &model.User{ID: "u2"}, true},
-		{"author", &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityFollowers, Text: &empty}, &model.User{ID: "u1"}, false},
-		{"specified target", &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilitySpecified, VisibleUserIDs: []string{"u2"}, Text: &empty}, &model.User{ID: "u2"}, false},
-		{"public anonymous", &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic, Text: &empty}, nil, false},
+		{"follower", &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityFollowers, Text: nil}, &model.User{ID: "u2"}, true},
+		{"author", &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityFollowers, Text: nil}, &model.User{ID: "u1"}, false},
+		{"specified target", &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilitySpecified, VisibleUserIDs: []string{"u2"}, Text: nil}, &model.User{ID: "u2"}, false},
+		{"public anonymous", &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic, Text: nil}, nil, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -969,9 +984,8 @@ func TestTranslate_VisibleViewers_PassVisibilityGate(t *testing.T) {
 				fRepo.Followings["f1"] = &model.Following{ID: "f1", FollowerID: tc.viewer.ID, FolloweeID: "u1"}
 			}
 			rec := postExtra(h.Translate, `{"noteId":"n1","targetLang":"en"}`, tc.viewer)
-			assert.Equal(t, http.StatusBadRequest, rec.Code)
-			code, _ := translateBody(t, rec)
-			assert.Equal(t, "CANNOT_TRANSLATE", code, "visibility gate を通過し text-empty 経路に到達する")
+			// 可視 → null-text の 204 に到達 (invisible なら 400 で手前 reject)。
+			assert.Equal(t, http.StatusNoContent, rec.Code, "visibility gate を通過し null-text 経路 (204) に到達する")
 		})
 	}
 }

--- a/internal/api/notes/handler_query_test.go
+++ b/internal/api/notes/handler_query_test.go
@@ -619,6 +619,38 @@ func TestConversation_OK(t *testing.T) {
 	assert.Equal(t, "root", resp[0]["id"])
 }
 
+// #1948-17: 非可視な祖先は walk を打ち切らず hideNote stub で返す (upstream
+// packMany(_, me) の hideNote 挙動)。可視な祖先 (gp) は通常通り返る。
+func TestConversation_HiddenAncestorStubbed(t *testing.T) {
+	h, repo := newQueryHandler(t)
+	// leaf(public) -> secret(followers, 匿名には不可視, text 有り) -> gp(public)。
+	gp := seedPublicNote(repo, "gp")
+	gpID := gp.ID
+	secretTxt := "secret content"
+	secret := &model.Note{ID: "secret", UserID: "author", Visibility: model.NoteVisibilityFollowers, ReplyID: &gpID, Text: &secretTxt, Reactions: datatypes.JSON([]byte("{}"))}
+	putUserOnNote(secret)
+	repo.Notes["secret"] = secret
+	leaf := seedPublicNote(repo, "leaf")
+	sID := "secret"
+	leaf.ReplyID = &sID
+
+	// 匿名 viewer: secret は followers-only なので不可視 → stub。
+	c, rec := newJSONRequest(t, "/api/notes/conversation", `{"noteId":"leaf"}`)
+	require.NoError(t, h.Conversation(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 2, "不可視祖先で打ち切らず gp まで返る (#1948-17)")
+	// nearest-first: [secret(stub), gp]。
+	assert.Equal(t, "secret", resp[0]["id"])
+	assert.Equal(t, true, resp[0]["isHidden"], "不可視祖先は isHidden:true で stub (#1948-17)")
+	assert.Nil(t, resp[0]["text"], "stub は text を消す (#1948-17)")
+	assert.NotContains(t, rec.Body.String(), "secret content", "本文が leak しない")
+	// gp は public なので通常表示。
+	assert.Equal(t, "gp", resp[1]["id"])
+	assert.NotEqual(t, true, resp[1]["isHidden"])
+}
+
 func TestConversation_LimitClamping(t *testing.T) {
 	h, repo := newQueryHandler(t)
 	seedPublicNote(repo, "n1")

--- a/internal/core/note/note_query_service.go
+++ b/internal/core/note/note_query_service.go
@@ -136,9 +136,18 @@ func (s *QueryService) ListChildren(viewer *model.User, noteID, untilID, sinceID
 	return s.noteRepo.ListChildrenOf(noteID, viewerIDOf(viewer), untilID, sinceID, limit)
 }
 
-// Conversation walks up the reply chain from the given noteID and returns
-// up to `limit` ancestors, ordered from oldest to newest. The starting note
-// itself is NOT included. Notes the viewer cannot see terminate the walk.
+// Conversation walks up the reply chain from the given noteID and returns up to
+// `limit` ancestors nearest-first ([direct parent, ..., deepest ancestor]),
+// matching upstream conversation.ts which pushes ancestors in walk order without
+// reversal (#1948-17). The starting note itself is NOT included.
+//
+// 重要 (#1948-17): ancestor は visibility で filter せず raw に返す。upstream
+// conversation.ts は findOneBy({id}) で全 ancestor を walk し、packMany(_, me) 側
+// の hideNote で非可視 note を stub する。よって walk を可視性で打ち切らない
+// (以前は CanSeeNote で break しており、可視な祖先まで truncate していた)。返り値
+// には閲覧不可な ancestor も含まれるため、**呼び出し側は CanSee で判定して非可視
+// note を entity.HideNoteEntity で stub する責務を負う** (handler 側で実施)。起点
+// note の可視性は従来どおり Show で gate する。
 func (s *QueryService) Conversation(viewer *model.User, noteID string, limit, offset int) ([]*model.Note, error) {
 	start, err := s.Show(viewer, noteID)
 	if err != nil {
@@ -170,9 +179,8 @@ func (s *QueryService) Conversation(viewer *model.User, noteID string, limit, of
 		if err != nil {
 			break
 		}
-		if !CanSeeNote(viewer, parent, s.followingRepo) {
-			break
-		}
+		// 可視性で break しない: 非可視な祖先も含めて辿り、stub 化は呼び出し側に
+		// 委ねる (upstream packMany hideNote 挙動、#1948-17)。
 		visited[parentID] = struct{}{}
 		i++
 		// 最初の offset 件 (note に近い親) は skip する。
@@ -181,8 +189,8 @@ func (s *QueryService) Conversation(viewer *model.User, noteID string, limit, of
 		}
 		current = parent
 	}
-	// 古い順 (最深の親を先頭) に並び替える
-	reverseNotes(ancestors)
+	// upstream は nearest-first ([直接の親, ..., 最深] ) で返す。以前の
+	// reverseNotes(oldest-first) を削除 (#1948-17)。
 	return ancestors, nil
 }
 
@@ -191,6 +199,13 @@ func (s *QueryService) Conversation(viewer *model.User, noteID string, limit, of
 //
 // upstream Misskey の notes/state は isFavorited / isMutedThread のみを返す
 // (isWatching は廃止) ため、こちらも同じ shape に揃える。
+//
+// 可視性 gate について (#1948-17): upstream notes/state.ts は findOneByOrFail({id})
+// のみで visibility check を持たず、note ID を知る viewer は閲覧不可 note の
+// isFavorited/isMutedThread を読め、かつ存在(200)/不在(500)を区別できる existence
+// oracle になる。mk-go は requireVisible(CanSeeNote) で gate し、閲覧不可・不在の
+// 両方を NO_SUCH_NOTE に潰す。これは upstream より strict だが existence oracle と
+// state leak を塞ぐ意図的な deviation として維持する (gate を外さない)。
 func (s *QueryService) State(viewer *model.User, noteID string) (*NoteState, error) {
 	// State は note.ID と note.ThreadID しか触らないので軽量経路で十分 (#425)。
 	note, err := s.requireVisible(viewer, noteID)
@@ -251,10 +266,4 @@ func (s *QueryService) filterVisible(viewer *model.User, rows []*model.Note) []*
 		}
 	}
 	return out
-}
-
-func reverseNotes(notes []*model.Note) {
-	for i, j := 0, len(notes)-1; i < j; i, j = i+1, j-1 {
-		notes[i], notes[j] = notes[j], notes[i]
-	}
 }

--- a/internal/core/note/note_query_service_test.go
+++ b/internal/core/note/note_query_service_test.go
@@ -292,9 +292,9 @@ func TestQueryService_Conversation_Walks(t *testing.T) {
 	out, err := svc.Conversation(nil, "c", 10, 0)
 	require.NoError(t, err)
 	require.Len(t, out, 2)
-	// 古い順 (祖先が先頭)
-	assert.Equal(t, "g", out[0].ID)
-	assert.Equal(t, "p", out[1].ID)
+	// nearest-first (直接の親が先頭、upstream conversation.ts、#1948-17)
+	assert.Equal(t, "p", out[0].ID)
+	assert.Equal(t, "g", out[1].ID)
 }
 
 func TestQueryService_Conversation_DefaultLimit(t *testing.T) {
@@ -322,9 +322,9 @@ func TestQueryService_Conversation_LimitRespected(t *testing.T) {
 	out, err := svc.Conversation(nil, "d", 2, 0)
 	require.NoError(t, err)
 	require.Len(t, out, 2)
-	// 直近の親2件: c, b. 古い順なのでb, c
-	assert.Equal(t, "b", out[0].ID)
-	assert.Equal(t, "c", out[1].ID)
+	// 直近の親2件: c, b。nearest-first なので c, b (#1948-17)
+	assert.Equal(t, "c", out[0].ID)
+	assert.Equal(t, "b", out[1].ID)
 }
 
 // #1554 offset は note に近い親を skip する (upstream conversation.ts:72-74)。
@@ -339,12 +339,12 @@ func TestQueryService_Conversation_Offset(t *testing.T) {
 	cID := "c"
 	noteRepo.Notes["d"] = &model.Note{ID: "d", UserID: "u", Visibility: model.NoteVisibilityPublic, ReplyID: &cID}
 
-	// offset=1: 最近の親 c を skip → b, a を収集。古い順で a, b。
+	// offset=1: 最近の親 c を skip → b, a を収集。nearest-first で b, a (#1948-17)。
 	out, err := svc.Conversation(nil, "d", 10, 1)
 	require.NoError(t, err)
 	require.Len(t, out, 2)
-	assert.Equal(t, "a", out[0].ID)
-	assert.Equal(t, "b", out[1].ID)
+	assert.Equal(t, "b", out[0].ID)
+	assert.Equal(t, "a", out[1].ID)
 
 	// offset=1 + limit=1: c skip → b のみ。
 	out, err = svc.Conversation(nil, "d", 1, 1)
@@ -353,16 +353,23 @@ func TestQueryService_Conversation_Offset(t *testing.T) {
 	assert.Equal(t, "b", out[0].ID)
 }
 
-func TestQueryService_Conversation_HiddenAncestorTerminates(t *testing.T) {
+// #1948-17: 閲覧不可な祖先は walk を打ち切らず raw に含める (stub 化は handler の
+// 責務)。以前は CanSeeNote で break して可視な祖先まで truncate していた。
+func TestQueryService_Conversation_HiddenAncestorIncludedRaw(t *testing.T) {
 	svc, noteRepo, _ := newQueryService(t)
-	noteRepo.Notes["secret"] = &model.Note{ID: "secret", UserID: "author", Visibility: model.NoteVisibilityFollowers}
+	// チェーン: leaf(public) -> secret(followers, 不可視) -> gp(public)。
+	gpID := "gp"
+	noteRepo.Notes["gp"] = &model.Note{ID: "gp", UserID: "author", Visibility: model.NoteVisibilityPublic}
+	noteRepo.Notes["secret"] = &model.Note{ID: "secret", UserID: "author", Visibility: model.NoteVisibilityFollowers, ReplyID: &gpID}
 	secretID := "secret"
 	noteRepo.Notes["leaf"] = &model.Note{ID: "leaf", UserID: "viewer", Visibility: model.NoteVisibilityPublic, ReplyID: &secretID}
 
 	out, err := svc.Conversation(&model.User{ID: "viewer"}, "leaf", 10, 0)
 	require.NoError(t, err)
-	// 親は閲覧不可なのでチェーンが切れる
-	assert.Empty(t, out)
+	// 不可視 secret で打ち切らず、その先の可視 gp も返る (nearest-first)。
+	require.Len(t, out, 2)
+	assert.Equal(t, "secret", out[0].ID, "不可視祖先も raw に含む (handler が stub する、#1948-17)")
+	assert.Equal(t, "gp", out[1].ID, "不可視祖先の先の可視 note も truncate しない (#1948-17)")
 }
 
 func TestQueryService_Conversation_StartMissing(t *testing.T) {


### PR DESCRIPTION
## Summary

#1948 全面互換性再監査の MEDIUM 候補 [17]。notes/conversation の順序・可視性、notes/state、
translate を upstream に揃える。

## 主な変更点

- **notes/conversation 順序** (`note_query_service.go`): `reverseNotes` を削除し nearest-first
  ([直接の親, ..., 最深]) で返す。upstream conversation.ts は reversal 無しで返し frontend が
  `res.reverse()` するため、旧 oldest-first は二重反転で表示順が壊れていた (real bug fix)。
- **notes/conversation 可視性** (`note_query_service.go` + `handler.go`): 非可視な祖先で walk を
  打ち切らず raw に含めて辿り、handler が `CanSee` 判定で `entity.HideNoteEntity` stub する
  (upstream は packMany(_, me) の hideNote で stub)。以前は CanSeeNote で break し、可視な祖先まで
  truncate していた。stub は note ID 突合で ApplyHardMute の drop に強い。
- **notes/state** (`note_query_service.go`): upstream は visibility gate 無しで existence oracle +
  state leak になるが、mk-go は requireVisible gate を**維持**する deliberate deviation として
  docstring 文書化。
- **notes/translate** (`handler_extra.go`): upstream translate.ts:86-88 と同じく `text==null` で 204
  (res optional return;)。独自 CANNOT_TRANSLATE を廃止し、translator-nil(unavailable) check を
  note fetch / visibility / null-text check の後ろへ移して upstream 順序に揃える。空文字 "" は
  upstream 同様 DeepL へ素通し。

## テスト

- conversation: nearest-first 順序 / 非可視祖先を含めて gp まで返る (QueryService) / handler が
  hidden 祖先を isHidden:true・text:null で stub し本文 leak しない。
- translate: null-text → 204 / 可視 viewer は null-text 204 到達 / translator-nil でも null-text 先行。
- notes 90.7% / core/note 95.0%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビュー (敵対的テストで本文漏洩を実証検査) で漏洩なしを確認。canUseTranslator role-policy
拒否時の error が 403 ROLE_PERMISSION_DENIED で upstream の 503 UNAVAILABLE と乖離する既存 middleware
の問題 (本 diff 対象外) を #2010 に分離した。

## 関連

- 親: #1948

Closes #2011
