### PR TITLE
Fix tag parity (#1948-18): note.tags 正規化 + search-by-tag query 正規化 + ListMentions ASC

### DIFF
--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -1284,7 +1284,9 @@ func (r *Resolver) ingestNoteWithCreated(body []byte, deliveringActorURI string,
 	if note.CW != nil {
 		hashtagSources = append(hashtagSources, *note.CW)
 	}
-	if tags := hashtag.Extract(hashtagSources...); len(tags) > 0 {
+	// note.tags は upstream と同じく normalizeForSearch (NFKC+lowercase) + 128drop
+	// + 32cap で正規化して格納する (#1948-18)。
+	if tags := hashtag.ExtractNoteTags(hashtagSources...); len(tags) > 0 {
 		note.Tags = pq.StringArray(tags)
 	}
 	// AP `attachment` 配列を drive_file 行に upsert (#378)。link 形式のみで
@@ -1576,7 +1578,7 @@ func (r *Resolver) UpdateRemoteNote(body []byte, actorURI string) (*model.Note, 
 	if existing.CW != nil {
 		hashtagSources = append(hashtagSources, *existing.CW)
 	}
-	newTags := hashtag.Extract(hashtagSources...)
+	newTags := hashtag.ExtractNoteTags(hashtagSources...) // 正規化して格納 (#1948-18)
 	tagsChanged := !slices.Equal([]string(existing.Tags), newTags)
 	if tagsChanged {
 		// Extract は hashtag が無いと nil を返すが、nil の pq.StringArray は

--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -629,7 +629,10 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 		if in.CW != nil {
 			hashtagParts = append(hashtagParts, *in.CW)
 		}
-		tags = hashtag.Extract(hashtagParts...)
+		// upstream NoteCreateService は note.tags を normalizeForSearch (NFKC +
+		// lowercase) で正規化し、>128 char を drop、32 件 cap してから格納する。
+		// search-by-tag が同 normalize を query に適用するため一致させる (#1948-18)。
+		tags = hashtag.ExtractNoteTags(hashtagParts...)
 	}
 
 	note := &model.Note{

--- a/internal/misc/hashtag/extract.go
+++ b/internal/misc/hashtag/extract.go
@@ -10,6 +10,7 @@ package hashtag
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	"github.com/shiroha-a/mk/internal/activitypub/mfm"
 	"github.com/shiroha-a/mk/internal/misc/searchnorm"
@@ -18,6 +19,10 @@ import (
 // MaxUserTags は user.tags に格納する hashtag の最大件数。upstream
 // (i/update / ApPersonService) の `.splice(0, 32)` と一致させる。
 const MaxUserTags = 32
+
+// MaxNoteTags は note.tags に格納する hashtag の最大件数。upstream
+// NoteCreateService の `.splice(0, 32)` と一致させる。
+const MaxNoteTags = 32
 
 // MaxTagLength は note.tags 列の varchar(128) 制約に合わせた tag 長
 // 上限。これを超える tag は truncate される (drop ではなく trim にする
@@ -50,6 +55,68 @@ func Extract(parts ...string) []string {
 		}
 		seen[key] = struct{}{}
 		out = append(out, tag)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// ExtractNoteTags extracts hashtags from the given text fragments and returns
+// them in the form stored in note.tags: filtered to <=128 code points (dropped,
+// not truncated), capped at MaxNoteTags, and normalized via searchnorm.Normalize
+// (NFKC + lowercase), de-duplicated. Mirrors upstream NoteCreateService
+// (`extractHashtags(...).filter(t => Array.from(t).length <= 128).splice(0, 32)`
+// then `tags.map(normalizeForSearch)` on store, #1948-18). search-by-tag は同じ
+// normalizeForSearch を query に適用するため、stored 値と一致する。
+func ExtractNoteTags(parts ...string) []string {
+	return NormalizeNoteTags(mfm.CollectHashtags(parts...))
+}
+
+// NormalizeNoteTags applies the note.tags store normalization to a pre-extracted
+// tag list (used for AP-received apHashtags where the tags come from the remote
+// Object rather than MFM extraction). >128 code-point tags are dropped, the list
+// is capped at MaxNoteTags, each is normalized, and duplicates collapse (#1948-18).
+func NormalizeNoteTags(tags []string) []string {
+	if len(tags) == 0 {
+		return nil
+	}
+	// upstream の順序 (NoteCreateService.ts:581,632) は raw dedup(extractHashtags の
+	// unique) → filter(<=128 code point) → splice(0,32) → map(normalizeForSearch)。
+	// 順序が重要: cap を normalize より**前**に効かせないと、case/width 衝突で空いた
+	// cap slot に upstream が落とす tag が残り、>32 tag note で stored tags がずれる
+	// (#1948-18)。よって RAW のまま dedup + 128filter + 32cap してから normalize する。
+	rawSeen := make(map[string]struct{}, len(tags))
+	capped := make([]string, 0, MaxNoteTags)
+	for _, tag := range tags {
+		if utf8.RuneCountInString(tag) > MaxTagLength {
+			continue
+		}
+		if _, dup := rawSeen[tag]; dup {
+			continue
+		}
+		rawSeen[tag] = struct{}{}
+		capped = append(capped, tag)
+		if len(capped) >= MaxNoteTags {
+			break
+		}
+	}
+	// normalize して post-normalize の clean dedup を行う。upstream は normalize 後の
+	// duplicate (例 'Misskey'/'misskey' → ['misskey','misskey']) をそのまま格納するが、
+	// `@> ARRAY[]` 検索・trends 集計は duplicate に非感応なので clean array にする
+	// (surviving source tag 集合は cap を先に効かせたので upstream と一致)。
+	normSeen := make(map[string]struct{}, len(capped))
+	out := make([]string, 0, len(capped))
+	for _, tag := range capped {
+		n := searchnorm.Normalize(tag)
+		if n == "" {
+			continue
+		}
+		if _, ok := normSeen[n]; ok {
+			continue
+		}
+		normSeen[n] = struct{}{}
+		out = append(out, n)
 	}
 	if len(out) == 0 {
 		return nil

--- a/internal/misc/hashtag/extract_test.go
+++ b/internal/misc/hashtag/extract_test.go
@@ -151,6 +151,65 @@ func TestExtractUserTags(t *testing.T) {
 	}
 }
 
+// #1948-18: ExtractNoteTags は note.tags を NFKC+lowercase 正規化し、>128 char を
+// drop、32 件 cap、case-insensitive dedup する (upstream NoteCreateService)。
+func TestExtractNoteTags(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"normalizes to lowercase", []string{"#Misskey and #misskey"}, []string{"misskey"}},
+		{"NFKC folds full-width", []string{"#Ｍｉｓｓｋｅｙ"}, []string{"misskey"}},
+		{"no hashtags returns nil", []string{"plain text"}, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ExtractNoteTags(tc.in...))
+		})
+	}
+}
+
+// #1948-18: >128 code point の tag は drop する (truncate ではない)。
+func TestExtractNoteTags_DropsTooLong(t *testing.T) {
+	long := strings.Repeat("a", 129)
+	got := ExtractNoteTags("#short #" + long)
+	assert.Equal(t, []string{"short"}, got, ">128 char tag は drop され short のみ残る (#1948-18)")
+}
+
+// #1948-18: NormalizeNoteTags は AP 由来の事前抽出 tag 配列を同じく正規化する。
+func TestNormalizeNoteTags(t *testing.T) {
+	assert.Equal(t, []string{"misskey", "art"}, NormalizeNoteTags([]string{"Misskey", "misskey", "Art"}))
+	assert.Nil(t, NormalizeNoteTags(nil))
+	assert.Nil(t, NormalizeNoteTags([]string{strings.Repeat("x", 200)}), ">128 char は drop")
+}
+
+// #1948-18: cap(32) は normalize より前に効く (upstream splice→map 順)。case 衝突で
+// 空いた slot に upstream が落とす tag が残らないことを確認する。
+func TestNormalizeNoteTags_CapBeforeNormalize(t *testing.T) {
+	// ['Misskey','misskey','a1'..'a31'] (33 raw-distinct)。upstream は raw cap32 で
+	// ['Misskey','misskey','a1'..'a30'] を残し a31 を drop → normalize → ['misskey','a1'..'a30']。
+	in := []string{"Misskey", "misskey"}
+	for i := 1; i <= 31; i++ {
+		in = append(in, "a"+string(rune('0'+i/10))+string(rune('0'+i%10)))
+	}
+	got := NormalizeNoteTags(in)
+	assert.Contains(t, got, "misskey")
+	assert.Contains(t, got, "a01")
+	assert.Contains(t, got, "a30")
+	assert.NotContains(t, got, "a31", "cap が normalize より前に効くので a31 は drop (#1948-18)")
+}
+
+// caps at MaxNoteTags (32) entries.
+func TestExtractNoteTags_Cap(t *testing.T) {
+	parts := make([]string, 0, 40)
+	for i := 0; i < 40; i++ {
+		parts = append(parts, "#tag"+string(rune('a'+i%26))+string(rune('0'+i/26)))
+	}
+	got := ExtractNoteTags(strings.Join(parts, " "))
+	assert.Len(t, got, MaxNoteTags)
+}
+
 // caps at MaxUserTags (32) entries.
 func TestExtractUserTags_Cap(t *testing.T) {
 	parts := make([]string, 0, 40)

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/shiroha-a/mk/internal/misc/searchnorm"
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/gorm"
 )
@@ -819,7 +820,15 @@ func (r *noteRepository) ListMentions(userID, visibility string, following bool,
 	if following {
 		q = q.Where(`("userId" IN (SELECT "followeeId" FROM "following" WHERE "followerId" = ?) OR "userId" = ?)`, userID, userID)
 	}
-	q = q.Order(paginationOrder(sinceID, untilID, "id")).Limit(limit)
+	// upstream mentions.ts:69 は makePaginationQuery を使わず、sinceId/sinceDate が
+	// あれば untilId の有無に関わらず ASC、無ければ DESC で order する。汎用
+	// paginationOrder (ASC は sinceID && !untilID のみ) と異なるので mentions 専用
+	// の order に揃える (#1948-18)。
+	mentionsOrder := "id DESC"
+	if sinceID != "" {
+		mentionsOrder = "id ASC"
+	}
+	q = q.Order(mentionsOrder).Limit(limit)
 	if sinceID != "" {
 		q = q.Where("id > ?", sinceID)
 	}
@@ -847,8 +856,11 @@ func (r *noteRepository) SearchByTag(tagGroups [][]string, viewerID string, limi
 	for _, g := range tagGroups {
 		clean := make([]string, 0, len(g))
 		for _, t := range g {
-			if t != "" {
-				clean = append(clean, t)
+			// upstream search-by-tag.ts:106,113 は query tag を normalizeForSearch
+			// (NFKC+lowercase) してから `:tag <@ note.tags` で突合する。note.tags も
+			// 同 normalize で格納されるので、query も正規化して一致させる (#1948-18)。
+			if n := searchnorm.Normalize(t); n != "" {
+				clean = append(clean, n)
 			}
 		}
 		if len(clean) == 0 {

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -2362,6 +2362,48 @@ func TestNoteRepository_SearchByTag(t *testing.T) {
 	assert.NotEmpty(t, notes)
 }
 
+// #1948-18: query は normalizeForSearch (NFKC+lowercase) してから突合するので、
+// 正規化済み note.tags ("misskey") を 'Misskey' や全角 query で検索できる。
+func TestNoteRepository_SearchByTag_QueryNormalized(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	user := insertTestUser(t, "tagn_u", "tagnuser")
+	defer cleanupUser(t, user.ID)
+	// note.tags は正規化済み (lowercase) を格納する前提。
+	n := &model.Note{ID: "tagn_n1", UserID: user.ID, Visibility: "public", Tags: []string{"misskey"}}
+	require.NoError(t, testDB.Create(n).Error)
+	defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, n.ID)
+
+	// 大文字混在 query → normalize で 'misskey' に。
+	notes, err := repo.SearchByTag([][]string{{"Misskey"}}, "", 10, "", "", model.NoteSearchTagFilter{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, notes, "大文字 query が normalize されて match (#1948-18)")
+
+	// 全角 query → NFKC で 'misskey' に。
+	notes, err = repo.SearchByTag([][]string{{"Ｍｉｓｓｋｅｙ"}}, "", 10, "", "", model.NoteSearchTagFilter{})
+	require.NoError(t, err)
+	assert.NotEmpty(t, notes, "全角 query が NFKC normalize されて match (#1948-18)")
+}
+
+// #1948-18: mentions は sinceId があれば untilId の有無に関わらず ASC で order する
+// (upstream mentions.ts:69)。汎用 paginationOrder (sinceID && !untilID で ASC) と異なる。
+func TestNoteRepository_ListMentions_SinceIDWithUntilID_ASC(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	author := insertTestUser(t, "mord_a", "mordauthor")
+	target := insertTestUser(t, "mord_t", "mordtarget")
+	defer cleanupUser(t, author.ID)
+	defer cleanupUser(t, target.ID)
+	for _, nid := range []string{"mord1", "mord2", "mord3"} {
+		n := &model.Note{ID: nid, UserID: author.ID, Visibility: "public", Mentions: []string{target.ID}}
+		require.NoError(t, testDB.Create(n).Error)
+		defer testDB.Exec(`DELETE FROM "note" WHERE id = ?`, nid)
+	}
+	// sinceID + untilID 両方指定: upstream は ASC。
+	out, err := repo.ListMentions(target.ID, "", false, 50, "mord0", "mord9")
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(out), 2)
+	assert.True(t, out[0].ID < out[1].ID, "sinceId 指定時は untilId があっても ASC (#1948-18)")
+}
+
 // #1683 query (外側OR・内側AND) の複合タグ検索を実 SQL で検証する。
 func TestNoteRepository_SearchByTag_OrOfAnd(t *testing.T) {
 	repo := NewNoteRepository(testDB)


### PR DESCRIPTION
## Summary

#1948 全面互換性再監査の MEDIUM 候補 [18]。note.tags の正規化、search-by-tag の query 正規化、
notes/mentions の order を upstream に揃える。

## 主な変更点

- **note.tags store 正規化** (`hashtag/extract.go`): `ExtractNoteTags` / `NormalizeNoteTags` を追加。
  upstream NoteCreateService.ts:581,632 と同じく raw dedup → `<=128` code point filter (drop) →
  32 cap → `normalizeForSearch` (NFKC+lowercase) で note.tags を格納。**cap を normalize より前**に
  効かせ、case/width 衝突で空いた slot に余分な tag が残らないようにして surviving source tag 集合を
  upstream と一致させる。`note_create_service` と AP `resolver` (create/update) の note tag 格納を切替。
- **search-by-tag query 正規化** (`repository/note.go`): SearchByTag で各 query tag を
  `searchnorm.Normalize` してから `tags @> ARRAY[?]` 突合 (upstream search-by-tag.ts:106,113)。
  single tag / query group 両 path をカバー。
- **ListMentions order** (`repository/note.go`): 汎用 paginationOrder を mentions 専用 order
  (`sinceID != "" なら untilID の有無に関わらず ASC`) に (upstream mentions.ts:69)。

## テスト

- hashtag: ExtractNoteTags の lowercase/NFKC/128drop/32cap、NormalizeNoteTags の AP 配列正規化、
  cap-before-normalize の surviving set。
- repository (統合): SearchByTag が大文字/全角 query を normalize して正規化済 note.tags に match、
  ListMentions が sinceId+untilId 両指定で ASC。
- hashtag 91.5% / repository 90.0%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで「dedup を cap より前に効かせると >32 tag note で surviving tag が upstream とずれる」
MEDIUM を発見し、cap-before-normalize に修正した。query 正規化を backfill 無しで入れると旧 uppercase/
全角 note.tags が検索不能になる forward-only regression は本番負荷を考慮し #2013 に分離した。

## 関連

- 親: #1948

Closes #2014
