### PR TITLE
Fix NoteDraft pack parity (#1948-19): reply/renote/channel resolve + poll/date 形式

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -938,6 +938,25 @@ func (h *Handler) BulkShow(c echo.Context) error {
 	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))
 }
 
+// packReferencedNote packs a single note referenced by a draft (reply/renote)
+// for the viewer. upstream の `noteEntityService.pack(noteId, me, {skipHide:false})`
+// に合わせ、(1) timeline の hard-mute drop は適用しない (upstream pack には
+// hard-mute が無い)、(2) viewer が閲覧不可な note (followers 非フォロワー /
+// specified 対象外) は entity.HideNoteEntity で本文を blank し isHidden を立てる
+// (upstream shouldHideNote→hideNote)。draft は owner-only だが、replyId/renoteId に
+// 任意の note ID を入れて非可視 note の本文を読み出す leak を塞ぐ (#1948-19)。
+func (h *Handler) packReferencedNote(ctx context.Context, n *model.Note, viewer *model.User) entity.NoteEntity {
+	packed := entity.PackNotes(ctx, []*model.Note{n}, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
+	h.fieldResolver().Apply(packed, viewer)
+	notehide.HideEmbeds(viewer, packed)
+	out := packed[0]
+	// queryService 未配線時は fail-closed で hide (= 検証不能なら隠す)。
+	if h.queryService == nil || !h.queryService.CanSee(viewer, n) {
+		entity.HideNoteEntity(&out)
+	}
+	return out
+}
+
 // packMany serializes a list of notes into NoteEntity objects.
 // driveFileRepoが設定されている場合、ファイル情報を解決してFilesに含める。
 // viewerがnon-nilの場合、myReactionなどのviewer依存フィールドも解決する。

--- a/internal/api/notes/handler_drafts.go
+++ b/internal/api/notes/handler_drafts.go
@@ -1,6 +1,7 @@
 package notes
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
 	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/queue/driver"
@@ -28,17 +30,21 @@ func (h *Handler) DraftsList(c echo.Context) error {
 		return c.JSON(http.StatusOK, []any{})
 	}
 	// upstream drafts/list.ts は limit(default30/max100) + sinceId/untilId +
-	// scheduled(boolean) を受ける (#1538)。sinceDate/untilDate は mk-go の
-	// id-based keyset 方針 (NoteDraft に createdAt 列が無い) のため非対応。
+	// sinceDate/untilDate + scheduled(boolean) を受ける (#1538)。NoteDraft.id は
+	// aidx で時刻を内包するので、sinceDate/untilDate は id cursor に正規化して
+	// keyset pagination に乗せる (#1948-19)。
 	var req struct {
 		Limit     int    `json:"limit"`
 		SinceID   string `json:"sinceId"`
 		UntilID   string `json:"untilId"`
+		SinceDate *int64 `json:"sinceDate"`
+		UntilDate *int64 `json:"untilDate"`
 		Scheduled *bool  `json:"scheduled"`
 	}
 	_ = c.Bind(&req)
 	limit := pagination.ClampLimit(req.Limit, 30, 100)
-	drafts, err := h.draftRepo.ListByUser(user.ID, req.SinceID, req.UntilID, req.Scheduled, limit)
+	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	drafts, err := h.draftRepo.ListByUser(user.ID, sinceID, untilID, req.Scheduled, limit)
 	if err != nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
@@ -52,7 +58,7 @@ func (h *Handler) DraftsList(c echo.Context) error {
 	for i, d := range drafts {
 		// drafts は viewer 自身のものなので user を埋める (repo は Preload しない)。
 		d.User = user
-		out[i] = h.packDraft(d, fileByID)
+		out[i] = h.packDraft(c.Request().Context(), user, d, fileByID)
 	}
 	return c.JSON(http.StatusOK, out)
 }
@@ -191,7 +197,7 @@ func (h *Handler) DraftsCreate(c echo.Context) error {
 	}
 	draft.User = user
 	// upstream res は { createdDraft: NoteDraft } で包む。
-	return c.JSON(http.StatusOK, map[string]any{"createdDraft": h.packDraft(draft, nil)})
+	return c.JSON(http.StatusOK, map[string]any{"createdDraft": h.packDraft(c.Request().Context(), user, draft, nil)})
 }
 
 // DraftsUpdate handles POST /api/notes/drafts/update.
@@ -323,7 +329,7 @@ func (h *Handler) DraftsUpdate(c echo.Context) error {
 	}
 	draft.User = user
 	// upstream res は { updatedDraft: NoteDraft } で包む。
-	return c.JSON(http.StatusOK, map[string]any{"updatedDraft": h.packDraft(draft, nil)})
+	return c.JSON(http.StatusOK, map[string]any{"updatedDraft": h.packDraft(c.Request().Context(), user, draft, nil)})
 }
 
 // draftPoll mirrors the upstream notes/drafts poll param object.
@@ -558,7 +564,7 @@ func (h *Handler) PollsRecommendation(c echo.Context) error {
 // packDraft packs a draft. fileByID, when non-nil, is a pre-resolved DriveFile
 // map (List uses it to batch all drafts' files in one query, avoiding N+1).
 // When nil, files are resolved per-draft (single create/update/show path).
-func (h *Handler) packDraft(d *model.NoteDraft, fileByID map[string]entity.DriveFileEntity) map[string]any {
+func (h *Handler) packDraft(ctx context.Context, viewer *model.User, d *model.NoteDraft, fileByID map[string]entity.DriveFileEntity) map[string]any {
 	const tsFmt = "2006-01-02T15:04:05.000Z"
 	visibleUserIDs := []string(d.VisibleUserIDs)
 	if visibleUserIDs == nil {
@@ -583,11 +589,23 @@ func (h *Handler) packDraft(d *model.NoteDraft, fileByID map[string]entity.Drive
 		"channelId":           d.ChannelID,
 		"hashtag":             d.Hashtag,
 		"isActuallyScheduled": d.IsActuallyScheduled,
-		// 解決済みオブジェクトは未対応 (ID は上で返す)。
-		"reply":   nil,
-		"renote":  nil,
-		"channel": nil,
-		"files":   h.draftFiles(fileIDs, fileByID),
+		"files":               h.draftFiles(fileIDs, fileByID),
+	}
+	// upstream NoteDraftEntityService.pack (detail) は replyId/renoteId set 時のみ
+	// reply/renote を解決し (見つからなければ null)、未設定なら key を省略する
+	// (#1948-19)。reply は detail:false、renote は detail:true 相当。
+	if d.ReplyID != nil {
+		result["reply"] = h.packDraftNote(ctx, viewer, *d.ReplyID)
+	}
+	if d.RenoteID != nil {
+		result["renote"] = h.packDraftNote(ctx, viewer, *d.RenoteID)
+	}
+	// channel は channelId set かつ channel が見つかったときだけ {id,name,color,
+	// isSensitive,allowRenoteToExternal,userId} を出力、それ以外は key 省略 (#1948-19)。
+	if d.ChannelID != nil {
+		if ch := h.packDraftChannel(*d.ChannelID); ch != nil {
+			result["channel"] = ch
+		}
 	}
 	if t, err := h.idGen.ParseTime(d.ID); err == nil {
 		result["createdAt"] = t.UTC().Format(tsFmt)
@@ -610,10 +628,10 @@ func (h *Handler) packDraft(d *model.NoteDraft, fileByID map[string]entity.Drive
 			"multiple":     d.PollMultiple,
 			"expiredAfter": d.PollExpiredAfter,
 		}
+		// upstream は expiresAt: pollExpiresAt?.toISOString() で、nil のとき key を
+		// 省略する (undefined。null ではない、#1948-19)。
 		if d.PollExpiresAt != nil {
 			poll["expiresAt"] = d.PollExpiresAt.UTC().Format(tsFmt)
-		} else {
-			poll["expiresAt"] = nil
 		}
 		result["poll"] = poll
 	} else {
@@ -623,6 +641,43 @@ func (h *Handler) packDraft(d *model.NoteDraft, fileByID map[string]entity.Drive
 		result["user"] = entity.PackUserLite(d.User)
 	}
 	return result
+}
+
+// packDraftNote resolves a draft's reply/renote target Note and packs it for the
+// viewer, returning nil when the note no longer exists (upstream
+// nullIfEntityNotFound). noteRepo 未配線時も nil (#1948-19)。
+func (h *Handler) packDraftNote(ctx context.Context, viewer *model.User, noteID string) any {
+	if h.noteRepo == nil {
+		return nil
+	}
+	n, err := h.noteRepo.FindByIDWithUser(noteID)
+	if err != nil || n == nil {
+		return nil
+	}
+	// packMany は timeline 用 hard-mute drop を行い非可視 note を漏らすため使わない。
+	// packReferencedNote が hard-mute skip + visibility hide を行う (#1948-19)。
+	return h.packReferencedNote(ctx, n, viewer)
+}
+
+// packDraftChannel resolves a draft's channel into the upstream NoteDraft.channel
+// summary {id,name,color,isSensitive,allowRenoteToExternal,userId}, or nil when
+// the channel is missing / channelRepo unwired so the caller omits the key (#1948-19).
+func (h *Handler) packDraftChannel(channelID string) map[string]any {
+	if h.channelRepo == nil {
+		return nil
+	}
+	ch, err := h.channelRepo.FindByID(channelID)
+	if err != nil || ch == nil {
+		return nil
+	}
+	return map[string]any{
+		"id":                    ch.ID,
+		"name":                  ch.Name,
+		"color":                 ch.Color,
+		"isSensitive":           ch.IsSensitive,
+		"allowRenoteToExternal": ch.AllowRenoteToExternal,
+		"userId":                ch.UserID,
+	}
 }
 
 // draftFiles resolves a draft's fileIds to packed DriveFiles in order. When

--- a/internal/api/notes/handler_drafts_test.go
+++ b/internal/api/notes/handler_drafts_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -14,7 +15,9 @@ import (
 	"github.com/shiroha-a/mk/internal/queue/driver"
 
 	"github.com/labstack/echo/v4"
+	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	corenote "github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/server/middleware"
@@ -153,6 +156,113 @@ func TestDraftsList_WithData(t *testing.T) {
 	var resp []any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Len(t, resp, 1)
+}
+
+// #1948-19: packDraft は replyId/renoteId set 時に Note を resolve し、未設定なら
+// key を省略する。channelId 同様。poll.expiresAt は nil で key 省略。
+func TestPackDraft_ResolvesReplyRenoteChannelAndPoll(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	noteRepo := testutil.NewMockNoteRepository()
+	noteRepo.Notes["reply1"] = &model.Note{ID: "reply1", UserID: "author", Visibility: "public", Reactions: datatypes.JSON([]byte("{}")), User: &model.User{ID: "author", AvatarDecorations: datatypes.JSON([]byte("[]"))}}
+	noteRepo.Notes["renote1"] = &model.Note{ID: "renote1", UserID: "author", Visibility: "public", Reactions: datatypes.JSON([]byte("{}")), User: &model.User{ID: "author", AvatarDecorations: datatypes.JSON([]byte("[]"))}}
+	h.noteRepo = noteRepo
+	// public note は viewer に可視なので CanSee=true。queryService を wire する。
+	h.queryService = corenote.NewQueryService(noteRepo, testutil.NewMockFollowingRepository())
+	chRepo := testutil.NewMockChannelRepository()
+	owner := "u1"
+	chRepo.Channels["ch1"] = &model.Channel{ID: "ch1", Name: "general", Color: "#fff", IsSensitive: true, AllowRenoteToExternal: false, UserID: &owner}
+	h.channelRepo = chRepo
+
+	replyID, renoteID, channelID := "reply1", "renote1", "ch1"
+	repo.drafts["d1"] = &model.NoteDraft{
+		ID: "d1", UserID: "u1", Visibility: "public",
+		ReplyID: &replyID, RenoteID: &renoteID, ChannelID: &channelID,
+		HasPoll: true, PollChoices: pq.StringArray{"a", "b"}, // PollExpiresAt nil
+	}
+	rec := postDraft(h.DraftsList, `{}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	d := resp[0]
+	// reply/renote が resolve される。
+	reply, ok := d["reply"].(map[string]any)
+	require.True(t, ok, "replyId set なら reply object を resolve (#1948-19)")
+	assert.Equal(t, "reply1", reply["id"])
+	renote, ok := d["renote"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "renote1", renote["id"])
+	// channel summary。
+	ch, ok := d["channel"].(map[string]any)
+	require.True(t, ok, "channelId set なら channel summary を resolve (#1948-19)")
+	assert.Equal(t, "general", ch["name"])
+	assert.Equal(t, true, ch["isSensitive"])
+	// poll.expiresAt は nil なので key 省略。
+	poll := d["poll"].(map[string]any)
+	_, hasExp := poll["expiresAt"]
+	assert.False(t, hasExp, "poll.expiresAt nil は key 省略 (#1948-19)")
+}
+
+// #1948-19 (security): draft owner が閲覧不可な note を replyId に入れても、その
+// 本文は漏れず hideNote stub される (followers/specified の intrinsic hide)。
+func TestPackDraft_ReplyToInvisibleNote_Hidden(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	noteRepo := testutil.NewMockNoteRepository()
+	secret := "TOP SECRET BODY"
+	// followers-only note by author; viewer (u1) は author を follow していない。
+	noteRepo.Notes["secret1"] = &model.Note{ID: "secret1", UserID: "author", Visibility: "followers", Text: &secret, Reactions: datatypes.JSON([]byte("{}")), User: &model.User{ID: "author", AvatarDecorations: datatypes.JSON([]byte("[]"))}}
+	h.noteRepo = noteRepo
+	h.queryService = corenote.NewQueryService(noteRepo, testutil.NewMockFollowingRepository())
+
+	replyID := "secret1"
+	repo.drafts["d1"] = &model.NoteDraft{ID: "d1", UserID: "u1", Visibility: "public", ReplyID: &replyID}
+	rec := postDraft(h.DraftsList, `{}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "TOP SECRET BODY", "非可視 reply note の本文が漏れない (#1948-19)")
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	reply := resp[0]["reply"].(map[string]any)
+	assert.Equal(t, true, reply["isHidden"], "非可視 reply は isHidden:true で stub (#1948-19)")
+	assert.Nil(t, reply["text"], "stub は text を消す")
+}
+
+// #1948-19: replyId/renoteId/channelId 未設定なら reply/renote/channel key を省略する。
+func TestPackDraft_OmitsKeysWhenUnset(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	text := "plain"
+	repo.drafts["d1"] = &model.NoteDraft{ID: "d1", UserID: "u1", Text: &text, Visibility: "public"}
+	rec := postDraft(h.DraftsList, `{}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	d := resp[0]
+	for _, k := range []string{"reply", "renote", "channel"} {
+		_, has := d[k]
+		assert.False(t, has, k+" は未設定時に key 省略 (#1948-19)")
+	}
+}
+
+// #1948-19: drafts/list は sinceDate/untilDate を id cursor に正規化する。
+func TestDraftsList_DateCursor(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	idGen, _ := id.NewGenerator("aidx")
+	// 2 件: 古い (2020) と新しい (2026)。
+	oldID := idGen.Generate(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+	newID := idGen.Generate(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	repo.drafts[oldID] = &model.NoteDraft{ID: oldID, UserID: "u1", Visibility: "public"}
+	repo.drafts[newID] = &model.NoteDraft{ID: newID, UserID: "u1", Visibility: "public"}
+	// sinceDate = 2023 → 2026 の draft のみ (id > sinceID)。
+	body := `{"sinceDate":` + itoaMillis(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)) + `}`
+	rec := postDraft(h.DraftsList, body, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1, "sinceDate cursor で 2023 以降の draft のみ (#1948-19)")
+	assert.Equal(t, newID, resp[0]["id"])
+}
+
+func itoaMillis(t time.Time) string {
+	return strconv.FormatInt(t.UnixMilli(), 10)
 }
 
 // --- DraftsCreate ---


### PR DESCRIPTION
## Summary

#1948 全面互換性再監査の MEDIUM 候補 [19]。NoteDraft pack の reply/renote/channel resolve と
poll/date 形式を upstream NoteDraftEntityService に揃える。

## 主な変更点

- **reply/renote resolve** (`handler_drafts.go`): replyId/renoteId set 時に Note を resolve (見つから
  なければ null)、未設定なら key 省略 (upstream `replyId ? nullIfEntityNotFound(...) : undefined`)。
- **channel resolve**: channelId set かつ found なら `{id,name,color,isSensitive,allowRenoteToExternal,
  userId}`、それ以外 key 省略。
- **poll.expiresAt**: nil で key 省略 (upstream `pollExpiresAt?.toISOString()`)。
- **drafts/list date cursor**: sinceDate/untilDate を `id.NormalizeCursor` で id cursor に正規化
  (NoteDraft.id は aidx で時刻内包)。
- **packReferencedNote** (`handler.go`、security): reply/renote の Note を pack する際、timeline の
  hard-mute drop を適用せず (upstream pack は hard-mute しない)、viewer が閲覧不可な note は
  `entity.HideNoteEntity` で本文を blank し `isHidden` を立てる。draft owner が任意の note ID を
  replyId/renoteId に入れて非可視 note の本文を読み出す leak を塞ぐ。

## テスト

- reply/renote/channel resolve + poll.expiresAt 省略 / 未設定で key 省略 / drafts/list の date cursor /
  **非可視 reply note の本文非露出 + isHidden:true** (security)。
- notes 90.8%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで以下を発見し対応した:
- **HIGH (content leak)**: packMany 経由だと非可視 reply/renote の本文が漏れる → packReferencedNote で
  visibility hide を追加し本 PR で修正 (security 再レビューで leak なしを確認)。
- MEDIUM: reply が detail:true で pack され upstream detail:false と乖離 → #2016 に分離。
- DraftsCreate の reply 可視性検証欠如 (本文 leak は本 PR で塞いだが create-time error parity) → #2017。

## 関連

- 親: #1948

Closes #2018
