### PR TITLE
Fix streaming parity (#1948-20): admin gate 緩和 + hashtag q 全グループ検証

### DIFF
--- a/internal/stream/channels/admin.go
+++ b/internal/stream/channels/admin.go
@@ -7,9 +7,19 @@ import (
 	"github.com/shiroha-a/mk/internal/stream"
 )
 
-// AdminRoleChecker checks whether a user has admin privileges.
+// AdminRoleChecker checks whether a user has moderator/admin privileges.
+//
+// upstream の admin stream channel は streaming layer で role check せず、
+// requireCredential=true (native session) または kind='read:admin:stream'
+// permission (OAuth token) のみで gate する。`read:admin:stream` は moderator
+// 用 scope なので moderator が購読できるのが意図。mk-go は native session に
+// role/permission 概念を持たないため、その scope 意図を server-side の
+// moderator check で代替する (= upstream より厳格だが abuse report 等の event
+// を漏らさず moderator にも届ける)。以前は IsAdministrator で admin 限定にして
+// おり、moderator を不当に弾いていた (#1948-20)。IsModerator は administrator
+// も含む。
 type AdminRoleChecker interface {
-	IsAdministrator(userID string) bool
+	IsModerator(userID string) bool
 }
 
 // AdminChannel forwards admin-only events. Requires authenticated admin user.
@@ -40,8 +50,10 @@ func (c *AdminChannel) Init(_ json.RawMessage) error {
 	if !ok || user == nil {
 		return stream.ErrInvalidParams
 	}
-	// admin権限チェック
-	if c.roleChecker == nil || !c.roleChecker.IsAdministrator(user.ID) {
+	// moderator/admin 権限チェック (read:admin:stream scope 相当、AdminRoleChecker
+	// の docstring 参照)。moderator も abuse report 等を受信できる (#1948-20。以前は
+	// IsAdministrator で admin 限定だった)。
+	if c.roleChecker == nil || !c.roleChecker.IsModerator(user.ID) {
 		return stream.ErrInvalidParams
 	}
 	c.connected = true

--- a/internal/stream/channels/hashtag.go
+++ b/internal/stream/channels/hashtag.go
@@ -37,9 +37,16 @@ func (c *HashtagChannel) Init(params json.RawMessage) error {
 	if len(params) > 0 {
 		_ = json.Unmarshal(params, &p)
 	}
-	// TS Misskey は q が配列でない/要素がないと init が false を返して接続拒否
-	if len(p.Q) == 0 || len(p.Q[0]) == 0 {
+	// upstream hashtag.ts:36-42 は `q.every(x => Array.isArray(x) && x.length >= 1)`
+	// で**全グループ**が非空であることを要求し、1 つでも空なら接続拒否する。以前は
+	// q[0] (第1グループ) のみ検証していた (#1948-20)。
+	if len(p.Q) == 0 {
 		return stream.ErrInvalidParams
+	}
+	for _, group := range p.Q {
+		if len(group) == 0 {
+			return stream.ErrInvalidParams
+		}
 	}
 	c.filter = parseNoteFilter(params)
 	// q を正規化して保持し、全グループの全タグの distinct 正規化キーを購読する。

--- a/internal/stream/channels/new_channels_test.go
+++ b/internal/stream/channels/new_channels_test.go
@@ -15,19 +15,21 @@ var errAntennaLookup = errors.New("antenna lookup failed")
 
 // mockRoleChecker is a test double for AdminRoleChecker.
 type mockRoleChecker struct {
-	admins map[string]bool
+	mods map[string]bool
 }
 
-func (m *mockRoleChecker) IsAdministrator(userID string) bool {
-	return m.admins[userID]
+func (m *mockRoleChecker) IsModerator(userID string) bool {
+	return m.mods[userID]
 }
 
-func newAdminCh(ctx stream.ChannelContext, isAdmin bool) stream.Channel {
+// newAdminCh builds an admin channel where the connecting user is a moderator
+// (= admin stream は moderator scope で gate される、#1948-20) per the flag.
+func newAdminCh(ctx stream.ChannelContext, isMod bool) stream.Channel {
 	userID := ""
 	if u, ok := ctx.User().(*model.User); ok && u != nil {
 		userID = u.ID
 	}
-	checker := &mockRoleChecker{admins: map[string]bool{userID: isAdmin}}
+	checker := &mockRoleChecker{mods: map[string]bool{userID: isMod}}
 	return NewAdminFactory(checker).New(ctx)
 }
 
@@ -99,6 +101,17 @@ func TestHashtag_EmptyQ(t *testing.T) {
 	ch := NewHashtag(ctx)
 	err := ch.Init(json.RawMessage(`{}`))
 	assert.ErrorIs(t, err, stream.ErrInvalidParams)
+	assert.Empty(t, ctx.subs)
+	ch.Dispose()
+}
+
+// #1948-20: 全グループが非空でなければ接続拒否する (upstream q.every(x.length>=1))。
+// 第1グループが非空でも後続グループが空なら reject。
+func TestHashtag_EmptyGroupRejected(t *testing.T) {
+	ctx := newCtx(nil)
+	ch := NewHashtag(ctx)
+	err := ch.Init(json.RawMessage(`{"q":[["a"],[]]}`))
+	assert.ErrorIs(t, err, stream.ErrInvalidParams, "後続グループが空なら接続拒否 (#1948-20)")
 	assert.Empty(t, ctx.subs)
 	ch.Dispose()
 }


### PR DESCRIPTION
## Summary

#1948 全面互換性再監査の MEDIUM 候補 [20] の一部。streaming channel parity のうち hot-path 変更を
要さない 2 項目を対応する。

## 主な変更点

- **admin stream channel** (`admin.go`): `AdminRoleChecker` を `IsAdministrator` → `IsModerator` に
  緩和し Init の gate も IsModerator に。upstream の admin stream は streaming layer で role check せず
  requireCredential + `kind='read:admin:stream'` (moderator scope) で gate するため、moderator も
  abuse report 等を受信できる必要がある。per-user topic `adminStream:<id>` で他人 event は漏れず、
  IsModerator は administrator を含むので既存 admin も維持。以前は admin 限定で moderator を不当に
  弾いていた。
- **hashtag channel** (`hashtag.go`): q 検証を「第1グループのみ非空」→「全グループ非空」に
  (upstream `hashtag.ts:36-42` の `q.every(x.length>=1)`)。

## テスト

- admin: moderator(true)/non-moderator(false) の connect 可否。
- hashtag: 後続グループが空 (`{"q":[["a"],[]]}`) で接続拒否。
- stream/channels 92.1%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

候補 [20] の残 3 項目 (per-subscriber renote.myReaction / renote.reply followers-only drop /
user_list per-membership withReplies) は streaming の hot path に作用し per-connection 処理 / embed
depth 変更 / 性能影響を要するため、設計 + benchmark を伴う dedicated PR (#2020) に分離した。敵対的
レビューで admin gate 緩和に security 後退が無いこと (read:admin:stream は moderator scope、per-user
topic で漏洩なし) を確認した。

## 関連

- 親: #1948

Closes #2021
