### PR TITLE
Fix AP inbox parity (#1948-21): Undo(Follow) request cancel + Like name fallback + Move target gate

### DIFF
--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -763,10 +763,16 @@ func (p *Processor) handleUndoFollow(act genericActivity, inner genericActivity)
 	if err != nil {
 		return errors.New("unknown followee")
 	}
-	if err := p.followingService.Unfollow(follower.ID, followee.ID); err != nil {
-		if errors.Is(err, corefollowing.ErrNotFollowing) {
-			return nil
-		}
+	if err := p.followingService.Unfollow(follower.ID, followee.ID); err != nil &&
+		!errors.Is(err, corefollowing.ErrNotFollowing) {
+		return err
+	}
+	// locked local followee 宛の pending follow request を取り消す。upstream
+	// undoFollow は requestExist を見て cancelFollowRequest を呼ぶ。これが無いと
+	// remote が accept 前に Undo(Follow) を送った場合、phantom な follow request 行と
+	// receiveFollowRequest 通知が残る (handleReject と同じ pattern、#1948-21)。
+	if err := p.followingService.CancelRequest(follower.ID, followee.ID); err != nil &&
+		!errors.Is(err, corefollowing.ErrRequestNotFound) {
 		return err
 	}
 	return nil
@@ -1271,6 +1277,13 @@ func (p *Processor) handleLike(act genericActivity) error {
 	reaction := like.Content
 	if like.MisskeyReaction != "" {
 		reaction = like.MisskeyReaction
+	}
+	// upstream like() は reaction を `_misskey_reaction ?? content ?? name` で解決
+	// する。一部の Mastodon-fork / Pleroma 系 EmojiReact は shortcode を `name` に
+	// 乗せるため、content/_misskey_reaction が無ければ name を fallback に使う
+	// (#1948-21)。like.Name は埋め込み Object の name (AS activity の name)。
+	if reaction == "" {
+		reaction = like.Name
 	}
 	// reversi game session URI (`/games/{UUID}/{sessionID}`) は CherryPick
 	// 拡張の reaction 連合。純正 Misskey フロントは `reacted` を表示する UI を
@@ -1895,6 +1908,20 @@ func (p *Processor) handleFlag(act genericActivity) error {
 // リモートactorのプロフィールを強制再取得する。TTLキャッシュをバイパスして
 // movedTo/alsoKnownAsの最新値を反映する。
 func (p *Processor) handleMove(act genericActivity) error {
+	// upstream move() は activity.target を getApHrefNullable で読み、無い/不正なら
+	// 'skip: invalid activity target' で早期 return する。target が無い Move で
+	// ForceResolveActor (TTL-bypass の強制 refetch) を発火させない (#1948-21)。
+	// getApHrefNullable は string か object.href を読む (id ではない) ので、同じ
+	// 受理集合になるよう readApHref を使う。
+	var t struct {
+		Target json.RawMessage `json:"target"`
+	}
+	if len(act.raw) > 0 {
+		_ = json.Unmarshal(act.raw, &t)
+	}
+	if readApHref(t.Target) == "" {
+		return nil // skip: invalid activity target
+	}
 	if _, err := p.resolver.ForceResolveActor(act.Actor); err != nil {
 		return err
 	}
@@ -2039,6 +2066,28 @@ func readObjectString(raw json.RawMessage) (string, error) {
 		return "", errors.New("object missing id")
 	}
 	return obj.ID, nil
+}
+
+// readApHref mirrors upstream getApHrefNullable: it returns the value when it is
+// a bare URI string, or its `href` property when it is an AS Link/object, and ""
+// otherwise (including {id}-only objects, which upstream also treats as absent).
+// Used for fields like Move.target that upstream reads via getApHrefNullable
+// rather than getApId (#1948-21).
+func readApHref(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var obj struct {
+		Href string `json:"href"`
+	}
+	if err := json.Unmarshal(raw, &obj); err == nil {
+		return obj.Href
+	}
+	return ""
 }
 
 // readActorString reads an activity's actor field, supporting both string and

--- a/internal/core/federation/processor_step_f_test.go
+++ b/internal/core/federation/processor_step_f_test.go
@@ -222,6 +222,25 @@ func TestProcess_LikeWithContent(t *testing.T) {
 	}
 }
 
+// #1948-21: content/_misskey_reaction が無い Like は activity.name を reaction の
+// fallback に使う (upstream `_misskey_reaction ?? content ?? name`)。一部の
+// Mastodon-fork / Pleroma 系 EmojiReact は shortcode を name に乗せる。
+func TestProcess_LikeWithName(t *testing.T) {
+	env := newFullProcessor(t, aliceActor)
+	env.noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "bob", Visibility: model.NoteVisibilityPublic}
+	body := []byte(`{
+		"type": "Like",
+		"actor": "https://remote.example/users/alice",
+		"object": "https://example.com/notes/n1",
+		"name": "🐧"
+	}`)
+	require.NoError(t, env.processor.Process(body))
+	require.Len(t, env.reactionRepo.Reactions, 1)
+	for _, r := range env.reactionRepo.Reactions {
+		assert.Equal(t, "🐧", r.Reaction, "content/_misskey_reaction 無しなら name を reaction に使う (#1948-21)")
+	}
+}
+
 func TestProcess_LikeWithMisskeyReaction(t *testing.T) {
 	// _misskey_reaction は content より優先される
 	env := newFullProcessor(t, aliceActor)

--- a/internal/core/federation/processor_test.go
+++ b/internal/core/federation/processor_test.go
@@ -264,6 +264,67 @@ func TestProcess_UndoFollow(t *testing.T) {
 	assert.Empty(t, followingRepo.Followings)
 }
 
+// #1948-21: locked local user 宛の Undo(Follow) は pending FollowRequest を取り消す
+// (upstream undoFollow は cancelFollowRequest を呼ぶ。これが無いと phantom request が残る)。
+func TestProcess_UndoFollowCancelsPendingRequest(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	followingRepo := testutil.NewMockFollowingRepository()
+	followReqRepo := testutil.NewMockFollowRequestRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	resolver := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(aliceActor)}, idGen)
+	followingSvc := corefollowing.NewService(repo, followingRepo, followReqRepo, idGen)
+	p := federation.NewProcessor(resolver, followingSvc, nil, nil, repo, noteRepo)
+	p.SetLocalBaseURL("https://example.com")
+	p.SetInboundFollowAcceptor(&stubInboundFollowAcceptor{})
+	// locked local user → Follow は FollowRequest を作る。
+	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob", IsLocked: true}
+
+	follow := []byte(`{
+		"type": "Follow",
+		"id": "https://remote.example/follows/1",
+		"actor": "https://remote.example/users/alice",
+		"object": "https://example.com/users/bob"
+	}`)
+	require.NoError(t, p.Process(follow))
+	received, _ := followReqRepo.CountReceived("bob")
+	require.Equal(t, int64(1), received, "locked user への Follow で FollowRequest が作られる")
+
+	undo := []byte(`{
+		"type": "Undo",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"type": "Follow",
+			"actor": "https://remote.example/users/alice",
+			"object": "https://example.com/users/bob"
+		}
+	}`)
+	require.NoError(t, p.Process(undo))
+	received, _ = followReqRepo.CountReceived("bob")
+	assert.Equal(t, int64(0), received, "Undo(Follow) で pending FollowRequest が削除される (#1948-21)")
+}
+
+// #1948-21: target が無い Move は actor を force-resolve しない (upstream は
+// 'skip: invalid activity target')。
+func TestProcess_MoveWithoutTargetSkips(t *testing.T) {
+	p, repo, _, _ := newProcessor(t, aliceActor)
+	body := []byte(`{"type":"Move","actor":"https://remote.example/users/alice"}`)
+	require.NoError(t, p.Process(body))
+	_, err := repo.FindByURI("https://remote.example/users/alice")
+	assert.Error(t, err, "target が無い Move は actor を force-resolve しない (#1948-21)")
+}
+
+// #1948-21: target がある Move は actor を force-resolve する (upstream updatePerson)。
+func TestProcess_MoveWithTargetResolvesActor(t *testing.T) {
+	p, repo, _, _ := newProcessor(t, aliceActor)
+	body := []byte(`{"type":"Move","actor":"https://remote.example/users/alice","target":"https://remote.example/users/alice2"}`)
+	require.NoError(t, p.Process(body))
+	u, err := repo.FindByURI("https://remote.example/users/alice")
+	require.NoError(t, err, "target がある Move は actor を force-resolve する (#1948-21)")
+	assert.NotNil(t, u)
+}
+
 func TestProcess_UndoUnknownType(t *testing.T) {
 	p, _, _, _ := newProcessor(t, aliceActor)
 	undo := []byte(`{
@@ -697,13 +758,30 @@ func TestProcess_FlagFromNote(t *testing.T) {
 
 func TestProcess_Move(t *testing.T) {
 	p, _, _ := newProcessorWithBlocking(t)
-	// Moveはactorの再解決のみ
+	// target を伴う Move は actor を再解決する (target-less の skip は
+	// TestProcess_MoveWithoutTargetSkips で別途 pin、#1948-21)。
 	body := []byte(`{
 		"type": "Move",
 		"actor": "https://remote.example/users/alice",
-		"object": "https://remote.example/users/alice"
+		"object": "https://remote.example/users/alice",
+		"target": "https://remote.example/users/alice2"
 	}`)
 	require.NoError(t, p.Process(body))
+}
+
+// #1948-21: target が AS Link object ({href:...}) 形式でも getApHrefNullable 相当に
+// href を読んで受理する (readObjectString の {id} 読みでは誤 skip していた)。
+func TestProcess_MoveTargetHrefObject(t *testing.T) {
+	p, repo, _, _ := newProcessor(t, aliceActor)
+	body := []byte(`{
+		"type": "Move",
+		"actor": "https://remote.example/users/alice",
+		"target": {"type": "Link", "href": "https://remote.example/users/alice2"}
+	}`)
+	require.NoError(t, p.Process(body))
+	u, err := repo.FindByURI("https://remote.example/users/alice")
+	require.NoError(t, err, "{href} 形式 target でも actor を force-resolve する (#1948-21)")
+	assert.NotNil(t, u)
 }
 
 // --- EmojiReaction ---


### PR DESCRIPTION
## Summary

#1948 全面互換性再監査の候補 [21] のうち AP inbox processor の 3 修正を upstream ApInboxService に
揃える。

## 主な変更点

- **Undo(Follow) request cancel** (`handleUndoFollow`): Unfollow に加えて `CancelRequest` を呼び
  pending FollowRequest を取り消す。upstream undoFollow は requestExist を見て cancelFollowRequest を
  呼ぶ。これが無いと remote が accept 前に Undo(Follow) を送った場合、locked local user に phantom な
  follow request 行 + receiveFollowRequest 通知が残る (既マージの handleReject と同じ pattern。
  ErrNotFollowing / ErrRequestNotFound は swallow)。
- **Like name fallback** (`handleLike`): reaction 解決を `_misskey_reaction ?? content ?? name` に。
  name に reaction shortcode を乗せる Mastodon-fork / Pleroma 系 EmojiReact に対応。
- **Move target gate** (`handleMove`): activity.target が無い/不正なら skip し、ForceResolveActor
  (TTL-bypass の強制 refetch) を発火させない。upstream move() の `getApHrefNullable` に揃え、
  string / `{href}` を読む `readApHref` を追加 (readObjectString の `{id}` 読みでは AS Link object
  形式の target を誤 skip していた)。

## テスト

- Undo(Follow) で pending FollowRequest が削除される / Move 無 target は skip・有 target (string と
  `{href}` 両形式) は force-resolve / Like の name fallback。
- federation 90.3%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで Move target gate の `readObjectString` ({id} 読み) が upstream `getApHrefNullable`
({href} 読み) と受理集合がズレる MEDIUM を発見し、`readApHref` (string/{href}) に修正した。Collection
unroll (#2023) と Pin/UnpinNote の Add/Remove 連合配信 (#2024) は別 issue に分離。

## 関連

- 親: #1948

Closes #2025
