### PR TITLE
Fix discovery parity (#1948-22a): nodeinfo headers/values + XRD bare content-type

### DIFF
--- a/internal/api/nodeinfo/handler.go
+++ b/internal/api/nodeinfo/handler.go
@@ -2,6 +2,7 @@
 package nodeinfo
 
 import (
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"time"
@@ -72,7 +73,7 @@ func (h *Handler) SetProxyAccountResolver(r func() (string, bool)) {
 
 // Version2_1 handles GET /nodeinfo/2.1.
 func (h *Handler) Version2_1(c echo.Context) error {
-	return c.JSON(http.StatusOK, h.buildDocument("2.1"))
+	return h.serveDocument(c, "2.1")
 }
 
 // Version2_0 handles GET /nodeinfo/2.0. /.well-known/nodeinfo が 2.0 リンクも
@@ -80,7 +81,27 @@ func (h *Handler) Version2_1(c echo.Context) error {
 // (#1777)。schema 2.0 には software.repository が無いので省略する (upstream は
 // version 2.0 で software.repository を delete する)。
 func (h *Handler) Version2_0(c echo.Context) error {
-	return c.JSON(http.StatusOK, h.buildDocument("2.0"))
+	return h.serveDocument(c, "2.0")
+}
+
+// serveDocument serializes and writes the nodeinfo document with the upstream
+// NodeinfoServerService response headers: a schema-profiled Content-Type
+// (`application/json; profile="...schema/<ver>#"`), `Cache-Control: public,
+// max-age=600`, and the CORS/Expose headers. c.JSON forces application/json so
+// the document is written via c.Blob with an explicit Content-Type (#1948-22).
+func (h *Handler) serveDocument(c echo.Context, version string) error {
+	body, err := json.Marshal(h.buildDocument(version))
+	if err != nil {
+		return c.NoContent(http.StatusInternalServerError)
+	}
+	hdr := c.Response().Header()
+	hdr.Set("Cache-Control", "public, max-age=600")
+	hdr.Set("Access-Control-Allow-Headers", "Accept")
+	hdr.Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+	hdr.Set("Access-Control-Allow-Origin", "*")
+	hdr.Set("Access-Control-Expose-Headers", "Vary")
+	ct := `application/json; profile="http://nodeinfo.diaspora.software/ns/schema/` + version + `#"`
+	return c.Blob(http.StatusOK, ct, body)
 }
 
 // buildDocument assembles the nodeinfo document for the given schema version
@@ -186,23 +207,16 @@ func (h *Handler) buildDocument(version string) map[string]any {
 	// 統計値は repo 経由で集計。未配線なら 0 (#403)。DB error は nodeinfo を
 	// 丸ごと failさせるより partial 値で返す方が federation crawler に優しい
 	// ので slog.Warn でログだけ残して 0 fallback する。
-	var usersTotal, usersMonth, usersHalf, localPosts, localComments int64
+	// upstream NodeinfoServerService は activeHalfyear/activeMonth を `null` 固定
+	// (コメント `// 重い`)、localComments を `0` 固定にしている。total と localPosts
+	// だけ実集計する。strict parity のため mk-go も同じ wire 値に揃え、month/halfyear
+	// の active-user 集計と localComments 集計の DB aggregation も省く (#1948-22)。
+	var usersTotal, localPosts int64
 	if h.userRepo != nil {
-		now := h.clock()
 		if v, err := h.userRepo.CountLocalUsers(); err != nil {
 			slog.Warn("nodeinfo: CountLocalUsers failed", "err", err)
 		} else {
 			usersTotal = v
-		}
-		if v, err := h.userRepo.CountLocalUsersActiveSince(now.AddDate(0, -1, 0)); err != nil {
-			slog.Warn("nodeinfo: CountLocalUsersActiveSince(month) failed", "err", err)
-		} else {
-			usersMonth = v
-		}
-		if v, err := h.userRepo.CountLocalUsersActiveSince(now.AddDate(0, -6, 0)); err != nil {
-			slog.Warn("nodeinfo: CountLocalUsersActiveSince(halfyear) failed", "err", err)
-		} else {
-			usersHalf = v
 		}
 	}
 	if h.noteRepo != nil {
@@ -210,11 +224,6 @@ func (h *Handler) buildDocument(version string) map[string]any {
 			slog.Warn("nodeinfo: CountLocalNotes failed", "err", err)
 		} else {
 			localPosts = v
-		}
-		if v, err := h.noteRepo.CountLocalComments(); err != nil {
-			slog.Warn("nodeinfo: CountLocalComments failed", "err", err)
-		} else {
-			localComments = v
 		}
 	}
 
@@ -243,11 +252,11 @@ func (h *Handler) buildDocument(version string) map[string]any {
 		"usage": map[string]any{
 			"users": map[string]any{
 				"total":          usersTotal,
-				"activeMonth":    usersMonth,
-				"activeHalfyear": usersHalf,
+				"activeMonth":    nil, // upstream は null 固定 (`// 重い`)
+				"activeHalfyear": nil,
 			},
 			"localPosts":    localPosts,
-			"localComments": localComments,
+			"localComments": 0, // upstream は 0 固定
 		},
 		"metadata": metadata,
 	}

--- a/internal/api/nodeinfo/handler_test.go
+++ b/internal/api/nodeinfo/handler_test.go
@@ -36,6 +36,33 @@ func TestVersion2_1(t *testing.T) {
 	assert.Equal(t, softwareRepository, sw["repository"])
 }
 
+// #1948-22: upstream NodeinfoServerService は schema-profile つき Content-Type +
+// Cache-Control: public, max-age=600 + CORS/Expose ヘッダを返す。
+func TestVersion2_1_ResponseHeaders(t *testing.T) {
+	h := NewHandler(&config.Config{Version: "0.0.0", Host: "example.com"})
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/nodeinfo/2.1", nil)
+	rec := httptest.NewRecorder()
+	require.NoError(t, h.Version2_1(e.NewContext(req, rec)))
+	assert.Equal(t, `application/json; profile="http://nodeinfo.diaspora.software/ns/schema/2.1#"`, rec.Header().Get("Content-Type"))
+	assert.Equal(t, "public, max-age=600", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "GET, OPTIONS", rec.Header().Get("Access-Control-Allow-Methods"))
+	assert.Equal(t, "Accept", rec.Header().Get("Access-Control-Allow-Headers"))
+	assert.Equal(t, "Vary", rec.Header().Get("Access-Control-Expose-Headers"))
+}
+
+// #1948-22: 2.0 は 2.0# profile を返す。
+func TestVersion2_0_ResponseHeaders(t *testing.T) {
+	h := NewHandler(&config.Config{Version: "0.0.0", Host: "example.com"})
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/nodeinfo/2.0", nil)
+	rec := httptest.NewRecorder()
+	require.NoError(t, h.Version2_0(e.NewContext(req, rec)))
+	assert.Equal(t, `application/json; profile="http://nodeinfo.diaspora.software/ns/schema/2.0#"`, rec.Header().Get("Content-Type"))
+	assert.Equal(t, "public, max-age=600", rec.Header().Get("Cache-Control"))
+}
+
 // admin で設定した Meta.Name / Description がnodeinfo.metadata に反映される
 // (#348)。これが効かないとリモートが受け取る nodeName はconfig default
 // (= host) のまま更新されない。
@@ -216,10 +243,11 @@ func TestVersion2_1_UsageStatsFromRepos(t *testing.T) {
 	usage := resp["usage"].(map[string]any)
 	users := usage["users"].(map[string]any)
 	assert.Equal(t, float64(4), users["total"]) // u1-u4 local
-	assert.Equal(t, float64(2), users["activeMonth"])
-	assert.Equal(t, float64(3), users["activeHalfyear"])
+	// #1948-22: upstream は activeMonth/activeHalfyear=null、localComments=0 固定。
+	assert.Nil(t, users["activeMonth"])
+	assert.Nil(t, users["activeHalfyear"])
 	assert.Equal(t, float64(5), usage["localPosts"])
-	assert.Equal(t, float64(2), usage["localComments"])
+	assert.Equal(t, float64(0), usage["localComments"])
 }
 
 // repo のerror path を通して slog.Warn 分岐を cover する。他の test
@@ -269,8 +297,8 @@ func TestVersion2_1_UsageStatsCountErrorsFallbackToZero(t *testing.T) {
 	usage := resp["usage"].(map[string]any)
 	users := usage["users"].(map[string]any)
 	assert.Equal(t, float64(0), users["total"])
-	assert.Equal(t, float64(0), users["activeMonth"])
-	assert.Equal(t, float64(0), users["activeHalfyear"])
+	assert.Nil(t, users["activeMonth"])
+	assert.Nil(t, users["activeHalfyear"])
 	assert.Equal(t, float64(0), usage["localPosts"])
 	assert.Equal(t, float64(0), usage["localComments"])
 }
@@ -290,8 +318,8 @@ func TestVersion2_1_UsageStatsZeroWhenReposMissing(t *testing.T) {
 	usage := resp["usage"].(map[string]any)
 	users := usage["users"].(map[string]any)
 	assert.Equal(t, float64(0), users["total"])
-	assert.Equal(t, float64(0), users["activeMonth"])
-	assert.Equal(t, float64(0), users["activeHalfyear"])
+	assert.Nil(t, users["activeMonth"])
+	assert.Nil(t, users["activeHalfyear"])
 	assert.Equal(t, float64(0), usage["localPosts"])
 	assert.Equal(t, float64(0), usage["localComments"])
 }

--- a/internal/api/wellknown/handler.go
+++ b/internal/api/wellknown/handler.go
@@ -130,7 +130,7 @@ func (h *Handler) Webfinger(c echo.Context) error {
 		if err != nil {
 			return c.NoContent(http.StatusInternalServerError)
 		}
-		return c.Blob(http.StatusOK, "application/xrd+xml; charset=utf-8", append([]byte(xml.Header), body...))
+		return c.Blob(http.StatusOK, "application/xrd+xml", append([]byte(xml.Header), body...))
 	}
 
 	resp := map[string]any{
@@ -147,7 +147,7 @@ func (h *Handler) Webfinger(c echo.Context) error {
 	if err != nil {
 		return c.NoContent(http.StatusInternalServerError)
 	}
-	return c.Blob(http.StatusOK, "application/jrd+json; charset=utf-8", body)
+	return c.Blob(http.StatusOK, "application/jrd+json", body)
 }
 
 // HostMeta handles GET /.well-known/host-meta.
@@ -160,7 +160,7 @@ func (h *Handler) HostMeta(c echo.Context) error {
 <XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
   <Link rel="lrdd" type="application/xrd+xml" template="` + h.origin + `/.well-known/webfinger?resource={uri}"/>
 </XRD>`
-	return c.Blob(http.StatusOK, "application/xrd+xml; charset=utf-8", []byte(xml))
+	return c.Blob(http.StatusOK, "application/xrd+xml", []byte(xml))
 }
 
 // NodeInfoDiscovery handles GET /.well-known/nodeinfo.

--- a/internal/api/wellknown/handler_test.go
+++ b/internal/api/wellknown/handler_test.go
@@ -50,6 +50,23 @@ func TestWebfinger_AcctWithHost(t *testing.T) {
 	assert.Equal(t, "acct:alice@example.com", resp["subject"])
 }
 
+// #1948-22: upstream WellKnownServerService は jrd/xrd を bare content-type
+// (charset 無し) で返す。webfinger JRD と host-meta XRD の Content-Type を pin する。
+func TestWebfinger_JRDBareContentType(t *testing.T) {
+	h, repo := newHandler(t)
+	addUser(repo, "u1", "alice")
+	c, rec := newReq(t, "/.well-known/webfinger?resource=acct:alice@example.com")
+	require.NoError(t, h.Webfinger(c))
+	assert.Equal(t, "application/jrd+json", rec.Header().Get("Content-Type"))
+}
+
+func TestHostMeta_XRDBareContentType(t *testing.T) {
+	h, _ := newHandler(t)
+	c, rec := newReq(t, "/.well-known/host-meta")
+	require.NoError(t, h.HostMeta(c))
+	assert.Equal(t, "application/xrd+xml", rec.Header().Get("Content-Type"))
+}
+
 func TestWebfinger_AcctWithoutHost(t *testing.T) {
 	h, repo := newHandler(t)
 	addUser(repo, "u1", "alice")


### PR DESCRIPTION
## Summary

#1948 全面互換性再監査の候補 [22] (LOW まとめ) のうち、federation discovery (nodeinfo / XRD) の
wire-shape parity 5 件をまとめて対応する。残りの param-strictness 等は #2027 に tracking。

## 主な変更点

- **nodeinfo headers** (`nodeinfo/handler.go`): Version2_1/2_0 を `c.JSON` → `c.Blob` にし、upstream
  `NodeinfoServerService.ts:137-167` の応答ヘッダを付与 — schema-profile つき Content-Type
  (`application/json; profile="http://nodeinfo.diaspora.software/ns/schema/<ver>#"`)、
  `Cache-Control: public, max-age=600`、CORS 4 ヘッダ (Allow-Origin:*, Allow-Methods: GET, OPTIONS,
  Allow-Headers: Accept, Expose-Headers: Vary)。
- **nodeinfo values**: `usage.users.activeMonth`/`activeHalfyear` を null 固定、`usage.localComments`
  を 0 固定に (upstream `NodeinfoServerService.ts:68-69,92`。`// 重い` で month/halfyear 集計を廃止)。
  `CountLocalUsersActiveSince` / `CountLocalComments` の呼び出しを削除し DB aggregation も省く。
  `total`/`localPosts` は実集計のまま。
- **XRD/JRD content type** (`wellknown/handler.go`): webfinger XRD/JRD・host-meta の Content-Type を
  bare (charset 無し) の `application/xrd+xml` / `application/jrd+json` に (upstream
  `WellKnownServerService.ts:54-55`)。

## テスト

- nodeinfo 2.1/2.0 の Content-Type profile + Cache-Control + CORS ヘッダ / activeMonth・activeHalfyear
  が null・localComments が 0 / webfinger JRD・host-meta XRD の bare content-type。
- nodeinfo 97.2% / wellknown 96.2%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで wire-shape parity を全観点確認 (header 二重設定なし、activeMonth/localComments の
null/0 は #1977 型の誤変更でなく upstream 確定挙動への収束)。HIGH/MEDIUM の指摘なし。

## 関連

- 親: #1948
- 残 [22] tracking: #2027

Closes #2028
