### PR TITLE
Fix federation instance pack parity (#1991): upstream response に無い余剰 field を削除

### DIFF
--- a/internal/api/federation/handler.go
+++ b/internal/api/federation/handler.go
@@ -201,10 +201,9 @@ func (h *Handler) ShowInstance(c echo.Context) error {
 
 // instanceToMap shapes an Instance row into the JSON response object expected
 // by misskey-js. 不明値や nil ポインタはそのまま JSON null になるよう map に
-// 載せる。
-//
-// federating / subscribing / publishingは本家Misskeyと同様に
-// followingCount / followersCountから動的に計算する (DBには列を持たない)。
+// 載せる。response field は upstream InstanceEntityService.pack に揃える
+// (federating/subscribing/publishing/notRespondingSince は response field では
+// なく federation/instances の query param なので含めない、#1991)。
 //
 // isBlocked / isSilenced / isMediaSilenced は instance 列ではなく
 // meta.blockedHosts / silencedHosts / mediaSilencedHosts との suffix-match で
@@ -229,19 +228,21 @@ func instanceToMap(inst *model.Instance, hosts coreinstance.FederationHostSets, 
 		suspensionState = "softwareSuspended"
 	}
 	return map[string]any{
-		"id":                      inst.ID,
-		"firstRetrievedAt":        entity.ISOMillis(inst.FirstRetrievedAt),
-		"host":                    inst.Host,
-		"usersCount":              inst.UsersCount,
-		"notesCount":              inst.NotesCount,
-		"followingCount":          inst.FollowingCount,
-		"followersCount":          inst.FollowersCount,
-		"federating":              inst.FollowingCount > 0 || inst.FollowersCount > 0,
-		"subscribing":             inst.FollowersCount > 0,
-		"publishing":              inst.FollowingCount > 0,
+		"id":               inst.ID,
+		"firstRetrievedAt": entity.ISOMillis(inst.FirstRetrievedAt),
+		"host":             inst.Host,
+		"usersCount":       inst.UsersCount,
+		"notesCount":       inst.NotesCount,
+		"followingCount":   inst.FollowingCount,
+		"followersCount":   inst.FollowersCount,
+		// federating/subscribing/publishing は upstream では federation/instances の
+		// query 用 paramDef であって InstanceEntity の response field ではない。
+		// notRespondingSince も upstream InstanceEntityService.pack に無い (response は
+		// isNotResponding boolean のみ)。strict parity のため 4 余剰 field を削除した
+		// (#1991。frontend は federating 等を request filter としてのみ使い response を
+		// 読まない)。
 		"latestRequestReceivedAt": entity.ISOMillisPtr(inst.LatestRequestReceivedAt),
 		"isNotResponding":         inst.IsNotResponding,
-		"notRespondingSince":      inst.NotRespondingSince,
 		"isSuspended":             isSuspended,
 		"suspensionState":         suspensionState,
 		"isBlocked":               coreinstance.HostMatchesAny(hosts.Blocked, inst.Host),

--- a/internal/api/federation/handler_test.go
+++ b/internal/api/federation/handler_test.go
@@ -451,38 +451,27 @@ func TestShowInstance_MetaError(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
-// TestShowInstance_FederatingFlags verifies that the response includes the
-// computed federating / subscribing / publishing fields expected by misskey-js.
-func TestShowInstance_FederatingFlags(t *testing.T) {
-	cases := []struct {
-		name        string
-		following   int
-		followers   int
-		federating  bool
-		subscribing bool
-		publishing  bool
-	}{
-		{name: "no federation", following: 0, followers: 0, federating: false, subscribing: false, publishing: false},
-		{name: "only outgoing", following: 3, followers: 0, federating: true, subscribing: false, publishing: true},
-		{name: "only incoming", following: 0, followers: 5, federating: true, subscribing: true, publishing: false},
-		{name: "bidirectional", following: 4, followers: 2, federating: true, subscribing: true, publishing: true},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			h, repo := newHandler(t)
-			inst := seedInstance(t, repo, "flags.example")
-			inst.FollowingCount = tc.following
-			inst.FollowersCount = tc.followers
+// TestShowInstance_OmitsNonUpstreamFields verifies that the response does NOT
+// include the federating/subscribing/publishing/notRespondingSince fields, which
+// are upstream federation/instances query params (not InstanceEntity response
+// fields). isNotResponding (boolean) is the upstream response field (#1991).
+func TestShowInstance_OmitsNonUpstreamFields(t *testing.T) {
+	h, repo := newHandler(t)
+	inst := seedInstance(t, repo, "flags.example")
+	inst.FollowingCount = 4
+	inst.FollowersCount = 2
 
-			c, rec := newReq(t, `{"host":"flags.example"}`)
-			require.NoError(t, h.ShowInstance(c))
-			require.Equal(t, http.StatusOK, rec.Code)
+	c, rec := newReq(t, `{"host":"flags.example"}`)
+	require.NoError(t, h.ShowInstance(c))
+	require.Equal(t, http.StatusOK, rec.Code)
 
-			var got map[string]any
-			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
-			assert.Equal(t, tc.federating, got["federating"])
-			assert.Equal(t, tc.subscribing, got["subscribing"])
-			assert.Equal(t, tc.publishing, got["publishing"])
-		})
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	for _, k := range []string{"federating", "subscribing", "publishing", "notRespondingSince"} {
+		_, has := got[k]
+		assert.False(t, has, k+" は upstream の response field でないため省略する (#1991)")
 	}
+	// upstream response の isNotResponding (boolean) は残す。
+	_, hasIsNotResponding := got["isNotResponding"]
+	assert.True(t, hasIsNotResponding, "isNotResponding は upstream response field")
 }


### PR DESCRIPTION
## Summary

#1948-10 (date-time .000Z) の敵対的レビューで発見した隣接 parity gap。federation instance の
response packer から upstream に無い余剰 field を削除する。

## 主な変更点

`internal/api/federation/handler.go` の `instanceToMap` (federation/instances・show-instance の
response) から 4 field を削除:

- `federating` / `subscribing` / `publishing`: upstream `federation/instances.ts` の **request query
  paramDef** であって `InstanceEntityService.pack` の response field ではない。frontend
  (about.federation.vue / admin/federation.vue) も `{federating:true}` の request filter としてのみ
  使い、response property としては読まない。
- `notRespondingSince`: upstream `InstanceEntityService.pack` / `federation-instance.ts` に無い。
  raw `*time.Time` を素で JSON 化しており RFC3339Nano になる二重問題もあった。response の
  `isNotResponding` (boolean) は upstream にあるため維持。

request 側の `federating`/`subscribing`/`publishing` filter param 処理は無変更。

## テスト

- `TestShowInstance_OmitsNonUpstreamFields`: 4 field が response に無く、isNotResponding が有ることを pin。
- federation 93.1%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで #1977 トラップ (frontend/misskey-js が response として参照する field を誤削除) で
ないことを確認: misskey-js の FederationInstance response 型・frontend の全消費箇所に 4 field の
response read が存在しないことを検証済み。

## 関連

- 親: #1948
- 発見元: #1948-10 の敵対的レビュー

Closes #1991
