### PR TITLE
Fix Undo(Follow) AP wire (#1993): published を付与し inner @context を落とす

### DIFF
--- a/internal/activitypub/parity_1948_11_render_test.go
+++ b/internal/activitypub/parity_1948_11_render_test.go
@@ -67,6 +67,16 @@ func TestRenderDeleteAndUndo_HavePublished(t *testing.T) {
 
 	uda := marshalMap(t, r.RenderUndoDeleteActor(author))
 	assert.Regexp(t, millisZ, uda["published"], "UndoDeleteActor.published は .000Z (#1948-11)")
+
+	// #1993: RenderUndoFollow (local→remote unfollow) も published(.000Z) を持つ。
+	uf := marshalMap(t, r.RenderUndoFollow("u1", "https://remote.example/users/b"))
+	assert.Regexp(t, millisZ, uf["published"], "UndoFollow.published は .000Z (#1993)")
+	assert.Equal(t, "Undo", uf["type"])
+	inner, ok := uf["object"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Follow", inner["type"])
+	_, hasCtx := inner["@context"]
+	assert.False(t, hasCtx, "inner Follow は @context を持たない (#1993)")
 }
 
 // #1948-11: RenderQuestionUpdate の published は .000Z だが、Activity ID は

--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -955,6 +955,28 @@ func (r *Renderer) RenderUndoBlock(blockerID, blockeeURI string) *Undo {
 	return u
 }
 
+// RenderUndoFollow wraps a Follow activity in an Undo for a local→remote
+// unfollow. upstream renderUndo は全ての Undo に published を付けるため、ここでも
+// .000Z published を入れる (#1993)。inner Follow の @context は upstream 同様
+// 落とす (outer Undo のみ @context を持つ)。
+func (r *Renderer) RenderUndoFollow(followerID, followeeURI string) *Undo {
+	inner := r.RenderFollow(followerID, followeeURI)
+	inner.Context = nil
+	u := &Undo{
+		Activity: Activity{
+			Object: Object{
+				ID:   inner.ID + "/undo",
+				Type: "Undo",
+			},
+			Actor:     r.urls.UserURI(followerID),
+			Published: time.Now().UTC().Format(publishedLayout),
+		},
+		Object: inner,
+	}
+	AddContext(u)
+	return u
+}
+
 // RenderFollowRelay returns the special-purpose Follow activity used to
 // subscribe the instance's relay system actor to a relay endpoint.
 //

--- a/internal/core/federation/following_delivery_hook.go
+++ b/internal/core/federation/following_delivery_hook.go
@@ -55,18 +55,8 @@ func (h *FollowingDeliveryHook) OnLocalUnfollowed(follower, followee *model.User
 	switch {
 	case shouldDeliverFollow(follower, followee):
 		// 標準的な local→remote unfollow。Undo(Follow) を follower 名義で送る。
-		follow := h.renderer.RenderFollow(follower.ID, *followee.URI)
-		undo := &activitypub.Undo{
-			Activity: activitypub.Activity{
-				Object: activitypub.Object{
-					Type: "Undo",
-					ID:   follow.ID + "/undo",
-				},
-				Actor: follow.Actor,
-			},
-			Object: follow,
-		}
-		activitypub.AddContext(undo)
+		// renderer 経由で組み、upstream renderUndo と同じく published(.000Z) を付ける (#1993)。
+		undo := h.renderer.RenderUndoFollow(follower.ID, *followee.URI)
 		body, _ := json.Marshal(undo)
 		if err := h.deliver.DeliverToUser(follower.ID, followee, body); err != nil {
 			slog.Warn("following delivery: unfollow failed",

--- a/internal/core/federation/following_delivery_hook_test.go
+++ b/internal/core/federation/following_delivery_hook_test.go
@@ -97,9 +97,16 @@ func TestFollowingHook_OnLocalUnfollowed_Remote(t *testing.T) {
 	var got map[string]any
 	require.NoError(t, json.Unmarshal(enq.calls[0].Body, &got))
 	assert.Equal(t, "Undo", got["type"])
+	// #1993: upstream renderUndo は全 Undo に published(.000Z) を付ける。
+	published, ok := got["published"].(string)
+	require.True(t, ok, "Undo(Follow) に published がある (#1993)")
+	assert.Regexp(t, `\.\d{3}Z$`, published, "published は toISOString() の .000Z 形式")
 	inner, ok := got["object"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "Follow", inner["type"])
+	// inner Follow は @context を持たない (outer Undo のみ持つ)。
+	_, hasCtx := inner["@context"]
+	assert.False(t, hasCtx, "inner Follow は @context を持たない (#1993)")
 }
 
 func TestFollowingHook_OnLocalUnfollowed_LocalSkipped(t *testing.T) {


### PR DESCRIPTION
## Summary

#1948-11 (AP outbound wire-shape) の敵対的レビューで発見した隣接 gap。local→remote unfollow の
Undo(Follow) に published が無く、inner Follow に余剰 @context が付いていた問題を是正する。

## 主な変更点

- **RenderUndoFollow** (`renderer.go`): `RenderUndoBlock` を踏襲した renderer メソッドを追加。inner
  Follow の `@context` を落とし (`inner.Context = nil`)、outer Undo に `published`(.000Z layout) を
  付与して `AddContext`。upstream `renderUndo` (ApRendererService.ts:637-646) は全 Undo に
  `published: new Date().toISOString()` を付け、`renderFollow` の inner object は @context を持たない。
- **following_delivery_hook** (`following_delivery_hook.go`): local→remote unfollow の手組み Undo を
  `h.renderer.RenderUndoFollow(...)` 呼び出しに置換。

これにより (1) published 欠落、(2) 余剰 nested @context、の 2 件の upstream 乖離を同時に是正する
(wire shape は upstream に近づく方向で、受信側の Undo(Follow) matching は id/actor/object に依存する
ため互換)。

## テスト

- RenderUndoFollow の published(.000Z) + inner Follow の @context 不在 / hook の OnLocalUnfollowed が
  published 付き Undo を配信。
- activitypub 92.6% / core/federation 90.3%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで wire 変更が published + inner @context 除去のみで、id/actor/object 構造は不変、
受信側非互換なしを確認。actor icon/image の sensitive/name (part2) は RenderPerson 側で avatar/banner
drive file の preload を要し marginal value のため #2031 に分離した。

## 関連

- 親: #1948
- 発見元: #1948-11 の敵対的レビュー

Closes #1993
