### PR TITLE
Fix public /users param parity (#1996): state を ['all','alive'] に enum 検証

### DIFF
--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -369,6 +369,19 @@ func (h *Handler) populateUserEmojis(u *model.User, lite *entity.UserLite) {
 
 // NewHandler creates a new users Handler.
 // followingService, noteRepo, idGen are optional for the bare /show endpoint.
+// ValidListState reports whether state is an accepted value for the public
+// /users listing. upstream users.ts:35 の state enum は ['all','alive']
+// (default 'all'); 空文字列は default 'all' として許容する。範囲外は ajv 同様に
+// reject する想定 (#1996)。
+func ValidListState(state string) bool {
+	switch state {
+	case "", "all", "alive":
+		return true
+	default:
+		return false
+	}
+}
+
 func NewHandler(
 	userService *user.Service,
 	followingService *corefollowing.Service,

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -1012,3 +1012,14 @@ func TestReportAbuse_SavesTargetUserHost(t *testing.T) {
 		assert.Equal(t, "remote.example", *r.TargetUserHost)
 	}
 }
+
+// #1996: public /users の state enum は ['all','alive'] (空は default 'all')。
+// 範囲外 (moderator/admin 等) は reject させる (= ValidListState=false → handler 400)。
+func TestValidListState(t *testing.T) {
+	for _, ok := range []string{"", "all", "alive"} {
+		assert.True(t, users.ValidListState(ok), "state=%q は許容 (#1996)", ok)
+	}
+	for _, bad := range []string{"moderator", "admin", "available", "suspended", "ALL"} {
+		assert.False(t, users.ValidListState(bad), "state=%q は範囲外で reject (#1996)", bad)
+	}
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1088,6 +1088,12 @@ func (s *Server) setupRoutes() {
 		if err := c.Bind(&req); err != nil {
 			return c.JSON(http.StatusOK, []any{})
 		}
+		// upstream users.ts:35 の state enum は ['all','alive'] (default 'all')。
+		// 範囲外 (moderator/admin 等の role state) は ajv が 400 で reject するので、
+		// public /users でも同じく弾く (ListUsers の role filter に到達させない、#1996)。
+		if !users.ValidListState(req.State) {
+			return apierr.JSONInvalidParam(c)
+		}
 		if req.Limit <= 0 {
 			req.Limit = 10
 		}


### PR DESCRIPTION
## Summary

#1948-12 (admin/show-users state) の敵対的レビューで発見した既存の軽微な gap。public /users が
`state` param を enum 検証せず ListUsers に素通ししていた問題を是正する。

## 主な変更点

- **`users.ValidListState`** (`handler.go`): `'', 'all', 'alive'` のみ true を返す helper を追加
  (upstream `users.ts:35` の `enum: ['all','alive'], default: 'all'`。空は default 'all' 扱い)。
- **public /users** (`router.go` inline handler): `state` が範囲外なら 400 INVALID_PARAM で reject
  (upstream ajv 挙動)。これまでは moderator/admin 等の role state が ListUsers の role filter に
  到達していた (ExplorableOnly intersect で結果は空だが parity 上は不一致)。

## テスト

- `TestValidListState`: '', 'all', 'alive' を許容、moderator/admin/available/suspended/ALL を reject。
- users 90.4%。`make fmt` / `go vet ./...` / `make test` green。inline handler の wire 層は e2e/drop-in
  でカバー (internal/server は CI 0% 例外、CLAUDE.md Section 8)。

## 補足

敵対的レビューで error code/id/status が upstream ajv (INVALID_PARAM / 3d81ceae... / 400) と一致、
upstream frontend (explore.users) が送る state は 'alive' または省略のみで drop-in regression 無しを
確認。origin/sort enum の未検証は本 PR 以前からの既存 gap で scope 外 (state のみ対応)。

## 関連

- 親: #1948
- 発見元: #1948-12 の敵対的レビュー

Closes #1996
