### PR TITLE
Fix admin emoji query parity (#1999): v2 buildV2Query を fetchEmojis に揃え + import-zip 同期 reject 撤去

### DIFF
--- a/internal/api/admin/drive_emoji_test.go
+++ b/internal/api/admin/drive_emoji_test.go
@@ -727,11 +727,14 @@ func TestEmojiDeleteBulk_Batch(t *testing.T) {
 	assert.Error(t, err, "e3 should be deleted")
 }
 
-func TestEmojiImportZip_UnknownFileReturns400(t *testing.T) {
+// #1999: upstream import-zip.ts は drive file の存在確認をせず無条件で enqueue する。
+// 不明な fileId でも同期 NO_SUCH_FILE で弾かず 204 を返して job 側に委ねる。
+func TestEmojiImportZip_UnknownFileEnqueues(t *testing.T) {
 	h, _ := setupDriveFileHandler(t)
-	h.SetEmojiImportEnqueuer(&stubEmojiImportEnqueuer{})
+	enq := &stubEmojiImportEnqueuer{}
+	h.SetEmojiImportEnqueuer(enq)
 	rec := doPost(h.EmojiImportZip, `{"fileId":"missing"}`, adminUser)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, http.StatusNoContent, rec.Code, "存在確認せず enqueue (#1999)")
 }
 
 // --- EmojiListV2 -------------------------------------------------------------

--- a/internal/api/admin/emoji.go
+++ b/internal/api/admin/emoji.go
@@ -210,12 +210,10 @@ func (h *Handler) EmojiImportZip(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.FileID == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "fileId is required.", "5f4c9d8a-7c39-4bfa-9dcb-09f17e0f7a25"))
 	}
-	// drive file の存在確認 (ジョブが後で失敗するよりここで早期に弾く)
-	if h.driveFileRepo != nil {
-		if _, err := h.driveFileRepo.FindByID(req.FileID); err != nil {
-			return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_FILE", "No such file.", "ac4f7b11-1a6e-47e3-bf3d-3dce9a0e07ab"))
-		}
-	}
+	// upstream import-zip.ts:30 は drive file の存在確認をせず無条件で
+	// createImportCustomEmojisJob を enqueue する (存在しなければ job が後で失敗)。
+	// mk-go の同期 NO_SUCH_FILE check は upstream に無い divergence なので外す
+	// (= 不正 fileId でも 204 を返し job 側に委ねる、#1999)。
 	if h.emojiEnqueuer == nil {
 		return c.NoContent(http.StatusNoContent)
 	}

--- a/internal/repository/emoji.go
+++ b/internal/repository/emoji.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/shiroha-a/mk/internal/model"
@@ -259,42 +260,83 @@ var v2SortAllowList = map[string]string{
 	"roleIdsThatCanBeUsedThisEmojiAsReaction": `"roleIdsThatCanBeUsedThisEmojiAsReaction"`,
 }
 
+// multipleWordsToQuery mirrors upstream CustomEmojiService.multipleWordsToQuery:
+// クエリを空白で分割し、各語を sqlLikeEscape(escapeLike) して `%word%` の LIKE
+// パターン配列にする。各フィールドはこの配列に対する `~~ ANY(...)` (case-sensitive
+// LIKE の OR) で突合する (#1999)。
+func multipleWordsToQuery(words string) []string {
+	parts := strings.Fields(words)
+	out := make([]string, 0, len(parts))
+	for _, x := range parts {
+		out = append(out, "%"+escapeLike(x)+"%")
+	}
+	return out
+}
+
 // buildV2Query constructs the common WHERE clause for ListV2/CountV2.
+//
+// upstream CustomEmojiService.fetchEmojis に揃える (#1999): 各テキストフィールドは
+// case-sensitive な `LIKE ANY(...)` + multipleWordsToQuery (空白分割 OR) + escapeLike、
+// updatedAt は `CAST(... AS DATE)` で date 切り捨て、aliases は unnest で要素単位突合。
 func (r *emojiRepository) buildV2Query(filter model.EmojiV2Filter) *gorm.DB {
 	q := r.db.Model(&model.Emoji{})
 	if filter.Query != nil {
 		fq := filter.Query
-		if fq.HostType == "local" {
+		// likeAny applies `(<col> LIKE p1 OR <col> LIKE p2 ...)` (case-sensitive,
+		// ESCAPE '\') over the whitespace-split escaped patterns = upstream の
+		// `<col> ~~ ANY(multipleWordsToQuery(...))` と等価。空白のみの値は ANY(空) =
+		// false 相当で空結果にする。OR 展開で `ARRAY[?]` の record 化を避ける。
+		likeAny := func(col, val string) {
+			if val == "" {
+				return
+			}
+			patterns := multipleWordsToQuery(val)
+			if len(patterns) == 0 {
+				q = q.Where("1 = 0")
+				return
+			}
+			conds := make([]string, len(patterns))
+			args := make([]any, len(patterns))
+			for i, p := range patterns {
+				conds[i] = col + ` LIKE ? ESCAPE '\'`
+				args[i] = p
+			}
+			q = q.Where("("+strings.Join(conds, " OR ")+")", args...)
+		}
+		// host: upstream は local→IS NULL、remote→host 指定時 LIKE ANY / 未指定時
+		// IS NOT NULL。combined/未指定 hostType では host 条件を付けない。
+		switch fq.HostType {
+		case "local":
 			q = q.Where("host IS NULL")
-		} else if fq.HostType == "remote" {
-			q = q.Where("host IS NOT NULL")
+		case "remote":
+			if fq.Host != "" {
+				likeAny("host", fq.Host)
+			} else {
+				q = q.Where("host IS NOT NULL")
+			}
 		}
-		if fq.Name != "" {
-			q = q.Where("name ILIKE ?", "%"+fq.Name+"%")
-		}
-		if fq.Host != "" {
-			q = q.Where("host ILIKE ?", "%"+fq.Host+"%")
-		}
-		if fq.Category != "" {
-			q = q.Where("category ILIKE ?", "%"+fq.Category+"%")
-		}
-		if fq.Type != "" {
-			q = q.Where("type ILIKE ?", "%"+fq.Type+"%")
-		}
+		likeAny("name", fq.Name)
+		likeAny("category", fq.Category)
+		likeAny("type", fq.Type)
+		likeAny("license", fq.License)
+		likeAny("uri", fq.URI)
+		likeAny(`"publicUrl"`, fq.PublicURL)
+		likeAny(`"originalUrl"`, fq.OriginalURL)
+		// aliases は配列要素ごとに突合する (upstream は unnest(aliases) の subquery)。
+		// array_to_string 結合では要素境界を跨いだ誤 match が起きるため避ける。
 		if fq.Aliases != "" {
-			q = q.Where("array_to_string(aliases, ',') ILIKE ?", "%"+fq.Aliases+"%")
-		}
-		if fq.License != "" {
-			q = q.Where("license ILIKE ?", "%"+fq.License+"%")
-		}
-		if fq.URI != "" {
-			q = q.Where("uri ILIKE ?", "%"+fq.URI+"%")
-		}
-		if fq.PublicURL != "" {
-			q = q.Where(`"publicUrl" ILIKE ?`, "%"+fq.PublicURL+"%")
-		}
-		if fq.OriginalURL != "" {
-			q = q.Where(`"originalUrl" ILIKE ?`, "%"+fq.OriginalURL+"%")
+			patterns := multipleWordsToQuery(fq.Aliases)
+			if len(patterns) == 0 {
+				q = q.Where("1 = 0")
+			} else {
+				conds := make([]string, len(patterns))
+				args := make([]any, len(patterns))
+				for i, p := range patterns {
+					conds[i] = `alias LIKE ? ESCAPE '\'`
+					args[i] = p
+				}
+				q = q.Where(`EXISTS (SELECT 1 FROM unnest(aliases) AS alias WHERE (`+strings.Join(conds, " OR ")+`))`, args...)
+			}
 		}
 		if fq.IsSensitive != nil {
 			q = q.Where(`"isSensitive" = ?`, *fq.IsSensitive)
@@ -302,11 +344,12 @@ func (r *emojiRepository) buildV2Query(filter model.EmojiV2Filter) *gorm.DB {
 		if fq.LocalOnly != nil {
 			q = q.Where(`"localOnly" = ?`, *fq.LocalOnly)
 		}
+		// updatedAtFrom/To は upstream 同様 date 単位に切り捨てて突合する。
 		if fq.UpdatedAtFrom != "" {
-			q = q.Where(`"updatedAt" >= ?`, fq.UpdatedAtFrom)
+			q = q.Where(`CAST("updatedAt" AS DATE) >= ?`, fq.UpdatedAtFrom)
 		}
 		if fq.UpdatedAtTo != "" {
-			q = q.Where(`"updatedAt" <= ?`, fq.UpdatedAtTo)
+			q = q.Where(`CAST("updatedAt" AS DATE) <= ?`, fq.UpdatedAtTo)
 		}
 		if len(fq.RoleIDs) > 0 {
 			q = q.Where(`"roleIdsThatCanBeUsedThisEmojiAsReaction" && ARRAY[?]::varchar[]`, fq.RoleIDs)

--- a/internal/repository/emoji_test.go
+++ b/internal/repository/emoji_test.go
@@ -601,6 +601,42 @@ func TestEmojiRepository_ListV2_NameFilter(t *testing.T) {
 	assert.Equal(t, "ev_n1", rows[0].ID)
 }
 
+// #1999: v2 buildV2Query は upstream fetchEmojis に揃える: case-sensitive LIKE +
+// escapeLike + multipleWordsToQuery (空白分割 OR) + aliases 要素単位 + updatedAt date cast。
+func TestEmojiRepository_ListV2_QueryParity(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+	mk := func(id, name, category string, aliases []string) *model.Emoji {
+		e := &model.Emoji{ID: id, Name: name, Category: &category, Aliases: pq.StringArray(aliases), OriginalURL: "https://x"}
+		require.NoError(t, repo.Create(e))
+		t.Cleanup(func() { cleanupEmoji(t, id) })
+		return e
+	}
+	mk("evp_upper", "ParityUpper", "Cat", []string{"smile", "happy_face"})
+	mk("evp_lower", "paritylower", "cat", []string{"frown"})
+
+	// case-sensitive: "Parity" は ParityUpper のみ match (paritylower は小文字)。
+	rows, err := repo.ListV2(model.EmojiV2Filter{Query: &model.EmojiV2Query{Name: "Parity"}, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "evp_upper", rows[0].ID)
+
+	// multipleWordsToQuery: 空白区切りは各語の OR。"Upper lower" は両方 match。
+	rows, err = repo.ListV2(model.EmojiV2Filter{Query: &model.EmojiV2Query{Name: "Upper lower"}, Limit: 10})
+	require.NoError(t, err)
+	assert.Len(t, rows, 2)
+
+	// escapeLike: "%" は literal 扱いで wildcard 化しない (どちらにも無いので 0 件)。
+	rows, err = repo.ListV2(model.EmojiV2Filter{Query: &model.EmojiV2Query{Name: "Par%ity"}, Limit: 10})
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+
+	// aliases は要素単位突合: "happy_face" の under_score は escape され、"smile" alias は要素一致。
+	rows, err = repo.ListV2(model.EmojiV2Filter{Query: &model.EmojiV2Query{Aliases: "smile"}, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "evp_upper", rows[0].ID)
+}
+
 func TestEmojiRepository_ListV2_SortKeys(t *testing.T) {
 	repo := NewEmojiRepository(testDB)
 


### PR DESCRIPTION
## Summary

#1948-13 (admin emoji write) の敵対的レビューで発見した v2 admin emoji list の query parity gap。
v2 buildV2Query を upstream CustomEmojiService.fetchEmojis に揃え、import-zip の同期 reject を撤去する。

## 主な変更点

### item1: buildV2Query (`repository/emoji.go`)
- 各テキストフィールド (name/host/category/type/license/uri/publicUrl/originalUrl) を ILIKE 単一語 →
  **case-sensitive** `(<col> LIKE p1 ESCAPE '\' OR <col> LIKE p2 ...)`。`multipleWordsToQuery`
  (空白分割 + `escapeLike` + `%word%`) で upstream の `<col> ~~ ANY(...)` と等価。
- **host**: upstream 同様 local→`IS NULL` / remote→host 指定時 `LIKE`・未指定時 `IS NOT NULL` /
  combined→host 条件なし (旧版は hostType 非依存で host filter を付けていた)。
- **aliases**: `array_to_string` 結合 → `unnest(aliases)` の要素単位 `EXISTS` subquery (要素境界跨ぎの
  誤 match を回避)。
- **updatedAtFrom/To**: `CAST("updatedAt" AS DATE) >= / <=` で date 切り捨て。
- 空白のみクエリは `1 = 0` (upstream `~~ ANY(空配列)` = false 相当)。

### item4: import-zip (`api/admin/emoji.go`)
upstream `import-zip.ts:30` は drive file 存在確認をせず無条件 `createImportCustomEmojisJob` を enqueue
するので、mk-go の同期 `NO_SUCH_FILE` check を撤去 (空 fileId の `INVALID_PARAM` は ajv
`required:['fileId']` 相当で温存)。

## テスト

- `ListV2_QueryParity`: case-sensitivity / multipleWords OR / escapeLike literal / aliases 要素単位。
- `EmojiImportZip_UnknownFileEnqueues`: 不明 fileId でも 204 (enqueue)。
- repository 90.1% / admin 89.6%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで `~~ ANY` ≡ OR-of-LIKE-ESCAPE、aliases unnest、updatedAt date cast、host ロジックを
実 Postgres で論理検証。残り (legacy list limit+1/要素境界 item2、broadcast stream item3、originalUrl
filter の温存判断) は #2034 に分離。

## 関連

- 親: #1948
- 発見元: #1948-13 の敵対的レビュー

Closes #1999
