### PR TITLE
Fix drive channel event parity (#2002): fileCreated/Updated を packed self、fileDeleted を id 文字列に

### DIFF
--- a/internal/core/drive/drive_service.go
+++ b/internal/core/drive/drive_service.go
@@ -84,16 +84,19 @@ func ValidateFileName(name string) bool {
 // WebSocket subscribers (the "drive" channel) can be pushed in real time.
 // パッケージ間の循環依存を避けるためinterfaceで受け取る(実装はinternal/
 // stream)。eventTypeは"fileCreated"/"fileUpdated"/"fileDeleted"。
+// PublishDriveEvent body は upstream publishDriveStream に揃え、fileCreated /
+// fileUpdated は packed DriveFileEntity (self)、fileDeleted は file id 文字列を
+// 渡す (#2002)。型が event ごとに異なるため any で受ける。
 type StreamingPublisher interface {
-	PublishDriveEvent(userID, eventType string, file *model.DriveFile)
+	PublishDriveEvent(userID, eventType string, body any)
 }
 
 // FolderStreamingPublisher receives drive folder life-cycle events for the
 // "drive" WebSocket channel. upstream の publishDriveStream(userID,
 // 'folderCreated'|'folderUpdated', folderObj) / ('folderDeleted', folder.id)
 // に対応する (#1564)。body は packed folder (created/updated) または folder
-// id 文字列 (deleted)。StreamingPublisher (file 専用、*model.DriveFile 固定)
-// とは payload 型が異なるため別 interface にする。実装は internal/stream。
+// id 文字列 (deleted)。file 系イベントを扱う StreamingPublisher とは eventType
+// 名前空間が別なので interface を分けている。実装は internal/stream。
 type FolderStreamingPublisher interface {
 	PublishDriveFolderEvent(userID, eventType string, body any)
 }
@@ -223,11 +226,11 @@ func (s *Service) SetVideoProcessor(p VideoProcessor) {
 }
 
 // publishEvent is a tiny best-effort wrapper around publisher.PublishDriveEvent.
-func (s *Service) publishEvent(userID, eventType string, f *model.DriveFile) {
+func (s *Service) publishEvent(userID, eventType string, body any) {
 	if s.publisher == nil || userID == "" {
 		return
 	}
-	s.publisher.PublishDriveEvent(userID, eventType, f)
+	s.publisher.PublishDriveEvent(userID, eventType, body)
 }
 
 // UploadInput is the parameter set for Service.Upload.
@@ -441,7 +444,8 @@ func (s *Service) Upload(ctx context.Context, in UploadInput) (*model.DriveFile,
 	// stream publish 系を skip する。publishEvent / mainStreamPublisher は
 	// それぞれ userID を必要とする。
 	if in.User != nil {
-		s.publishEvent(in.User.ID, "fileCreated", f)
+		// upstream は packedFile (self) を drive channel に送る (#2002)。
+		s.publishEvent(in.User.ID, "fileCreated", entity.PackDriveFileSelf(f, s.idGen))
 		// Misskey本家DriveService.addFileはdrive topicに加えてmainにも
 		// driveFileCreatedをemitしてUploader自身のUI(ドロップアップロード等)
 		// を即時反映させる(TS: DriveService.ts:665)。
@@ -727,7 +731,7 @@ func (s *Service) Update(user *model.User, id string, in UpdateInput) (*model.Dr
 	if err != nil {
 		return nil, err
 	}
-	s.publishEvent(user.ID, "fileUpdated", updated)
+	s.publishEvent(user.ID, "fileUpdated", entity.PackDriveFileSelf(updated, s.idGen))
 	return updated, nil
 }
 
@@ -754,7 +758,8 @@ func (s *Service) Delete(user *model.User, id string) error {
 	if err := s.fileRepo.Delete(f); err != nil {
 		return err
 	}
-	s.publishEvent(user.ID, "fileDeleted", f)
+	// upstream は fileDeleted に file.id (文字列) だけを送る (#2002)。
+	s.publishEvent(user.ID, "fileDeleted", f.ID)
 	if s.chartHook != nil {
 		s.chartHook.OnFileDeleted(f)
 	}

--- a/internal/core/drive/drive_service_test.go
+++ b/internal/core/drive/drive_service_test.go
@@ -924,10 +924,12 @@ func TestDeleteFolder_HasChildrenError(t *testing.T) {
 // stubDriveStreamPublisher records every PublishDriveEvent call.
 type stubDriveStreamPublisher struct {
 	events []string // "<userID>:<eventType>"
+	bodies []any    // body passed for each call (#2002)
 }
 
-func (s *stubDriveStreamPublisher) PublishDriveEvent(userID, eventType string, _ *model.DriveFile) {
+func (s *stubDriveStreamPublisher) PublishDriveEvent(userID, eventType string, body any) {
 	s.events = append(s.events, userID+":"+eventType)
+	s.bodies = append(s.bodies, body)
 }
 
 func TestUpload_PublishesStreamingEvent(t *testing.T) {
@@ -938,6 +940,10 @@ func TestUpload_PublishesStreamingEvent(t *testing.T) {
 	_, err := svc.Upload(context.Background(), drive.UploadInput{User: user, Body: []byte("hi"), Name: "x.txt"})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"u1:fileCreated"}, pub.events)
+	// #2002: fileCreated は packed DriveFileEntity (self) を送る (raw *model.DriveFile ではない)。
+	require.Len(t, pub.bodies, 1)
+	_, ok := pub.bodies[0].(entity.DriveFileEntity)
+	assert.True(t, ok, "fileCreated body は DriveFileEntity (#2002)")
 }
 
 func TestUpdate_PublishesStreamingEvent(t *testing.T) {
@@ -952,6 +958,10 @@ func TestUpdate_PublishesStreamingEvent(t *testing.T) {
 	_, err = svc.Update(user, f.ID, drive.UpdateInput{Name: &name})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"u1:fileUpdated"}, pub.events)
+	// #2002: fileUpdated も packed DriveFileEntity (self)。
+	require.Len(t, pub.bodies, 1)
+	_, ok := pub.bodies[0].(entity.DriveFileEntity)
+	assert.True(t, ok, "fileUpdated body は DriveFileEntity (#2002)")
 }
 
 func TestDelete_PublishesStreamingEvent(t *testing.T) {
@@ -964,6 +974,9 @@ func TestDelete_PublishesStreamingEvent(t *testing.T) {
 	svc.SetStreamingPublisher(pub)
 	require.NoError(t, svc.Delete(user, f.ID))
 	assert.Equal(t, []string{"u1:fileDeleted"}, pub.events)
+	// #2002: fileDeleted は file id 文字列のみ (upstream publishDriveStream(_, 'fileDeleted', file.id))。
+	require.Len(t, pub.bodies, 1)
+	assert.Equal(t, f.ID, pub.bodies[0], "fileDeleted body は file id 文字列 (#2002)")
 }
 
 // stubChartHook captures chart hook fires from the drive service.

--- a/internal/stream/note_publisher.go
+++ b/internal/stream/note_publisher.go
@@ -389,23 +389,25 @@ func NewDrivePublisher(pub PubSubPublisher) *DrivePublisher {
 	return &DrivePublisher{pub: pub}
 }
 
-// PublishDriveEvent wraps the drive file in `{type, body}` envelope and
-// publishes to drive:<userID>.
-func (p *DrivePublisher) PublishDriveEvent(userID, eventType string, file *model.DriveFile) {
-	if p.pub == nil || userID == "" || file == nil || eventType == "" {
+// PublishDriveEvent wraps the drive event body in a `{type, body}` envelope and
+// publishes to drive:<userID>. body は upstream publishDriveStream に揃え、
+// fileCreated/fileUpdated は packed DriveFileEntity、fileDeleted は file id 文字列
+// (#2002)。
+func (p *DrivePublisher) PublishDriveEvent(userID, eventType string, body any) {
+	if p.pub == nil || userID == "" || body == nil || eventType == "" {
 		return
 	}
 	envelope := map[string]any{
 		"type": eventType,
-		"body": file,
+		"body": body,
 	}
-	body, err := json.Marshal(envelope)
+	raw, err := json.Marshal(envelope)
 	if err != nil {
 		slog.Warn("drive publisher: marshal failed", "err", err)
 		return
 	}
 	topic := "drive:" + userID
-	if err := p.pub.Publish(context.Background(), topic, json.RawMessage(body)); err != nil {
+	if err := p.pub.Publish(context.Background(), topic, json.RawMessage(raw)); err != nil {
 		slog.Warn("drive publisher: publish failed", "topic", topic, "err", err)
 	}
 }


### PR DESCRIPTION
## Summary

#1948-14 (drive getPublicProperties) の敵対的レビューで発見した shape drift。drive channel の
fileCreated/fileUpdated/fileDeleted が packed entity ではなく raw `*model.DriveFile` を serialize して
いた問題を是正する。

## 主な変更点

- **`StreamingPublisher.PublishDriveEvent`** の signature を `file *model.DriveFile` → `body any` に変更
  (event ごとに body 型が異なるため)。
- **fileCreated / fileUpdated**: `entity.PackDriveFileSelf` (self packed `DriveFileEntity`) を送る
  (upstream `DriveService.ts:664/710` は `self:true` の packedFile、misskey-js `fileCreated/fileUpdated:
  (payload: DriveFile)`)。
- **fileDeleted**: `file.id` 文字列のみを送る (upstream `DriveService.ts:842` / misskey-js
  `fileDeleted: (payload: DriveFile['id'])`)。旧 mk-go は raw model を送っており型不一致だった。

## テスト

- fileCreated/fileUpdated の body が `DriveFileEntity`、fileDeleted の body が file id 文字列であることを
  stub publisher で assert。
- core/drive 97.7% / stream 91.1%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで misskey-js `streaming.types.ts` / `GlobalEventService` の `DriveEventTypes` と完全一致、
PackDriveFileSelf が正しい packer (main-stream `driveFileCreated` と一貫、#1948-14)、fileDeleted の
id 文字列化が drop-in を壊さない (frontend MkDrive は fileCreated のみ消費) ことを確認。

## 関連

- 親: #1948
- 発見元: #1948-14 の敵対的レビュー

Closes #2002
