### PR TITLE
Fix notes/translate error parity (#2010): canUseTranslator 拒否を 400 UNAVAILABLE に

### DIFF
--- a/internal/api/notes/handler_extra.go
+++ b/internal/api/notes/handler_extra.go
@@ -487,6 +487,18 @@ func (h *Handler) Translate(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "noteId and targetLang are required.", "3d81ceae-475f-4600-b2a8-2bc116157532"))
 	}
 
+	// upstream translate.ts:72-75: canUseTranslator policy が false なら note fetch より
+	// 前に 503 UNAVAILABLE を返す。汎用 RequireRolePolicy middleware の 403
+	// ROLE_PERMISSION_DENIED ではなく translate 固有の error なので handler 側で評価する
+	// (#2010)。policyProvider 未配線 (test) では gate を skip。
+	if u := middleware.GetUser(c); u != nil && h.policyProvider != nil {
+		if v, ok := h.policyProvider.GetUserPolicies(u.ID)["canUseTranslator"].(bool); !ok || !v {
+			// upstream の unavailable error は httpStatusCode 未指定 + kind 既定 'client'
+			// なので ApiCallService が 400 にマップする (503 ではない、#2010)。
+			return c.JSON(http.StatusBadRequest, apierr.Error("UNAVAILABLE", "Translate of notes unavailable.", "50a70314-2d8a-431b-b433-efa5cc56444c"))
+		}
+	}
+
 	// upstream translate.ts の順序に合わせる (#1948-17): note fetch → visibility →
 	// text==null で 204 → unavailable → translate。translator-nil(unavailable) を
 	// note/text check より前に置くと、null-text note が upstream の 204 ではなく
@@ -515,7 +527,8 @@ func (h *Handler) Translate(c echo.Context) error {
 	}
 
 	if h.translator == nil {
-		return c.JSON(http.StatusServiceUnavailable, apierr.Error("UNAVAILABLE", "Translator is not configured.", "50a70314-2d8a-431b-b433-efa5cc56444c"))
+		// upstream deeplAuthKey==null も同 unavailable error で 400 (#2010)。
+		return c.JSON(http.StatusBadRequest, apierr.Error("UNAVAILABLE", "Translate of notes unavailable.", "50a70314-2d8a-431b-b433-efa5cc56444c"))
 	}
 
 	result, err := h.translator.Translate(c.Request().Context(), *n.Text, req.TargetLang)

--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -881,6 +881,30 @@ func TestClips_Success(t *testing.T) {
 
 // --- Translate ---
 
+// #2010: canUseTranslator policy が false なら note fetch より前に 503 UNAVAILABLE を
+// 返す (汎用 RequireRolePolicy の 403 ROLE_PERMISSION_DENIED ではない、upstream translate.ts:72-75)。
+func TestTranslate_CannotUseTranslator_503Unavailable(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	h.SetPolicyProvider(&draftStubPolicyProvider{policies: map[string]any{"canUseTranslator": false}})
+	txt := "hello"
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic, Text: &txt}
+	rec := postExtra(h.Translate, `{"noteId":"n1","targetLang":"en"}`, &model.User{ID: "viewer"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "canUseTranslator false は 400 UNAVAILABLE (#2010)")
+	assert.Contains(t, rec.Body.String(), "UNAVAILABLE")
+	assert.Contains(t, rec.Body.String(), "50a70314", "translate 固有 error id")
+}
+
+// #2010: canUseTranslator true なら policy gate を通過する。null-text note を使い、
+// gate 通過後に note fetch → text==null で 204 に到達することで gate-pass を確認する
+// (gate で弾かれていれば note fetch 前に 400 になる)。
+func TestTranslate_CanUseTranslator_PassesPolicyGate(t *testing.T) {
+	h, noteRepo, _ := newExtraHandler(t)
+	h.SetPolicyProvider(&draftStubPolicyProvider{policies: map[string]any{"canUseTranslator": true}})
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic, Text: nil}
+	rec := postExtra(h.Translate, `{"noteId":"n1","targetLang":"en"}`, &model.User{ID: "viewer"})
+	assert.Equal(t, http.StatusNoContent, rec.Code, "policy gate 通過後 null-text 204 に到達 (#2010)")
+}
+
 func TestTranslate_NoTranslator(t *testing.T) {
 	// #1948-17: translator-nil(unavailable) check は note fetch / text check の後に
 	// 移動したので、可視 + text 有りの note を seed して 503 path を踏ませる。
@@ -888,7 +912,7 @@ func TestTranslate_NoTranslator(t *testing.T) {
 	txt := "hello"
 	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "u1", Visibility: model.NoteVisibilityPublic, Text: &txt}
 	rec := postExtra(h.Translate, `{"noteId":"n1","targetLang":"en"}`, nil)
-	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 // #1948-17: text == null の note は upstream translate.ts:86-88 と同じく 204

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1385,9 +1385,11 @@ func (s *Server) setupRoutes() {
 	api.POST("/notes/user-list-timeline", notesHandler.UserListTimeline, middleware.RequireAuth(), middleware.RequireScope("read:account"))
 	api.POST("/notes/search-by-tag", notesHandler.SearchByTag)
 	api.POST("/notes/clips", notesHandler.Clips)
+	// canUseTranslator は upstream translate.ts 同様 handler 側で評価し、拒否時は
+	// 503 UNAVAILABLE を返す (RequireRolePolicy の 403 ではない、#2010)。
 	api.POST("/notes/translate", notesHandler.Translate,
 		middleware.RequireAuth(),
-		middleware.RequireRolePolicy(roleService, corerole.PolicyCanUseTranslator), middleware.RequireScope("read:account"))
+		middleware.RequireScope("read:account"))
 	api.POST("/notes/show-partial-bulk", notesHandler.ShowPartialBulk)
 	// notes/drafts + notes/thread-muting + notes/polls/recommendation (実データ)
 	noteDraftRepo := repository.NewNoteDraftRepository(s.db)


### PR DESCRIPTION
## Summary

#1948-17 (translate null-text) の敵対的レビューで発見した error 乖離。notes/translate の
canUseTranslator 拒否が汎用 middleware の 403 ROLE_PERMISSION_DENIED を返していたが、upstream は
translate 固有の UNAVAILABLE を **400** で返す。

## 主な変更点

- **route** (`router.go`): notes/translate から `RequireRolePolicy(canUseTranslator)` middleware を外す
  (`RequireAuth` + `RequireScope("read:account")` は維持)。
- **handler** (`handler_extra.go`): Translate 先頭 (bind 後・note fetch 前、upstream translate.ts:72-75
  と同順) で `policyProvider.GetUserPolicies(u.ID)["canUseTranslator"]` が false なら UNAVAILABLE
  (50a70314-...) を返す。upstream の unavailable error は `httpStatusCode` 未指定 + `kind` 既定 'client'
  なので ApiCallService が **400** にマップする (503 ではない)。
- 既存の translator-nil path も同じ unavailable error なので **503 → 400** に揃え、message も upstream の
  'Translate of notes unavailable.' に統一。
- admin bypass は upstream translate (requiredRolePolicy meta でない in-handler check) に無いので
  mk-go も付けない (旧 RequireRolePolicy→HasRolePolicy 経由の admin 無条件 pass も解消)。

## テスト

- canUseTranslator false → 400 UNAVAILABLE (id 50a70314) / canUseTranslator true → policy gate 通過
  (null-text note で 204 到達) / NoTranslator → 400。
- notes 90.8%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで upstream の client-kind error が 400 にマップされること (ApiCallService #sendApiError +
error.ts の kind 既定) を確認し、503→400 に修正した。golden_error_status.json は curated subset で
notes/translate 非対象 (gate なし)。横展開確認: import 系 / users/search は requiredRolePolicy meta 経由の
generic ROLE_PERMISSION_DENIED で middleware のまま正しい。

## 関連

- 親: #1948
- 発見元: #1948-17 の敵対的レビュー

Closes #2010
