### PR TITLE
Fix NoteDraft reply detail level (#2016): reply を detail:false で pack

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -945,7 +945,7 @@ func (h *Handler) BulkShow(c echo.Context) error {
 // specified 対象外) は entity.HideNoteEntity で本文を blank し isHidden を立てる
 // (upstream shouldHideNote→hideNote)。draft は owner-only だが、replyId/renoteId に
 // 任意の note ID を入れて非可視 note の本文を読み出す leak を塞ぐ (#1948-19)。
-func (h *Handler) packReferencedNote(ctx context.Context, n *model.Note, viewer *model.User) entity.NoteEntity {
+func (h *Handler) packReferencedNote(ctx context.Context, n *model.Note, viewer *model.User, detail bool) entity.NoteEntity {
 	packed := entity.PackNotes(ctx, []*model.Note{n}, h.idGen, h.instanceLookup(), h.emojiLookup(), h.reactionReader())
 	h.fieldResolver().Apply(packed, viewer)
 	notehide.HideEmbeds(viewer, packed)
@@ -953,6 +953,16 @@ func (h *Handler) packReferencedNote(ctx context.Context, n *model.Note, viewer 
 	// queryService 未配線時は fail-closed で hide (= 検証不能なら隠す)。
 	if h.queryService == nil || !h.queryService.CanSee(viewer, n) {
 		entity.HideNoteEntity(&out)
+	}
+	// PackNotes は top-level を常に detail:true で pack する。draft の reply は
+	// upstream で detail:false なので detail block (clippedCount/poll/myReaction/
+	// nested reply/renote embed) を落とす (#2016。reactions 自体は detail 外で残す)。
+	if !detail {
+		out.ClippedCount = nil
+		out.Poll = nil
+		out.MyReaction = nil
+		out.Reply = nil
+		out.Renote = nil
 	}
 	return out
 }

--- a/internal/api/notes/handler_drafts.go
+++ b/internal/api/notes/handler_drafts.go
@@ -595,10 +595,12 @@ func (h *Handler) packDraft(ctx context.Context, viewer *model.User, d *model.No
 	// reply/renote を解決し (見つからなければ null)、未設定なら key を省略する
 	// (#1948-19)。reply は detail:false、renote は detail:true 相当。
 	if d.ReplyID != nil {
-		result["reply"] = h.packDraftNote(ctx, viewer, *d.ReplyID)
+		// reply は upstream で detail:false (clippedCount/poll/myReaction/nested embed 省略、#2016)。
+		result["reply"] = h.packDraftNote(ctx, viewer, *d.ReplyID, false)
 	}
 	if d.RenoteID != nil {
-		result["renote"] = h.packDraftNote(ctx, viewer, *d.RenoteID)
+		// renote は detail:true。
+		result["renote"] = h.packDraftNote(ctx, viewer, *d.RenoteID, true)
 	}
 	// channel は channelId set かつ channel が見つかったときだけ {id,name,color,
 	// isSensitive,allowRenoteToExternal,userId} を出力、それ以外は key 省略 (#1948-19)。
@@ -646,7 +648,7 @@ func (h *Handler) packDraft(ctx context.Context, viewer *model.User, d *model.No
 // packDraftNote resolves a draft's reply/renote target Note and packs it for the
 // viewer, returning nil when the note no longer exists (upstream
 // nullIfEntityNotFound). noteRepo 未配線時も nil (#1948-19)。
-func (h *Handler) packDraftNote(ctx context.Context, viewer *model.User, noteID string) any {
+func (h *Handler) packDraftNote(ctx context.Context, viewer *model.User, noteID string, detail bool) any {
 	if h.noteRepo == nil {
 		return nil
 	}
@@ -656,7 +658,8 @@ func (h *Handler) packDraftNote(ctx context.Context, viewer *model.User, noteID 
 	}
 	// packMany は timeline 用 hard-mute drop を行い非可視 note を漏らすため使わない。
 	// packReferencedNote が hard-mute skip + visibility hide を行う (#1948-19)。
-	return h.packReferencedNote(ctx, n, viewer)
+	// reply は detail:false、renote は detail:true で pack する (#2016)。
+	return h.packReferencedNote(ctx, n, viewer, detail)
 }
 
 // packDraftChannel resolves a draft's channel into the upstream NoteDraft.channel

--- a/internal/api/notes/handler_drafts_test.go
+++ b/internal/api/notes/handler_drafts_test.go
@@ -203,6 +203,39 @@ func TestPackDraft_ResolvesReplyRenoteChannelAndPoll(t *testing.T) {
 	assert.False(t, hasExp, "poll.expiresAt nil は key 省略 (#1948-19)")
 }
 
+// #2016: draft の reply は upstream で detail:false (clippedCount/poll/myReaction/
+// nested embed を省く)、renote は detail:true。clippedCount は detail:true で常に
+// 出力 (&n.ClippedCount)、detail:false で省略されるので、reply は省略・renote は
+// 出力されることを確認する。
+func TestPackDraft_ReplyDetailFalse_RenoteDetailTrue(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	noteRepo := testutil.NewMockNoteRepository()
+	mkNote := func(id string) *model.Note {
+		return &model.Note{ID: id, UserID: "author", Visibility: "public",
+			Reactions: datatypes.JSON([]byte("{}")), User: &model.User{ID: "author", AvatarDecorations: datatypes.JSON([]byte("[]"))}}
+	}
+	noteRepo.Notes["reply1"] = mkNote("reply1")
+	noteRepo.Notes["renote1"] = mkNote("renote1")
+	h.noteRepo = noteRepo
+	h.queryService = corenote.NewQueryService(noteRepo, testutil.NewMockFollowingRepository())
+
+	replyID, renoteID := "reply1", "renote1"
+	repo.drafts["d1"] = &model.NoteDraft{ID: "d1", UserID: "u1", Visibility: "public", ReplyID: &replyID, RenoteID: &renoteID}
+	rec := postDraft(h.DraftsList, `{}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	d := resp[0]
+
+	reply := d["reply"].(map[string]any)
+	_, hasClipped := reply["clippedCount"]
+	assert.False(t, hasClipped, "reply は detail:false なので clippedCount 省略 (#2016)")
+
+	renote := d["renote"].(map[string]any)
+	_, rHasClipped := renote["clippedCount"]
+	assert.True(t, rHasClipped, "renote は detail:true なので clippedCount 出力 (#2016)")
+}
+
 // #1948-19 (security): draft owner が閲覧不可な note を replyId に入れても、その
 // 本文は漏れず hideNote stub される (followers/specified の intrinsic hide)。
 func TestPackDraft_ReplyToInvisibleNote_Hidden(t *testing.T) {


### PR DESCRIPTION
## Summary

#1948-19 (NoteDraft pack) の敵対的レビューで発見した MEDIUM。draft の reply が upstream の detail:false
ではなく detail:true で pack され、余分な detail block フィールドが付いていた問題を是正する。

## 主な変更点

- **`packReferencedNote`** (`handler.go`): `detail bool` 引数を追加し、`!detail` のとき upstream の
  detail block (`NoteEntityService.ts:432` の `clippedCount`/`reply`/`renote`/`poll`/`myReaction`) に
  対応する `ClippedCount`/`Poll`/`MyReaction`/`Reply`/`Renote` を nil にする。`reactions`/`reactionCount`/
  `url`/`uri` 等の detail 外フィールドは残す。
- **`packDraftNote`** (`handler_drafts.go`): `detail` を thread し、reply は detail:false、renote は
  detail:true で呼ぶ (upstream `NoteDraftEntityService.ts:140-148`)。

## テスト

- reply が clippedCount を省略、renote が clippedCount を出力することを確認。
- notes 90.9%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで detail block の 5 フィールドが upstream と過不足なく一致、detail 外フィールドの取りこぼし
なし、HideNoteEntity との順序・冗長 strip も害なしを確認。

## 関連

- 親: #1948
- 発見元: #1948-19 の敵対的レビュー

Closes #2016
