### PR TITLE
Fix notes/drafts/create・update reply/renote 検証 (#2017)

### DIFF
--- a/internal/api/notes/handler_drafts.go
+++ b/internal/api/notes/handler_drafts.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/api/pagination"
+	corenote "github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
@@ -161,6 +162,10 @@ func (h *Handler) DraftsCreate(c echo.Context) error {
 	if pollAlreadyExpired(req.Poll, now) {
 		return c.JSON(http.StatusBadRequest, apierr.Error("CANNOT_CREATE_ALREADY_EXPIRED_POLL", "Cannot create an already expired poll.", "04da457d-b083-4055-9082-955525eda5a5"))
 	}
+	// reply/renote target の存在・可視性・pure-renote 検証 (#2017)。
+	if status, body := h.validateDraftReplyRenote(user, req.ReplyID, req.RenoteID, req.Visibility, draftCreateReplyRenoteErrs); status != 0 {
+		return c.JSON(status, body)
+	}
 	draft := &model.NoteDraft{
 		ID:                  h.idGen.Generate(now),
 		UserID:              user.ID,
@@ -276,6 +281,12 @@ func (h *Handler) DraftsUpdate(c echo.Context) error {
 	if req.Hashtag != nil {
 		draft.Hashtag = req.Hashtag
 	}
+	// reply/renote はリクエストで明示指定された場合のみ検証する。upstream update は
+	// data.replyId/renoteId が undefined のとき検証 block を skip するので、既存 draft の
+	// 値を再検証して編集不能にしない (#2017)。code/id は update endpoint 固有。
+	if status, body := h.validateDraftReplyRenote(user, req.ReplyID, req.RenoteID, req.Visibility, draftUpdateReplyRenoteErrs); status != 0 {
+		return c.JSON(status, body)
+	}
 	// scheduled 関連 field の変更検出 (#1045 Phase 2-C)。リクエストに
 	// scheduledAt / isActuallyScheduled が含まれている場合のみ削除 + 再
 	// enqueue する。それ以外は既存 draft 状態を維持。
@@ -338,6 +349,80 @@ type draftPoll struct {
 	Multiple     bool     `json:"multiple"`
 	ExpiresAt    *int64   `json:"expiresAt"`
 	ExpiredAfter *int64   `json:"expiredAfter"`
+}
+
+// draftReplyRenoteErrs holds the 4 reply/renote error responses that differ
+// between drafts/create.ts and drafts/update.ts. renote-visibility / reply-invisible
+// / reply-pure-renote are identical between the two endpoints (#2017)。
+type draftReplyRenoteErrs struct {
+	noSuchRenote   map[string]any
+	noSuchReply    map[string]any
+	pureRenote     map[string]any // renote target が pure renote
+	replySpecified map[string]any
+}
+
+// draftCreateReplyRenoteErrs / draftUpdateReplyRenoteErrs map the same validation
+// to the endpoint-specific code/id (drafts/create.ts vs drafts/update.ts の
+// meta.errors)。upstream は NoteDraftService が共通の internal error を throw し、
+// 各 endpoint の catch が別 code/id にマップする (#2017)。
+var draftCreateReplyRenoteErrs = draftReplyRenoteErrs{
+	noSuchRenote:   apierr.Error("NO_SUCH_RENOTE_TARGET", "No such renote target.", "b5c90186-4ab0-49c8-9bba-a1f76c282ba4"),
+	noSuchReply:    apierr.Error("NO_SUCH_REPLY_TARGET", "No such reply target.", "749ee0f6-d3da-459a-bf02-282e2da4292c"),
+	pureRenote:     apierr.Error("CANNOT_RENOTE_TO_A_PURE_RENOTE", "You can not Renote a pure Renote.", "fd4cc33e-2a37-48dd-99cc-9b806eb2031a"),
+	replySpecified: apierr.Error("CANNOT_REPLY_TO_SPECIFIED_VISIBILITY_NOTE_WITH_EXTENDED_VISIBILITY", "You cannot reply to a specified visibility note with extended visibility.", "ed940410-535c-4d5e-bfa3-af798671e93c"),
+}
+
+var draftUpdateReplyRenoteErrs = draftReplyRenoteErrs{
+	noSuchRenote:   apierr.Error("NO_SUCH_RENOTE", "No such renote.", "64929870-2540-4d11-af41-3b484d78c956"),
+	noSuchReply:    apierr.Error("NO_SUCH_REPLY", "No such reply.", "c4721841-22fc-4bb7-ad3d-897ef1d375b5"),
+	pureRenote:     apierr.Error("CANNOT_RENOTE", "Cannot renote.", "76cc5583-5a14-4ad3-8717-0298507e32db"),
+	replySpecified: apierr.Error("CANNOT_REPLY_TO_SPECIFIED_NOTE_WITH_EXTENDED_VISIBILITY", "You cannot reply to a specified visibility note with extended visibility.", "ed940410-535c-4d5e-bfa3-af798671e93c"),
+}
+
+// validateDraftReplyRenote validates the draft's reply/renote targets, mirroring
+// upstream NoteDraftService.validate (renote → reply order)。replyID/renoteID は
+// **リクエストで明示指定された値**を渡すこと (upstream は data.replyId != null の
+// ときだけ検証し、既存 draft の値は再検証しない、#2017)。errs は endpoint 固有の
+// code/id。戻り値 status==0 は検証成功。noteRepo/viewer 未配線時は skip。
+func (h *Handler) validateDraftReplyRenote(viewer *model.User, replyID, renoteID *string, visibility string, errs draftReplyRenoteErrs) (int, map[string]any) {
+	if h.noteRepo == nil || viewer == nil {
+		return 0, nil
+	}
+	if renoteID != nil {
+		t, err := h.noteRepo.FindByIDWithUser(*renoteID)
+		if err != nil || t == nil {
+			return http.StatusBadRequest, errs.noSuchRenote
+		}
+		if corenote.IsPureRenote(t) {
+			return http.StatusBadRequest, errs.pureRenote
+		}
+		// renote 対象が他人の followers note / specified note は (renote 経由の公開
+		// 拡散になるため) 拒否する。upstream は isVisibleForMe ではなくこの 2 条件のみ。
+		if (t.Visibility == model.NoteVisibilityFollowers && t.UserID != viewer.ID) || t.Visibility == model.NoteVisibilitySpecified {
+			return http.StatusBadRequest, apierr.Error("CANNOT_RENOTE_DUE_TO_VISIBILITY", "You can not Renote due to target visibility.", "be9529e9-fe72-4de0-ae43-0b363c4938af")
+		}
+	}
+	if replyID != nil {
+		t, err := h.noteRepo.FindByIDWithUser(*replyID)
+		if err != nil || t == nil {
+			return http.StatusBadRequest, errs.noSuchReply
+		}
+		// 可視性チェックを pure-renote より先に行う (mk-go の existence-oracle hardening
+		// doctrine、note_create_service の Devin #270 と同方針)。upstream NoteDraftService は
+		// pure-renote を先に見るが、不可視 note の「pure-renote か否か」を error code で
+		// 漏らさないよう mk-go では invisible を優先する。error code 自体は upstream 互換。
+		// queryService 未配線時は fail-closed で invisible 扱い。
+		if h.queryService == nil || !h.queryService.CanSee(viewer, t) {
+			return http.StatusBadRequest, apierr.Error("CANNOT_REPLY_TO_AN_INVISIBLE_NOTE", "You cannot reply to an invisible Note.", "b98980fa-3780-406c-a935-b6d0eeee10d1")
+		}
+		if corenote.IsPureRenote(t) {
+			return http.StatusBadRequest, apierr.Error("CANNOT_REPLY_TO_A_PURE_RENOTE", "You can not reply to a pure Renote.", "3ac74a84-8fd5-4bb0-870f-01804f82ce15")
+		}
+		if t.Visibility == model.NoteVisibilitySpecified && visibility != string(model.NoteVisibilitySpecified) {
+			return http.StatusBadRequest, errs.replySpecified
+		}
+	}
+	return 0, nil
 }
 
 // allDraftFilesOwned reports whether every fileID exists and is owned by

--- a/internal/api/notes/handler_drafts.go
+++ b/internal/api/notes/handler_drafts.go
@@ -162,8 +162,16 @@ func (h *Handler) DraftsCreate(c echo.Context) error {
 	if pollAlreadyExpired(req.Poll, now) {
 		return c.JSON(http.StatusBadRequest, apierr.Error("CANNOT_CREATE_ALREADY_EXPIRED_POLL", "Cannot create an already expired poll.", "04da457d-b083-4055-9082-955525eda5a5"))
 	}
-	// reply/renote target の存在・可視性・pure-renote 検証 (#2017)。
-	if status, body := h.validateDraftReplyRenote(user, req.ReplyID, req.RenoteID, req.Visibility, draftCreateReplyRenoteErrs); status != 0 {
+	// reply/renote target の存在・可視性・pure-renote 検証 (#2017)。create endpoint
+	// 固有の code/id (drafts/create.ts meta.errors) で 400 を返す。error 文字列を
+	// この handler 内に直接置くことで entitycompat の error-id gate が正しい endpoint
+	// に紐付けられる (package-level var だと textual に別 handler へ誤割当される)。
+	if status, body := h.validateDraftReplyRenote(user, req.ReplyID, req.RenoteID, req.Visibility, draftReplyRenoteErrs{
+		noSuchRenote:   apierr.Error("NO_SUCH_RENOTE_TARGET", "No such renote target.", "b5c90186-4ab0-49c8-9bba-a1f76c282ba4"),
+		noSuchReply:    apierr.Error("NO_SUCH_REPLY_TARGET", "No such reply target.", "749ee0f6-d3da-459a-bf02-282e2da4292c"),
+		pureRenote:     apierr.Error("CANNOT_RENOTE_TO_A_PURE_RENOTE", "You can not Renote a pure Renote.", "fd4cc33e-2a37-48dd-99cc-9b806eb2031a"),
+		replySpecified: apierr.Error("CANNOT_REPLY_TO_SPECIFIED_VISIBILITY_NOTE_WITH_EXTENDED_VISIBILITY", "You cannot reply to a specified visibility note with extended visibility.", "ed940410-535c-4d5e-bfa3-af798671e93c"),
+	}); status != 0 {
 		return c.JSON(status, body)
 	}
 	draft := &model.NoteDraft{
@@ -283,8 +291,15 @@ func (h *Handler) DraftsUpdate(c echo.Context) error {
 	}
 	// reply/renote はリクエストで明示指定された場合のみ検証する。upstream update は
 	// data.replyId/renoteId が undefined のとき検証 block を skip するので、既存 draft の
-	// 値を再検証して編集不能にしない (#2017)。code/id は update endpoint 固有。
-	if status, body := h.validateDraftReplyRenote(user, req.ReplyID, req.RenoteID, req.Visibility, draftUpdateReplyRenoteErrs); status != 0 {
+	// 値を再検証して編集不能にしない (#2017)。code/id は update endpoint 固有
+	// (drafts/update.ts meta.errors)。error 文字列を handler 内に直接置く理由は
+	// DraftsCreate 側のコメント参照。
+	if status, body := h.validateDraftReplyRenote(user, req.ReplyID, req.RenoteID, req.Visibility, draftReplyRenoteErrs{
+		noSuchRenote:   apierr.Error("NO_SUCH_RENOTE", "No such renote.", "64929870-2540-4d11-af41-3b484d78c956"),
+		noSuchReply:    apierr.Error("NO_SUCH_REPLY", "No such reply.", "c4721841-22fc-4bb7-ad3d-897ef1d375b5"),
+		pureRenote:     apierr.Error("CANNOT_RENOTE", "Cannot renote.", "76cc5583-5a14-4ad3-8717-0298507e32db"),
+		replySpecified: apierr.Error("CANNOT_REPLY_TO_SPECIFIED_NOTE_WITH_EXTENDED_VISIBILITY", "You cannot reply to a specified visibility note with extended visibility.", "ed940410-535c-4d5e-bfa3-af798671e93c"),
+	}); status != 0 {
 		return c.JSON(status, body)
 	}
 	// scheduled 関連 field の変更検出 (#1045 Phase 2-C)。リクエストに
@@ -359,24 +374,6 @@ type draftReplyRenoteErrs struct {
 	noSuchReply    map[string]any
 	pureRenote     map[string]any // renote target が pure renote
 	replySpecified map[string]any
-}
-
-// draftCreateReplyRenoteErrs / draftUpdateReplyRenoteErrs map the same validation
-// to the endpoint-specific code/id (drafts/create.ts vs drafts/update.ts の
-// meta.errors)。upstream は NoteDraftService が共通の internal error を throw し、
-// 各 endpoint の catch が別 code/id にマップする (#2017)。
-var draftCreateReplyRenoteErrs = draftReplyRenoteErrs{
-	noSuchRenote:   apierr.Error("NO_SUCH_RENOTE_TARGET", "No such renote target.", "b5c90186-4ab0-49c8-9bba-a1f76c282ba4"),
-	noSuchReply:    apierr.Error("NO_SUCH_REPLY_TARGET", "No such reply target.", "749ee0f6-d3da-459a-bf02-282e2da4292c"),
-	pureRenote:     apierr.Error("CANNOT_RENOTE_TO_A_PURE_RENOTE", "You can not Renote a pure Renote.", "fd4cc33e-2a37-48dd-99cc-9b806eb2031a"),
-	replySpecified: apierr.Error("CANNOT_REPLY_TO_SPECIFIED_VISIBILITY_NOTE_WITH_EXTENDED_VISIBILITY", "You cannot reply to a specified visibility note with extended visibility.", "ed940410-535c-4d5e-bfa3-af798671e93c"),
-}
-
-var draftUpdateReplyRenoteErrs = draftReplyRenoteErrs{
-	noSuchRenote:   apierr.Error("NO_SUCH_RENOTE", "No such renote.", "64929870-2540-4d11-af41-3b484d78c956"),
-	noSuchReply:    apierr.Error("NO_SUCH_REPLY", "No such reply.", "c4721841-22fc-4bb7-ad3d-897ef1d375b5"),
-	pureRenote:     apierr.Error("CANNOT_RENOTE", "Cannot renote.", "76cc5583-5a14-4ad3-8717-0298507e32db"),
-	replySpecified: apierr.Error("CANNOT_REPLY_TO_SPECIFIED_NOTE_WITH_EXTENDED_VISIBILITY", "You cannot reply to a specified visibility note with extended visibility.", "ed940410-535c-4d5e-bfa3-af798671e93c"),
 }
 
 // validateDraftReplyRenote validates the draft's reply/renote targets, mirroring

--- a/internal/api/notes/handler_drafts_test.go
+++ b/internal/api/notes/handler_drafts_test.go
@@ -203,6 +203,76 @@ func TestPackDraft_ResolvesReplyRenoteChannelAndPoll(t *testing.T) {
 	assert.False(t, hasExp, "poll.expiresAt nil は key 省略 (#1948-19)")
 }
 
+// #2017: DraftsCreate は reply/renote target の存在・可視性・pure-renote を検証し、
+// drafts/create.ts meta.errors の code/id で 400 を返す。
+func TestDraftsCreate_ReplyRenoteValidation(t *testing.T) {
+	h, _ := newDraftHandlerWithRepo()
+	noteRepo := testutil.NewMockNoteRepository()
+	mk := func(id, vis string) *model.Note {
+		txt := "body"
+		return &model.Note{ID: id, UserID: "author", Visibility: model.NoteVisibility(vis), Text: &txt,
+			Reactions: datatypes.JSON([]byte("{}")), User: &model.User{ID: "author", AvatarDecorations: datatypes.JSON([]byte("[]"))}}
+	}
+	noteRepo.Notes["visible"] = mk("visible", "public")
+	noteRepo.Notes["followers"] = mk("followers", "followers")
+	h.noteRepo = noteRepo
+	h.queryService = corenote.NewQueryService(noteRepo, testutil.NewMockFollowingRepository())
+	u := &model.User{ID: "u1"}
+
+	cases := []struct {
+		name, body, wantCode string
+		wantStatus           int
+	}{
+		{"no such reply", `{"text":"x","replyId":"missing"}`, "NO_SUCH_REPLY_TARGET", http.StatusBadRequest},
+		{"invisible reply", `{"text":"x","replyId":"followers"}`, "CANNOT_REPLY_TO_AN_INVISIBLE_NOTE", http.StatusBadRequest},
+		{"no such renote", `{"text":"x","renoteId":"missing"}`, "NO_SUCH_RENOTE_TARGET", http.StatusBadRequest},
+		{"renote of others followers", `{"text":"x","renoteId":"followers"}`, "CANNOT_RENOTE_DUE_TO_VISIBILITY", http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := postDraft(h.DraftsCreate, tc.body, u)
+			assert.Equal(t, tc.wantStatus, rec.Code)
+			assert.Contains(t, rec.Body.String(), tc.wantCode, "#2017")
+		})
+	}
+
+	// 可視 public note への reply は成功 (draft 作成 200)。
+	rec := postDraft(h.DraftsCreate, `{"text":"x","replyId":"visible"}`, u)
+	assert.Equal(t, http.StatusOK, rec.Code, "可視 reply target は通過 (#2017)")
+}
+
+// #2017: DraftsUpdate は (1) update endpoint 固有の error code/id を返す
+// (NO_SUCH_REPLY ≠ create の NO_SUCH_REPLY_TARGET)、(2) reply/renote をリクエストで
+// 明示指定したときのみ検証し、既存 draft の値を再検証しない (over-rejection 回避)。
+func TestDraftsUpdate_ReplyRenoteValidation(t *testing.T) {
+	h, repo := newDraftHandlerWithRepo()
+	noteRepo := testutil.NewMockNoteRepository()
+	secret := "s"
+	noteRepo.Notes["followers"] = &model.Note{ID: "followers", UserID: "author", Visibility: model.NoteVisibilityFollowers, Text: &secret,
+		Reactions: datatypes.JSON([]byte("{}")), User: &model.User{ID: "author", AvatarDecorations: datatypes.JSON([]byte("[]"))}}
+	h.noteRepo = noteRepo
+	h.queryService = corenote.NewQueryService(noteRepo, testutil.NewMockFollowingRepository())
+	u := &model.User{ID: "u1"}
+
+	// (1) update endpoint 固有 code: NO_SUCH_REPLY / c4721841 (create の TARGET 系ではない)。
+	repo.drafts["d1"] = &model.NoteDraft{ID: "d1", UserID: "u1", Visibility: "public"}
+	rec := postDraft(h.DraftsUpdate, `{"draftId":"d1","replyId":"missing"}`, u)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	var er struct {
+		Error struct{ Code, ID string } `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &er))
+	assert.Equal(t, "NO_SUCH_REPLY", er.Error.Code, "update は NO_SUCH_REPLY (#2017)")
+	assert.Equal(t, "c4721841-22fc-4bb7-ad3d-897ef1d375b5", er.Error.ID)
+
+	// (2) over-rejection 回避: 既存 draft の replyId が invisible でも、replyId を
+	// 指定しない update は再検証されず成功する。
+	replyID := "followers"
+	repo.drafts["d2"] = &model.NoteDraft{ID: "d2", UserID: "u1", Visibility: "public", ReplyID: &replyID}
+	rec = postDraft(h.DraftsUpdate, `{"draftId":"d2","text":"new"}`, u)
+	assert.Equal(t, http.StatusOK, rec.Code, "replyId 未指定の update は既存値を再検証しない (#2017 HIGH-2)")
+}
+
 // #2016: draft の reply は upstream で detail:false (clippedCount/poll/myReaction/
 // nested embed を省く)、renote は detail:true。clippedCount は detail:true で常に
 // 出力 (&n.ClippedCount)、detail:false で省略されるので、reply は省略・renote は


### PR DESCRIPTION
## Summary

#1948-19 (NoteDraft pack) の敵対的レビューで発見。mk-go の DraftsCreate / DraftsUpdate が reply/renote
target の存在・可視性検証を欠いており、任意の note ID を replyId/renoteId に持つ draft を作成できた
(本文 leak は #1948-19 で packDraftNote hide により塞いだが、create-time の error parity が未対応)。

## 主な変更点

- **`validateDraftReplyRenote`** (`handler_drafts.go`): upstream `NoteDraftService.validate` に倣い、
  renote (not-found / pure-renote / 他人 followers・specified visibility) → reply (not-found / invisible /
  pure-renote / specified-extended) を同順で検証。全 error は client-kind なので **400**。
- **create / update の error code 差**: upstream は共通 service が internal id を throw し、各 endpoint
  の catch が別 code/id にマップする。4 値 (renote-not-found・renote-pure・reply-not-found・reply-specified)
  を `draftCreateReplyRenoteErrs` / `draftUpdateReplyRenoteErrs` で作り分け (例: create
  `NO_SUCH_REPLY_TARGET`/749ee0f6 vs update `NO_SUCH_REPLY`/c4721841)。
- **DraftsUpdate は request 明示値で検証**: `req.ReplyID`/`req.RenoteID` (未指定=nil) を使い、既存 draft
  値を再検証しない (upstream `data.replyId != null` guard。merge 後値だと invisible 化した reply を持つ
  draft が編集不能になる over-reject regression を回避)。
- reply の invisible チェックを pure-renote より先に評価 (mk-go の existence-oracle hardening doctrine、
  error code 自体は upstream 互換)。

## テスト

- create: 不明 reply/renote → NO_SUCH_*_TARGET、invisible reply → CANNOT_REPLY_TO_AN_INVISIBLE_NOTE、
  他人 followers renote → CANNOT_RENOTE_DUE_TO_VISIBILITY、可視 reply → 200。
- update: NO_SUCH_REPLY/c4721841 (create と別 code)、replyId 未指定 update が既存 invisible reply を
  弾かない (over-reject 回避)。
- notes 90.8%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで当初 update が create の code/id を返す HIGH と merge 後値の over-reject HIGH を発見し、
両方修正・再レビューで解消を確認。blocked / channel 検証 (YOU_HAVE_BEEN_BLOCKED / NO_SUCH_CHANNEL /
CANNOT_RENOTE_TO_EXTERNAL) は block/channel repo wiring を要するため #2039 に分離。

## 関連

- 親: #1948
- 発見元: #1948-19 の敵対的レビュー

Closes #2017
