### PR TITLE
Fix AP inbox parity (#2023): Collection/OrderedCollection を unroll する

### DIFF
--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -358,6 +358,16 @@ func (p *Processor) Process(body []byte) error {
 		}
 	}
 
+	return p.dispatchActivity(act, 0)
+}
+
+// maxCollectionDepth bounds nested Collection/OrderedCollection unrolling so a
+// collection-of-collections cannot recurse without limit (#2023).
+const maxCollectionDepth = 1
+
+// dispatchActivity routes a parsed activity to its handler. depth tracks
+// Collection/OrderedCollection unrolling so handleCollection can bound recursion.
+func (p *Processor) dispatchActivity(act genericActivity, depth int) error {
 	switch strings.ToLower(act.Type) {
 	case "follow":
 		return p.handleFollow(act)
@@ -411,8 +421,67 @@ func (p *Processor) Process(body []byte) error {
 		return p.handleReversiLeave(act)
 	case "misskey:chatmessage":
 		return p.handleChatMessage(act)
+	case "collection", "orderedcollection":
+		return p.handleCollection(act, depth)
 	}
 	return ErrUnsupportedActivity
+}
+
+// handleCollection unrolls a Collection / OrderedCollection activity, dispatching
+// each inline item whose id host matches the collection actor's host. Mirrors
+// upstream ApInboxService.performActivity の collection branch: items 数が
+// recursion limit を超えたら skip、各 item は extractDbHost(item.id) ==
+// extractDbHost(actor.uri) を要求する (spoofing 防止)。URI 文字列の item は解決せず
+// skip する (fetch 増幅を避ける; relay の inline 配送のみ対応、#2023)。
+func (p *Processor) handleCollection(act genericActivity, depth int) error {
+	if depth >= maxCollectionDepth {
+		return nil // skip: nested collection beyond depth limit
+	}
+	var col struct {
+		Items        []json.RawMessage `json:"items"`
+		OrderedItems []json.RawMessage `json:"orderedItems"`
+	}
+	if len(act.raw) > 0 {
+		_ = json.Unmarshal(act.raw, &col)
+	}
+	// upstream は type に応じて片方のみ読む (Collection→items / OrderedCollection→
+	// orderedItems)。
+	items := col.OrderedItems
+	if strings.ToLower(act.Type) == "collection" {
+		items = col.Items
+	}
+	// 過大な collection は upstream の getRecursionLimit と同様に弾く。
+	if len(items) >= resolveRecursionLimit {
+		return nil
+	}
+	actorHost, err := hostFromURI(act.Actor)
+	if err != nil {
+		return nil
+	}
+	for _, item := range items {
+		var itemAct genericActivity
+		if err := json.Unmarshal(item, &itemAct); err != nil {
+			// 文字列 URI 等の inline でない item は skip。
+			continue
+		}
+		itemAct.raw = item
+		// per-item: id host == collection actor host を要求する (upstream の host 一致
+		// check)。punyHost で IDN/大文字を正規化して比較する (#1850 と同方針)。
+		itemHost, herr := hostFromURI(itemAct.ID)
+		if itemAct.ID == "" || herr != nil || punyHost(itemHost) != punyHost(actorHost) {
+			continue
+		}
+		// upstream performActivity は collection item を **collection の認証済み actor**
+		// の権威で performOneActivity に渡す (item.actor は使わない)。item が別 actor を
+		// 詐称しても collection actor として処理されるよう actor を上書きする (#2023
+		// security)。これにより third-party actor を詐称した reaction/announce 等の
+		// 注入を防ぐ。
+		itemAct.Actor = act.Actor
+		if derr := p.dispatchActivity(itemAct, depth+1); derr != nil && !errors.Is(derr, ErrUnsupportedActivity) {
+			slog.Error("federation: collection item failed", "id", itemAct.ID, "type", itemAct.Type, "err", derr)
+		}
+	}
+	return nil
 }
 
 // ExtractActorIRI returns the authoritative actor IRI of an inbound activity,

--- a/internal/core/federation/processor_step_f_test.go
+++ b/internal/core/federation/processor_step_f_test.go
@@ -1735,3 +1735,75 @@ func TestProcess_AnnounceCreateError(t *testing.T) {
 	err := p.Process(body)
 	assert.Error(t, err)
 }
+
+// #2023: OrderedCollection / Collection を受信したら items を unroll し、id host が
+// collection actor の host と一致する各 item を dispatch する。host 不一致 item は skip。
+func TestProcess_CollectionUnrollsItems(t *testing.T) {
+	env := newFullProcessor(t, aliceActor)
+	env.noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "bob", Visibility: model.NoteVisibilityPublic}
+	body := []byte(`{
+		"type": "OrderedCollection",
+		"actor": "https://remote.example/users/alice",
+		"orderedItems": [
+			{
+				"id": "https://remote.example/likes/l1",
+				"type": "Like",
+				"actor": "https://remote.example/users/alice",
+				"object": "https://example.com/notes/n1",
+				"content": "⭐"
+			}
+		]
+	}`)
+	require.NoError(t, env.processor.Process(body))
+	require.Len(t, env.reactionRepo.Reactions, 1, "collection 内の Like が dispatch される (#2023)")
+}
+
+// #2023: item の id host が collection actor の host と一致しないときは skip する。
+func TestProcess_CollectionSkipsHostMismatch(t *testing.T) {
+	env := newFullProcessor(t, aliceActor)
+	env.noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "bob", Visibility: model.NoteVisibilityPublic}
+	body := []byte(`{
+		"type": "Collection",
+		"actor": "https://remote.example/users/alice",
+		"items": [
+			{
+				"id": "https://evil.example/likes/l2",
+				"type": "Like",
+				"actor": "https://remote.example/users/alice",
+				"object": "https://example.com/notes/n1",
+				"content": "❤"
+			}
+		]
+	}`)
+	require.NoError(t, env.processor.Process(body))
+	assert.Empty(t, env.reactionRepo.Reactions, "host 不一致 item は skip (#2023)")
+}
+
+// #2023 (security): collection item が別 actor を詐称しても、collection の認証 actor の
+// 権威で処理される (item.actor は使わない)。詐称 reaction が victim 名義で記録されない。
+func TestProcess_CollectionItemActorSpoofIgnored(t *testing.T) {
+	env := newFullProcessor(t, aliceActor)
+	env.noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "bob", Visibility: model.NoteVisibilityPublic}
+	// collection actor は alice@remote.example。item は victim@other.example を actor に詐称。
+	// item.id host は remote.example で collection actor と一致するため host check は通過するが、
+	// actor は collection actor (alice) に上書きされる。
+	body := []byte(`{
+		"type": "OrderedCollection",
+		"actor": "https://remote.example/users/alice",
+		"orderedItems": [
+			{
+				"id": "https://remote.example/likes/spoof",
+				"type": "Like",
+				"actor": "https://other.example/users/victim",
+				"object": "https://example.com/notes/n1",
+				"content": "⭐"
+			}
+		]
+	}`)
+	require.NoError(t, env.processor.Process(body))
+	require.Len(t, env.reactionRepo.Reactions, 1)
+	for _, r := range env.reactionRepo.Reactions {
+		// reaction は alice (collection actor) 名義であり victim 名義ではない。
+		assert.NotContains(t, r.UserID, "victim", "詐称 actor では記録されない (#2023 security)")
+	}
+}


### PR DESCRIPTION
## Summary

#1948-21 の監査で確認した optional hardening。upstream `performActivity` は配送 activity が
Collection / OrderedCollection の場合 items を unroll して各 item を処理するが、mk-go は collection
受信時に中身を全 drop していた (relay interop)。

## 主な変更点

- **`dispatchActivity(act, depth)`**: Process の type switch を抽出。`collection`/`orderedcollection`
  case を追加。
- **`handleCollection`** (`processor.go`): upstream `ApInboxService.performActivity` の collection branch を移植 —
  - type に応じ `items` (Collection) / `orderedItems` (OrderedCollection) を読む。
  - 件数 `>= resolveRecursionLimit(256)` で skip (upstream getRecursionLimit)。
  - 各 inline item の `id` host == collection actor host を `punyHost` 正規化で要求。
  - `maxCollectionDepth=1` で nested collection の再帰を bound。
  - URI 文字列 item は解決せず skip (fetch 増幅 DoS 回避; relay の inline 配送のみ対応)。
- **security**: item は collection の**認証済み actor** の権威で処理する (`itemAct.Actor = act.Actor` で
  上書き、item.actor は使わない)。upstream `performOneActivity(actor, item)` と同じ authority model で、
  third-party actor を詐称した reaction/announce 等の collection 経由注入を防ぐ。

## テスト

- collection 内の Like が dispatch される / host 不一致 item は skip / **item.actor 詐称が無視され
  collection actor の権威で処理される** (security)。
- federation 90.3%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで「item.actor を無検証で actor 扱いする」spoofing HIGH と host 比較の punyHost 欠落
MEDIUM を発見し、actor 上書き + punyHost 正規化で修正した。本機能は LOW/optional (vanilla Misskey peer
は collection 配送しない) だが relay interop の hardening。

## 関連

- 親: #1948
- 発見元: #1948-21

Closes #2023
