### PR TITLE
Document update-membership の意図的乖離 (#2005): mk-go の堅牢挙動を維持

### DIFF
--- a/internal/api/users/lists.go
+++ b/internal/api/users/lists.go
@@ -316,6 +316,10 @@ func (h *Handler) ListsUpdateMembership(c echo.Context) error {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_LIST", "No such list.", "7f44670e-ab16-43b8-b4c1-ccd2ee89cc02"))
 	}
 	if err := h.userListRepo.UpdateMembership(req.ListID, req.UserID, req.WithReplies); err != nil {
+		// membership 行が無い (= 対象 user が list member でない) ときは NO_SUCH_USER
+		// (404)。upstream は user レコード存在時 (member でないだけ) は 500 を投げ、
+		// NO_SUCH_USER は user 自体が無いときのみだが、mk-go は両ケースを 404 NO_SUCH_USER に
+		// 寄せた方が合理的なのでそちらを採る (#2005 で方針決定: mk-go の堅牢挙動を維持)。
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "588e7f72-c744-4a61-b180-d354e912bda2"))
 		}

--- a/internal/api/users/lists_test.go
+++ b/internal/api/users/lists_test.go
@@ -608,3 +608,29 @@ func TestListsUpdateMembership_MemberNotFound(t *testing.T) {
 	rec := postStub(h.ListsUpdateMembership, `{"listId":"l1","userId":"ghost","withReplies":true}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
+
+// #2005: update-membership の意図的挙動を pin する。(1) withReplies 省略 (nil) は既存値を
+// 維持して 204 (upstream は TypeORM 空 SET で 500 だが mk-go は堅牢挙動を採る)。
+// (2) member でない user 指定は NO_SUCH_USER 404 (upstream は user 存在時 500 だが mk-go は 404)。
+func TestListsUpdateMembership_DeliberateDeviations(t *testing.T) {
+	h, _ := newTestHandler(t)
+	repo := testutil.NewMockUserListRepository()
+	h.SetUserListRepo(repo)
+	seedListWithMember(repo, "l1", "owner", "member1", false) // WithReplies: true で seed
+	owner := &model.User{ID: "owner"}
+
+	// (1) withReplies 省略 → 既存 true を維持、204。
+	rec := postStub(h.ListsUpdateMembership, `{"listId":"l1","userId":"member1"}`, owner)
+	assert.Equal(t, http.StatusNoContent, rec.Code, "省略は 204 (#2005)")
+	assert.Equal(t, true, repo.Members[0].WithReplies, "省略時は既存値維持 (#2005)")
+
+	// withReplies=false を明示 → 更新される。
+	rec = postStub(h.ListsUpdateMembership, `{"listId":"l1","userId":"member1","withReplies":false}`, owner)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, false, repo.Members[0].WithReplies, "明示値は更新 (#2005)")
+
+	// (2) member でない user → NO_SUCH_USER 404。
+	rec = postStub(h.ListsUpdateMembership, `{"listId":"l1","userId":"notmember"}`, owner)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_USER", "非 member は NO_SUCH_USER 404 (#2005)")
+}


### PR DESCRIPTION
## Summary

#1948-15 (lists/channels null-clear) の敵対的レビューで、users/lists/update-membership の upstream
挙動が当初 finding の前提と異なる (edge case で 500 を投げる) ことが判明した。#2005 で方針を決定:
**mk-go のより堅牢な挙動を維持する** (挙動変更なし、文書化 + テスト追加のみ)。

## 決定内容

1. **withReplies 省略時**: upstream `UserListService.updateMembership` は `update({id}, {withReplies:
   undefined})` で TypeORM が空 SET 句の `UpdateValuesMissingError` を throw し **500**。mk-go は
   `*bool` の nil を「既存値維持」と解釈して **204** (#1948-15 で既に文書化済)。
2. **NO_SUCH_USER の発火**: mk-go は membership 行が無い (= 非 member) とき **NO_SUCH_USER 404**。
   upstream の NO_SUCH_USER は user レコード自体が無いときのみで、user 存在時の非 member は **500**。
   mk-go は両ケースを 404 に寄せる方が合理的なのでその挙動を維持 (本 PR で doc コメント追加)。

いずれも upstream の edge-case 500 を replicate するより堅牢で、standard client は常に withReplies を
送り member のみ更新するため実害はない。

## 主な変更点

- `lists.go`: NO_SUCH_USER の deliberate deviation を doc コメント化 (withReplies 側は既存コメント)。
- `lists_test.go`: 省略時の既存値維持 204 / 明示値更新 / 非 member の NO_SUCH_USER 404 を pin。

## テスト

- `TestListsUpdateMembership_DeliberateDeviations`。users カバレッジ維持。`make fmt`/`go vet`/`make test` green。

## 関連

- 親: #1948
- 発見元: #1948-15 の敵対的レビュー

Closes #2005
