### PR TITLE
Fix actor icon/image parity (#2031): drive file 由来の sensitive/name を付与

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -224,6 +224,10 @@ type Renderer struct {
 	// meta.bannerUrl を実行時に解決する lookup (#1969)。meta は admin が変更しうる
 	// ため static でなく lookup で都度取得する。nil なら system fallback 無し。
 	instanceImages func() (iconURL, bannerURL string)
+	// driveFileMeta は actor の avatar/banner drive file の isSensitive / comment を
+	// 解決する lookup (#2031)。upstream renderImage は actor icon/image に
+	// sensitive: file.isSensitive / name: file.comment を付ける。nil なら付けない。
+	driveFileMeta func(fileID string) (isSensitive bool, comment *string, ok bool)
 }
 
 // NewRenderer constructs a Renderer.
@@ -242,6 +246,30 @@ func (r *Renderer) URLs() *URLBuilder {
 // as the icon/image fallback for system actors in RenderPerson (#1969).
 func (r *Renderer) SetInstanceImageLookup(fn func() (iconURL, bannerURL string)) {
 	r.instanceImages = fn
+}
+
+// SetDriveFileMetaLookup wires a lookup that resolves an avatar/banner drive
+// file's isSensitive / comment, used to populate actor icon/image sensitive/name
+// in RenderPerson (#2031). nil disables the enrichment (falls back to {type,url}).
+func (r *Renderer) SetDriveFileMetaLookup(fn func(fileID string) (isSensitive bool, comment *string, ok bool)) {
+	r.driveFileMeta = fn
+}
+
+// applyDriveFileMeta sets img.Sensitive / img.Name from the drive file fileID via
+// the driveFileMeta lookup (upstream renderImage: sensitive=file.isSensitive,
+// name=file.comment)。fileID 空 / lookup 未配線 / 見つからない時は no-op (#2031)。
+func (r *Renderer) applyDriveFileMeta(img *Image, fileID *string) {
+	if img == nil || fileID == nil || *fileID == "" || r.driveFileMeta == nil {
+		return
+	}
+	sensitive, comment, ok := r.driveFileMeta(*fileID)
+	if !ok {
+		return
+	}
+	img.Sensitive = &sensitive
+	if comment != nil {
+		img.Name = *comment
+	}
 }
 
 // RenderOrderedCollection builds an AS OrderedCollection (#1876)。upstream
@@ -378,6 +406,8 @@ func (r *Renderer) RenderPerson(u *model.User, profile *model.UserProfile, publi
 	switch {
 	case u.AvatarURL != nil && *u.AvatarURL != "":
 		p.Icon = &Image{Type: "Image", URL: *u.AvatarURL}
+		// drive file 由来の avatar には sensitive/name を付ける (#2031)。
+		r.applyDriveFileMeta(p.Icon, u.AvatarID)
 	case isSystem && instanceIcon != "":
 		p.Icon = &Image{Type: "Image", URL: instanceIcon}
 	default:
@@ -388,6 +418,7 @@ func (r *Renderer) RenderPerson(u *model.User, profile *model.UserProfile, publi
 	switch {
 	case u.BannerURL != nil && *u.BannerURL != "":
 		p.Image = &Image{Type: "Image", URL: *u.BannerURL}
+		r.applyDriveFileMeta(p.Image, u.BannerID)
 	case isSystem && instanceBanner != "":
 		p.Image = &Image{Type: "Image", URL: instanceBanner}
 	}

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -172,6 +172,38 @@ func TestRenderer_RenderPerson(t *testing.T) {
 	assert.Equal(t, avatar, p.Icon.URL)
 }
 
+// #2031: drive file 由来の actor avatar/banner には sensitive (file.isSensitive) /
+// name (file.comment) を付ける (upstream renderImage)。lookup 未配線時は付けない。
+func TestRenderer_RenderPerson_IconSensitiveName(t *testing.T) {
+	r := newRenderer()
+	comment := "alt text"
+	r.SetDriveFileMetaLookup(func(fileID string) (bool, *string, bool) {
+		switch fileID {
+		case "avatarfile":
+			return true, &comment, true
+		case "bannerfile":
+			return false, nil, true
+		}
+		return false, nil, false
+	})
+	avatar, banner := "https://example.com/a.png", "https://example.com/b.png"
+	avatarID, bannerID := "avatarfile", "bannerfile"
+	u := &model.User{
+		ID: "u1", Username: "alice",
+		AvatarURL: &avatar, AvatarID: &avatarID,
+		BannerURL: &banner, BannerID: &bannerID,
+	}
+	p := r.RenderPerson(u, nil, "PUBKEY", nil)
+	require.NotNil(t, p.Icon)
+	require.NotNil(t, p.Icon.Sensitive)
+	assert.True(t, *p.Icon.Sensitive, "avatar の sensitive=file.isSensitive (#2031)")
+	assert.Equal(t, "alt text", p.Icon.Name, "avatar の name=file.comment (#2031)")
+	require.NotNil(t, p.Image)
+	require.NotNil(t, p.Image.Sensitive)
+	assert.False(t, *p.Image.Sensitive, "banner の sensitive=false")
+	assert.Equal(t, "", p.Image.Name, "banner の comment nil は name 省略")
+}
+
 func TestRenderer_URLs(t *testing.T) {
 	r := newRenderer()
 	require.NotNil(t, r.URLs())

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -546,6 +546,15 @@ func (s *Server) setupRoutes() {
 		}
 		return icon, banner
 	})
+	// actor の avatar/banner drive file の isSensitive / comment を解決して
+	// AP icon/image に sensitive/name を付ける (#2031)。
+	apRenderer.SetDriveFileMetaLookup(func(fileID string) (bool, *string, bool) {
+		f, err := driveFileRepo.FindByID(fileID)
+		if err != nil || f == nil {
+			return false, nil, false
+		}
+		return f.IsSensitive, f.Comment, true
+	})
 	// config.URL は "https://example.com" 形式。ホスト部分だけ抽出して
 	// apRenderer と webfinger 側で共有する (下の resolver 設定でも再利用)。
 	localHost := ""


### PR DESCRIPTION
## Summary

#1993 part2。actor の avatar/banner drive file 由来の AP icon/image に `sensitive` / `name` を付与し、
upstream `renderImage` に揃える。

## 主な変更点

- **Renderer** (`renderer.go`): `driveFileMeta` lookup field + `SetDriveFileMetaLookup` +
  `applyDriveFileMeta(img, fileID)` を追加。RenderPerson の avatar(`p.Icon`)/banner(`p.Image`) 構築時に
  drive file の `isSensitive` → `Image.Sensitive`、`comment` → `Image.Name` を付与
  (upstream `renderImage` の `sensitive: file.isSensitive` / `name: file.comment`)。
- **適用条件**: `AvatarURL`/`BannerURL` が drive file 由来 (AvatarID/BannerID set) のときのみ。
  identicon / system instance icon fallback には付けない (upstream の renderImage 限定と一致)。
- **router.go**: `SetDriveFileMetaLookup` を `driveFileRepo.FindByID` に wire。

## テスト

- avatar の sensitive=true / name=comment、banner の sensitive=false / comment nil で name 省略。
- activitypub 92.6%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで sensitive が false でも出力される点 (upstream 一致)、mediaType を付けない点
(actor renderImage は mediaType 無しで一致)、remote actor 混入なし (RenderPerson 全呼出元に local
guard)、query 数が upstream と同等で hot path でない点を確認。`name` の null を omitempty で省略するのは
mk-go 既存 Document の house style と一貫 (AS 上 null ⇄ 欠落はほぼ等価)。

## 関連

- 親: #1948
- 元: #1993 part2

Closes #2031
