### PR TITLE
Fix Pin/Unpin federation (#2024): Add/Remove(featured collection) を followers へ配信

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -1120,6 +1120,43 @@ func (r *Renderer) RenderInvite(ownerID string, inner any, targetURI string) *In
 // ChatService.leaveRoom's renderRemove: actor = object = the leaving user,
 // target = the room. id は addContext 互換で `{baseURL}/{UUID}` を必ず入れる
 // (id 無し activity は受信側 InboxProcessor で弾かれる)。
+// RenderAddToFeatured builds an Add activity announcing that a local user pinned
+// a note into their featured collection (upstream NotePiningService.deliverPinnedChange
+// + renderAdd、#2024)。target=featured collection、object=note URI。
+func (r *Renderer) RenderAddToFeatured(userID, noteID string) *Add {
+	a := &Add{
+		Activity: Activity{
+			Object: Object{
+				ID:   r.urls.baseURL + "/" + uuid.NewString(),
+				Type: "Add",
+			},
+			Actor: r.urls.UserURI(userID),
+		},
+		Object: r.urls.NoteURI(noteID),
+		Target: r.urls.UserFeatured(userID),
+	}
+	AddContext(a)
+	return a
+}
+
+// RenderRemoveFromFeatured builds a Remove activity announcing that a local user
+// unpinned a note from their featured collection (upstream renderRemove、#2024)。
+func (r *Renderer) RenderRemoveFromFeatured(userID, noteID string) *Remove {
+	rm := &Remove{
+		Activity: Activity{
+			Object: Object{
+				ID:   r.urls.baseURL + "/" + uuid.NewString(),
+				Type: "Remove",
+			},
+			Actor: r.urls.UserURI(userID),
+		},
+		Object: r.urls.NoteURI(noteID),
+		Target: r.urls.UserFeatured(userID),
+	}
+	AddContext(rm)
+	return rm
+}
+
 func (r *Renderer) RenderChatRoomRemove(leavingUserURI, roomURI string) *Remove {
 	rm := &Remove{
 		Activity: Activity{

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -1375,3 +1375,21 @@ func TestRenderer_RenderNote_NoPollResolver(t *testing.T) {
 	assert.Equal(t, "Note", out.Type)
 	assert.Empty(t, out.OneOf)
 }
+
+// #2024: RenderAddToFeatured / RenderRemoveFromFeatured は featured collection への
+// note pin/unpin を Add/Remove(target=featured, object=note URI) で表現する。
+func TestRenderer_RenderAddRemoveFeatured(t *testing.T) {
+	r := newRenderer()
+	add := marshalMap(t, r.RenderAddToFeatured("u1", "n1"))
+	assert.Equal(t, "Add", add["type"])
+	assert.Equal(t, "https://example.com/users/u1", add["actor"])
+	assert.Equal(t, "https://example.com/users/u1/collections/featured", add["target"])
+	assert.Equal(t, "https://example.com/notes/n1", add["object"])
+	assert.NotEmpty(t, add["id"], "addContext 相当の id を持つ")
+	assert.NotNil(t, add["@context"])
+
+	rm := marshalMap(t, r.RenderRemoveFromFeatured("u1", "n1"))
+	assert.Equal(t, "Remove", rm["type"])
+	assert.Equal(t, "https://example.com/users/u1/collections/featured", rm["target"])
+	assert.Equal(t, "https://example.com/notes/n1", rm["object"])
+}

--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -464,8 +464,18 @@ type Invite struct {
 // Remove represents a Remove activity. CherryPick group chat federation uses
 // it to announce a member leaving a chat room: actor and object are the
 // leaving member's actor URI, target is the room URI. Mirrors
-// ApRendererService.renderRemove.
+// ApRendererService.renderRemove. featured collection からの note unpin にも使う
+// (target=featured collection, object=note URI、#2024)。
 type Remove struct {
+	Activity
+	Object any    `json:"object"`
+	Target string `json:"target,omitempty"`
+}
+
+// Add represents an Add activity, used to federate a note pin into the actor's
+// featured collection (target=featured collection, object=note URI). Mirrors
+// ApRendererService.renderAdd (#2024)。
+type Add struct {
 	Activity
 	Object any    `json:"object"`
 	Target string `json:"target,omitempty"`
@@ -622,6 +632,8 @@ func AddContext(o any) {
 	case *Invite:
 		v.Context = ctx
 	case *Remove:
+		v.Context = ctx
+	case *Add:
 		v.Context = ctx
 	case *Undo:
 		v.Context = ctx

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -99,6 +99,9 @@ type Handler struct {
 	// streaming connection に reload signal を流す (#791)。未配線時は
 	// publish skip = 旧挙動 (= reconnect で反映)。
 	hardMutePublisher HardMutePublisher
+	// pinDeliveryHook は note pin/unpin 時に Add/Remove(featured) を followers へ
+	// 配信する (#2024)。未配線なら連合配信 skip。
+	pinDeliveryHook PinDeliveryHook
 	// profileUpdateHook は profile 編集時に Update(Person) を followers へ
 	// 配信する (#1560)。nil なら配信しない。
 	profileUpdateHook ProfileUpdateHook
@@ -156,6 +159,17 @@ type HardMutePublisher interface {
 // profile edit (#1560)。実装は core/federation。
 type ProfileUpdateHook interface {
 	OnLocalProfileUpdated(userID string)
+}
+
+// PinDeliveryHook delivers Add/Remove(featured collection) to remote followers
+// when a local user pins/unpins a note (#2024)。実装は core/federation。
+type PinDeliveryHook interface {
+	OnLocalPinChanged(userID, noteID string, isAddition bool)
+}
+
+// SetPinDeliveryHook wires the AP Add/Remove featured-collection delivery hook (#2024)。
+func (h *Handler) SetPinDeliveryHook(hook PinDeliveryHook) {
+	h.pinDeliveryHook = hook
 }
 
 // SetHardMutePublisher wires a publisher that emits wordmute reload events
@@ -1797,6 +1811,11 @@ func (h *Handler) Pin(c echo.Context) error {
 		}
 	}
 
+	// featured collection への pin を followers/relay へ連合配信 (#2024)。
+	if h.pinDeliveryHook != nil {
+		h.pinDeliveryHook.OnLocalPinChanged(me.ID, req.NoteID, true)
+	}
+
 	return h.Me(c)
 }
 
@@ -1814,6 +1833,11 @@ func (h *Handler) Unpin(c echo.Context) error {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "454170ce-9d63-4a43-9da1-ea10afe81e21"))
 		}
 		return apierr.JSONInternalError(c)
+	}
+
+	// featured collection からの unpin を followers/relay へ連合配信 (#2024)。
+	if h.pinDeliveryHook != nil {
+		h.pinDeliveryHook.OnLocalPinChanged(me.ID, req.NoteID, false)
 	}
 
 	return h.Me(c)

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -2103,6 +2103,46 @@ func TestPin_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// fakePinHook records OnLocalPinChanged calls for #2024 wiring tests.
+type fakePinHook struct {
+	calls []struct {
+		userID, noteID string
+		isAddition     bool
+	}
+}
+
+func (f *fakePinHook) OnLocalPinChanged(userID, noteID string, isAddition bool) {
+	f.calls = append(f.calls, struct {
+		userID, noteID string
+		isAddition     bool
+	}{userID, noteID, isAddition})
+}
+
+// #2024: Pin/Unpin 成功時に PinDeliveryHook が (userID, noteID, isAddition) で呼ばれ、
+// 失敗時は呼ばれない。
+func TestPin_InvokesDeliveryHook(t *testing.T) {
+	h, repo, noteRepo, _ := newTestHandler(t)
+	hook := &fakePinHook{}
+	h.SetPinDeliveryHook(hook)
+	user := &model.User{ID: "user1", Username: "user1", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["user1"] = user
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "user1"}
+
+	require.Equal(t, http.StatusOK, post(h.Pin, `{"noteId":"n1"}`, user).Code)
+	require.Len(t, hook.calls, 1)
+	assert.Equal(t, "user1", hook.calls[0].userID)
+	assert.Equal(t, "n1", hook.calls[0].noteID)
+	assert.True(t, hook.calls[0].isAddition, "pin は isAddition=true (#2024)")
+
+	require.Equal(t, http.StatusOK, post(h.Unpin, `{"noteId":"n1"}`, user).Code)
+	require.Len(t, hook.calls, 2)
+	assert.False(t, hook.calls[1].isAddition, "unpin は isAddition=false (#2024)")
+
+	// pin 失敗 (note 不在) では hook を呼ばない。
+	require.Equal(t, http.StatusNotFound, post(h.Pin, `{"noteId":"ghost"}`, user).Code)
+	assert.Len(t, hook.calls, 2, "pin 失敗時は hook を呼ばない (#2024)")
+}
+
 func TestPin_NoteNotFound(t *testing.T) {
 	h, repo, _, _ := newTestHandler(t)
 	user := &model.User{ID: "user1", AvatarDecorations: datatypes.JSON([]byte("[]"))}

--- a/internal/core/federation/pin_delivery_hook.go
+++ b/internal/core/federation/pin_delivery_hook.go
@@ -1,0 +1,78 @@
+package federation
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/shiroha-a/mk/internal/activitypub"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// PinDeliveryHook delivers an Add / Remove(featured collection) activity to a
+// local user's remote followers when they pin / unpin a note (#2024、upstream
+// NotePiningService.deliverPinnedChange)。これにより remote instance が actor の
+// featured collection (pinned notes) の変更を反映できる。
+//
+// upstream の gate に合わせ、local user かつ note が !localOnly かつ visibility が
+// public/home のときだけ配信する (それ以外は連合露出範囲外)。失敗はベスト
+// エフォートで log のみ。
+type PinDeliveryHook struct {
+	deliver  *DeliverService
+	renderer *activitypub.Renderer
+	userRepo repository.UserRepository
+	noteRepo repository.NoteRepository
+	// relay は pin 変更を relay subscriber にも fan-out する optional 依存
+	// (upstream deliverToRelays)。nil なら relay 配送 skip。
+	relay RelayBroadcaster
+}
+
+// NewPinDeliveryHook constructs a PinDeliveryHook.
+func NewPinDeliveryHook(deliver *DeliverService, renderer *activitypub.Renderer, userRepo repository.UserRepository, noteRepo repository.NoteRepository) *PinDeliveryHook {
+	return &PinDeliveryHook{deliver: deliver, renderer: renderer, userRepo: userRepo, noteRepo: noteRepo}
+}
+
+// SetRelayBroadcaster wires the relay fan-out target (#2024)。
+func (h *PinDeliveryHook) SetRelayBroadcaster(r RelayBroadcaster) {
+	h.relay = r
+}
+
+// OnLocalPinChanged renders Add (pin) / Remove (unpin) and fans it out to the
+// user's remote followers + relays (#2024)。
+func (h *PinDeliveryHook) OnLocalPinChanged(userID, noteID string, isAddition bool) {
+	if h.deliver == nil || h.renderer == nil || h.userRepo == nil || h.noteRepo == nil {
+		return
+	}
+	user, err := h.userRepo.FindByID(userID)
+	if err != nil || user == nil || !user.IsLocal() {
+		return
+	}
+	note, err := h.noteRepo.FindByID(noteID)
+	if err != nil || note == nil {
+		return
+	}
+	// upstream NotePiningService の gate: localOnly や followers/specified note は
+	// 連合配信しない (featured collection に出ない)。
+	if note.LocalOnly || (note.Visibility != model.NoteVisibilityPublic && note.Visibility != model.NoteVisibilityHome) {
+		return
+	}
+	var activity any
+	if isAddition {
+		activity = h.renderer.RenderAddToFeatured(userID, noteID)
+	} else {
+		activity = h.renderer.RenderRemoveFromFeatured(userID, noteID)
+	}
+	body, err := json.Marshal(activity)
+	if err != nil {
+		return
+	}
+	if err := h.deliver.DeliverToFollowers(userID, body); err != nil {
+		slog.Warn("pin delivery: deliver to followers failed", "userID", userID, "noteID", noteID, "err", err)
+	}
+	if h.relay != nil {
+		if err := h.relay.DeliverToAccepted(context.Background(), userID, activity); err != nil {
+			slog.Warn("pin delivery: relay deliver failed", "userID", userID, "noteID", noteID, "err", err)
+		}
+	}
+}

--- a/internal/core/federation/pin_delivery_hook_test.go
+++ b/internal/core/federation/pin_delivery_hook_test.go
@@ -1,0 +1,70 @@
+package federation_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/activitypub"
+	federation "github.com/shiroha-a/mk/internal/core/federation"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newPinHook(t *testing.T) (*federation.PinDeliveryHook, *stubEnqueuer, *testutil.MockUserRepository, *testutil.MockFollowingRepository, *testutil.MockUserKeypairRepository, *testutil.MockNoteRepository) {
+	t.Helper()
+	deliver, enq, userRepo, followingRepo, keypairRepo := newDeliverService(t)
+	noteRepo := testutil.NewMockNoteRepository()
+	renderer := activitypub.NewRenderer(activitypub.NewURLBuilder("https://example.com"))
+	hook := federation.NewPinDeliveryHook(deliver, renderer, userRepo, noteRepo)
+	return hook, enq, userRepo, followingRepo, keypairRepo, noteRepo
+}
+
+// #2024: public/home note の pin は Add(featured)、unpin は Remove を followers へ配信。
+func TestPinHook_DeliversAddRemoveForPublicNote(t *testing.T) {
+	hook, enq, userRepo, followingRepo, keypairRepo, noteRepo := newPinHook(t)
+	installLocalSigner(t, userRepo, keypairRepo)
+	followingRepo.RemoteInboxes["alice"] = []string{"https://remote.example/inbox"}
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "alice", Visibility: model.NoteVisibilityPublic}
+
+	hook.OnLocalPinChanged("alice", "n1", true)
+	require.Len(t, enq.calls, 1)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(enq.calls[0].Body, &got))
+	assert.Equal(t, "Add", got["type"])
+	assert.Equal(t, "https://example.com/users/alice/collections/featured", got["target"])
+	assert.Equal(t, "https://example.com/notes/n1", got["object"])
+
+	enq.calls = nil
+	hook.OnLocalPinChanged("alice", "n1", false)
+	require.Len(t, enq.calls, 1)
+	require.NoError(t, json.Unmarshal(enq.calls[0].Body, &got))
+	assert.Equal(t, "Remove", got["type"], "unpin は Remove (#2024)")
+}
+
+// #2024: localOnly / followers-or-specified note は連合露出範囲外なので配信しない。
+func TestPinHook_SkipsLocalOnlyAndFollowers(t *testing.T) {
+	hook, enq, userRepo, followingRepo, keypairRepo, noteRepo := newPinHook(t)
+	installLocalSigner(t, userRepo, keypairRepo)
+	followingRepo.RemoteInboxes["alice"] = []string{"https://remote.example/inbox"}
+	noteRepo.Notes["local"] = &model.Note{ID: "local", UserID: "alice", Visibility: model.NoteVisibilityPublic, LocalOnly: true}
+	noteRepo.Notes["fol"] = &model.Note{ID: "fol", UserID: "alice", Visibility: model.NoteVisibilityFollowers}
+
+	hook.OnLocalPinChanged("alice", "local", true)
+	hook.OnLocalPinChanged("alice", "fol", true)
+	assert.Empty(t, enq.calls, "localOnly / followers note は連合配信しない (#2024)")
+}
+
+// #2024: remote user / 不在 note は配信しない。
+func TestPinHook_SkipsRemoteAndMissing(t *testing.T) {
+	hook, enq, userRepo, _, keypairRepo, noteRepo := newPinHook(t)
+	installLocalSigner(t, userRepo, keypairRepo)
+	host := "remote.example"
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob", Host: &host}
+	noteRepo.Notes["n1"] = &model.Note{ID: "n1", UserID: "bob", Visibility: model.NoteVisibilityPublic}
+
+	hook.OnLocalPinChanged("bob", "n1", true)      // remote user
+	hook.OnLocalPinChanged("alice", "ghost", true) // 不在 note
+	assert.Empty(t, enq.calls)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2145,6 +2145,10 @@ func (s *Server) setupRoutes() {
 	profileUpdateHook.SetKeypairExtraRepo(keypairExtraRepo)
 	profileUpdateHook.SetRelayBroadcaster(relaySvc)
 	iHandler.SetProfileUpdateHook(profileUpdateHook)
+	// note pin/unpin の Add/Remove(featured collection) を followers/relay へ配信 (#2024)。
+	pinDeliveryHook := corefederation.NewPinDeliveryHook(deliverService, apRenderer, userRepo, noteRepo)
+	pinDeliveryHook.SetRelayBroadcaster(relaySvc)
+	iHandler.SetPinDeliveryHook(pinDeliveryHook)
 	notePublisher := stream.NewNotePublisher(streamPubSub, idGen)
 	notePublisher.SetEmojiLookup(emojiRepo)
 	notePublisher.SetInstanceLookup(instanceRepo)


### PR DESCRIPTION
## Summary

#1948-21 の scope に含まれていた outbound 機能。local user が note を pin/unpin した際、featured
collection への Add/Remove activity を followers + relay へ配信する (upstream
`NotePiningService.deliverPinnedChange`)。inbound `handleAdd`/`handleRemove` は実装済。

## 主な変更点

- **renderer** (`types.go`/`renderer.go`): `Add` struct + `AddContext` の `*Add` case を追加。
  `RenderAddToFeatured(userID, noteID)` / `RenderRemoveFromFeatured(userID, noteID)` を追加
  (`actor`=UserURI, `target`=featured collection, `object`=note URI, `id`+`@context`。upstream
  `ApRendererService.renderAdd`/`renderRemove` + `addContext` の id 注入と一致)。
- **PinDeliveryHook** (`pin_delivery_hook.go`): `OnLocalPinChanged(userID, noteID, isAddition)` —
  upstream gate (`isLocalUser && !localOnly && visibility ∈ {public,home}`) で Add/Remove を
  `DeliverToFollowers` + relay `DeliverToAccepted` に配信。配信失敗は best-effort (pin 操作を巻き戻さない)。
- **i/handler**: `Pin`/`Unpin` が `PinNote`/`UnpinNote` 成功後に hook を呼ぶ (失敗時は呼ばない)。
  `router.go` で wire。

## テスト

- renderer の Add/Remove shape / hook が public note で Add(pin)・Remove(unpin) を配信、localOnly・
  followers note / remote user / 不在 note を skip / i/handler が Pin/Unpin 成功時に hook を呼び失敗時は
  呼ばない。
- activitypub 92.6% / federation 90.1% / i 90.6%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで shape / gate / delivery (followers+relay) / trigger / 二重配信なしを upstream と照合し
parity 違反なしを確認 (home visibility の relay 配信が upstream 忠実であることも含む)。inbound Add/Remove
の受信反映は本タスク (outbound 専用) のスコープ外。

## 関連

- 親: #1948
- 発見元: #1948-21

Closes #2024
