### PR TITLE
Fix admin emoji query parity (#2034): originalUrl filter 撤去 + legacy aliases 要素単位突合

### DIFF
--- a/internal/repository/emoji.go
+++ b/internal/repository/emoji.go
@@ -213,8 +213,10 @@ func (r *emojiRepository) ListWithFilter(query, category string, local bool, sin
 		} else {
 			// upstream list.ts は JS String.includes (case-sensitive 部分一致) で
 			// in-memory filter する。mk-go も case-sensitive LIKE に揃える (#1948-13)。
+			// aliases は upstream の `aliases.some(a => a.includes(q))` と同じく要素単位で
+			// 突合する (array_to_string 結合だと要素境界を跨いだ誤 match が起きる、#2034)。
 			like := "%" + escapeLike(query) + "%"
-			q = q.Where(`name LIKE ? ESCAPE '\' OR array_to_string(aliases, ',') LIKE ? ESCAPE '\' OR category LIKE ? ESCAPE '\'`, like, like, like)
+			q = q.Where(`name LIKE ? ESCAPE '\' OR EXISTS (SELECT 1 FROM unnest(aliases) AS alias WHERE alias LIKE ? ESCAPE '\') OR category LIKE ? ESCAPE '\'`, like, like, like)
 		}
 	}
 	if category != "" {
@@ -321,7 +323,9 @@ func (r *emojiRepository) buildV2Query(filter model.EmojiV2Filter) *gorm.DB {
 		likeAny("license", fq.License)
 		likeAny("uri", fq.URI)
 		likeAny(`"publicUrl"`, fq.PublicURL)
-		likeAny(`"originalUrl"`, fq.OriginalURL)
+		// originalUrl は upstream v2 list の paramDef にあるが fetchEmojis では WHERE 句に
+		// 使われず無視される。filter すると upstream と乖離するため適用しない (#2034。
+		// EmojiV2Query.OriginalURL は request 互換のため残すが query では使わない)。
 		// aliases は配列要素ごとに突合する (upstream は unnest(aliases) の subquery)。
 		// array_to_string 結合では要素境界を跨いだ誤 match が起きるため避ける。
 		if fq.Aliases != "" {

--- a/internal/repository/emoji_test.go
+++ b/internal/repository/emoji_test.go
@@ -902,3 +902,32 @@ func TestEmojiRepository_ListV2_TypeFilter(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, rows, 1)
 }
+
+// #2034: v2 list の originalUrl filter は upstream fetchEmojis で無視されるので、
+// originalUrl query を指定しても絞り込まれない。
+func TestEmojiRepository_ListV2_OriginalURLIgnored(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+	e := &model.Emoji{ID: "evou1", Name: "evouname", OriginalURL: "https://real.example/x"}
+	require.NoError(t, repo.Create(e))
+	defer cleanupEmoji(t, e.ID)
+	rows, err := repo.ListV2(model.EmojiV2Filter{Query: &model.EmojiV2Query{Name: "evouname", OriginalURL: "nonmatching"}, Limit: 10})
+	require.NoError(t, err)
+	assert.Len(t, rows, 1, "originalUrl filter は無視される (#2034)")
+}
+
+// #2034: legacy list の aliases は要素単位で突合する (array_to_string 結合の要素境界
+// 跨ぎ誤 match を避ける)。
+func TestEmojiRepository_ListWithFilter_AliasesElementBoundary(t *testing.T) {
+	repo := NewEmojiRepository(testDB)
+	e := &model.Emoji{ID: "elb1", Name: "elbname", OriginalURL: "https://x", Aliases: pq.StringArray{"foo", "bar"}}
+	require.NoError(t, repo.Create(e))
+	defer cleanupEmoji(t, e.ID)
+	// "foo,bar" は結合文字列 "foo,bar" には部分一致するが、単一 alias には無い。
+	rows, err := repo.ListWithFilter("foo,bar", "", false, "", "", 10, 0)
+	require.NoError(t, err)
+	assert.Empty(t, rows, "要素境界を跨いだ query は match しない (#2034)")
+	// 単一要素 "foo" は match する。
+	rows, err = repo.ListWithFilter("foo", "", false, "", "", 10, 0)
+	require.NoError(t, err)
+	assert.Len(t, rows, 1)
+}


### PR DESCRIPTION
## Summary

#1999 (admin emoji v2 query) の敵対的レビューで残した emoji query parity の 2 項目を対応する。

## 主な変更点

- **v2 buildV2Query**: `originalUrl` filter を撤去。upstream v2 admin emoji list は paramDef で
  `originalUrl` を受理するが `CustomEmojiService.fetchEmojis` の WHERE 句に使わず**無視**する。mk-go が
  filter していたのは upstream に無い挙動なので撤去 (`EmojiV2Query.OriginalURL` は request bind 互換の
  ため残す。drop-in frontend も originalUrl を検索 filter として送らない)。
- **legacy ListWithFilter**: aliases 突合を `array_to_string(aliases, ',') LIKE` → `EXISTS (SELECT 1
  FROM unnest(aliases) AS alias WHERE alias LIKE ...)` に変更。upstream legacy list の
  `aliases.some(a => a.includes(q))` (要素単位) と一致し、結合文字列の要素境界跨ぎ誤 match を回避。
  v2 (#1999) と同じパターンに揃える。

## テスト

- v2 originalUrl query が無視され絞り込まれない / legacy aliases が `"foo,bar"` で要素 `["foo","bar"]` を
  誤 match せず単一要素 `"foo"` で match。
- repository 90.1%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで originalUrl 撤去が upstream parity 正しく drop-in を壊さないこと、legacy aliases unnest が
`aliases.some` と論理等価で空配列誤 match なし・case-sensitivity 維持を確認。broadcast stream
(emojiAdded/Updated/Deleted) は emoji 固有でない cross-cutting infra (announcements と共有) のため #2046
に切り出し。legacy list の limit+1 quirk は upstream 自身の off-by-one bug 追従で低価値のため未対応。

## 関連

- 親: #1948
- 元: #1999 のレビュー

Closes #2034
