### PR TITLE
Add note.tags backfill tool (#2013): 既存 note を NFKC+lowercase 正規化

### DIFF
--- a/cmd/backfill-note-tags/main.go
+++ b/cmd/backfill-note-tags/main.go
@@ -1,0 +1,79 @@
+// Command backfill-note-tags normalizes existing note.tags to the NFKC +
+// lowercase form that NoteCreateService now stores for new notes (#1948-18 /
+// #2013). It is needed because search-by-tag normalizes the query, so old
+// uppercase / full-width tags would otherwise stop matching.
+//
+// 本番 (大きな note テーブル) では負荷を考慮し、--batch / --sleep-ms で速度を
+// 絞り、maintenance window で段階実行すること。--from で中断地点から再開できる。
+// 冪等なので途中失敗しても --from で安全に再開でき、再実行しても既正規化 note は
+// touch しない。まず --dry-run で更新件数を見積もってから実行するのを推奨する。
+//
+// 性能上の注意: WHERE 句の `cardinality(tags) > 0` に対応する index は無いため、
+// tagged note が疎なテーブルでは LIMIT 前に空 tag 行の heap filter が走り、各 batch の
+// レイテンシが膨らみうる。事前に --dry-run で総走査コストを実測し、必要なら一時的に
+// `CREATE INDEX CONCURRENTLY ... ON note (id) WHERE cardinality(tags) > 0` を貼って
+// から実行 (完了後 DROP) することを検討する。
+//
+// なお >32 個の case-variant 重複 tag を持つ古い note では、backfill 結果が「今 fresh
+// に作成した場合の値」と完全一致しないことがある (旧 Extract は case-insensitive dedup、
+// 現 NormalizeNoteTags は case-sensitive dedup)。全 tag は正しく正規化され検索可能で、
+// 余分に残るのは marginal tag のみ (検索上は寛容側) なのでデータ破損ではない。
+//
+//	backfill-note-tags -config .config/default.yml -dry-run
+//	backfill-note-tags -config .config/default.yml -batch 1000 -sleep-ms 200
+//	backfill-note-tags -config .config/default.yml -from <last-id>   # 再開
+package main
+
+import (
+	"flag"
+	"log"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/config"
+	"github.com/shiroha-a/mk/internal/maintenance"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func main() {
+	cfgPath := flag.String("config", "/app/.config/default.yml", "path to mk-go config file")
+	batchSize := flag.Int("batch", 1000, "notes per keyset batch")
+	sleepMs := flag.Int("sleep-ms", 100, "sleep between batches to limit DB load")
+	fromID := flag.String("from", "", "resume from note id (exclusive)")
+	dryRun := flag.Bool("dry-run", false, "count changes without writing")
+	flag.Parse()
+
+	cfg, err := config.Load(*cfgPath)
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+	db, err := gorm.Open(postgres.Open(cfg.DSN()), &gorm.Config{})
+	if err != nil {
+		log.Fatalf("open db: %v", err)
+	}
+
+	cursor := *fromID
+	var totalScanned, totalUpdated int
+	for {
+		res, err := maintenance.BackfillNoteTagsBatch(db, cursor, *batchSize, *dryRun)
+		if err != nil {
+			log.Fatalf("backfill batch (cursor=%q): %v", cursor, err)
+		}
+		if res.Scanned == 0 {
+			break
+		}
+		cursor = res.LastID
+		totalScanned += res.Scanned
+		totalUpdated += res.Updated
+		log.Printf("batch scanned=%d updated=%d cursor=%s (total scanned=%d updated=%d)",
+			res.Scanned, res.Updated, cursor, totalScanned, totalUpdated)
+		if *sleepMs > 0 {
+			time.Sleep(time.Duration(*sleepMs) * time.Millisecond)
+		}
+	}
+	mode := "applied"
+	if *dryRun {
+		mode = "dry-run (no writes)"
+	}
+	log.Printf("done [%s]: scanned=%d updated=%d", mode, totalScanned, totalUpdated)
+}

--- a/internal/maintenance/note_tags_backfill.go
+++ b/internal/maintenance/note_tags_backfill.go
@@ -1,0 +1,68 @@
+// Package maintenance holds app-level batch jobs that cannot be expressed as
+// pure SQL migrations (e.g. NFKC normalization). They are driven by standalone
+// CLIs under cmd/ and are safe to run incrementally against a live DB.
+package maintenance
+
+import (
+	"slices"
+
+	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/misc/hashtag"
+	"github.com/shiroha-a/mk/internal/model"
+	"gorm.io/gorm"
+)
+
+// NoteTagsBackfillResult reports the outcome of one keyset batch.
+type NoteTagsBackfillResult struct {
+	Scanned int    // notes inspected this batch
+	Updated int    // notes whose tags changed (0 when dryRun only counts)
+	LastID  string // greatest note id seen; "" when no rows remained
+}
+
+// BackfillNoteTagsBatch normalizes one keyset batch of non-empty note.tags via
+// hashtag.NormalizeNoteTags (NFKC + lowercase + >128 drop + 32 cap + dedup),
+// matching what NoteCreateService now stores for new notes (#1948-18 / #2013).
+//
+// 既存 note は旧 hashtag.Extract で original-case のまま格納されており、search-by-tag
+// の query が normalize されるため uppercase/全角 tag が match しなくなる回帰がある。
+// これを batch で正規化する。fromID より大きい id の note を id ASC で batchSize 件
+// 取り、変更があった行だけ UPDATE する。dryRun は UPDATE をせず件数のみ数える。
+//
+// 戻り値の LastID を次回の fromID に渡せば再開可能 (resumable)。LastID=="" は対象が
+// 尽きたことを示す。NFKC は SQL で表現できないため app-level で行う。
+func BackfillNoteTagsBatch(db *gorm.DB, fromID string, batchSize int, dryRun bool) (NoteTagsBackfillResult, error) {
+	if batchSize <= 0 {
+		batchSize = 1000
+	}
+	var notes []*model.Note
+	q := db.Model(&model.Note{}).
+		Select("id", "tags").
+		Where("id > ? AND cardinality(tags) > 0", fromID).
+		Order("id ASC").
+		Limit(batchSize)
+	if err := q.Find(&notes).Error; err != nil {
+		return NoteTagsBackfillResult{}, err
+	}
+	res := NoteTagsBackfillResult{}
+	for _, n := range notes {
+		res.Scanned++
+		res.LastID = n.ID
+		normalized := hashtag.NormalizeNoteTags([]string(n.Tags))
+		if slices.Equal([]string(n.Tags), normalized) {
+			continue
+		}
+		res.Updated++
+		if dryRun {
+			continue
+		}
+		// nil は SQL NULL になり note.tags (NOT NULL) を壊すので空配列に倒す。
+		newTags := pq.StringArray(normalized)
+		if newTags == nil {
+			newTags = pq.StringArray{}
+		}
+		if err := db.Model(&model.Note{}).Where("id = ?", n.ID).Update("tags", newTags).Error; err != nil {
+			return res, err
+		}
+	}
+	return res, nil
+}

--- a/internal/maintenance/note_tags_backfill_test.go
+++ b/internal/maintenance/note_tags_backfill_test.go
@@ -1,0 +1,108 @@
+package maintenance
+
+import (
+	"os"
+	"testing"
+
+	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+var testDB *gorm.DB
+
+func TestMain(m *testing.M) {
+	db, err := testutil.OpenTestDB()
+	if err != nil {
+		panic("failed to open test DB: " + err.Error())
+	}
+	testDB = db
+	testutil.ApplyMigrations(testDB)
+	os.Exit(m.Run())
+}
+
+func seedBackfillUser(t *testing.T, id string) {
+	t.Helper()
+	token := "tok_" + id
+	require.NoError(t, testDB.Create(&model.User{
+		ID: id, Username: id, UsernameLower: id, Token: &token,
+		AvatarDecorations: datatypes.JSON([]byte("[]")),
+	}).Error)
+	t.Cleanup(func() { testDB.Exec(`DELETE FROM "user" WHERE id = ?`, id) })
+}
+
+func seedBackfillNote(t *testing.T, id, userID string, tags []string) {
+	t.Helper()
+	require.NoError(t, testDB.Create(&model.Note{
+		ID: id, UserID: userID, Visibility: model.NoteVisibilityPublic, Tags: pq.StringArray(tags),
+	}).Error)
+	t.Cleanup(func() { testDB.Exec(`DELETE FROM "note" WHERE id = ?`, id) })
+}
+
+func tagsOf(t *testing.T, id string) []string {
+	t.Helper()
+	var n model.Note
+	require.NoError(t, testDB.Select("id", "tags").First(&n, "id = ?", id).Error)
+	return []string(n.Tags)
+}
+
+// #2013: backfill は uppercase/全角 tag を NFKC+lowercase 正規化し、既に正規化済の
+// note と空 tag note は変更しない。
+func TestBackfillNoteTagsBatch(t *testing.T) {
+	seedBackfillUser(t, "bf_u1")
+	seedBackfillNote(t, "bf_n1", "bf_u1", []string{"Misskey", "ＴＯＫＹＯ"}) // uppercase + 全角
+	seedBackfillNote(t, "bf_n2", "bf_u1", []string{"already"})          // 正規化済
+	seedBackfillNote(t, "bf_n3", "bf_u1", []string{})                   // 空 (filter で除外)
+
+	res, err := BackfillNoteTagsBatch(testDB, "", 100, false)
+	require.NoError(t, err)
+	assert.Equal(t, 2, res.Scanned, "非空 tag note のみ scan (n1, n2)")
+	assert.Equal(t, 1, res.Updated, "n1 のみ正規化で変更")
+
+	assert.Equal(t, []string{"misskey", "tokyo"}, tagsOf(t, "bf_n1"), "n1 が NFKC+lowercase 正規化 (#2013)")
+	assert.Equal(t, []string{"already"}, tagsOf(t, "bf_n2"), "n2 は不変")
+}
+
+// #2013: dry-run は更新件数を数えるが書き込まない。
+func TestBackfillNoteTagsBatch_DryRun(t *testing.T) {
+	seedBackfillUser(t, "bfd_u1")
+	seedBackfillNote(t, "bfd_n1", "bfd_u1", []string{"Upper"})
+
+	res, err := BackfillNoteTagsBatch(testDB, "", 100, true)
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Updated, "dry-run でも変更予定を数える")
+	assert.Equal(t, []string{"Upper"}, tagsOf(t, "bfd_n1"), "dry-run は書き込まない (#2013)")
+}
+
+// #2013: keyset 再開。fromID より大きい id のみ処理する。
+func TestBackfillNoteTagsBatch_Resumable(t *testing.T) {
+	seedBackfillUser(t, "bfr_u1")
+	seedBackfillNote(t, "bfr_a", "bfr_u1", []string{"AAA"})
+	seedBackfillNote(t, "bfr_b", "bfr_u1", []string{"BBB"})
+
+	// fromID="bfr_a" は bfr_a を除外し bfr_b のみ処理。
+	res, err := BackfillNoteTagsBatch(testDB, "bfr_a", 100, false)
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Scanned)
+	assert.Equal(t, "bfr_b", res.LastID)
+	assert.Equal(t, []string{"AAA"}, tagsOf(t, "bfr_a"), "fromID 以下は触らない")
+	assert.Equal(t, []string{"bbb"}, tagsOf(t, "bfr_b"), "fromID より大は正規化")
+}
+
+// #2013: batchSize<=0 は 1000 に default 化する。空文字列 tag のみの note は
+// 正規化で全 drop され tags が空配列にクリアされる (newTags==nil → '{}')。
+func TestBackfillNoteTagsBatch_DefaultBatchAndEmptyClear(t *testing.T) {
+	seedBackfillUser(t, "bfe_u1")
+	seedBackfillNote(t, "bfe_n1", "bfe_u1", []string{""}) // 空文字列 element
+
+	// batchSize=0 → default。
+	res, err := BackfillNoteTagsBatch(testDB, "bfe_", 0, false)
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Scanned)
+	assert.Equal(t, 1, res.Updated)
+	assert.Empty(t, tagsOf(t, "bfe_n1"), "全 drop で tags が空配列にクリアされる (#2013)")
+}


### PR DESCRIPTION
## Summary

#1948-18 で新規 note の tags を `normalizeForSearch` (NFKC+lowercase) で格納し search-by-tag の query も
正規化したが、**既存 note** は旧 `hashtag.Extract` で original-case のまま格納されており、uppercase/全角
tag が検索できない回帰が残っていた。NFKC は SQL で表現できないため app-level batch ツールを実装する。

## 主な変更点

- **`internal/maintenance.BackfillNoteTagsBatch`**: `id > fromID AND cardinality(tags) > 0` の note を
  id ASC で `batchSize` 件取得し、`hashtag.NormalizeNoteTags` (= store 経路 `ExtractNoteTags` と同一関数)
  で正規化、変更があった行だけ `tags` 列を UPDATE。`LastID` で resumable、`dryRun` 対応。冪等
  (再実行で既正規化 note は touch しない)。`note` テーブルに `updatedAt` 列は無く単一列 update なので
  edit 扱いの誤発火もなし。
- **`cmd/backfill-note-tags`**: config 読込 → keyset loop (`-batch`/`-sleep-ms`/`-from`/`-dry-run`)。
  本番は段階実行・事前 dry-run・(疎テーブルでの) 一時 partial index を usage に明記。

## テスト

- NFKC+lowercase 正規化 / 既正規化・空 tag note の不変 / dry-run 非書き込み / keyset 再開 / batchSize
  default / 全 drop で空配列クリア (testcontainers)。
- maintenance 90.9%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで正規化の store/backfill/query 三者一致、冪等性・無限ループ不可・単一列 update・NOT NULL
防御を確認 (データ破損・正規化乖離なし)。性能注意 (cardinality filter に index 無し → 疎テーブルで
PK walk + per-row filter) を usage doc に明記。**本番 (UDS) は operator が maintenance window で実行する
想定で、本 PR では実行しない**。

## 関連

- 親: #1948
- 発見元: #1948-18

Closes #2013
