### PR TITLE
Fix value-semantics parity (#2027 batch1): ping number / alsoKnownAs [] / bubble-game cacheSec

### DIFF
--- a/internal/api/bubblegame/handler.go
+++ b/internal/api/bubblegame/handler.go
@@ -113,5 +113,10 @@ func (h *Handler) Ranking(c echo.Context) error {
 		}
 		result[i] = entry
 	}
+	// upstream ranking.ts は cacheSec:60 → 未認証 GET に Cache-Control: public,
+	// max-age=60 を付ける (ApiCallService。POST/認証済みには付けない、#2027)。
+	if c.Request().Method == http.MethodGet && middleware.GetUser(c) == nil && middleware.GetToken(c) == "" {
+		c.Response().Header().Set("Cache-Control", "public, max-age=60")
+	}
 	return c.JSON(http.StatusOK, result)
 }

--- a/internal/api/bubblegame/handler_test.go
+++ b/internal/api/bubblegame/handler_test.go
@@ -176,6 +176,17 @@ func TestRanking_GetWithQueryParam(t *testing.T) {
 	var resp []any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Len(t, resp, 1)
+	// #2027: 未認証 GET には cacheSec:60 由来の Cache-Control が付く。
+	assert.Equal(t, "public, max-age=60", rec.Header().Get("Cache-Control"))
+}
+
+// #2027: POST (= 非 GET) には Cache-Control を付けない。
+func TestRanking_PostNoCacheControl(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.records = []*model.BubbleGameRecord{{ID: "r1", Score: 200}}
+	rec := post(h.Ranking, `{"gameMode":"normal"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, rec.Header().Get("Cache-Control"), "POST には Cache-Control を付けない (#2027)")
 }
 
 // GET で gameMode が無ければ POST 同様 400。

--- a/internal/api/meta/handler.go
+++ b/internal/api/meta/handler.go
@@ -189,8 +189,10 @@ func (h *Handler) Meta(c echo.Context) error {
 // Ping returns a simple pong response.
 // POST /api/ping
 func (h *Handler) Ping(c echo.Context) error {
+	// upstream ping.ts は `{ pong: Date.now() }` (epoch-ms number) を返す。
+	// misskey-js PingResponse.pong も number 型 (boolean ではない、#2027)。
 	return c.JSON(http.StatusOK, map[string]any{
-		"pong": true,
+		"pong": time.Now().UnixMilli(),
 	})
 }
 

--- a/internal/api/meta/handler_test.go
+++ b/internal/api/meta/handler_test.go
@@ -130,7 +130,10 @@ func TestPing(t *testing.T) {
 
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	assert.Equal(t, true, resp["pong"])
+	// #2027: pong は epoch-ms number (boolean ではない)。JSON round-trip で float64。
+	pong, ok := resp["pong"].(float64)
+	require.True(t, ok, "pong は number (#2027)")
+	assert.Greater(t, pong, float64(0))
 }
 
 // requireSetup は rootUserId が nil のとき true を返す。

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -690,18 +690,22 @@ func (d *UserDetailed) ResolveMoveTargets(u *model.User, resolve MoveTargetResol
 		}
 	}
 	if u.AlsoKnownAs != nil && *u.AlsoKnownAs != "" {
-		var ids []string
+		ids := []string{} // 非 nil。解決後 0 件でも [] を serialize する。
+		hadURI := false
 		for _, uri := range strings.Split(*u.AlsoKnownAs, ",") {
 			uri = strings.TrimSpace(uri)
 			if uri == "" {
 				continue
 			}
+			hadURI = true
 			if id, ok := resolve(uri); ok {
 				ids = append(ids, id)
 			}
 		}
-		// upstream は解決後 0 件なら null (空配列にしない)。
-		if len(ids) > 0 {
+		// upstream は `xs.length === 0 ? null : xs.filter(...)` で、xs は解決結果の配列
+		// (filter 前)。alsoKnownAs に >=1 URI があれば xs.length>=1 なので、全 URI が
+		// 解決不能でも null ではなく [] を返す。URI が皆無のときだけ null (#2027)。
+		if hadURI {
 			d.AlsoKnownAs = ids
 		}
 	}

--- a/internal/entity/user_test.go
+++ b/internal/entity/user_test.go
@@ -311,6 +311,26 @@ func TestResolveMoveTargets(t *testing.T) {
 	assert.Equal(t, []string{"x_id", "y_id"}, d.AlsoKnownAs)
 }
 
+// #2027: alsoKnownAs に URI はあるが全て解決不能なら、null ではなく [] を返す
+// (upstream xs.length===0?null は URI 皆無のときだけ true)。
+func TestResolveMoveTargets_AllUnresolvableYieldsEmptyArray(t *testing.T) {
+	aka := "https://unknown.example/users/a, https://unknown.example/users/b"
+	u := &model.User{ID: "u1", AlsoKnownAs: &aka}
+	resolve := func(string) (string, bool) { return "", false } // 全て解決不能
+
+	d := PackUserDetailed(u, nil)
+	d.ResolveMoveTargets(u, resolve)
+	require.NotNil(t, d.AlsoKnownAs, "URI があれば全解決不能でも [] (#2027)")
+	assert.Empty(t, d.AlsoKnownAs)
+
+	// URI が皆無 (空文字列) のときは null のまま。
+	empty := ""
+	u2 := &model.User{ID: "u2", AlsoKnownAs: &empty}
+	d2 := PackUserDetailed(u2, nil)
+	d2.ResolveMoveTargets(u2, resolve)
+	assert.Nil(t, d2.AlsoKnownAs, "URI 皆無は null")
+}
+
 func TestResolveMoveTargets_NilAndUnresolvable(t *testing.T) {
 	// nil resolve / nil user は no-op。
 	d := UserDetailed{}
@@ -318,14 +338,16 @@ func TestResolveMoveTargets_NilAndUnresolvable(t *testing.T) {
 	assert.Nil(t, d.MovedTo)
 	assert.Nil(t, d.AlsoKnownAs)
 
-	// すべて解決不能なら null のまま (空配列にしない)。
+	// alsoKnownAs に URI があれば全解決不能でも [] (upstream xs.length>=1 → filter→[]、
+	// #2027)。movedTo は解決不能なら null のまま。
 	movedURI := "https://x/u"
 	aka := "https://y/u"
 	u := &model.User{MovedToURI: &movedURI, AlsoKnownAs: &aka}
 	d2 := UserDetailed{}
 	d2.ResolveMoveTargets(u, func(string) (string, bool) { return "", false })
 	assert.Nil(t, d2.MovedTo)
-	assert.Nil(t, d2.AlsoKnownAs, "all-unresolvable alsoKnownAs stays null, not []")
+	require.NotNil(t, d2.AlsoKnownAs)
+	assert.Empty(t, d2.AlsoKnownAs, "URI があれば全解決不能でも [] (#2027)")
 }
 
 func TestPackUserDetailed_MemoNullNotOmitted(t *testing.T) {


### PR DESCRIPTION
## Summary

#1948-22 (LOW まとめ) の残 param/value-semantics (#2027 tracking) のうち、value-semantics 3 件を
batch で対応する。

## 主な変更点

- **ping** (`meta/handler.go`): `{"pong": true}` → `{"pong": time.Now().UnixMilli()}` (epoch-ms number)。
  upstream `ping.ts` は `{ pong: Date.now() }`、misskey-js `PingResponse.pong` は `number`。
- **alsoKnownAs** (`entity/user.go` ResolveMoveTargets): alsoKnownAs に >=1 URI があれば全 URI 解決不能
  でも `null` でなく `[]` を返す。upstream `UserEntityService` は `xs.length === 0 ? null : xs.filter(...)`
  で、`xs` は解決結果配列 (filter 前) なので URI が >=1 あれば `[]`、URI 皆無のときだけ `null`。
- **bubble-game ranking** (`bubblegame/handler.go`): `cacheSec:60` → 未認証 GET に
  `Cache-Control: public, max-age=60` (charts の setCacheControl と同 convention)。

## テスト

- ping が number / alsoKnownAs 全解決不能で [] ・URI 皆無で null / ranking GET に Cache-Control・POST に
  付けない。旧テスト3件 (ping boolean・alsoKnownAs null×2) を upstream parity の正しい値に更新。
- meta 98.5% / entity 96.2% / bubblegame 100%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで 3 件とも upstream と意味的一致を確認。bubble-game の cacheSec 判定が無効/suspended token
付き GET で raw-token を見ない点 (charts と共通の既存 convention) は別 issue #2049 に分離。#2027 の残テーマ
(param-strictness / flash search / meta policies 等) は引き続き小 PR で消化。

## 関連

- 親: #1948
- tracking: #2027 (本 PR で value-semantics 3 件)
