### PR TITLE
Fix userList streaming parity (#2020 item3): per-member withReplies reply gate

### DIFF
--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2093,7 +2093,8 @@ func (s *Server) setupRoutes() {
 	streamRegistry.Register("hashtag", channels.NewHashtag)
 	streamRegistry.RegisterCredentialed("antenna", channels.NewAntennaFactory(antennaRepo).New)
 	streamRegistry.Register("channel", channels.NewChannelTimeline)
-	streamRegistry.Register("userList", channels.NewUserList)
+	// userList は membership lookup を渡して per-member withReplies gate を有効化 (#2020)。
+	streamRegistry.Register("userList", channels.NewUserListFactory(userListRepo).New)
 	streamRegistry.Register("roleTimeline", channels.NewRoleTimelineFactory(roleService).New)
 	streamRegistry.RegisterCredentialed("admin", channels.NewAdminFactory(roleService).New)
 	// serverStats / queueStats は publisher を後段で構築するため、ここでは

--- a/internal/stream/channels/new_channels_test.go
+++ b/internal/stream/channels/new_channels_test.go
@@ -1012,3 +1012,63 @@ func TestHybridTimeline_FilterDefault(t *testing.T) {
 	ch.OnRedisEvent([]byte(`{"text":"reply","replyId":"p1"}`))
 	assert.Len(t, ctx.sentType, 1) // 増えない
 }
+
+// stubMembershipLookup is a test double for UserListMembershipLookup.
+type stubMembershipLookup struct {
+	members []*model.UserListMembership
+}
+
+func (s *stubMembershipLookup) ListMembers(string) ([]*model.UserListMembership, error) {
+	return s.members, nil
+}
+
+// #2020: userList channel は Init で per-member withReplies を snapshot し、reply を
+// upstream user-list.ts と同じ per-member gate で drop する。
+func TestUserList_PerMemberWithRepliesGate(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"}) // viewer = alice (list owner)
+	lookup := &stubMembershipLookup{members: []*model.UserListMembership{
+		{UserID: "bob", WithReplies: false},
+		{UserID: "carol", WithReplies: true},
+	}}
+	ch := NewUserListFactory(lookup).New(ctx)
+	require.NoError(t, ch.Init(json.RawMessage(`{"listId":"l1"}`)))
+
+	send := func(payload string) int {
+		ctx.sentType = nil
+		ch.OnRedisEvent([]byte(payload))
+		return len(ctx.sentType)
+	}
+
+	// bob (withReplies=false) の第三者 reply → drop。
+	assert.Equal(t, 0, send(`{"id":"n1","userId":"bob","visibility":"public","reply":{"userId":"dave","visibility":"public"}}`),
+		"withReplies=false member の第三者 reply は drop (#2020)")
+	// bob の接続主 (alice) への reply → pass。
+	assert.Equal(t, 1, send(`{"id":"n2","userId":"bob","visibility":"public","reply":{"userId":"alice","visibility":"public"}}`),
+		"接続主への reply は pass")
+	// bob の自己 reply (bob→bob) → pass。
+	assert.Equal(t, 1, send(`{"id":"n2b","userId":"bob","visibility":"public","reply":{"userId":"bob","visibility":"public"}}`),
+		"自己 reply は pass")
+	// carol (withReplies=true) の通常 public reply → pass。
+	assert.Equal(t, 1, send(`{"id":"n3","userId":"carol","visibility":"public","reply":{"userId":"dave","visibility":"public"}}`),
+		"withReplies=true member の reply は pass")
+	// carol の followers reply で viewer が reply 先を follow していない → drop。
+	ctx.followingSnap = map[string]bool{}
+	assert.Equal(t, 0, send(`{"id":"n4","userId":"carol","visibility":"public","reply":{"userId":"dave","visibility":"followers"}}`),
+		"withReplies=true で followers reply 先を非フォローなら drop (#2020)")
+	// carol の followers reply で viewer が reply 先を follow → pass。
+	ctx.followingSnap = map[string]bool{"dave": true}
+	assert.Equal(t, 1, send(`{"id":"n4b","userId":"carol","visibility":"public","reply":{"userId":"dave","visibility":"followers"}}`),
+		"reply 先を follow していれば pass")
+	// reply でない note は gate 対象外。
+	assert.Equal(t, 1, send(`{"id":"n5","userId":"bob","visibility":"public"}`), "reply でない note は pass")
+}
+
+// #2020: lookup 未配線 (NewUserList) では reply gate を skip (後方互換)。
+func TestUserList_NoLookupSkipsReplyGate(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	ch := NewUserList(ctx)
+	require.NoError(t, ch.Init(json.RawMessage(`{"listId":"l1"}`)))
+	ctx.sentType = nil
+	ch.OnRedisEvent([]byte(`{"id":"n1","userId":"bob","visibility":"public","reply":{"userId":"dave","visibility":"public"}}`))
+	assert.Len(t, ctx.sentType, 1, "lookup 未配線時は reply gate skip (後方互換、#2020)")
+}

--- a/internal/stream/channels/user_list.go
+++ b/internal/stream/channels/user_list.go
@@ -7,30 +7,51 @@ import (
 	"github.com/shiroha-a/mk/internal/stream"
 )
 
+// UserListMembershipLookup fetches a list's memberships so the channel can
+// snapshot per-member withReplies at Init (#2020、upstream user-list.ts の
+// membershipsMap)。
+type UserListMembershipLookup interface {
+	ListMembers(listID string) ([]*model.UserListMembership, error)
+}
+
 // UserListChannel forwards notes from members of a user list.
 //
-// upstream `user-list.ts` は per-membership の withReplies (= 各 list member
-// の MiUserListMembership.withReplies) で reply を gate する設計だが、mk-go
-// にはまだ list membership に紐づく withReplies model が無いため、本 channel
-// は connect 時の `withReplies` boolean param のみで gate する暫定実装。
-//
-// #1063 で noteFilter.shouldEmit から reply blanket-drop を撤廃した副作用で、
-// 現状は `withReplies=false` でも reply が pass-through する。upstream の
-// 「per-member withReplies が default false で reply を drop」semantics より
-// 緩い (= 全 member の reply を見せる) degrade だが、旧 mk-go の「list 全体で
-// reply を drop」よりは upstream 寄り。完全互換 (= per-member gate) は
-// `model.UserListMembership.WithReplies` 追加と Init での map snapshot
-// 取得を伴うので別 issue で扱う想定。
+// upstream `user-list.ts` は Init で `membershipsMap[userId] = {withReplies}` を
+// snapshot し、reply を per-member の withReplies で gate する。mk-go も
+// membershipLookup が配線されていれば同じく Init snapshot を取って per-member
+// gate する (#2020)。lookup 未配線時は従来どおり reply gate を skip する
+// (後方互換、test 経路)。
 type UserListChannel struct {
 	ctx         stream.ChannelContext
 	topic       string
 	streamTopic string
 	filter      noteFilter
+	memberships UserListMembershipLookup
+	// withRepliesByUser は member userID → withReplies の Init snapshot。
+	// nil の間は per-member reply gate を skip する。
+	withRepliesByUser map[string]bool
 }
 
-// NewUserList returns a channel factory for "userList".
+// NewUserList returns a "userList" channel without a membership lookup. reply は
+// per-member gate されず従来挙動 (主に test 経路)。本番は NewUserListFactory を使う。
 func NewUserList(ctx stream.ChannelContext) stream.Channel {
 	return &UserListChannel{ctx: ctx}
+}
+
+// UserListFactory carries the membership lookup so per-member withReplies gating
+// is available (#2020)。
+type UserListFactory struct {
+	memberships UserListMembershipLookup
+}
+
+// NewUserListFactory constructs a UserListFactory with the given membership lookup.
+func NewUserListFactory(m UserListMembershipLookup) *UserListFactory {
+	return &UserListFactory{memberships: m}
+}
+
+// New builds a new UserListChannel. Usable as a stream.ChannelFactory.
+func (f *UserListFactory) New(ctx stream.ChannelContext) stream.Channel {
+	return &UserListChannel{ctx: ctx, memberships: f.memberships}
 }
 
 func (c *UserListChannel) Init(params json.RawMessage) error {
@@ -53,6 +74,16 @@ func (c *UserListChannel) Init(params json.RawMessage) error {
 	// withRepliesパラメータがtrueなら上書き
 	if p.WithReplies != nil && *p.WithReplies {
 		c.filter.WithReplies = true
+	}
+	// per-member withReplies を Init で snapshot する (upstream membershipsMap、#2020)。
+	// lookup 未配線時は nil のまま = reply gate skip (後方互換)。
+	if c.memberships != nil {
+		c.withRepliesByUser = map[string]bool{}
+		if members, err := c.memberships.ListMembers(p.ListID); err == nil {
+			for _, m := range members {
+				c.withRepliesByUser[m.UserID] = m.WithReplies
+			}
+		}
 	}
 	c.topic = "userListTimeline:" + p.ListID
 	c.ctx.Subscribe(c.topic)
@@ -95,6 +126,11 @@ func (c *UserListChannel) OnRedisEvent(payload []byte) {
 	if !userListVisibilityShouldEmit(payload, viewerID, c.ctx.FollowingSnapshot()) {
 		return
 	}
+	// per-member withReplies gate (#2020)。snapshot 配線時のみ適用。
+	if c.withRepliesByUser != nil &&
+		!userListReplyShouldEmit(payload, viewerID, c.withRepliesByUser, c.ctx.FollowingSnapshot()) {
+		return
+	}
 	payload = hideEmbeds(c.ctx, payload)
 	_ = c.ctx.Send("note", json.RawMessage(payload))
 }
@@ -115,6 +151,46 @@ func (c *UserListChannel) Dispose() {
 type userListVisibilityPayload struct {
 	UserID     string `json:"userId"`
 	Visibility string `json:"visibility"`
+}
+
+// userListReplyPayload は reply gate が参照する最小 fields。
+type userListReplyPayload struct {
+	UserID string `json:"userId"`
+	Reply  *struct {
+		UserID     string `json:"userId"`
+		Visibility string `json:"visibility"`
+	} `json:"reply"`
+}
+
+// userListReplyShouldEmit applies upstream user-list.ts の per-member withReplies
+// reply gate (#2020):
+//   - 投稿者 (note.userId) の withReplies が true: reply 先が followers visibility で
+//     viewer が reply.userId を follow していなければ drop。
+//   - withReplies が false: 「接続主 (viewer) への reply」「接続主自身の投稿」「投稿者の
+//     自己 reply」のいずれでもなければ drop。
+//
+// reply でない note / parse 失敗は pass (visibility gate 側で fail-closed 済)。
+func userListReplyShouldEmit(payload []byte, viewerID string, withRepliesByUser, following map[string]bool) bool {
+	var note userListReplyPayload
+	if err := json.Unmarshal(payload, &note); err != nil || note.Reply == nil {
+		return true
+	}
+	isMe := viewerID != "" && viewerID == note.UserID
+	if withRepliesByUser[note.UserID] {
+		if note.Reply.Visibility == "followers" {
+			if following == nil {
+				return false
+			}
+			_, follows := following[note.Reply.UserID]
+			return follows
+		}
+		return true
+	}
+	// withReplies=false: 接続主への reply / 接続主の投稿 / 自己 reply 以外は drop。
+	if note.Reply.UserID != viewerID && !isMe && note.Reply.UserID != note.UserID {
+		return false
+	}
+	return true
 }
 
 // userListVisibilityShouldEmit returns false when a `followers` visibility note


### PR DESCRIPTION
## Summary

#1948-20 (streaming parity) から分離した hot-path 3 項目 (#2020) のうち、**user_list per-member
withReplies gate** を実装する。残り 2 項目 (per-subscriber renote.myReaction / renote.reply
followers-only drop) は #2020 に継続。

## 主な変更点

- **`UserListMembershipLookup` + `UserListFactory`** (`user_list.go`): Init で `ListMembers(listId)` を
  snapshot し `withRepliesByUser map[userID]bool` を構築。lookup 未配線 (`NewUserList`) は後方互換で
  reply gate を skip。
- **per-member reply gate** (`OnRedisEvent`): visibility gate 後に upstream `user-list.ts` onNote の
  reply gate を適用 —
  - 投稿者の `withReplies=true`: reply が followers visibility で viewer が `reply.userId` を非フォロー
    なら drop。
  - `withReplies=false`: 「reply 先=viewer」「投稿者=viewer」「自己 reply (reply.userId=note.userId)」の
    いずれでもなければ drop。
- **router.go**: `NewUserListFactory(userListRepo).New` を wire。

## テスト

- withReplies=false の第三者 reply drop / 接続主への reply・自己 reply pass / withReplies=true の通常
  reply pass・followers reply の非フォロー drop / フォロー pass / 非 reply pass / lookup 未配線で gate
  skip (後方互換)。
- stream/channels 92.2%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで gate ロジックが upstream onNote と完全一致 (AND/OR・isMe・self-reply・presence-based
follow check)、non-member drop 省略の安全性 (fanout が member note のみ送る)、後方互換・性能 (in-memory
map、DB lookup は Init 1 回)・fail-closed 整合を確認。membership snapshot が Init-only (upstream は 5s
refresh) の staleness は取りこぼし方向 (leak でない) で #2051 に分離。

## 関連

- 親: #1948
- tracking: #2020 (本 PR で item3。item1/item2 は継続)
