### PR TITLE
Fix userList snapshot staleness (#2051): membership event で withReplies snapshot を live 更新

### DIFF
--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -55,13 +55,17 @@ type Handler struct {
 	bufReader            entity.BufferedReactionsReader
 	userListFavoriteRepo UserListFavoriteRepository
 	userListRepo         repository.UserListRepository
-	clipRepo             repository.ClipRepository
-	clipFavoriteRepo     repository.ClipFavoriteRepository
-	flashRepo            repository.FlashRepository
-	galleryRepo          repository.GalleryRepository
-	pageRepo             repository.PageRepository
-	piningRepo           repository.UserNotePiningRepository
-	fieldRes             *entity.NoteFieldResolver
+	// userListEventPub は update-membership で withReplies が変わった際に
+	// userListStream へ userUpdated を流し、接続中の userList channel の snapshot を
+	// live 更新するために使う (#2051)。未配線なら通知しない。
+	userListEventPub UserListMembershipEventPublisher
+	clipRepo         repository.ClipRepository
+	clipFavoriteRepo repository.ClipFavoriteRepository
+	flashRepo        repository.FlashRepository
+	galleryRepo      repository.GalleryRepository
+	pageRepo         repository.PageRepository
+	piningRepo       repository.UserNotePiningRepository
+	fieldRes         *entity.NoteFieldResolver
 	// userRepo は users/notes / users/search-by-username-and-host 経由で
 	// 表示する note list の hardMutedWords filter (#787) に使う。
 	userRepo repository.UserRepository
@@ -184,6 +188,18 @@ func (h *Handler) SetAbuseReportFanout(lister ModeratorLister, notifier AbuseRep
 // unwired の場合 users/reactions は access control を skip して
 // noteReactionRepo の有無に応じて空配列か list を返す test 互換 path に
 // 落ちる (= production 影響なし、test 用 fall-through)。
+// UserListMembershipEventPublisher publishes membership events (here:
+// userUpdated for a withReplies change) to userListStream:{listId} (#2051)。
+type UserListMembershipEventPublisher interface {
+	PublishUserListEvent(listID, eventType string, body any)
+}
+
+// SetUserListEventPublisher wires the userListStream publisher used to live-update
+// connected userList channels when update-membership changes withReplies (#2051)。
+func (h *Handler) SetUserListEventPublisher(p UserListMembershipEventPublisher) {
+	h.userListEventPub = p
+}
+
 func (h *Handler) SetUserRepo(r repository.UserRepository) {
 	h.userRepo = r
 }

--- a/internal/api/users/lists.go
+++ b/internal/api/users/lists.go
@@ -325,6 +325,15 @@ func (h *Handler) ListsUpdateMembership(c echo.Context) error {
 		}
 		return apierr.JSONInternalError(c)
 	}
+	// withReplies を明示変更したときは userListStream へ userUpdated を流し、接続中の
+	// userList channel の per-member snapshot を live 更新する (#2051。upstream は 5s
+	// poll で反映するが mk-go は event 駆動)。
+	if req.WithReplies != nil && h.userListEventPub != nil {
+		h.userListEventPub.PublishUserListEvent(req.ListID, "userUpdated", map[string]any{
+			"id":          req.UserID,
+			"withReplies": *req.WithReplies,
+		})
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/api/users/lists_test.go
+++ b/internal/api/users/lists_test.go
@@ -634,3 +634,43 @@ func TestListsUpdateMembership_DeliberateDeviations(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 	assert.Contains(t, rec.Body.String(), "NO_SUCH_USER", "非 member は NO_SUCH_USER 404 (#2005)")
 }
+
+// stubUserListEventPub records PublishUserListEvent calls (#2051)。
+type stubUserListEventPub struct {
+	calls []struct {
+		listID, eventType string
+		body              any
+	}
+}
+
+func (s *stubUserListEventPub) PublishUserListEvent(listID, eventType string, body any) {
+	s.calls = append(s.calls, struct {
+		listID, eventType string
+		body              any
+	}{listID, eventType, body})
+}
+
+// #2051: update-membership で withReplies を明示変更したときだけ userUpdated を流す。
+func TestListsUpdateMembership_EmitsUserUpdated(t *testing.T) {
+	h, _ := newTestHandler(t)
+	repo := testutil.NewMockUserListRepository()
+	h.SetUserListRepo(repo)
+	pub := &stubUserListEventPub{}
+	h.SetUserListEventPublisher(pub)
+	seedListWithMember(repo, "l1", "owner", "member1", false)
+	owner := &model.User{ID: "owner"}
+
+	// withReplies 省略 → event 無し。
+	postStub(h.ListsUpdateMembership, `{"listId":"l1","userId":"member1"}`, owner)
+	assert.Empty(t, pub.calls, "withReplies 省略時は userUpdated を流さない (#2051)")
+
+	// withReplies=true 明示 → userUpdated {id, withReplies:true}。
+	postStub(h.ListsUpdateMembership, `{"listId":"l1","userId":"member1","withReplies":true}`, owner)
+	require.Len(t, pub.calls, 1)
+	assert.Equal(t, "l1", pub.calls[0].listID)
+	assert.Equal(t, "userUpdated", pub.calls[0].eventType)
+	body, ok := pub.calls[0].body.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "member1", body["id"])
+	assert.Equal(t, true, body["withReplies"])
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2345,6 +2345,9 @@ func (s *Server) setupRoutes() {
 	userListHandler.SetFavoriteRepo(userListFavoriteRepo)                                      // #1550: show forPublic likedCount/isLiked
 	userListHandler.SetProxyFollow(listProxyFollow)                                            // #1704: push remote member proxy follow
 	userListHandler.SetUserListEventPublisher(stream.NewUserListStreamPublisher(streamPubSub)) // #1549: push/pull userAdded/userRemoved
+	// users/lists/update-membership の withReplies 変更を userUpdated として流し、接続中の
+	// userList channel snapshot を live 更新する (#2051)。
+	usersHandler.SetUserListEventPublisher(stream.NewUserListStreamPublisher(streamPubSub))
 	// list は requireCredential:false の public endpoint (userId 指定で他人の
 	// public list を閲覧可、#1550)。未認証 && userId 未指定は handler が INVALID_PARAM。
 	api.POST("/users/lists/list", userListHandler.List, middleware.RequireScope("read:account"))

--- a/internal/stream/channels/new_channels_test.go
+++ b/internal/stream/channels/new_channels_test.go
@@ -3,6 +3,7 @@ package channels
 import (
 	"encoding/json"
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/shiroha-a/mk/internal/model"
@@ -1071,4 +1072,59 @@ func TestUserList_NoLookupSkipsReplyGate(t *testing.T) {
 	ctx.sentType = nil
 	ch.OnRedisEvent([]byte(`{"id":"n1","userId":"bob","visibility":"public","reply":{"userId":"dave","visibility":"public"}}`))
 	assert.Len(t, ctx.sentType, 1, "lookup 未配線時は reply gate skip (後方互換、#2020)")
+}
+
+// #2051: userUpdated event で per-member withReplies snapshot を live 更新し、
+// userRemoved で除去する。userUpdated は client へ forward しない。
+func TestUserList_MembershipSnapshotLiveUpdate(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	lookup := &stubMembershipLookup{members: []*model.UserListMembership{{UserID: "bob", WithReplies: false}}}
+	ch := NewUserListFactory(lookup).New(ctx)
+	require.NoError(t, ch.Init(json.RawMessage(`{"listId":"l1"}`)))
+
+	replyNote := `{"id":"n1","userId":"bob","visibility":"public","reply":{"userId":"dave","visibility":"public"}}`
+	send := func(payload string) int {
+		ctx.sentType = nil
+		ch.OnRedisEvent([]byte(payload))
+		return len(ctx.sentType)
+	}
+
+	// 初期 (bob withReplies=false): 第三者 reply は drop。
+	assert.Equal(t, 0, send(replyNote), "withReplies=false で drop")
+	// userUpdated で bob を withReplies=true に (client へは流さない)。
+	assert.Equal(t, 0, send(`{"type":"userUpdated","body":{"id":"bob","withReplies":true}}`),
+		"userUpdated は client へ流さない (#2051)")
+	// 更新後: bob の第三者 reply が pass。
+	assert.Equal(t, 1, send(replyNote), "userUpdated で withReplies=true 反映 → reply pass (#2051)")
+	// userRemoved で bob を除去 (client へ forward) → 以降 absent (default false)。
+	assert.Equal(t, 1, send(`{"type":"userRemoved","body":{"id":"bob"}}`), "userRemoved は forward")
+	assert.Equal(t, 0, send(replyNote), "userRemoved 後は absent → withReplies=false → drop")
+}
+
+// #2051: note 配信と membership event は別 topic で並行 fanout されうるため、
+// withRepliesByUser は mu で保護される。-race で並行アクセスの安全性を検証する。
+func TestUserList_ConcurrentSnapshotAndNote(t *testing.T) {
+	ctx := newCtx(&model.User{ID: "alice"})
+	lookup := &stubMembershipLookup{members: []*model.UserListMembership{{UserID: "bob", WithReplies: false}}}
+	ch := NewUserListFactory(lookup).New(ctx)
+	require.NoError(t, ch.Init(json.RawMessage(`{"listId":"l1"}`)))
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	// goroutine A: membership event で snapshot を書き換え続ける。
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			ch.OnRedisEvent([]byte(`{"type":"userUpdated","body":{"id":"bob","withReplies":true}}`))
+			ch.OnRedisEvent([]byte(`{"type":"userUpdated","body":{"id":"bob","withReplies":false}}`))
+		}
+	}()
+	// goroutine B: note 配信で snapshot を読み続ける。
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			ch.OnRedisEvent([]byte(`{"id":"n1","userId":"bob","visibility":"public","reply":{"userId":"dave","visibility":"public"}}`))
+		}
+	}()
+	wg.Wait()
 }

--- a/internal/stream/channels/user_list.go
+++ b/internal/stream/channels/user_list.go
@@ -2,6 +2,7 @@ package channels
 
 import (
 	"encoding/json"
+	"sync"
 
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/stream"
@@ -27,8 +28,11 @@ type UserListChannel struct {
 	streamTopic string
 	filter      noteFilter
 	memberships UserListMembershipLookup
-	// withRepliesByUser は member userID → withReplies の Init snapshot。
-	// nil の間は per-member reply gate を skip する。
+	// withRepliesByUser は member userID → withReplies の snapshot。Init で構築し、
+	// userAdded/userRemoved event で live 更新する (#2051)。nil の間は per-member
+	// reply gate を skip する。note 配信 (userListTimeline:) と membership event
+	// (userListStream:) は別 topic で並行 fanout されうるため mu で保護する。
+	mu                sync.RWMutex
 	withRepliesByUser map[string]bool
 }
 
@@ -102,8 +106,13 @@ func (c *UserListChannel) OnRedisEvent(payload []byte) {
 		Type string          `json:"type"`
 		Body json.RawMessage `json:"body"`
 	}
-	if json.Unmarshal(payload, &env) == nil && (env.Type == "userAdded" || env.Type == "userRemoved") {
-		_ = c.ctx.Send(env.Type, env.Body)
+	if json.Unmarshal(payload, &env) == nil && (env.Type == "userAdded" || env.Type == "userRemoved" || env.Type == "userUpdated") {
+		c.applyMembershipEvent(env.Type, env.Body)
+		// userUpdated は snapshot 更新専用の internal event。upstream に無く frontend も
+		// 解さないので client へは流さない (#2051)。
+		if env.Type != "userUpdated" {
+			_ = c.ctx.Send(env.Type, env.Body)
+		}
 		return
 	}
 
@@ -126,13 +135,54 @@ func (c *UserListChannel) OnRedisEvent(payload []byte) {
 	if !userListVisibilityShouldEmit(payload, viewerID, c.ctx.FollowingSnapshot()) {
 		return
 	}
-	// per-member withReplies gate (#2020)。snapshot 配線時のみ適用。
-	if c.withRepliesByUser != nil &&
-		!userListReplyShouldEmit(payload, viewerID, c.withRepliesByUser, c.ctx.FollowingSnapshot()) {
-		return
+	// per-member withReplies gate (#2020)。snapshot 配線時のみ適用。投稿者の
+	// withReplies を mu 下で 1 件 lookup してから gate に渡す (#2051)。
+	if c.withRepliesByUser != nil {
+		var author struct {
+			UserID string `json:"userId"`
+		}
+		_ = json.Unmarshal(payload, &author)
+		c.mu.RLock()
+		authorWithReplies := c.withRepliesByUser[author.UserID]
+		c.mu.RUnlock()
+		if !userListReplyShouldEmit(payload, viewerID, authorWithReplies, c.ctx.FollowingSnapshot()) {
+			return
+		}
 	}
 	payload = hideEmbeds(c.ctx, payload)
 	_ = c.ctx.Send("note", json.RawMessage(payload))
+}
+
+// applyMembershipEvent live-updates the withReplies snapshot on membership
+// events (#2051):
+//   - userAdded: body は UserLite (id のみ、withReplies を持たない) なので新規 member は
+//     withReplies=false default で追加 (upstream の membership 作成時 default と一致)。
+//   - userUpdated: update-membership による withReplies 変更を body の値で反映。
+//   - userRemoved: snapshot から除去。
+//
+// これにより upstream user-list.ts の 5s poll refresh と等価な add/remove/toggle 反映を
+// event 駆動で実現する。
+func (c *UserListChannel) applyMembershipEvent(eventType string, body json.RawMessage) {
+	if c.withRepliesByUser == nil {
+		return // gate 未配線時は snapshot を保持しない
+	}
+	var u struct {
+		ID          string `json:"id"`
+		WithReplies bool   `json:"withReplies"`
+	}
+	if json.Unmarshal(body, &u) != nil || u.ID == "" {
+		return
+	}
+	c.mu.Lock()
+	switch eventType {
+	case "userAdded":
+		c.withRepliesByUser[u.ID] = false // UserLite body は withReplies を持たない (新規 default false)
+	case "userUpdated":
+		c.withRepliesByUser[u.ID] = u.WithReplies // body の withReplies を反映 (#2051)
+	case "userRemoved":
+		delete(c.withRepliesByUser, u.ID)
+	}
+	c.mu.Unlock()
 }
 
 func (c *UserListChannel) OnClientMessage(string, json.RawMessage) {}
@@ -170,13 +220,15 @@ type userListReplyPayload struct {
 //     自己 reply」のいずれでもなければ drop。
 //
 // reply でない note / parse 失敗は pass (visibility gate 側で fail-closed 済)。
-func userListReplyShouldEmit(payload []byte, viewerID string, withRepliesByUser, following map[string]bool) bool {
+// authorWithReplies は投稿者 (note.userId) の membership withReplies (呼び出し側で
+// lookup 済)。
+func userListReplyShouldEmit(payload []byte, viewerID string, authorWithReplies bool, following map[string]bool) bool {
 	var note userListReplyPayload
 	if err := json.Unmarshal(payload, &note); err != nil || note.Reply == nil {
 		return true
 	}
 	isMe := viewerID != "" && viewerID == note.UserID
-	if withRepliesByUser[note.UserID] {
+	if authorWithReplies {
 		if note.Reply.Visibility == "followers" {
 			if following == nil {
 				return false


### PR DESCRIPTION
## Summary

#2052 (userList per-member withReplies gate) は Init snapshot のみで、upstream `user-list.ts` の
`setInterval(updateListUsers, 5000)` 相当の live refresh が無く stale だった。membership event 駆動で
add/remove/withReplies-toggle を反映する。

## 主な変更点

- **`user_list.go`**: `UserListChannel` に `mu sync.RWMutex` + `applyMembershipEvent`。
  - `userAdded`: withReplies=false で追加 (UserLite body は withReplies を持たず upstream default と一致)。
  - `userUpdated`: body の withReplies を反映 (toggle)。
  - `userRemoved`: snapshot から除去。
  - note 配信 (`userListTimeline:`) と membership event (`userListStream:`) は別 topic で並行 fanout
    されうる (dispatcher が topic ごとに別 goroutine) ため `mu` で保護。note path は投稿者の withReplies
    を `mu.RLock` で 1 件 lookup して gate に渡す。
  - `userUpdated` は upstream に無い internal event なので client へ forward しない。
- **`api/users/lists.go`**: `ListsUpdateMembership` で `withReplies` を明示変更したときのみ
  `userUpdated {id, withReplies}` を emit (省略時は #2005 通り既存維持で emit しない)。
- **`api/users/handler.go`**: `UserListMembershipEventPublisher` interface + `SetUserListEventPublisher`。
- **`router.go`**: usersHandler に publisher を wire。

## テスト

- userUpdated で withReplies toggle が gate に反映 / userRemoved で除去 / userUpdated を client へ
  forward しない / update-membership が withReplies 明示時のみ userUpdated emit / 並行 (note 配信 +
  membership event) `-race` 安全性。
- stream/channels 92.1% / users 90.4%。`make fmt` / `go vet ./...` / `go test -race` green。

## 補足

敵対的レビューで race/leak/regression なしを確認 (`go test -race ./internal/stream/...` pass)。mk-go の
member 判定は fanout 時に DB live 解決するため snapshot は withReplies gate 専用で、stale の影響は toggle
のみに限局され本 PR がその gap を閉じる。userUpdated emit は owner 認証済 update-membership 経由のみで
偽装経路なし、購読者は当 channel のみで他経路 leak なし。

## 関連

- 親: #1948
- 元: #2052 (#2020 item3) のレビュー

Closes #2051
