### PR TITLE
Fix cacheSec Cache-Control parity (#2049): raw token ベースで判定

### DIFF
--- a/internal/api/bubblegame/handler.go
+++ b/internal/api/bubblegame/handler.go
@@ -115,7 +115,8 @@ func (h *Handler) Ranking(c echo.Context) error {
 	}
 	// upstream ranking.ts は cacheSec:60 → 未認証 GET に Cache-Control: public,
 	// max-age=60 を付ける (ApiCallService。POST/認証済みには付けない、#2027)。
-	if c.Request().Method == http.MethodGet && middleware.GetUser(c) == nil && middleware.GetToken(c) == "" {
+	// token は raw token (HasRawToken) で見るので無効 token GET でも cache を付けない (#2049)。
+	if c.Request().Method == http.MethodGet && middleware.GetUser(c) == nil && !middleware.HasRawToken(c) {
 		c.Response().Header().Set("Cache-Control", "public, max-age=60")
 	}
 	return c.JSON(http.StatusOK, result)

--- a/internal/api/bubblegame/handler_test.go
+++ b/internal/api/bubblegame/handler_test.go
@@ -189,6 +189,22 @@ func TestRanking_PostNoCacheControl(t *testing.T) {
 	assert.Empty(t, rec.Header().Get("Cache-Control"), "POST には Cache-Control を付けない (#2027)")
 }
 
+// #2049: raw token を付けた GET (= 無効/suspended token で anonymous に落ちた場合) は
+// HasRawToken=true なので Cache-Control を付けない (upstream `!token` 判定)。
+func TestRanking_GetWithRawTokenNoCacheControl(t *testing.T) {
+	h, repo := newTestHandler()
+	repo.records = []*model.BubbleGameRecord{{ID: "r1", Score: 200}}
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/?gameMode=normal", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	// auth middleware が raw token 検出時に積む flag (#2049) を simulate する。
+	c.Set("misskeyRawTokenPresent", true)
+	_ = h.Ranking(c)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, rec.Header().Get("Cache-Control"), "raw token GET には Cache-Control を付けない (#2049)")
+}
+
 // GET で gameMode が無ければ POST 同様 400。
 func TestRanking_GetMissingGameMode(t *testing.T) {
 	h, _ := newTestHandler()

--- a/internal/api/charts/handler.go
+++ b/internal/api/charts/handler.go
@@ -245,9 +245,11 @@ func (h *Handler) parseRequest(req *Request) (chart.Span, int, *time.Time, *para
 // request に optional 適用済みのため、RequireAuth 無しの chart route でも
 // GetUser/GetToken が populate される (未認証なら nil / "")。
 func setCacheControl(c echo.Context) {
+	// upstream `!token && !user` の token は raw token なので、無効/suspended token を
+	// 付けた GET でも cache を付けない (HasRawToken、#2049)。
 	if c.Request().Method == http.MethodGet &&
 		middleware.GetUser(c) == nil &&
-		middleware.GetToken(c) == "" {
+		!middleware.HasRawToken(c) {
 		c.Response().Header().Set("Cache-Control", "public, max-age=3600")
 	}
 }

--- a/internal/server/middleware/auth.go
+++ b/internal/server/middleware/auth.go
@@ -41,6 +41,11 @@ const (
 	// read this flag to return 403 YOUR_ACCOUNT_SUSPENDED instead of 401
 	// CREDENTIAL_REQUIRED (upstream ApiCallService.ts、#1559)。
 	suspendedContextKey contextKey = "misskeySuspended"
+	// rawTokenPresentContextKey flags that the request carried a raw auth token
+	// (Bearer / body `i`), regardless of whether it resolved to a valid user.
+	// upstream ApiCallService が cacheSec の Cache-Control 判定を raw token (`!token`)
+	// で行うため、無効/suspended/deleted token でも cache を付けないようにする (#2049)。
+	rawTokenPresentContextKey contextKey = "misskeyRawTokenPresent"
 )
 
 // AuthScope is the OAuth scope view of an authenticated request. IsApp is
@@ -123,6 +128,9 @@ func (a *AuthMiddleware) Authenticate() echo.MiddlewareFunc {
 			if token == "" {
 				return next(c)
 			}
+			// raw token が存在することを記録する (解決可否に依らず)。cacheSec の
+			// Cache-Control 判定が upstream の `!token` (raw token) を見るため (#2049)。
+			c.Set(string(rawTokenPresentContextKey), true)
 
 			user, scopes, tokenID, isApp, err := a.resolveUser(token)
 			if err != nil {
@@ -290,6 +298,15 @@ func GetToken(c echo.Context) string {
 		return ""
 	}
 	return t
+}
+
+// HasRawToken reports whether the request carried a raw auth token (Bearer /
+// body `i`), regardless of whether it resolved to a valid user. cacheSec
+// endpoints use this so an invalid/suspended/deleted token still suppresses the
+// public Cache-Control, matching upstream ApiCallService's `!token` check (#2049).
+func HasRawToken(c echo.Context) bool {
+	v, _ := c.Get(string(rawTokenPresentContextKey)).(bool)
+	return v
 }
 
 // GetAuthScope returns the OAuth scope view for the current request, or nil

--- a/internal/server/middleware/auth_test.go
+++ b/internal/server/middleware/auth_test.go
@@ -161,9 +161,39 @@ func TestAuthenticate_SuspendedUserTreatedAsAnonymous(t *testing.T) {
 	handler := auth.Authenticate()(func(c echo.Context) error {
 		assert.Nil(t, GetUser(c), "凍結 user は context に attach されない")
 		assert.Equal(t, "", GetToken(c), "凍結 user は token も context に attach されない")
+		// raw token は存在する (解決できなくても)。cacheSec gate がこれで cache を抑える (#2049)。
+		assert.True(t, HasRawToken(c), "raw token は HasRawToken=true (#2049)")
 		return c.String(http.StatusOK, "ok")
 	})
 	require.NoError(t, handler(c))
+}
+
+// #2049: 無効/suspended/deleted token を付けた未認証 GET は HasRawToken=true なので
+// cacheSec endpoint で public Cache-Control を付けない (upstream `!token` 判定)。一方
+// token を一切付けない GET は HasRawToken=false。
+func TestAuthenticate_HasRawToken(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	tokenRepo := testutil.NewMockAccessTokenRepository()
+	auth := NewAuthMiddleware(userRepo, tokenRepo)
+	e := echo.New()
+
+	// token 無し → HasRawToken=false。
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	c := e.NewContext(req, httptest.NewRecorder())
+	require.NoError(t, auth.Authenticate()(func(c echo.Context) error {
+		assert.False(t, HasRawToken(c), "token 無しは HasRawToken=false")
+		return nil
+	})(c))
+
+	// query param i= の token (解決不能でも transient error 経路で anonymous) → HasRawToken=true。
+	deleted := &model.User{ID: "ud", Username: "del", IsDeleted: true}
+	userRepo.Tokens["dtok"] = deleted
+	req2 := httptest.NewRequest(http.MethodGet, "/?i=dtok", nil)
+	c2 := e.NewContext(req2, httptest.NewRecorder())
+	require.NoError(t, auth.Authenticate()(func(c echo.Context) error {
+		assert.True(t, HasRawToken(c), "deleted token でも raw token はあるので HasRawToken=true")
+		return nil
+	})(c2))
 }
 
 func TestAuthenticate_DeletedUserTreatedAsAnonymous(t *testing.T) {


### PR DESCRIPTION
## Summary

#2027 batch のレビューで発見した cacheSec endpoint 共通の parity gap を修正する。upstream
`ApiCallService` は Cache-Control を `request.method === 'GET' && endpoint.meta.cacheSec && !token && !user`
で付与し、`token` は **raw token** (Authorization Bearer / body `i`)。mk-go は `GetToken(c)==""` を見ていたが
`GetToken` は token が valid user に解決できたときのみ context に積まれるため、無効/suspended/deleted token を
付けた未認証 GET でも cache を付けてしまっていた。

## 主な変更点

- **`middleware/auth.go`**: `Authenticate` で `extractToken` 後 `token != ""` なら `rawTokenPresentContextKey`
  を立てる (resolveUser の成否に依らない)。`HasRawToken(c) bool` accessor を追加。
- **`charts/handler.go` setCacheControl** / **`bubblegame/handler.go` Ranking**: `GetToken(c)==""` →
  `!HasRawToken(c)` に変更。`GET && GetUser==nil && !HasRawToken` のとき public Cache-Control を付ける
  (`!token && !user` と論理等価)。max-age は charts=3600 / bubble-game=60 で不変。

## テスト

- suspended/deleted token で `HasRawToken=true` (anonymous でも) / token 無しで `false` / bubble-game の
  raw token GET で Cache-Control を付けない。既存の no-token GET cache・valid token・POST は不変。
- middleware 96.7% / charts 100% / bubblegame 100%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで `!token`(raw)判定との論理等価性・flag set タイミング (NotFound は 401 で handler 未到達、
suspended/deleted は anonymous + HasRawToken=true)・regression 不在・security 誤用不在を確認。同種の
ungated cache (fetchrss writeCachedJSON が method/token/user を gate せず無条件付与) は #2054 に分離。

## 関連

- 親: #1948
- 元: #2027 batch のレビュー

Closes #2049
