### PR TITLE
Add broadcast stream infra + emoji events (#2046): emojiAdded/Updated/Deleted を全 connection へ配信

### DIFF
--- a/internal/api/admin/emoji.go
+++ b/internal/api/admin/emoji.go
@@ -52,6 +52,7 @@ func (h *Handler) EmojiAddAliasesBulk(c echo.Context) error {
 				"emojiId", e.ID, "err", err)
 		}
 	}
+	h.publishEmojiUpdatedByIDs(req.IDs) // #2046
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -135,6 +136,7 @@ func (h *Handler) EmojiCopy(c echo.Context) error {
 		"emojiId": copied.ID,
 		"emoji":   &copied,
 	})
+	h.publishEmojiAdded(&copied) // #2046
 	return c.JSON(http.StatusOK, map[string]any{"id": copied.ID})
 }
 
@@ -181,6 +183,8 @@ func (h *Handler) EmojiDeleteBulk(c echo.Context) error {
 		}
 		h.logModerationMany(c, entries)
 	}
+	// 削除前 snapshot を broadcast (#2046)。snapshot 取得失敗時は空で no-op。
+	h.publishEmojiDeleted(snapshots...)
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -308,6 +312,7 @@ func (h *Handler) EmojiRemoveAliasesBulk(c echo.Context) error {
 				"emojiId", e.ID, "err", err)
 		}
 	}
+	h.publishEmojiUpdatedByIDs(req.IDs) // #2046
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -331,6 +336,7 @@ func (h *Handler) EmojiSetAliasesBulk(c echo.Context) error {
 	if err := h.emojiRepo.UpdateFieldsMany(req.IDs, map[string]any{"aliases": pq.StringArray(req.Aliases)}); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 	}
+	h.publishEmojiUpdatedByIDs(req.IDs) // #2046
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -352,6 +358,7 @@ func (h *Handler) EmojiSetCategoryBulk(c echo.Context) error {
 	if err := h.emojiRepo.UpdateFieldsMany(req.IDs, map[string]any{"category": nullableString(req.Category)}); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 	}
+	h.publishEmojiUpdatedByIDs(req.IDs) // #2046
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -381,5 +388,6 @@ func (h *Handler) EmojiSetLicenseBulk(c echo.Context) error {
 	if err := h.emojiRepo.UpdateFieldsMany(req.IDs, map[string]any{"license": nullableString(req.License)}); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.InternalError())
 	}
+	h.publishEmojiUpdatedByIDs(req.IDs) // #2046
 	return c.NoContent(http.StatusNoContent)
 }

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -92,6 +92,10 @@ type Handler struct {
 	abuseRepo     repository.AbuseReportRepository
 	modLogService *moderationlog.Service
 	emojiRepo     repository.EmojiRepository
+	// broadcastPub は emoji の add/update/delete を broadcast stream へ流し、全
+	// connection の emoji picker を live-refresh するために使う (#2046)。未配線なら
+	// 通知しない。
+	broadcastPub  BroadcastPublisher
 	driveFileRepo repository.DriveFileRepository
 	// driveBulkDeleter は federation/delete-all-files で host のファイルを物理
 	// ストレージ込みで削除し drive 使用量を減算する (#1772)。未配線時は
@@ -2243,6 +2247,61 @@ func (h *Handler) RolesUpdateDefaultPolicies(c echo.Context) error {
 // SetEmojiRepo attaches the emoji repository.
 func (h *Handler) SetEmojiRepo(r repository.EmojiRepository) { h.emojiRepo = r }
 
+// BroadcastPublisher emits an instance-wide stream event to every connected
+// client. Implemented by *stream.BroadcastPublisher (#2046)。
+type BroadcastPublisher interface {
+	PublishBroadcast(eventType string, body any)
+}
+
+// SetBroadcastPublisher wires the broadcast stream publisher used to emit
+// emojiAdded / emojiUpdated / emojiDeleted (#2046)。nil disables emission.
+func (h *Handler) SetBroadcastPublisher(p BroadcastPublisher) { h.broadcastPub = p }
+
+// publishEmojiAdded emits emojiAdded `{emoji}` (single packed emoji).
+func (h *Handler) publishEmojiAdded(e *model.Emoji) {
+	if h.broadcastPub == nil {
+		return
+	}
+	h.broadcastPub.PublishBroadcast("emojiAdded", map[string]any{"emoji": entity.PackEmojiDetailed(e)})
+}
+
+// publishEmojiUpdated emits emojiUpdated `{emojis:[...]}` (packed array).
+func (h *Handler) publishEmojiUpdated(emojis ...*model.Emoji) {
+	if h.broadcastPub == nil || len(emojis) == 0 {
+		return
+	}
+	packed := make([]any, len(emojis))
+	for i, e := range emojis {
+		packed[i] = entity.PackEmojiDetailed(e)
+	}
+	h.broadcastPub.PublishBroadcast("emojiUpdated", map[string]any{"emojis": packed})
+}
+
+// publishEmojiDeleted emits emojiDeleted `{emojis:[...]}` (packed array).
+func (h *Handler) publishEmojiDeleted(emojis ...*model.Emoji) {
+	if h.broadcastPub == nil || len(emojis) == 0 {
+		return
+	}
+	packed := make([]any, len(emojis))
+	for i, e := range emojis {
+		packed[i] = entity.PackEmojiDetailed(e)
+	}
+	h.broadcastPub.PublishBroadcast("emojiDeleted", map[string]any{"emojis": packed})
+}
+
+// publishEmojiUpdatedByIDs re-fetches the given emoji ids and emits a single
+// emojiUpdated event (upstream bulk ops の packDetailedMany(ids) 相当、#2046)。
+func (h *Handler) publishEmojiUpdatedByIDs(ids []string) {
+	if h.broadcastPub == nil || h.emojiRepo == nil || len(ids) == 0 {
+		return
+	}
+	rows, err := h.emojiRepo.FindManyByIDs(ids)
+	if err != nil || len(rows) == 0 {
+		return
+	}
+	h.publishEmojiUpdated(rows...)
+}
+
 // EmojiAdd handles POST /api/admin/emoji/add.
 //
 // upstream Misskey TS は `fileId` を必須として drive 経由でしか emoji を
@@ -2326,6 +2385,8 @@ func (h *Handler) EmojiAdd(c echo.Context) error {
 		"emojiId": e.ID,
 		"emoji":   e,
 	})
+	// local emoji の追加を broadcast stream へ流し emoji picker を live-refresh (#2046)。
+	h.publishEmojiAdded(e)
 	// upstream は EmojiDetailed (packDetailed) を返す。raw model.Emoji を返すと
 	// `url` が欠落し originalUrl/publicUrl/uri/type 等の内部 field が漏れる。
 	return c.JSON(http.StatusOK, entity.PackEmojiDetailed(e))
@@ -2447,6 +2508,9 @@ func (h *Handler) EmojiUpdate(c echo.Context) error {
 	}
 	// 以降の UpdateFields / moderation log は解決済み id を使う。
 	req.ID = before.ID
+	// name 変更判定用に旧 name を UpdateFields 前に控える (#2046 broadcast 用。
+	// GORM では before は別 struct だが、in-place 更新する実装に依らず安全側)。
+	oldName := before.Name
 	fields := map[string]any{}
 	if req.Name != nil {
 		// リネーム時は同名 local emoji の重複を弾く (SAME_NAME_EMOJI_EXISTS)。
@@ -2518,6 +2582,14 @@ func (h *Handler) EmojiUpdate(c echo.Context) error {
 		"before":  before,
 		"after":   after,
 	})
+	// broadcast stream へ流す (#2046)。upstream は name 変更時のみ
+	// emojiDeleted(old)+emojiAdded(new)、それ以外は emojiUpdated(after)。
+	if req.Name != nil && *req.Name != oldName {
+		h.publishEmojiDeleted(before)
+		h.publishEmojiAdded(after)
+	} else {
+		h.publishEmojiUpdated(after)
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -2556,6 +2628,8 @@ func (h *Handler) EmojiDelete(c echo.Context) error {
 		"emojiId": req.ID,
 		"emoji":   snapshot,
 	})
+	// 削除を broadcast stream へ流し emoji picker から消す (#2046)。
+	h.publishEmojiDeleted(snapshot)
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -2653,6 +2653,82 @@ func TestEmojiAdd_NilRepo(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
+// captureBroadcast records PublishBroadcast calls (#2046)。
+type captureBroadcast struct {
+	events []string
+}
+
+func (c *captureBroadcast) PublishBroadcast(eventType string, _ any) {
+	c.events = append(c.events, eventType)
+}
+
+// #2046: emoji の add/update/delete が broadcast stream へ emojiAdded/Updated/Deleted を流す。
+// name 変更 update は emojiDeleted+emojiAdded。
+func TestEmoji_BroadcastEvents(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	emojiRepo := testutil.NewMockEmojiRepository()
+	h.SetEmojiRepo(emojiRepo)
+	bc := &captureBroadcast{}
+	h.SetBroadcastPublisher(bc)
+
+	// add → emojiAdded。
+	rec := doPost(h.EmojiAdd, `{"name":"smile","url":"https://example.com/s.png"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, []string{"emojiAdded"}, bc.events)
+
+	// non-name update → emojiUpdated。
+	bc.events = nil
+	emojiRepo.Emojis["test@"] = &model.Emoji{ID: "e1", Name: "test"}
+	rec = doPost(h.EmojiUpdate, `{"id":"e1","category":"face"}`, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, []string{"emojiUpdated"}, bc.events)
+
+	// name 変更 update → emojiDeleted + emojiAdded。
+	bc.events = nil
+	emojiRepo.Emojis["ren@"] = &model.Emoji{ID: "e2", Name: "ren"}
+	rec = doPost(h.EmojiUpdate, `{"id":"e2","name":"renamed"}`, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, []string{"emojiDeleted", "emojiAdded"}, bc.events)
+
+	// delete → emojiDeleted。
+	bc.events = nil
+	emojiRepo.Emojis["del@"] = &model.Emoji{ID: "e3", Name: "del"}
+	rec = doPost(h.EmojiDelete, `{"id":"e3"}`, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, []string{"emojiDeleted"}, bc.events)
+}
+
+// #2046: bulk 操作 (set-category-bulk / delete-bulk / copy) も broadcast を流す。
+func TestEmoji_BroadcastEvents_Bulk(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	emojiRepo := testutil.NewMockEmojiRepository()
+	h.SetEmojiRepo(emojiRepo)
+	bc := &captureBroadcast{}
+	h.SetBroadcastPublisher(bc)
+	emojiRepo.Emojis["a@"] = &model.Emoji{ID: "ba1", Name: "a"}
+	emojiRepo.Emojis["b@"] = &model.Emoji{ID: "ba2", Name: "b"}
+
+	// set-category-bulk → emojiUpdated (1 件にまとめる)。
+	bc.events = nil
+	rec := doPost(h.EmojiSetCategoryBulk, `{"ids":["ba1","ba2"],"category":"face"}`, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, []string{"emojiUpdated"}, bc.events)
+
+	// delete-bulk → emojiDeleted。
+	bc.events = nil
+	rec = doPost(h.EmojiDeleteBulk, `{"ids":["ba1","ba2"]}`, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, []string{"emojiDeleted"}, bc.events)
+
+	// copy (remote → local) → emojiAdded。
+	bc.events = nil
+	host := "remote.example"
+	emojiRepo.Emojis["srcemoji@remote.example"] = &model.Emoji{ID: "src1", Name: "srcemoji", Host: &host}
+	rec = doPost(h.EmojiCopy, `{"emojiId":"src1"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, []string{"emojiAdded"}, bc.events)
+}
+
 func TestEmojiUpdate_Success(t *testing.T) {
 	h, _, _, _ := newTestHandler(t)
 	emojiRepo := testutil.NewMockEmojiRepository()

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2138,6 +2138,8 @@ func (s *Server) setupRoutes() {
 	// rules を refresh する subscriber を起動 (#791)。i/update 側 publisher
 	// と同じ topic 名を共有 (= stream.WordMuteReloadTopic)。
 	streamManager.SubscribeWordMuteReload()
+	// broadcast stream (emojiAdded/Updated/Deleted 等) を全 connection へ forward (#2046)。
+	streamManager.SubscribeBroadcast()
 	iHandler.SetHardMutePublisher(&hardMutePublisherAdapter{pubsub: streamPubSub})
 	// profile 編集を remote followers に Update(Person) で配信する (#1560)。
 	// actor endpoint と同じ shape にするため ed25519 keypair を、follower 以外の
@@ -2432,6 +2434,8 @@ func (s *Server) setupRoutes() {
 	galleryHandler.SetModLog(modLogService) // #1548: moderator による gallery post 削除の監査ログ
 	flashHandler.SetModLog(modLogService)   // #1548: moderator による flash 削除の監査ログ
 	adminHandler.SetEmojiRepo(emojiRepo)
+	// emoji の add/update/delete を broadcast stream へ流し emoji picker を live-refresh (#2046)。
+	adminHandler.SetBroadcastPublisher(stream.NewBroadcastPublisher(streamPubSub))
 	adminHandler.SetDriveFileRepo(driveFileRepo)
 	adminHandler.SetDriveBulkDeleter(driveService) // #1772: delete-all-files の物理削除 + 使用量減算
 	// bulk drive cleanup (clean-remote-files / delete-all-files-of-a-user) で

--- a/internal/stream/broadcast.go
+++ b/internal/stream/broadcast.go
@@ -1,0 +1,97 @@
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+)
+
+// BroadcastTopic is the Redis pubsub channel that carries instance-wide stream
+// events (emojiAdded / emojiUpdated / emojiDeleted など) delivered to every
+// connected client. upstream `GlobalEventService.publishBroadcastStream` の
+// `broadcast` channel に相当する (#2046)。
+const BroadcastTopic = "broadcast"
+
+// BroadcastEnvelope is the JSON wire format on BroadcastTopic: a `{type, body}`
+// pair that the Manager forwards to every connection as a top-level WS message
+// (upstream Connection.onBroadcastMessage → sendMessageToWs(type, body))。
+type BroadcastEnvelope struct {
+	Type string          `json:"type"`
+	Body json.RawMessage `json:"body"`
+}
+
+// BroadcastPublisher emits `{type, body}` envelopes to BroadcastTopic.
+type BroadcastPublisher struct {
+	pub PubSubPublisher
+}
+
+// NewBroadcastPublisher constructs a BroadcastPublisher backed by the given
+// PubSubPublisher.
+func NewBroadcastPublisher(pub PubSubPublisher) *BroadcastPublisher {
+	return &BroadcastPublisher{pub: pub}
+}
+
+// PublishBroadcast emits an instance-wide event to every connected client.
+func (p *BroadcastPublisher) PublishBroadcast(eventType string, body any) {
+	if p == nil || p.pub == nil || eventType == "" {
+		return
+	}
+	rawBody, err := json.Marshal(body)
+	if err != nil {
+		slog.Warn("broadcast publisher: body marshal failed", "event", eventType, "err", err)
+		return
+	}
+	raw, err := json.Marshal(BroadcastEnvelope{Type: eventType, Body: rawBody})
+	if err != nil {
+		slog.Warn("broadcast publisher: envelope marshal failed", "event", eventType, "err", err)
+		return
+	}
+	if err := p.pub.Publish(context.Background(), BroadcastTopic, json.RawMessage(raw)); err != nil {
+		slog.Warn("broadcast publisher: publish failed", "event", eventType, "err", err)
+	}
+}
+
+// SubscribeBroadcast starts listening on BroadcastTopic and forwards each event
+// to every registered connection as a top-level `{type, body}` WS message
+// (#2046)。
+//
+// **同一 Manager に対して 1 度だけ呼ぶこと** ([[SubscribeWordMuteReload]] と同様、
+// 複数回呼ぶと handler が二重登録される)。bus が nil なら no-op。
+func (m *Manager) SubscribeBroadcast() {
+	if m.bus == nil {
+		return
+	}
+	m.bus.Subscribe(BroadcastTopic, func(raw []byte) {
+		var env BroadcastEnvelope
+		if err := json.Unmarshal(raw, &env); err != nil || env.Type == "" {
+			slog.Warn("stream: broadcast payload unmarshal failed", "err", err)
+			return
+		}
+		m.broadcastToAll(env.Type, env.Body)
+	})
+}
+
+// UnsubscribeBroadcast stops listening on BroadcastTopic (Manager.Shutdown 経路)。
+func (m *Manager) UnsubscribeBroadcast() {
+	if m.bus == nil {
+		return
+	}
+	m.bus.Unsubscribe(BroadcastTopic)
+}
+
+// broadcastToAll sends a `{type, body}` message to every registered connection.
+// Manager の mu は snapshot を取って早めに release し、Send (Connection 内部 mutex
+// で thread-safe) を lock 外で呼ぶ。
+func (m *Manager) broadcastToAll(eventType string, body json.RawMessage) {
+	m.mu.RLock()
+	targets := make([]*Connection, 0, len(m.conns))
+	for _, c := range m.conns {
+		targets = append(targets, c)
+	}
+	m.mu.RUnlock()
+
+	msg := map[string]any{"type": eventType, "body": body}
+	for _, c := range targets {
+		_ = c.Send(msg)
+	}
+}

--- a/internal/stream/broadcast_test.go
+++ b/internal/stream/broadcast_test.go
@@ -1,0 +1,87 @@
+package stream
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #2046: SubscribeBroadcast は broadcast topic の event を全 connection
+// (認証/匿名問わず) へ top-level {type, body} で forward する。
+func TestManager_SubscribeBroadcast_ForwardsToAllConnections(t *testing.T) {
+	bus := newStubBus()
+	m := NewManager(NewRegistry(), bus)
+
+	fc1, fc2 := newFakeConn(), newFakeConn()
+	c1 := NewConnection("c1", &model.User{ID: "alice"}, fc1)
+	c2 := NewConnection("c2", nil, fc2) // anonymous connection も受信する
+	go c1.Start()
+	go c2.Start()
+	m.register(c1)
+	m.register(c2)
+	t.Cleanup(func() { c1.Close(); c2.Close() })
+
+	m.SubscribeBroadcast()
+	require.Contains(t, bus.subs, BroadcastTopic)
+
+	env, _ := json.Marshal(BroadcastEnvelope{Type: "emojiAdded", Body: json.RawMessage(`{"emoji":{"id":"e1"}}`)})
+	bus.deliver(BroadcastTopic, env)
+
+	for _, fc := range []*fakeConn{fc1, fc2} {
+		require.Eventually(t, func() bool { return fc.writeCount() >= 1 }, time.Second, 5*time.Millisecond)
+		var msg struct {
+			Type string          `json:"type"`
+			Body json.RawMessage `json:"body"`
+		}
+		require.NoError(t, json.Unmarshal(fc.writeAt(0), &msg))
+		assert.Equal(t, "emojiAdded", msg.Type)
+		assert.JSONEq(t, `{"emoji":{"id":"e1"}}`, string(msg.Body))
+	}
+}
+
+// #2046: 不正な broadcast payload は drop され forward されない。
+func TestManager_SubscribeBroadcast_DropsInvalidPayload(t *testing.T) {
+	bus := newStubBus()
+	m := NewManager(NewRegistry(), bus)
+	fc := newFakeConn()
+	c := NewConnection("c1", &model.User{ID: "alice"}, fc)
+	go c.Start()
+	m.register(c)
+	t.Cleanup(func() { c.Close() })
+
+	m.SubscribeBroadcast()
+	bus.deliver(BroadcastTopic, []byte(`not-json`))
+	bus.deliver(BroadcastTopic, []byte(`{"type":"","body":null}`)) // type 空も drop
+
+	// forward されないことを確認 (短時間待っても write 0)。
+	time.Sleep(30 * time.Millisecond)
+	assert.Equal(t, 0, fc.writeCount())
+}
+
+// #2046: BroadcastPublisher は {type, body} envelope を broadcast topic へ publish する。
+func TestBroadcastPublisher_PublishBroadcast(t *testing.T) {
+	bus := &capturingPubSub{}
+	bp := NewBroadcastPublisher(bus)
+	bp.PublishBroadcast("emojiDeleted", map[string]any{"emojis": []any{map[string]any{"id": "e1"}}})
+
+	require.Len(t, bus.calls, 1)
+	assert.Equal(t, BroadcastTopic, bus.calls[0].topic)
+	raw, ok := bus.calls[0].payload.(json.RawMessage)
+	require.True(t, ok)
+	var env BroadcastEnvelope
+	require.NoError(t, json.Unmarshal(raw, &env))
+	assert.Equal(t, "emojiDeleted", env.Type)
+	assert.JSONEq(t, `{"emojis":[{"id":"e1"}]}`, string(env.Body))
+}
+
+// #2046: nil pub / 空 type は no-op (panic しない)。
+func TestBroadcastPublisher_NilAndEmpty(t *testing.T) {
+	NewBroadcastPublisher(nil).PublishBroadcast("emojiAdded", nil) // no panic
+	bus := &capturingPubSub{}
+	NewBroadcastPublisher(bus).PublishBroadcast("", map[string]any{"x": 1})
+	assert.Empty(t, bus.calls)
+}

--- a/internal/stream/manager.go
+++ b/internal/stream/manager.go
@@ -205,6 +205,7 @@ func (m *Manager) Shutdown() {
 	// pubsub subscriber goroutine を先に停止して、停止中の connection に
 	// reload signal が届かないようにする (#791)。
 	m.UnsubscribeWordMuteReload()
+	m.UnsubscribeBroadcast()
 	m.mu.Lock()
 	conns := make([]*Connection, 0, len(m.conns))
 	for _, c := range m.conns {


### PR DESCRIPTION
## Summary

#2034 から分離した broadcast stream infra (#2046)。upstream の `GlobalEventService.publishBroadcastStream`
+ `Connection.onBroadcastMessage` 相当を実装し、emoji の add/update/delete を全 connection へ配信して
emoji picker を live-refresh する。

## 主な変更点

- **`internal/stream/broadcast.go`** (新規):
  - `BroadcastPublisher.PublishBroadcast(type, body)`: `broadcast` topic へ `{type, body}` を publish。
  - `Manager.SubscribeBroadcast()`: `broadcast` topic を **1 度だけ**購読し、`broadcastToAll` で全 connection
    へ top-level `{type, body}` を forward (upstream `sendMessageToWs(type, body)` 相当)。`WordMuteReload`
    と同じ Manager-level 単一購読パターンで、per-connection 購読時の `subs` map 上書きを回避。
  - `UnsubscribeBroadcast()` を `Shutdown` に組込。`broadcastToAll` は `mu.RLock` で conns を snapshot し
    lock 外で `c.Send`。
- **`api/admin`**: emoji の add/update/delete/copy + bulk (add/remove/set aliases・set-category・
  set-license・delete-bulk) で broadcast 発火。形状は upstream `CustomEmojiService` に合わせ
  `emojiAdded={emoji}` / `emojiUpdated={emojis:[...]}` / `emojiDeleted={emojis:[...]}`。name 変更 update は
  `doNameUpdate` 分岐 (emojiDeleted(old)+emojiAdded(new))。
- **`router.go`**: `SubscribeBroadcast()` 起動 + admin に publisher 配線。

## テスト

- 全 connection (認証/匿名) へ forward / 不正 payload drop / publisher envelope / 全 emoji event
  (add/update non-name/update name-change/delete/bulk/copy) の event 種別。`go test -race` 込み。
- stream 90.8% / admin 89.7%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで event 形状の upstream parity・lifecycle (単一購読/Shutdown unsubscribe)・concurrency
(`-race` pass)・各 publish が success path のみ発火・nil publisher で no-op を確認。global
`announcementCreated` の broadcast 移行 (issue 完了条件) は本 infra を流用する follow-up #2056 に分離。

## 関連

- 親: #1948
- 元: #2034

Closes #2046
