### PR TITLE
Fix home/hybrid timeline parity (#2020 item2): followers-only renote.reply を drop

### DIFF
--- a/internal/stream/channels/note_filter.go
+++ b/internal/stream/channels/note_filter.go
@@ -414,6 +414,49 @@ func (n *notePayload) isPureRenote() bool {
 		(len(n.Poll) == 0 || string(n.Poll) == "null")
 }
 
+// renoteReplyProbe parses a pure-renote の renote.reply を見るための最小 fields。
+type renoteReplyProbe struct {
+	notePayload
+	Renote *struct {
+		Reply *replyMeta `json:"reply"`
+	} `json:"renote"`
+}
+
+// renoteReplyShouldEmit applies upstream home-/hybrid-timeline.ts の pure-renote
+// 用 renote.reply gate (#2020 item2):
+//
+//	if (isRenote && !isQuote && note.renote?.reply) {
+//	    if (reply.visibility === 'followers'
+//	        && !following.has(reply.userId)
+//	        && reply.userId !== me) return; // drop
+//	}
+//
+// pure renote 以外 / renote.reply が無い / followers 以外 / 自分宛て or follow 済は pass。
+// parse 失敗は他 gate に委ねて pass。local/global timeline は upstream に本 gate が
+// 無いので呼ばない。
+func renoteReplyShouldEmit(payload []byte, viewerID string, following map[string]bool) bool {
+	var probe renoteReplyProbe
+	if err := json.Unmarshal(payload, &probe); err != nil {
+		return true
+	}
+	if !probe.isPureRenote() || probe.Renote == nil || probe.Renote.Reply == nil {
+		return true
+	}
+	reply := probe.Renote.Reply
+	if reply.Visibility != "followers" {
+		return true
+	}
+	if viewerID != "" && reply.UserID == viewerID {
+		return true
+	}
+	if following != nil {
+		if _, ok := following[reply.UserID]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // shouldEmit returns true if the note passes non-reply filter conditions
 // (renote / file / hardmute). reply の表示可否は channel ごとに異なる
 // semantics で別途 replyShouldEmit が判定する (#1063)。

--- a/internal/stream/channels/note_filter_test.go
+++ b/internal/stream/channels/note_filter_test.go
@@ -344,3 +344,30 @@ func TestAnonRequireSigninDrop(t *testing.T) {
 		assert.False(t, anonRequireSigninDrop([]byte(`{not json`), ""))
 	})
 }
+
+// #2020 item2: pure renote の renote.reply が followers-only かつ viewer 非フォローなら
+// drop。それ以外 (非 pure renote / 非 followers / 自分宛て / follow 済 / renote.reply 無し)
+// は pass。
+func TestRenoteReplyShouldEmit(t *testing.T) {
+	pureFollowersReply := func(replyUser string) []byte {
+		return []byte(`{"userId":"author","renoteId":"r1","renote":{"reply":{"userId":"` + replyUser + `","visibility":"followers"}}}`)
+	}
+	// followers reply, viewer が dave を非フォロー → drop。
+	assert.False(t, renoteReplyShouldEmit(pureFollowersReply("dave"), "alice", map[string]bool{}))
+	// viewer が dave を follow → pass。
+	assert.True(t, renoteReplyShouldEmit(pureFollowersReply("dave"), "alice", map[string]bool{"dave": true}))
+	// reply.userId == viewer → pass。
+	assert.True(t, renoteReplyShouldEmit(pureFollowersReply("alice"), "alice", map[string]bool{}))
+	// snap nil + 非自分宛て → drop (fail-closed)。
+	assert.False(t, renoteReplyShouldEmit(pureFollowersReply("dave"), "alice", nil))
+	// public な renote.reply → pass。
+	assert.True(t, renoteReplyShouldEmit([]byte(`{"userId":"author","renoteId":"r1","renote":{"reply":{"userId":"dave","visibility":"public"}}}`), "alice", map[string]bool{}))
+	// quote renote (text あり = 非 pure renote) → gate 対象外、pass。
+	assert.True(t, renoteReplyShouldEmit([]byte(`{"userId":"author","renoteId":"r1","text":"q","renote":{"reply":{"userId":"dave","visibility":"followers"}}}`), "alice", map[string]bool{}))
+	// renote.reply 無し → pass。
+	assert.True(t, renoteReplyShouldEmit([]byte(`{"userId":"author","renoteId":"r1","renote":{}}`), "alice", map[string]bool{}))
+	// renote でない → pass。
+	assert.True(t, renoteReplyShouldEmit([]byte(`{"userId":"author"}`), "alice", map[string]bool{}))
+	// parse 失敗 → pass。
+	assert.True(t, renoteReplyShouldEmit([]byte(`not-json`), "alice", map[string]bool{}))
+}

--- a/internal/stream/channels/timeline.go
+++ b/internal/stream/channels/timeline.go
@@ -180,6 +180,10 @@ func (c *HomeTimelineChannel) OnRedisEvent(payload []byte) {
 	if !replyShouldEmit(payload, viewerID, c.ctx.FollowingSnapshot(), false, replyGateHome) {
 		return
 	}
+	// pure renote の renote.reply が followers-only かつ非フォローなら drop (#2020 item2)。
+	if !renoteReplyShouldEmit(payload, viewerID, c.ctx.FollowingSnapshot()) {
+		return
+	}
 	payload = hideEmbeds(c.ctx, payload)
 	_ = c.ctx.Send("note", json.RawMessage(payload))
 }
@@ -248,6 +252,10 @@ func (c *HybridTimelineChannel) OnRedisEvent(payload []byte) {
 		return
 	}
 	if !replyShouldEmit(payload, viewerID, c.ctx.FollowingSnapshot(), c.filter.WithReplies, replyGateHybrid) {
+		return
+	}
+	// pure renote の renote.reply が followers-only かつ非フォローなら drop (#2020 item2)。
+	if !renoteReplyShouldEmit(payload, viewerID, c.ctx.FollowingSnapshot()) {
 		return
 	}
 	payload = hideEmbeds(c.ctx, payload)

--- a/internal/stream/channels/timeline_test.go
+++ b/internal/stream/channels/timeline_test.go
@@ -351,3 +351,33 @@ func TestHybridTimeline_AnonymousReplyPassthrough(t *testing.T) {
 	ch.OnRedisEvent(payload)
 	require.Len(t, ctx.sentType, 1)
 }
+
+// #2020 item2: home/hybrid timeline は pure renote の renote.reply が followers-only
+// かつ viewer 非フォローなら note を drop する。
+func TestHomeHybridTimeline_DropsFollowersOnlyRenoteReply(t *testing.T) {
+	// home: viewer は author を follow するが renote.reply 先 (dave) は非フォロー。
+	dropRenote := `{"id":"n1","userId":"author","renoteId":"r1","renote":{"reply":{"userId":"dave","visibility":"followers"}}}`
+	passRenote := `{"id":"n2","userId":"author","renoteId":"r2","renote":{"reply":{"userId":"dave","visibility":"public"}}}`
+
+	for _, tc := range []struct {
+		name string
+		ch   func(stream.ChannelContext) stream.Channel
+	}{
+		{"home", NewHomeTimeline},
+		{"hybrid", NewHybridTimeline},
+	} {
+		ctx := newCtx(&model.User{ID: "viewer"})
+		ctx.followingSnap = map[string]bool{"author": true} // dave は含めない
+		ctx.policies = map[string]any{"ltlAvailable": true} // hybrid Init 用
+		ch := tc.ch(ctx)
+		require.NoError(t, ch.Init(nil))
+
+		ctx.sentType = nil
+		ch.OnRedisEvent([]byte(dropRenote))
+		assert.Empty(t, ctx.sentType, tc.name+": followers-only renote.reply を非フォローなら drop (#2020)")
+
+		ctx.sentType = nil
+		ch.OnRedisEvent([]byte(passRenote))
+		assert.Len(t, ctx.sentType, 1, tc.name+": public renote.reply は pass")
+	}
+}


### PR DESCRIPTION
## Summary

#2020 (streaming hot-path) の **item2: pure renote の followers-only renote.reply drop** を実装する。
item3 (user_list withReplies) は #2052 で対応済。item1 (renote.myReaction injection) は perf 設計を要する
ため #2058 に分離。

## 主な変更点

- **`note_filter.go`**: `renoteReplyShouldEmit` を追加。pure renote (`isPureRenote`) で `note.renote.reply`
  が followers visibility のとき、viewer が `reply.userId` を非フォロー かつ `reply.userId != viewer` なら
  drop。upstream home-/hybrid-timeline.ts onNote の
  `reply.visibility==='followers' && !following.has(reply.userId) && reply.userId !== me` と一致。
- **`timeline.go`**: home / hybrid の `OnRedisEvent` に本 gate を追加 (top-level reply gate の後)。
  local / global は upstream に本 gate が無いため非対象。

## テスト

- 単体: followers reply 非フォロー drop / follow 済 pass / 自分宛て pass / public pass / 非 pure renote
  (quote) pass / renote.reply 無し pass / parse 失敗 pass / snap nil fail-closed。
- 統合: home / hybrid channel が followers-only renote.reply を drop・public は pass。
- stream/channels 92.3%。`make fmt` / `go vet ./...` / `make test` green。

## 関連

- 親: #1948
- tracking: #2020 (本 PR で item2。item1=#2058 に分離、item3=#2052 済)
