### PR TITLE
Fix param-strictness parity (#2027 batch2): notify/score/on/visibility/content/poll の enum・required

### DIFF
--- a/internal/api/bubblegame/handler.go
+++ b/internal/api/bubblegame/handler.go
@@ -39,6 +39,10 @@ func (h *Handler) Register(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.Seed == "" || req.GameMode == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "score, seed, logs, gameMode, gameVersion are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
+	// upstream register.ts paramDef は score:{minimum:0}。負値を ajv 同様 400 で弾く (#2027)。
+	if req.Score < 0 {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "score must be >= 0.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	}
 
 	// シード検証: seedはUnixタイムスタンプ文字列
 	seedMs, err := strconv.ParseInt(req.Seed, 10, 64)

--- a/internal/api/bubblegame/handler_test.go
+++ b/internal/api/bubblegame/handler_test.go
@@ -245,3 +245,11 @@ func TestRanking_NilUser(t *testing.T) {
 	_, hasUser := resp[0]["user"]
 	assert.False(t, hasUser)
 }
+
+// #2027: score<0 は upstream の minimum:0 に従い 400 (seed parse より前に弾く)。
+func TestRegister_NegativeScoreRejected(t *testing.T) {
+	h, _ := newTestHandler()
+	rec := post(h.Register, `{"score":-1,"seed":"x","gameMode":"normal","gameVersion":1}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_PARAM")
+}

--- a/internal/api/flash/handler.go
+++ b/internal/api/flash/handler.go
@@ -74,6 +74,11 @@ func (h *Handler) Create(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.Title == "" || req.Script == "" || req.Summary == nil || req.Permissions == nil {
 		return apierr.JSONInvalidParam(c)
 	}
+	// upstream flash/create.ts は visibility:{enum:['public','private']}。空は public
+	// default (service 側) なので許容、それ以外の非 enum 値は 400 で弾く (#2027)。
+	if req.Visibility != "" && req.Visibility != "public" && req.Visibility != "private" {
+		return apierr.JSONInvalidParam(c)
+	}
 	f, err := h.svc.Create(coreflash.CreateInput{
 		OwnerID:     user.ID,
 		Title:       req.Title,
@@ -136,6 +141,10 @@ func (h *Handler) Update(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req UpdateRequest
 	if err := c.Bind(&req); err != nil || req.FlashID == "" {
+		return apierr.JSONInvalidParam(c)
+	}
+	// upstream flash/update.ts も visibility:{enum:['public','private']} (#2027)。
+	if req.Visibility != nil && *req.Visibility != "public" && *req.Visibility != "private" {
 		return apierr.JSONInvalidParam(c)
 	}
 	f, err := h.svc.Update(user.ID, req.FlashID, coreflash.UpdateInput{

--- a/internal/api/flash/handler_test.go
+++ b/internal/api/flash/handler_test.go
@@ -713,3 +713,11 @@ func TestMyLikes_RepoError(t *testing.T) {
 	require.NoError(t, h.MyLikes(c))
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
+
+// #2027: visibility enum 外は 400。
+func TestCreate_InvalidVisibility(t *testing.T) {
+	h, _, _ := newHandler(t)
+	c, rec := newReq(t, `{"title":"t","script":"s","summary":"","permissions":[],"visibility":"bogus"}`)
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/internal/api/following/relation.go
+++ b/internal/api/following/relation.go
@@ -78,6 +78,11 @@ func (h *Handler) UpdateFollow(c echo.Context) error {
 	}
 	fields := map[string]any{}
 	if req.Notify != nil {
+		// upstream update.ts paramDef は notify:{enum:['normal','none']}。enum 外を
+		// verbatim 保存すると DB 列が壊れるので ajv 同様 400 で弾く (#2027)。
+		if !validNotify(*req.Notify) {
+			return apierr.JSONInvalidParam(c)
+		}
 		fields["notify"] = normalizeNotify(*req.Notify)
 	}
 	if req.WithReplies != nil {
@@ -91,6 +96,12 @@ func (h *Handler) UpdateFollow(c echo.Context) error {
 		return apierr.JSONInternalError(c)
 	}
 	return c.JSON(http.StatusOK, entity.PackUserLite(meBundle.User))
+}
+
+// validNotify reports whether v is one of upstream's `notify` enum values
+// ('normal' / 'none')。enum 外は ajv で 400 になるので caller で弾く (#2027)。
+func validNotify(v string) bool {
+	return v == "normal" || v == "none"
 }
 
 // normalizeNotify converts the upstream `notify` enum ("normal" / "none") to
@@ -120,6 +131,10 @@ func (h *Handler) UpdateFollowAll(c echo.Context) error {
 	}
 	fields := map[string]any{}
 	if req.Notify != nil {
+		// upstream update-all.ts も notify:{enum:['normal','none']} (#2027)。
+		if !validNotify(*req.Notify) {
+			return apierr.JSONInvalidParam(c)
+		}
 		// upstream #17385 互換: notify="none" は SQL NULL に正規化する。
 		fields["notify"] = normalizeNotify(*req.Notify)
 	}

--- a/internal/api/following/relation_test.go
+++ b/internal/api/following/relation_test.go
@@ -160,3 +160,21 @@ func TestUpdateFollow_NotifyNormal_StoredAsString(t *testing.T) {
 	require.NotNil(t, fRepo.Followings["f1"].Notify)
 	assert.Equal(t, "normal", *fRepo.Followings["f1"].Notify)
 }
+
+// #2027: notify enum (normal/none) 外は 400 で弾く (verbatim 保存しない)。
+func TestUpdateFollow_InvalidNotifyEnum(t *testing.T) {
+	h, repo, fRepo, _ := newTestHandlerWithRepos(t)
+	alice := addUser(repo, "alice", false)
+	bob := addUser(repo, "bob", false)
+	fRepo.Followings["f1"] = &model.Following{ID: "f1", FollowerID: alice.ID, FolloweeID: bob.ID}
+	rec := postJSON(h.UpdateFollow, `{"userId":"bob","notify":"bogus"}`, alice)
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "notify enum 外は 400 (#2027)")
+}
+
+// #2027: update-all も notify enum 外を 400 で弾く。
+func TestUpdateFollowAll_InvalidNotifyEnum(t *testing.T) {
+	h, repo, _, _ := newTestHandlerWithRepos(t)
+	alice := addUser(repo, "alice", false)
+	rec := postJSON(h.UpdateFollowAll, `{"notify":"bogus"}`, alice)
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "update-all notify enum 外は 400 (#2027)")
+}

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -490,10 +490,20 @@ func validateCreateInput(req *CreateRequest, fileIDs []string) error {
 		if n := len(req.Poll.Choices); n < 2 || n > 10 {
 			return errors.New("poll must have between 2 and 10 choices")
 		}
+		seen := make(map[string]bool, len(req.Poll.Choices))
 		for _, ch := range req.Poll.Choices {
 			if n := len([]rune(ch)); n < 1 || n > 50 {
 				return errors.New("each poll choice must be between 1 and 50 characters")
 			}
+			// upstream notes/create.ts poll.choices は uniqueItems:true (#2027)。
+			if seen[ch] {
+				return errors.New("poll choices must be unique")
+			}
+			seen[ch] = true
+		}
+		// upstream poll.expiredAfter は minimum:1 (#2027)。
+		if req.Poll.ExpiredAfter != nil && *req.Poll.ExpiredAfter < 1 {
+			return errors.New("expiredAfter must be at least 1")
 		}
 	}
 	// text のみで成立する note (renote/file/poll 無し) は空白だけの text を弾く

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -1033,3 +1033,16 @@ func TestBulkShow_NoBody(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "[]\n", rec.Body.String())
 }
+
+// #2027: poll choices uniqueItems + expiredAfter>=1 を validateCreateInput が弾く。
+func TestValidateCreateInput_PollUniqueAndExpiredAfter(t *testing.T) {
+	dupChoices := &CreateRequest{Poll: &PollRequest{Choices: []string{"a", "a"}}}
+	assert.Error(t, validateCreateInput(dupChoices, nil), "重複 choice は弾く")
+
+	ok := &CreateRequest{Poll: &PollRequest{Choices: []string{"a", "b"}}}
+	assert.NoError(t, validateCreateInput(ok, nil), "ユニークな choice は通る")
+
+	bad := int64(0)
+	badExpire := &CreateRequest{Poll: &PollRequest{Choices: []string{"a", "b"}, ExpiredAfter: &bad}}
+	assert.Error(t, validateCreateInput(badExpire, nil), "expiredAfter<1 は弾く")
+}

--- a/internal/api/pages/handler.go
+++ b/internal/api/pages/handler.go
@@ -76,6 +76,12 @@ func (h *Handler) SetUserSource(s UserBundleSource) {
 	h.userSource = s
 }
 
+// jsonAbsent reports whether a json.RawMessage field was omitted or sent as the
+// literal `null` (= ajv の required 違反相当、#2027)。
+func jsonAbsent(r json.RawMessage) bool {
+	return len(r) == 0 || string(r) == "null"
+}
+
 // CreateRequest is the request body for pages/create. Content / Variables
 // are stored verbatim into jsonb columns; we don't interpret them.
 type CreateRequest struct {
@@ -97,6 +103,12 @@ func (h *Handler) Create(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req CreateRequest
 	if err := c.Bind(&req); err != nil || req.Title == "" || req.Name == "" {
+		return apierr.JSONInvalidParam(c)
+	}
+	// upstream pages/create.ts は required:['title','name','content','variables','script']。
+	// content/variables の欠落 (omitted/null) を ajv 同様 400 で弾く (#2027。script は
+	// Go の string で omitted と "" を区別できないため presence 強制は見送る)。
+	if jsonAbsent(req.Content) || jsonAbsent(req.Variables) {
 		return apierr.JSONInvalidParam(c)
 	}
 	// upstream create.ts: eyeCatchingImageId 指定時は自分の drive file か検証し、

--- a/internal/api/pages/handler_test.go
+++ b/internal/api/pages/handler_test.go
@@ -47,7 +47,7 @@ func setUser(c echo.Context, userID string) {
 
 func TestCreate_Success(t *testing.T) {
 	h, _, _ := newHandler(t)
-	c, rec := newReq(t, `{"title":"t","name":"alpha"}`)
+	c, rec := newReq(t, `{"title":"t","name":"alpha","content":[],"variables":[]}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Create(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -74,7 +74,7 @@ func TestCreate_NameInvalidPattern(t *testing.T) {
 func TestCreate_EyeCatchingImageNoSuchFile(t *testing.T) {
 	h, _, _ := newHandler(t)
 	h.SetDriveFileRepo(testutil.NewMockDriveFileRepository()) // 空 = 不在
-	c, rec := newReq(t, `{"title":"t","name":"alpha","eyeCatchingImageId":"f_ghost"}`)
+	c, rec := newReq(t, `{"title":"t","name":"alpha","eyeCatchingImageId":"f_ghost","content":[],"variables":[]}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Create(c))
 	assert.Equal(t, http.StatusNotFound, rec.Code)
@@ -88,7 +88,7 @@ func TestCreate_EyeCatchingImageForeignFile(t *testing.T) {
 	other := "bob"
 	dr.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &other}
 	h.SetDriveFileRepo(dr)
-	c, rec := newReq(t, `{"title":"t","name":"alpha","eyeCatchingImageId":"f1"}`)
+	c, rec := newReq(t, `{"title":"t","name":"alpha","eyeCatchingImageId":"f1","content":[],"variables":[]}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Create(c))
 	assert.Equal(t, http.StatusNotFound, rec.Code)
@@ -101,7 +101,7 @@ func TestCreate_EyeCatchingImageOwned(t *testing.T) {
 	owner := "alice"
 	dr.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &owner}
 	h.SetDriveFileRepo(dr)
-	c, rec := newReq(t, `{"title":"t","name":"alpha","eyeCatchingImageId":"f1"}`)
+	c, rec := newReq(t, `{"title":"t","name":"alpha","eyeCatchingImageId":"f1","content":[],"variables":[]}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Create(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
@@ -138,7 +138,7 @@ func TestCreate_NameRequired(t *testing.T) {
 func TestCreate_NameConflict(t *testing.T) {
 	h, repo, _ := newHandler(t)
 	repo.Pages["existing"] = &model.Page{ID: "existing", UserID: "alice", Name: "alpha"}
-	c, rec := newReq(t, `{"title":"t","name":"alpha"}`)
+	c, rec := newReq(t, `{"title":"t","name":"alpha","content":[],"variables":[]}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Create(c))
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
@@ -158,7 +158,7 @@ func TestCreate_RepoError(t *testing.T) {
 	idGen, _ := id.NewGenerator("aidx")
 	svc := corepage.NewService(repo, testutil.NewMockPageLikeRepository(), idGen)
 	h := NewHandler(svc, idGen)
-	c, rec := newReq(t, `{"title":"t","name":"alpha"}`)
+	c, rec := newReq(t, `{"title":"t","name":"alpha","content":[],"variables":[]}`)
 	setUser(c, "alice")
 	require.NoError(t, h.Create(c))
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
@@ -1009,4 +1009,12 @@ func TestShow_NoDriveRepoKeepsDefaults(t *testing.T) {
 	require.True(t, ok)
 	assert.Empty(t, attached, "未配線なら空配列")
 	assert.Nil(t, row["eyeCatchingImage"], "未配線なら null")
+}
+
+// #2027: content/variables 欠落は 400。
+func TestCreate_ContentVariablesRequired(t *testing.T) {
+	h, _, _ := newHandler(t)
+	c, rec := newReq(t, `{"title":"t","name":"alpha","variables":[]}`)
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "content 欠落は 400 (#2027)")
 }

--- a/internal/api/webhooks/handler.go
+++ b/internal/api/webhooks/handler.go
@@ -85,11 +85,17 @@ func (h *Handler) SetRolePolicyProvider(p RolePolicyProvider) {
 }
 
 func packWebhook(w *model.Webhook) map[string]any {
+	// upstream の webhook.on は常に string[]。nil (旧 row 等) は [] に倒して
+	// response が null にならないようにする (#2027)。
+	on := w.On
+	if on == nil {
+		on = []string{}
+	}
 	return map[string]any{
 		"id":     w.ID,
 		"userId": w.UserID,
 		"name":   w.Name,
-		"on":     w.On,
+		"on":     on,
 		"url":    w.URL,
 		"secret": w.Secret,
 		"active": w.Active,
@@ -111,6 +117,11 @@ func (h *Handler) Create(c echo.Context) error {
 	}
 	if err := c.Bind(&req); err != nil || req.Name == "" || req.URL == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "name and url are required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
+	}
+	// upstream i/webhooks/create.ts は required:['name','url','on']。on 欠落 (nil) は
+	// ajv 同様 400 で弾く (空配列 [] は present 扱いで許容、#2027)。
+	if req.On == nil {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "on is required.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))
 	}
 	if !validateOnArray(req.On) {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "on must contain only webhookEventTypes values.", "ed1d7571-a3ac-4370-899c-0dbe5e230cc8"))

--- a/internal/api/webhooks/handler_test.go
+++ b/internal/api/webhooks/handler_test.go
@@ -174,7 +174,7 @@ func TestCreate_InvalidOnEnum(t *testing.T) {
 func TestCreate_Error(t *testing.T) {
 	h, repo := newTestHandler()
 	repo.createErr = errMock
-	rec := post(h.Create, `{"name":"test","url":"https://example.com"}`, &model.User{ID: "u1"})
+	rec := post(h.Create, `{"name":"test","url":"https://example.com","on":["note"]}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
@@ -194,7 +194,7 @@ func TestCreate_WebhookLimitExceeded(t *testing.T) {
 	h.SetRolePolicyProvider(&stubRolePolicyProvider{policies: map[string]any{
 		"webhookLimit": 2,
 	}})
-	rec := post(h.Create, `{"name":"test","url":"https://example.com"}`, &model.User{ID: "u1"})
+	rec := post(h.Create, `{"name":"test","url":"https://example.com","on":["note"]}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 	assert.Contains(t, rec.Body.String(), "TOO_MANY_WEBHOOKS")
 	assert.Contains(t, rec.Body.String(), "87a9bb19-111e-4e37-81d3-a3e7426453b0")
@@ -205,7 +205,7 @@ func TestCreate_WebhookLimit_PassesUnderLimit(t *testing.T) {
 	h.SetRolePolicyProvider(&stubRolePolicyProvider{policies: map[string]any{
 		"webhookLimit": 10,
 	}})
-	rec := post(h.Create, `{"name":"test","url":"https://example.com"}`, &model.User{ID: "u1"})
+	rec := post(h.Create, `{"name":"test","url":"https://example.com","on":["note"]}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusOK, rec.Code, "limit 内なら通常成功")
 }
 
@@ -222,7 +222,7 @@ func TestCreate_WebhookLimit_CountError(t *testing.T) {
 	h.SetRolePolicyProvider(&stubRolePolicyProvider{policies: map[string]any{
 		"webhookLimit": 5,
 	}})
-	rec := post(h.Create, `{"name":"test","url":"https://example.com"}`, &model.User{ID: "u1"})
+	rec := post(h.Create, `{"name":"test","url":"https://example.com","on":["note"]}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
@@ -499,4 +499,14 @@ func TestTest_InvalidParam(t *testing.T) {
 	h, _ := newTestHandler()
 	rec := post(h.Test, `{}`, &model.User{ID: "u1"})
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// #2027: on 欠落は 400、空配列 [] は present 扱いで許容。
+func TestCreate_OnRequired(t *testing.T) {
+	h, _ := newTestHandler()
+	rec := post(h.Create, `{"name":"t","url":"https://e.example"}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code, "on 欠落は 400 (#2027)")
+	rec = post(h.Create, `{"name":"t","url":"https://e.example","on":[]}`, &model.User{ID: "u1"})
+	assert.Equal(t, http.StatusOK, rec.Code, "空 on は許容")
+	assert.Contains(t, rec.Body.String(), `"on":[]`, "response on は [] (null でない、#2027)")
 }


### PR DESCRIPTION
## Summary

#2027 (param-strictness 残テーマ) を triage し、upstream ajv paramDef に揃える genuinely-open な 6 件を
batch で対応する (既に修正済み / deliberate deviation のものは除外)。

## 主な変更点

| endpoint | 変更 | upstream paramDef |
|---|---|---|
| following/update + update-all | `notify` enum(normal/none)外を 400 | `notify:{enum:['normal','none']}` |
| bubble-game/register | `score<0` を 400 | `score:{minimum:0}` |
| i/webhooks/create | `on` 欠落を 400 + packWebhook nil→[] | `required:['name','url','on']` |
| flash/create+update | `visibility` enum(public/private)外を 400 | `visibility:{enum:['public','private']}` |
| pages/create | `content`/`variables` 欠落を 400 | `required:[...,'content','variables',...]` |
| notes/create poll | choices uniqueItems + expiredAfter≥1 を 400 | `choices:{uniqueItems:true}`, `expiredAfter:{minimum:1}` |

following の notify は従来 enum 外文字列を DB 列に **verbatim 保存**する value-corruption だった
(`notify="none"→nil` の既存 normalize 挙動は不変)。webhooks の `on` は省略のみ拒否し空配列 `[]` は許容、
flash visibility は空文字 `""` を public default で許容。

## テスト

- 各 endpoint の enum/required 違反 → 400、正常値 (空配列・default・ユニーク choices) → 通過。既存 test の
  request body に now-required field を追加。
- 全 6 package 90%超 (bubblegame 100% / webhooks 98.1% / pages 97.4% / following 94.2% / flash 93.3% /
  notes 90.9%)。entitycompat golden gate green。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで 6 件とも upstream paramDef 一致・over-rejection なし (空配列/default/null 区別)・golden
gate 非破壊・notify value-corruption 解消を確認。残る LOW (pages script / flash visibility="" の
omitted-vs-empty 区別) は Go の非 pointer string 制約でコメント明示済。#2027 の他 param-strictness は
引き続き小 PR で消化。

## 関連

- 親: #1948
- tracking: #2027 (本 PR で param-strictness 6 件、batch1=#2050)
