### PR TITLE
Fix fetch-rss Cache-Control parity (#2054): cacheSec gate を GET+未認証+raw token 無しに限定

### DIFF
--- a/internal/api/fetchrss/handler.go
+++ b/internal/api/fetchrss/handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mmcdole/gofeed"
 	"github.com/shiroha-a/mk/internal/api/apierr"
 	"github.com/shiroha-a/mk/internal/safehttp"
+	"github.com/shiroha-a/mk/internal/server/middleware"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -222,7 +223,13 @@ func (h *Handler) Fetch(c echo.Context) error {
 // 同一になる (TS upstream とも整合)。
 func writeCachedJSON(c echo.Context, body []byte) error {
 	resp := c.Response()
-	resp.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", CacheSeconds))
+	// upstream fetch-rss.ts は cacheSec:180 + allowGet:true。ApiCallService は
+	// `GET && cacheSec && !token && !user` のときだけ Cache-Control を付ける。
+	// POST / 認証済み / raw token 付き GET には付けない (charts/bubble-game と同
+	// convention、#2054)。token は HasRawToken (解決可否に依らない) で判定する。
+	if c.Request().Method == http.MethodGet && middleware.GetUser(c) == nil && !middleware.HasRawToken(c) {
+		resp.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", CacheSeconds))
+	}
 	resp.Header().Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	resp.WriteHeader(http.StatusOK)
 	_, err := resp.Write(body)

--- a/internal/api/fetchrss/handler_test.go
+++ b/internal/api/fetchrss/handler_test.go
@@ -774,3 +774,26 @@ func TestPackItem_PublishedFallback(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, parsed.UTC().Equal(updated))
 }
+
+// #2054: POST と raw-token 付き GET には Cache-Control を付けない (upstream `!token && !user`)。
+func TestFetchRSS_CacheControlGate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, sampleRSS2)
+	}))
+	t.Cleanup(srv.Close)
+	h := newTestHandler(t, srv)
+
+	// POST → cache 無し。
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/fetch-rss", strings.NewReader(fmt.Sprintf(`{"url":%q}`, srv.URL)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	require.NoError(t, h.Fetch(e.NewContext(req, rec)))
+	assert.Empty(t, rec.Header().Get("Cache-Control"), "POST には Cache-Control を付けない (#2054)")
+
+	// raw token 付き GET → cache 無し (auth middleware が積む flag を simulate)。
+	c2, rec2 := newRequestCtx(http.MethodGet, "/api/fetch-rss?url="+url.QueryEscape(srv.URL))
+	c2.Set("misskeyRawTokenPresent", true)
+	require.NoError(t, h.Fetch(c2))
+	assert.Empty(t, rec2.Header().Get("Cache-Control"), "raw token GET には Cache-Control を付けない (#2054)")
+}


### PR DESCRIPTION
## Summary

#2049 (cacheSec raw token) のレビューで発見した同種 gap。`fetch-rss` の `writeCachedJSON` が
method/token/user を一切 gate せず無条件で `Cache-Control: public, max-age=180` を付けていた。

upstream `fetch-rss.ts` は `requireCredential:false, allowGet:true, cacheSec:60*3` で、ApiCallService は
`GET && cacheSec && !token && !user` のときだけ Cache-Control を付ける。

## 主な変更点

- **`writeCachedJSON`**: `c.Request().Method == GET && middleware.GetUser(c) == nil &&
  !middleware.HasRawToken(c)` のときだけ `Cache-Control` を付ける (charts/bubble-game/#2049 と同
  convention)。POST / 認証済み / 無効・suspended token 付き GET には付けない。

## テスト

- POST に Cache-Control を付けない / raw token 付き GET に付けない / 既存の未認証 GET は従来どおり
  `public, max-age=180` (TestFetchRSS_BasicRSS2)。
- fetchrss 97.1%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

#2049 で adversarial review 済みの cacheSec gate と同一ロジック (endpoint が違うだけ)。meta
(requireCredential:false / allowGet:true / cacheSec:180) と route (GET+POST 両方 Fetch) を確認済み。

## 関連

- 親: #1948
- 元: #2049 のレビュー

Closes #2054
