### PR TITLE
Add global announcementCreated broadcast (#2056): broadcast stream で全 client へ配信

### DIFF
--- a/internal/api/announcements/handler.go
+++ b/internal/api/announcements/handler.go
@@ -24,11 +24,19 @@ type MainStreamPublisher interface {
 	PublishMainEvent(userID, eventType string, body any)
 }
 
+// BroadcastPublisher emits an instance-wide event to every connected client
+// (internal/stream.BroadcastPublisher)。global announcement の
+// announcementCreated 配信に使う (#2056)。
+type BroadcastPublisher interface {
+	PublishBroadcast(eventType string, body any)
+}
+
 // Handler handles announcement-related API endpoints.
 type Handler struct {
 	repo                repository.AnnouncementRepository
 	idGen               id.Generator
 	mainStreamPublisher MainStreamPublisher
+	broadcastPublisher  BroadcastPublisher
 	modLogService       *moderationlog.Service
 	userRepo            repository.UserRepository
 }
@@ -43,6 +51,12 @@ func NewHandler(repo repository.AnnouncementRepository, idGen id.Generator) *Han
 // disables emit.
 func (h *Handler) SetMainStreamPublisher(p MainStreamPublisher) {
 	h.mainStreamPublisher = p
+}
+
+// SetBroadcastPublisher attaches the broadcast publisher used to emit
+// `announcementCreated` for global announcements (#2056). nil disables emit.
+func (h *Handler) SetBroadcastPublisher(p BroadcastPublisher) {
+	h.broadcastPublisher = p
 }
 
 // SetModLogService attaches the moderation log writer used by AdminCreate/
@@ -257,12 +271,15 @@ func (h *Handler) AdminCreate(c echo.Context) error {
 	if err := h.repo.Create(a); err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
-	// TS本家AnnouncementService.create(line 87): per-user announcement
-	// (userId指定)の場合のみmainにpublishする。global announcementは
-	// publishBroadcastStream経由だがGo側では別インフラ未実装なのでskip。
-	if h.mainStreamPublisher != nil && a.UserID != nil {
-		body := map[string]any{"announcement": entity.PackAnnouncement(a, h.idGen, false)}
-		h.mainStreamPublisher.PublishMainEvent(*a.UserID, "announcementCreated", body)
+	// upstream AnnouncementService.create: per-user (userId 指定) は main へ、
+	// global (userId 無し) は broadcast stream へ announcementCreated を流す (#2056)。
+	body := map[string]any{"announcement": entity.PackAnnouncement(a, h.idGen, false)}
+	if a.UserID != nil {
+		if h.mainStreamPublisher != nil {
+			h.mainStreamPublisher.PublishMainEvent(*a.UserID, "announcementCreated", body)
+		}
+	} else if h.broadcastPublisher != nil {
+		h.broadcastPublisher.PublishBroadcast("announcementCreated", body)
 	}
 	h.logAnnouncementAction(c, moderationlog.LogCreateGlobalAnnouncement, moderationlog.LogCreateUserAnnouncement, a, map[string]any{
 		"announcementId": a.ID,

--- a/internal/api/announcements/handler_test.go
+++ b/internal/api/announcements/handler_test.go
@@ -768,3 +768,20 @@ func TestAdminDelete_WritesAnnouncementLog(t *testing.T) {
 	require.Eventually(t, func() bool { return len(repo.Snapshot()) == 1 }, 500*time.Millisecond, 5*time.Millisecond)
 	assert.Equal(t, "deleteGlobalAnnouncement", repo.Snapshot()[0].Type)
 }
+
+// fakeBroadcastPub records PublishBroadcast calls (#2056)。
+type fakeBroadcastPub struct{ events []string }
+
+func (f *fakeBroadcastPub) PublishBroadcast(eventType string, _ any) {
+	f.events = append(f.events, eventType)
+}
+
+// #2056: global announcement (userId 無し) は broadcast stream へ announcementCreated を流す。
+func TestAdminCreate_GlobalBroadcasts(t *testing.T) {
+	h, _ := newTestHandler(t)
+	bc := &fakeBroadcastPub{}
+	h.SetBroadcastPublisher(bc)
+	rec := doPost(h.AdminCreate, `{"title":"News","text":"Big news!"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, []string{"announcementCreated"}, bc.events, "global は broadcast へ (#2056)")
+}

--- a/internal/core/announcement/creator.go
+++ b/internal/core/announcement/creator.go
@@ -27,34 +27,44 @@ type MainStreamPublisher interface {
 	PublishMainEvent(userID, eventType string, body any)
 }
 
+// BroadcastPublisher emits an instance-wide event to every connected client.
+// global announcement の announcementCreated 配信に使う (#2056)。
+type BroadcastPublisher interface {
+	PublishBroadcast(eventType string, body any)
+}
+
 // Creator persists announcements and publishes the `announcementCreated`
 // event for per-user announcements, like upstream AnnouncementService.create.
 type Creator struct {
 	repo      Repo
 	idGen     id.Generator
 	publisher MainStreamPublisher
+	broadcast BroadcastPublisher
 }
 
-// NewCreator constructs a Creator. publisher may be nil to disable the
-// stream emit (graceful for tests / partial wiring).
-func NewCreator(repo Repo, idGen id.Generator, publisher MainStreamPublisher) *Creator {
-	return &Creator{repo: repo, idGen: idGen, publisher: publisher}
+// NewCreator constructs a Creator. publisher / broadcast may be nil to disable
+// the corresponding stream emit (graceful for tests / partial wiring)。
+func NewCreator(repo Repo, idGen id.Generator, publisher MainStreamPublisher, broadcast BroadcastPublisher) *Creator {
+	return &Creator{repo: repo, idGen: idGen, publisher: publisher, broadcast: broadcast}
 }
 
 // Create persists the announcement and, for a per-user announcement
 // (UserID != nil), publishes `announcementCreated` to the target user's main
 // channel with the upstream event body shape ({"announcement": packed}).
 //
-// global announcement (UserID == nil) は本家では broadcast stream へ
-// publish されるが、mk-go は broadcast インフラ未実装のため skip する
-// (api/announcements AdminCreate と同じ判断)。
+// global announcement (UserID == nil) は upstream 同様 broadcast stream へ
+// publish する (#2056、broadcast インフラ #2046)。
 func (c *Creator) Create(a *model.Announcement) error {
 	if err := c.repo.Create(a); err != nil {
 		return err
 	}
-	if c.publisher != nil && a.UserID != nil {
-		body := map[string]any{"announcement": entity.PackAnnouncement(a, c.idGen, false)}
-		c.publisher.PublishMainEvent(*a.UserID, "announcementCreated", body)
+	body := map[string]any{"announcement": entity.PackAnnouncement(a, c.idGen, false)}
+	if a.UserID != nil {
+		if c.publisher != nil {
+			c.publisher.PublishMainEvent(*a.UserID, "announcementCreated", body)
+		}
+	} else if c.broadcast != nil {
+		c.broadcast.PublishBroadcast("announcementCreated", body)
 	}
 	return nil
 }

--- a/internal/core/announcement/creator_test.go
+++ b/internal/core/announcement/creator_test.go
@@ -37,6 +37,17 @@ func (f *fakePublisher) PublishMainEvent(userID, eventType string, body any) {
 	f.events = append(f.events, mainEvent{userID, eventType, body})
 }
 
+type broadcastEvent struct {
+	eventType string
+	body      any
+}
+
+type fakeBroadcast struct{ events []broadcastEvent }
+
+func (f *fakeBroadcast) PublishBroadcast(eventType string, body any) {
+	f.events = append(f.events, broadcastEvent{eventType, body})
+}
+
 func ptr[T any](v T) *T { return &v }
 
 func newAnnouncement(t *testing.T, userID *string) (*model.Announcement, id.Generator) {
@@ -60,7 +71,7 @@ func TestCreate_PerUserPublishesAnnouncementCreated(t *testing.T) {
 	a, idGen := newAnnouncement(t, ptr("mod1"))
 	repo := &fakeRepo{}
 	pub := &fakePublisher{}
-	c := NewCreator(repo, idGen, pub)
+	c := NewCreator(repo, idGen, pub, nil)
 
 	require.NoError(t, c.Create(a))
 	require.Len(t, repo.created, 1)
@@ -81,23 +92,44 @@ func TestCreate_PerUserPublishesAnnouncementCreated(t *testing.T) {
 	assert.Equal(t, "2026-06-01T12:00:00.000Z", packed["createdAt"])
 }
 
-func TestCreate_GlobalAnnouncementDoesNotPublish(t *testing.T) {
-	// global (UserID nil) は本家では broadcast stream 経路。mk-go は
-	// broadcast 未実装のため main-stream へは何も出さない。
+// #2056: global (UserID nil) は main へ出さず broadcast stream へ announcementCreated
+// を流す (upstream AnnouncementService.create の publishBroadcastStream)。
+func TestCreate_GlobalAnnouncementBroadcasts(t *testing.T) {
 	a, idGen := newAnnouncement(t, nil)
 	repo := &fakeRepo{}
 	pub := &fakePublisher{}
-	c := NewCreator(repo, idGen, pub)
+	bc := &fakeBroadcast{}
+	c := NewCreator(repo, idGen, pub, bc)
 
 	require.NoError(t, c.Create(a))
 	assert.Len(t, repo.created, 1)
-	assert.Empty(t, pub.events)
+	assert.Empty(t, pub.events, "global は main へ出さない")
+	require.Len(t, bc.events, 1, "global は broadcast へ出す (#2056)")
+	assert.Equal(t, "announcementCreated", bc.events[0].eventType)
+	body, ok := bc.events[0].body.(map[string]any)
+	require.True(t, ok)
+	packed, ok := body["announcement"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, a.ID, packed["id"])
+}
+
+// #2056: per-user announcement は broadcast へは出さない (main のみ)。
+func TestCreate_PerUserDoesNotBroadcast(t *testing.T) {
+	a, idGen := newAnnouncement(t, ptr("mod1"))
+	repo := &fakeRepo{}
+	pub := &fakePublisher{}
+	bc := &fakeBroadcast{}
+	c := NewCreator(repo, idGen, pub, bc)
+
+	require.NoError(t, c.Create(a))
+	assert.Len(t, pub.events, 1, "per-user は main へ出す")
+	assert.Empty(t, bc.events, "per-user は broadcast へ出さない")
 }
 
 func TestCreate_NilPublisherStillPersists(t *testing.T) {
 	a, idGen := newAnnouncement(t, ptr("mod1"))
 	repo := &fakeRepo{}
-	c := NewCreator(repo, idGen, nil)
+	c := NewCreator(repo, idGen, nil, nil)
 
 	require.NoError(t, c.Create(a))
 	assert.Len(t, repo.created, 1)
@@ -107,7 +139,7 @@ func TestCreate_RepoErrorPropagatesWithoutPublish(t *testing.T) {
 	a, idGen := newAnnouncement(t, ptr("mod1"))
 	repo := &fakeRepo{err: errors.New("db down")}
 	pub := &fakePublisher{}
-	c := NewCreator(repo, idGen, pub)
+	c := NewCreator(repo, idGen, pub, nil)
 
 	err := c.Create(a)
 	assert.Error(t, err)

--- a/internal/core/moderatoractivity/service_stream_test.go
+++ b/internal/core/moderatoractivity/service_stream_test.go
@@ -38,7 +38,7 @@ func TestCheck_AllInactive_PublishesAnnouncementCreatedPerModerator(t *testing.T
 	repo := &fakeAnnounce{}
 	pub := &fakeMainPublisher{}
 	// idGen=nil でも Creator は publish する (packed createdAt が空になるだけ)。
-	creator := coreannouncement.NewCreator(repo, nil, pub)
+	creator := coreannouncement.NewCreator(repo, nil, pub, nil)
 	s := NewService(mods, meta, &fakeProfiles{}, creator, &fakeWebhook{}, &fakeIDGen{}, nil)
 	s.now = func() time.Time { return now }
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2169,6 +2169,8 @@ func (s *Server) setupRoutes() {
 	drivePublisher := stream.NewDrivePublisher(streamPubSub)
 	reversiPublisher := stream.NewReversiGamePublisher(streamPubSub)
 	mainStreamPublisher := stream.NewMainStreamPublisher(streamPubSub)
+	// broadcast stream publisher (emoji / global announcement 等を全 connection へ、#2046/#2056)。
+	broadcastPublisher := stream.NewBroadcastPublisher(streamPubSub)
 	// #1549: report-abuse が各 moderator の adminStream:<id> へ newAbuseUserReport
 	// を配信できるよう admin publisher + moderator lister を usersHandler に配線。
 	usersHandler.SetAbuseReportFanout(roleService, stream.NewAdminStreamPublisher(streamPubSub))
@@ -2376,7 +2378,7 @@ func (s *Server) setupRoutes() {
 		roleService,
 		metaRepo,
 		userRepo,
-		coreannouncement.NewCreator(announcementRepo, idGen, mainStreamPublisher),
+		coreannouncement.NewCreator(announcementRepo, idGen, mainStreamPublisher, broadcastPublisher),
 		webhookService,
 		idGen,
 		miscsmtp.SubjectBodySenderFromMeta(metaRepo, s.config.ProxySmtp),
@@ -2388,6 +2390,7 @@ func (s *Server) setupRoutes() {
 	iHandler.SetAnnouncementRepo(announcementRepo)
 	announcementHandler := apiannouncements.NewHandler(announcementRepo, idGen)
 	announcementHandler.SetMainStreamPublisher(mainStreamPublisher)
+	announcementHandler.SetBroadcastPublisher(broadcastPublisher) // global announcementCreated (#2056)
 	api.POST("/announcements", announcementHandler.List)
 	api.POST("/i/read-announcement", announcementHandler.ReadAnnouncement, middleware.RequireAuth(), middleware.RequireScope("write:account"))
 
@@ -2435,7 +2438,7 @@ func (s *Server) setupRoutes() {
 	flashHandler.SetModLog(modLogService)   // #1548: moderator による flash 削除の監査ログ
 	adminHandler.SetEmojiRepo(emojiRepo)
 	// emoji の add/update/delete を broadcast stream へ流し emoji picker を live-refresh (#2046)。
-	adminHandler.SetBroadcastPublisher(stream.NewBroadcastPublisher(streamPubSub))
+	adminHandler.SetBroadcastPublisher(broadcastPublisher)
 	adminHandler.SetDriveFileRepo(driveFileRepo)
 	adminHandler.SetDriveBulkDeleter(driveService) // #1772: delete-all-files の物理削除 + 使用量減算
 	// bulk drive cleanup (clean-remote-files / delete-all-files-of-a-user) で


### PR DESCRIPTION
## Summary

#2046 (broadcast stream infra) を流用し、**global announcement (userId 無し) の announcementCreated を
broadcast 配信**する。upstream `AnnouncementService.create` は per-user→main / global→broadcast に分けるが、
mk-go は global を skip していた (接続中の client は再接続/再fetch まで stale)。

## 主な変更点

- **`api/announcements` AdminCreate**: `userId != nil → main` / `userId == nil → broadcast` に分岐。
  `BroadcastPublisher` interface + `SetBroadcastPublisher`。
- **`core/announcement` Creator.Create**: 同分岐。`NewCreator` に broadcast 引数追加 (moderatoractivity
  #1563 経路。実際は per-user 固定で broadcast には入らないが対称性のため配線)。
- **`router.go`**: 共有 `broadcastPublisher` 変数を admin(#2046 既存)/announcements/Creator に配線
  (`SubscribeBroadcast()` は起動済)。
- body は per-user と同一 `{announcement: PackAnnouncement(a, idGen, false)}`。

## テスト

- global → broadcast に announcementCreated・main へは出さない / per-user → main のみ broadcast へ出さない /
  AdminCreate global broadcast。nil publisher で panic しない。
- announcements 96.5% / announcement creator 100%。`make fmt` / `go vet ./...` / `make test` green。

## 補足

敵対的レビューで upstream 分岐一致・body shape 一致・2経路 (handler/Creator) disjoint で二重配信なし・nil
安全・update/delete は upstream も publish しないため create 限定が妥当、を確認。`isRead:false` は既存
PackAnnouncement の挙動 (本 PR の新規 divergence ではない)。

## 関連

- 親: #1948
- 元: #2046

Closes #2056
