### PR TITLE
Fix admin/roles/list parity (#2061): lastUsedAt DESC ordering + Assign/Unassign で lastUsedAt 更新

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -1843,7 +1843,8 @@ func (h *Handler) RolesShow(c echo.Context) error {
 
 // RolesList handles POST /api/admin/roles/list.
 func (h *Handler) RolesList(c echo.Context) error {
-	roles, err := h.roleService.List()
+	// upstream admin/roles/list.ts は lastUsedAt DESC で返す (#2061)。
+	roles, err := h.roleService.ListByLastUsed()
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -1930,7 +1930,8 @@ type failingListRoleRepo struct {
 	*testutil.MockRoleRepository
 }
 
-func (f *failingListRoleRepo) List() ([]*model.Role, error) { return nil, assert.AnError }
+func (f *failingListRoleRepo) List() ([]*model.Role, error)           { return nil, assert.AnError }
+func (f *failingListRoleRepo) ListByLastUsed() ([]*model.Role, error) { return nil, assert.AnError }
 
 func TestRolesList_Error(t *testing.T) {
 	failRepo := &failingListRoleRepo{testutil.NewMockRoleRepository()}

--- a/internal/api/roles/handler_test.go
+++ b/internal/api/roles/handler_test.go
@@ -373,7 +373,8 @@ type failingListRepo struct {
 	*testutil.MockRoleRepository
 }
 
-func (f *failingListRepo) List() ([]*model.Role, error) { return nil, assert.AnError }
+func (f *failingListRepo) List() ([]*model.Role, error)           { return nil, assert.AnError }
+func (f *failingListRepo) ListByLastUsed() ([]*model.Role, error) { return nil, assert.AnError }
 
 // --- Notes ---
 

--- a/internal/core/role/role_service.go
+++ b/internal/core/role/role_service.go
@@ -938,6 +938,12 @@ func (s *Service) Assign(userID, roleID string, expiresAt *time.Time) error {
 	if err := s.assignmentRepo.Create(a); err != nil {
 		return err
 	}
+	// upstream RoleService.assign は role.lastUsedAt を更新する (#2061)。eval は
+	// lastUsedAt を使わないので rolesListCache の invalidate は不要 (admin/roles/list は
+	// ListByLastUsed で fresh に引く)。失敗しても割当自体は成功扱いで続行する。
+	if err := s.roleRepo.UpdateFields(roleID, map[string]any{"lastUsedAt": time.Now()}); err != nil {
+		slog.Warn("role assign: lastUsedAt update failed", "role", roleID, "err", err)
+	}
 	s.InvalidateUserRoleCache(userID)
 	// public role の割当のみ通知する (upstream RoleService.assign の
 	// `if (role.isPublic && user.host === null)`)。local 判定は notifier 側の
@@ -959,6 +965,10 @@ func (s *Service) Unassign(userID, roleID string) error {
 	}
 	if err := s.assignmentRepo.Delete(userID, roleID); err != nil {
 		return err
+	}
+	// upstream RoleService.unassign も role.lastUsedAt を更新する (#2061)。
+	if err := s.roleRepo.UpdateFields(roleID, map[string]any{"lastUsedAt": time.Now()}); err != nil {
+		slog.Warn("role unassign: lastUsedAt update failed", "role", roleID, "err", err)
 	}
 	s.InvalidateUserRoleCache(userID)
 	return nil
@@ -1040,6 +1050,13 @@ func (s *Service) Show(id string) (*model.Role, error) {
 // List returns all roles.
 func (s *Service) List() ([]*model.Role, error) {
 	return s.roleRepo.List()
+}
+
+// ListByLastUsed returns roles ordered by lastUsedAt DESC for admin/roles/list
+// (upstream `order: { lastUsedAt: 'DESC' }`、#2061)。eval 用の cache を経由せず
+// 毎回 fresh で引くので、Assign/Unassign の lastUsedAt 更新が即反映される。
+func (s *Service) ListByLastUsed() ([]*model.Role, error) {
+	return s.roleRepo.ListByLastUsed()
 }
 
 // ExistingRoleIDSet returns the set of all current role ids. get-avatar-

--- a/internal/core/role/role_service_test.go
+++ b/internal/core/role/role_service_test.go
@@ -1596,3 +1596,30 @@ func TestService_GetModerators_NilUserRepo(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, mods)
 }
+
+// #2061: Assign / Unassign は role.lastUsedAt を更新する (upstream RoleService)。
+func TestAssignUnassign_UpdatesLastUsedAt(t *testing.T) {
+	svc, roleRepo, _, _ := newTestService(t)
+	old := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Admin", LastUsedAt: old}
+
+	require.NoError(t, svc.Assign("user1", "r1", nil))
+	assert.True(t, roleRepo.Roles["r1"].LastUsedAt.After(old), "Assign が lastUsedAt を更新 (#2061)")
+
+	roleRepo.Roles["r1"].LastUsedAt = old // reset
+	require.NoError(t, svc.Unassign("user1", "r1"))
+	assert.True(t, roleRepo.Roles["r1"].LastUsedAt.After(old), "Unassign が lastUsedAt を更新 (#2061)")
+}
+
+// #2061: ListByLastUsed は lastUsedAt DESC で返す。
+func TestService_ListByLastUsed(t *testing.T) {
+	svc, roleRepo, _, _ := newTestService(t)
+	roleRepo.Roles["a"] = &model.Role{ID: "a", LastUsedAt: time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)}
+	roleRepo.Roles["b"] = &model.Role{ID: "b", LastUsedAt: time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)}
+	roleRepo.Roles["c"] = &model.Role{ID: "c", LastUsedAt: time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)}
+
+	roles, err := svc.ListByLastUsed()
+	require.NoError(t, err)
+	require.Len(t, roles, 3)
+	assert.Equal(t, []string{"b", "c", "a"}, []string{roles[0].ID, roles[1].ID, roles[2].ID}, "lastUsedAt DESC (#2061)")
+}

--- a/internal/repository/role.go
+++ b/internal/repository/role.go
@@ -12,6 +12,10 @@ type RoleRepository interface {
 	Create(role *model.Role) error
 	FindByID(id string) (*model.Role, error)
 	List() ([]*model.Role, error)
+	// ListByLastUsed returns roles ordered by lastUsedAt DESC for admin/roles/list
+	// (upstream `order: { lastUsedAt: 'DESC' }`、#2061)。eval 用の List() (cached,
+	// displayOrder 順) とは別に毎回 fresh で引く。
+	ListByLastUsed() ([]*model.Role, error)
 	UpdateFields(id string, fields map[string]any) error
 	Delete(id string) error
 }
@@ -40,6 +44,16 @@ func (r *roleRepository) FindByID(id string) (*model.Role, error) {
 func (r *roleRepository) List() ([]*model.Role, error) {
 	var roles []*model.Role
 	if err := r.db.Order("\"displayOrder\" DESC, id ASC").Find(&roles).Error; err != nil {
+		return nil, err
+	}
+	return roles, nil
+}
+
+func (r *roleRepository) ListByLastUsed() ([]*model.Role, error) {
+	var roles []*model.Role
+	// upstream admin/roles/list.ts: `order: { lastUsedAt: 'DESC' }` (#2061)。
+	// 同 lastUsedAt の安定順のため id ASC を tie-breaker に足す。
+	if err := r.db.Order("\"lastUsedAt\" DESC, id ASC").Find(&roles).Error; err != nil {
 		return nil, err
 	}
 	return roles, nil

--- a/internal/repository/role_test.go
+++ b/internal/repository/role_test.go
@@ -350,3 +350,32 @@ func TestUserRepository_ListUsers_AdminFilterDedupsMultipleRoles(t *testing.T) {
 	}
 	assert.Equal(t, 1, count, "user with multiple admin roles should appear exactly once (= SQL IN subquery dedup)")
 }
+
+// #2061: ListByLastUsed は lastUsedAt DESC で返す。
+func TestRoleRepository_ListByLastUsed(t *testing.T) {
+	repo := NewRoleRepository(testDB)
+	mk := func(id string, year int) {
+		require.NoError(t, repo.Create(&model.Role{
+			ID: id, Name: id, UpdatedAt: time.Now(),
+			LastUsedAt:  time.Date(year, 1, 1, 0, 0, 0, 0, time.UTC),
+			Target:      model.RoleTargetManual,
+			Policies:    datatypes.JSON([]byte("{}")),
+			CondFormula: datatypes.JSON([]byte("{}")),
+		}))
+		t.Cleanup(func() { cleanupRole(t, id) })
+	}
+	mk("rlu_old", 2020)
+	mk("rlu_new", 2024)
+	mk("rlu_mid", 2022)
+
+	roles, err := repo.ListByLastUsed()
+	require.NoError(t, err)
+	// seed した 3 件が lastUsedAt DESC 順 (new→mid→old) で並ぶこと (他の既存 role が
+	// 混ざりうるので相対順序で検証)。
+	pos := map[string]int{}
+	for i, r := range roles {
+		pos[r.ID] = i
+	}
+	assert.Less(t, pos["rlu_new"], pos["rlu_mid"], "new は mid より前 (#2061)")
+	assert.Less(t, pos["rlu_mid"], pos["rlu_old"], "mid は old より前 (#2061)")
+}

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -6480,6 +6480,22 @@ func (m *MockRoleRepository) List() ([]*model.Role, error) {
 	return result, nil
 }
 
+// ListByLastUsed returns roles sorted by lastUsedAt DESC (id ASC tie-break),
+// mirroring the production query for admin/roles/list (#2061)。
+func (m *MockRoleRepository) ListByLastUsed() ([]*model.Role, error) {
+	result := make([]*model.Role, 0, len(m.Roles))
+	for _, r := range m.Roles {
+		result = append(result, r)
+	}
+	sort.SliceStable(result, func(i, j int) bool {
+		if result[i].LastUsedAt.Equal(result[j].LastUsedAt) {
+			return result[i].ID < result[j].ID
+		}
+		return result[i].LastUsedAt.After(result[j].LastUsedAt)
+	})
+	return result, nil
+}
+
 func (m *MockRoleRepository) UpdateFields(id string, fields map[string]any) error {
 	r, ok := m.Roles[id]
 	if !ok {
@@ -6547,6 +6563,11 @@ func (m *MockRoleRepository) UpdateFields(id string, fields map[string]any) erro
 	if v, ok := fields["policies"]; ok {
 		if b, ok := v.([]byte); ok {
 			r.Policies = b
+		}
+	}
+	if v, ok := fields["lastUsedAt"]; ok {
+		if t, ok := v.(time.Time); ok {
+			r.LastUsedAt = t
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

#2027 の triage で残した item。upstream `admin/roles/list.ts` は role を `lastUsedAt DESC` で返し、
`RoleService.assign`/`unassign` は `role.lastUsedAt` を更新するが、mk-go は `displayOrder DESC` で返し
lastUsedAt を Create でしか更新していなかった (2-part fix)。

## 主な変更点

- **`repository/role.go`**: `RoleRepository` に `ListByLastUsed()` (lastUsedAt DESC, id ASC tie-break)
  を追加。**eval 用の `List()` (displayOrder DESC, cached #1030) は不変**。全 impl (roleRepository +
  MockRoleRepository + 2 ad-hoc fake、embedded fake は継承) を更新。
- **`core/role/role_service.go`**: `ListByLastUsed()` service method + `Assign`/`Unassign` で
  `UpdateFields(roleID, {lastUsedAt: now})` (upstream 同様 fire-and-forget、失敗は warn log で続行)。
- **`api/admin` RolesList**: `roleService.List()` → `roleService.ListByLastUsed()`。

## テスト

- Assign/Unassign が lastUsedAt を更新 / ListByLastUsed が lastUsedAt DESC (service mock + repository
  integration)。
- core/role / repository / admin / roles / testutil 全 pass。`make fmt` / `go vet ./...` green。
  ローカルの repository following test は永続テスト DB の残データで duplicate-key 化するが本 PR 無関係
  (CI は shard ごとに fresh DB)。

## 補足

敵対的レビューで upstream parity (ordering / assign-unassign lastUsedAt 更新)・eval non-regression
(List() 不変、eval は lastUsedAt も list 順序も使わない)・interface 完全性・fire-and-forget 失敗
ハンドリングの upstream 一致・endpoint の fresh 性を確認。conditional role の動的付与は upstream も
assign() を通らず lastUsedAt を更新しないため取りこぼし無し。

## 関連

- 親: #1948
- 元: #2027 (triage で分離)

Closes #2061
