### PR TITLE
Add per-subscriber renote.myReaction injection (#2058): cache-based in-memory 算出

### DIFF
--- a/internal/entity/note.go
+++ b/internal/entity/note.go
@@ -570,6 +570,14 @@ func normalizeReactionKeys(raw datatypes.JSON) datatypes.JSON {
 	return data
 }
 
+// NormalizeReactionWithLegacy normalizes a raw reaction string (colon-form +
+// legacy text alias), e.g. `:smile:`→`:smile@.:`, `like`→`👍`。streaming channel の
+// renote.myReaction inject が REST 経路と同じ正規化を適用するための export wrapper
+// (#2058)。reactionAndUserPairCache は raw reaction を保持するため必須。
+func NormalizeReactionWithLegacy(raw string) string {
+	return normalizeReactionWithLegacy(raw)
+}
+
 // sumReactions decodes the reactions JSONB and sums all values.
 func sumReactions(raw datatypes.JSON) int {
 	if len(raw) == 0 {

--- a/internal/stream/channels/antenna.go
+++ b/internal/stream/channels/antenna.go
@@ -95,6 +95,8 @@ func (c *AntennaChannel) OnRedisEvent(payload []byte) {
 	// 消すと non-visible な引用/返信元が top-level antenna note 経由で漏れる
 	// IDOR を再 open する。
 	payload = hideEmbeds(c.ctx, payload)
+	// pure renote の renote.myReaction を viewer 毎に inject (#2058)。
+	payload = injectRenoteMyReaction(payload, viewerIDFromCtx(c.ctx))
 	_ = c.ctx.Send("note", json.RawMessage(payload))
 }
 

--- a/internal/stream/channels/channel_timeline.go
+++ b/internal/stream/channels/channel_timeline.go
@@ -64,6 +64,8 @@ func (c *ChannelTimelineChannel) OnRedisEvent(payload []byte) {
 		return
 	}
 	payload = hideEmbeds(c.ctx, payload)
+	// pure renote の renote.myReaction を viewer 毎に inject (#2058)。
+	payload = injectRenoteMyReaction(payload, viewerIDFromCtx(c.ctx))
 	_ = c.ctx.Send("note", json.RawMessage(payload))
 }
 

--- a/internal/stream/channels/hashtag.go
+++ b/internal/stream/channels/hashtag.go
@@ -117,6 +117,8 @@ func (c *HashtagChannel) OnRedisEvent(payload []byte) {
 		return
 	}
 	payload = hideEmbeds(c.ctx, payload)
+	// pure renote の renote.myReaction を viewer 毎に inject (#2058)。
+	payload = injectRenoteMyReaction(payload, viewerIDFromCtx(c.ctx))
 	_ = c.ctx.Send("note", json.RawMessage(payload))
 }
 

--- a/internal/stream/channels/note_filter.go
+++ b/internal/stream/channels/note_filter.go
@@ -3,6 +3,7 @@ package channels
 import (
 	"encoding/json"
 	"slices"
+	"strings"
 	"time"
 
 	corenote "github.com/shiroha-a/mk/internal/core/note"
@@ -11,6 +12,85 @@ import (
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/stream"
 )
+
+// injectRenoteMyReaction sets note.renote.myReaction for a pure renote whose
+// renote has reactions, computing the viewer's reaction IN-MEMORY from the
+// renote's reactionAndUserPairCache (upstream timeline channel onNote の
+// populateMyReaction cache 経路、#2058)。per-subscriber の DB lookup を避けるため
+// cache-only で算出し、cache が truncated (reaction 種類数 > pair 数) なら skip する
+// (upstream は DB fallback するが mk-go は cache のみ)。
+//
+// 非該当 (未認証 / pure renote でない / renote.reactions 空 / viewer 未 reaction /
+// cache truncated / parse 失敗) では payload を変えずに返す。
+func injectRenoteMyReaction(payload []byte, viewerID string) []byte {
+	if viewerID == "" {
+		return payload
+	}
+	var probe struct {
+		notePayload
+		Renote *struct {
+			Reactions json.RawMessage `json:"reactions"`
+			Cache     []string        `json:"reactionAndUserPairCache"`
+		} `json:"renote"`
+	}
+	if err := json.Unmarshal(payload, &probe); err != nil {
+		return payload
+	}
+	if !probe.isPureRenote() || probe.Renote == nil {
+		return payload
+	}
+	// upstream populateMyReaction は reactionsCount = Σ(reactions の値) (種類数でなく
+	// 総数) で cache 充足を判定する。総数 > cache 長なら cache は truncated なので
+	// 算出しない (upstream は DB fallback だが mk-go は cache-only、#2058)。
+	reactionCount := reactionValueSum(probe.Renote.Reactions)
+	if reactionCount == 0 || len(probe.Renote.Cache) < reactionCount {
+		return payload
+	}
+	prefix := viewerID + "/"
+	reaction := ""
+	for _, pair := range probe.Renote.Cache {
+		if strings.HasPrefix(pair, prefix) {
+			// pair suffix は raw reaction。REST 経路と同じく colon-form/legacy 正規化を
+			// 適用しないと reactions map の key (正規化済) と突合できない (#2058 HIGH)。
+			reaction = entity.NormalizeReactionWithLegacy(pair[len(prefix):])
+			break
+		}
+	}
+	if reaction == "" {
+		return payload // viewer は reaction していない → myReaction null のまま
+	}
+	// full unmarshal → set → re-marshal (hideNoteRawForViewer と同パターン)。算出に
+	// 成功した pure-renote-with-reactions のときだけ marshal するので hot-path 全体には
+	// 乗らない。
+	var full entity.NoteEntity
+	if err := json.Unmarshal(payload, &full); err != nil || full.Renote == nil {
+		return payload
+	}
+	full.Renote.MyReaction = &reaction
+	out, err := json.Marshal(&full)
+	if err != nil {
+		return payload
+	}
+	return out
+}
+
+// reactionValueSum returns Σ of a reactions JSON object's values (the total
+// reaction count, matching upstream `Object.values(reactions).reduce(...)` /
+// entity.sumReactions、#2058)。0 for null / empty / parse error。
+func reactionValueSum(raw json.RawMessage) int {
+	if len(raw) == 0 {
+		return 0
+	}
+	var m map[string]float64
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return 0
+	}
+	total := 0
+	for _, v := range m {
+		total += int(v)
+	}
+	return total
+}
 
 // viewerIDFromCtx extracts the authenticated user's ID from a ChannelContext.
 // Returns "" for anonymous connections so wordmute.MatchNote treats every

--- a/internal/stream/channels/note_filter_test.go
+++ b/internal/stream/channels/note_filter_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultNoteFilter(t *testing.T) {
@@ -343,4 +344,54 @@ func TestAnonRequireSigninDrop(t *testing.T) {
 	t.Run("malformed payload passes (fail to other gates)", func(t *testing.T) {
 		assert.False(t, anonRequireSigninDrop([]byte(`{not json`), ""))
 	})
+}
+
+// #2058: pure renote の renote.myReaction を reactionAndUserPairCache から in-memory 算出。
+func TestInjectRenoteMyReaction(t *testing.T) {
+	base := `{"id":"n1","userId":"author","renoteId":"r1","renote":{"id":"r1","reactions":{"👍":2},"reactionAndUserPairCache":["alice/👍","bob/❤"]}}`
+
+	// alice は reaction 済 → renote.myReaction="👍" がセットされる。
+	out := injectRenoteMyReaction([]byte(base), "alice")
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(out, &m))
+	renote := m["renote"].(map[string]any)
+	assert.Equal(t, "👍", renote["myReaction"], "viewer の reaction が inject される (#2058)")
+
+	// carol は未 reaction → payload 不変 (myReaction 無し)。
+	assert.Equal(t, base, string(injectRenoteMyReaction([]byte(base), "carol")), "未 reaction は不変")
+	// 未認証 (viewerID="") → 不変。
+	assert.Equal(t, base, string(injectRenoteMyReaction([]byte(base), "")), "anon は不変")
+	// quote renote (text あり = 非 pure renote) → 不変。
+	quote := `{"id":"n2","userId":"a","renoteId":"r1","text":"q","renote":{"reactions":{"👍":1},"reactionAndUserPairCache":["alice/👍"]}}`
+	assert.Equal(t, quote, string(injectRenoteMyReaction([]byte(quote), "alice")), "quote は対象外")
+	// renote.reactions 空 → 不変。
+	noReact := `{"id":"n3","userId":"a","renoteId":"r1","renote":{"reactions":{},"reactionAndUserPairCache":[]}}`
+	assert.Equal(t, noReact, string(injectRenoteMyReaction([]byte(noReact), "alice")), "reactions 空は対象外")
+	// cache が reaction 種類数より少ない (truncated) → 不変。
+	trunc := `{"id":"n4","userId":"a","renoteId":"r1","renote":{"reactions":{"👍":1,"❤":1},"reactionAndUserPairCache":["alice/👍"]}}`
+	assert.Equal(t, trunc, string(injectRenoteMyReaction([]byte(trunc), "alice")), "truncated cache は skip")
+	// renote でない → 不変。
+	plain := `{"id":"n5","userId":"a"}`
+	assert.Equal(t, plain, string(injectRenoteMyReaction([]byte(plain), "alice")))
+}
+
+// #2058 HIGH-1: truncated 判定は reaction 種類数でなく総数 (sum) で行う。
+// #2058 HIGH-2: pair suffix の raw reaction を colon-form/legacy 正規化する。
+func TestInjectRenoteMyReaction_SumAndNormalize(t *testing.T) {
+	// 単一種類だが総数 3 > cache 長 2 → truncated 扱いで skip (key-count なら誤って算出)。
+	trunc := `{"id":"n1","userId":"a","renoteId":"r1","renote":{"reactions":{"👍":3},"reactionAndUserPairCache":["bob/👍","carol/👍"]}}`
+	assert.Equal(t, trunc, string(injectRenoteMyReaction([]byte(trunc), "alice")), "総数>cache長は truncated で skip (#2058 HIGH-1)")
+
+	// legacy text reaction "like" は "👍" に正規化される。
+	legacy := `{"id":"n2","userId":"a","renoteId":"r1","renote":{"reactions":{"👍":1},"reactionAndUserPairCache":["alice/like"]}}`
+	out := injectRenoteMyReaction([]byte(legacy), "alice")
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(out, &m))
+	assert.Equal(t, "👍", m["renote"].(map[string]any)["myReaction"], "legacy reaction を正規化 (#2058 HIGH-2)")
+
+	// custom emoji :smile: は :smile@.: に正規化される。
+	custom := `{"id":"n3","userId":"a","renoteId":"r1","renote":{"reactions":{":smile@.:":1},"reactionAndUserPairCache":["alice/:smile:"]}}`
+	out = injectRenoteMyReaction([]byte(custom), "alice")
+	require.NoError(t, json.Unmarshal(out, &m))
+	assert.Equal(t, ":smile@.:", m["renote"].(map[string]any)["myReaction"], "custom emoji を正規化 (#2058 HIGH-2)")
 }

--- a/internal/stream/channels/role_timeline.go
+++ b/internal/stream/channels/role_timeline.go
@@ -79,6 +79,8 @@ func (c *RoleTimelineChannel) OnRedisEvent(payload []byte) {
 		return
 	}
 	payload = hideEmbeds(c.ctx, payload)
+	// pure renote の renote.myReaction を viewer 毎に inject (#2058)。
+	payload = injectRenoteMyReaction(payload, viewerIDFromCtx(c.ctx))
 	_ = c.ctx.Send("note", json.RawMessage(payload))
 }
 

--- a/internal/stream/channels/timeline.go
+++ b/internal/stream/channels/timeline.go
@@ -72,6 +72,8 @@ func (c *LocalTimelineChannel) OnRedisEvent(payload []byte) {
 		return
 	}
 	payload = hideEmbeds(c.ctx, payload)
+	// pure renote の renote.myReaction を viewer 毎に in-memory 算出して inject (#2058)。
+	payload = injectRenoteMyReaction(payload, viewerID)
 	_ = c.ctx.Send("note", json.RawMessage(payload))
 }
 
@@ -127,6 +129,8 @@ func (c *GlobalTimelineChannel) OnRedisEvent(payload []byte) {
 		return
 	}
 	payload = hideEmbeds(c.ctx, payload)
+	// pure renote の renote.myReaction を viewer 毎に in-memory 算出して inject (#2058)。
+	payload = injectRenoteMyReaction(payload, viewerID)
 	_ = c.ctx.Send("note", json.RawMessage(payload))
 }
 func (c *GlobalTimelineChannel) OnClientMessage(string, json.RawMessage) {}
@@ -181,6 +185,8 @@ func (c *HomeTimelineChannel) OnRedisEvent(payload []byte) {
 		return
 	}
 	payload = hideEmbeds(c.ctx, payload)
+	// pure renote の renote.myReaction を viewer 毎に in-memory 算出して inject (#2058)。
+	payload = injectRenoteMyReaction(payload, viewerID)
 	_ = c.ctx.Send("note", json.RawMessage(payload))
 }
 
@@ -251,6 +257,8 @@ func (c *HybridTimelineChannel) OnRedisEvent(payload []byte) {
 		return
 	}
 	payload = hideEmbeds(c.ctx, payload)
+	// pure renote の renote.myReaction を viewer 毎に in-memory 算出して inject (#2058)。
+	payload = injectRenoteMyReaction(payload, viewerID)
 	_ = c.ctx.Send("note", json.RawMessage(payload))
 }
 

--- a/internal/stream/channels/user_list.go
+++ b/internal/stream/channels/user_list.go
@@ -150,6 +150,8 @@ func (c *UserListChannel) OnRedisEvent(payload []byte) {
 		}
 	}
 	payload = hideEmbeds(c.ctx, payload)
+	// pure renote の renote.myReaction を viewer 毎に inject (#2058)。
+	payload = injectRenoteMyReaction(payload, viewerID)
 	_ = c.ctx.Send("note", json.RawMessage(payload))
 }
 

--- a/internal/stream/note_publisher.go
+++ b/internal/stream/note_publisher.go
@@ -128,6 +128,17 @@ func (p *NotePublisher) packNote(n *model.Note, author *model.User) []byte {
 		pairs = []string{}
 	}
 	pn.ReactionAndUserPairCache = &pairs
+	// pure renote の renote embed にも reactionAndUserPairCache を載せ、subscriber 側の
+	// timeline channel が renote.myReaction を per-viewer に in-memory 算出できるように
+	// する (upstream populateMyReaction の cache 経路、#2058)。renote model が preload
+	// されていれば DB の cache をそのまま渡す。
+	if pn.Renote != nil && noteForPack.Renote != nil {
+		rpairs := []string(noteForPack.Renote.ReactionAndUserPairCache)
+		if rpairs == nil {
+			rpairs = []string{}
+		}
+		pn.Renote.ReactionAndUserPairCache = &rpairs
+	}
 	// REST 経路と同じ後段 resolver を通して Files / Channel を埋める。
 	// viewer 引数は streaming fanout の性質上「自分宛て」が複数 subscriber
 	// に展開されるため特定不能。viewer=nil で Apply を呼ぶと

--- a/internal/stream/note_publisher_test.go
+++ b/internal/stream/note_publisher_test.go
@@ -812,3 +812,29 @@ func TestNotePublisher_EmitsReactionAndUserPairCache(t *testing.T) {
 	require.Contains(t, m2, "reactionAndUserPairCache")
 	assert.Equal(t, "[]", string(m2["reactionAndUserPairCache"]))
 }
+
+// #2058: pure renote の renote embed にも reactionAndUserPairCache を載せ、subscriber
+// 側 channel が renote.myReaction を算出できるようにする。
+func TestNotePublisher_EmitsRenoteReactionAndUserPairCache(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	pub := &stubPublisher{}
+	np := NewNotePublisher(pub, idGen)
+
+	renote := &model.Note{
+		ID: idGen.Generate(time.Now()), UserID: "u2", Visibility: model.NoteVisibilityPublic,
+		ReactionAndUserPairCache: []string{"userA/👍"},
+	}
+	n := &model.Note{
+		ID: idGen.Generate(time.Now()), UserID: "u1", Visibility: model.NoteVisibilityPublic,
+		RenoteID: &renote.ID, Renote: renote,
+	}
+	np.PublishNote("homeTimeline:u1", n, &model.User{ID: "u1", Username: "alice"})
+	require.Len(t, pub.payloads, 1)
+	var m map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(pub.payloads[0].(json.RawMessage), &m))
+	require.Contains(t, m, "renote")
+	var renoteObj map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(m["renote"], &renoteObj))
+	require.Contains(t, renoteObj, "reactionAndUserPairCache", "renote embed に cache を載せる (#2058)")
+	assert.JSONEq(t, `["userA/👍"]`, string(renoteObj["reactionAndUserPairCache"]))
+}


### PR DESCRIPTION
## Summary

#2020 から分離した streaming hot-path item。upstream の各 timeline channel `onNote` は pure renote
(isRenote && !isQuote) で `renote.reactions` が非空のとき `note.renote.myReaction = populateMyReaction(...)`
を viewer 毎に set するが、mk-go は renote embed に myReaction が無く client でも復元不能だった。
**per-subscriber の DB lookup を避ける cache-based in-memory 方式**で実装する。

## 主な変更点

- **`note_publisher`**: renote embed にも `reactionAndUserPairCache` を載せる (top-level cache #1640 の踏襲)。
  これで channel が renote.myReaction を in-memory 算出できる。
- **`channels/note_filter.go`** `injectRenoteMyReaction`: pure renote + `renote.reactions` 非空 + viewer
  認証済 なら、`renote.reactionAndUserPairCache` から viewer の pair (`viewerID/reaction`) を探して
  `renote.myReaction` を set (full NoteEntity unmarshal→set→re-marshal)。
  - `reactionsCount` は upstream 同様 **値の総和** (`Object.values(reactions).reduce`) で算出し、
    総和 > cache 長の truncated 時は skip (upstream は DB fallback だが mk-go は cache-only)。
  - pair suffix の raw reaction は `entity.NormalizeReactionWithLegacy` で REST と同じ colon-form/legacy
    正規化を適用 (reactions map key と突合できるように)。
- **9 channel** (home/local/hybrid/global timeline + channel_timeline + antenna + hashtag + role_timeline +
  user_list) の `Send("note")` 前に inject を配線 (upstream で populateMyReaction する全 channel と一致)。

## テスト

- viewer reaction の inject / 未 reaction・anon・quote・空 reactions・truncated(総和基準)・非 renote で
  不変 / legacy `like`→`👍`・custom `:smile:`→`:smile@.:` 正規化 / renote embed cache 出力。`go test -race`。
- stream 90.8% / channels 91.9%。`make fmt` / `go vet ./...` / `make test` / entitycompat golden gate green。

## 補足

敵対的レビューで指摘された 2 HIGH を修正済: (1) reactionsCount を種類数でなく総和で算出 (truncated 判定の
正確化)、(2) myReaction を REST と同じく正規化。perf は非該当 note が probe 1 回で verbatim return、
full re-marshal は pure-renote-with-reactions-で-viewer-reacted のみ。channel 網羅性 (9 channel) と
race 安全性も確認。buffered reaction pairs の concat 未対応は #2067 に分離。

## 関連

- 親: #1948 / tracking #2020 (item1)

Closes #2058
