### PR TITLE
Add 2026.5.4 → 2026.6.0 upstream 追従 triage doc (#2069)

### DIFF
--- a/docs/update/20260622-2069-triage.md
+++ b/docs/update/20260622-2069-triage.md
@@ -1,0 +1,424 @@
+# #2069 (2026.5.4 → 2026.6.0) upstream 追従 triage
+
+upstream Misskey 2026.6.0 (2026-06-22 release) の backend 差分 (`packages/backend/src/` + `migration/`、
+no-merges 27 commits) を `git show <sha>` で精読し、mk-go 側の該当箇所を grep + read で特定した結果。各 item に
+Gap 判定 + 推定難易度を付与し、sub-issue 化の前段とする。
+
+注: `third_party/misskey` fork は `2026.6.0-mk.0` tag (upstream 2026.6.0 + MkModal null-guard 1件) に
+配信済。本体 (mk-go) の `MisskeyVersion` 定数 / dropin 版数 bump は別管理 (本 tracker scope 外)。
+
+## サマリ
+
+mk-go の API/ActivityPub 互換性に影響しうる 15 件 (deps/refactor/test/build の N/A 12 件は末尾にまとめる)。
+
+| # | upstream | 領域 | Gap 判定 | 難易度 |
+|---|---|---|---|---|
+| 1 | SEC (fork) | TOTP token 再利用防止 + window 5→1 | 部分対応 (replay は #1555 で先行実装、window drift + コメント陳腐化) | S |
+| 2 | SEC (fork) | UrlPreview を常に SSRF-safe agent で fetch | 影響なし (常時 SSRF-safe transport) | N/A |
+| 3 | #17558 | inbox actor 欠落 activity を早期 400 | 部分対応 (crash 無し、enqueue 前 reject 未適用) | S |
+| 4 | #17563 | AP image attachment に width/height (outbound) | 未対応 (型はあるが populate 漏れ) | S |
+| 5 | #16488 | self-hostname 付き acct で profile 解決 | 影響なし (host を無視する実装で元々救済) | N/A |
+| 6 | #17576 | remote note mention 制限を raw count に | 未対応 (解決済ユーザー数で判定 = upstream 修正前) | S |
+| 7 | #15961 | followers note を direct 引用で direct 維持 | 未対応 (無条件 followers 強制 = 修正前) | S |
+| 8 | #16119 | 投稿日時範囲 (rangeStartAt/EndAt) でノート検索 | 未対応 (param 自体無し) | M |
+| 9 | #17463 | antennas/remove-note 新 API | 未対応 (endpoint 無し、Stream なので XDEL 要) | M |
+| 10 | #17499 | PerUserDriveChart で userId null file skip | 影響なし (二重ガード済) | N/A |
+| 11 | #17580 | OAuth2 Token Grant validation 堅牢化 | 影響なし (JSON/urlencoded 両対応済) | N/A |
+| 12 | #17389 | upload size を server 全体上限で cap + base-role aggregate | 未対応 (role policy が server cap されない) | M |
+| 13 | #17436 | admin/queue/pause + resume | 未対応 (endpoint + pause 機構 + modlog 全て無) | L |
+| 14 | #17513 | admin/reset-password エラーをダイアログ可能に | 実質対応済 (構造化エラー有、code/id 差異のみ) | S |
+| 15 | #17577/#17511/#17581 | note_favorite/user_note_pining の noteId index | 部分対応 (user_note_pining が noteId 単一 index 欠落) | S |
+
+**消化見込み**: 影響なし 4 件 (2, 5, 10, 11) + 実質対応 1 件 (14) = **5 件は close 候補**。新規実装が必要なのは
+**10 件**: S 6 件 (1, 3, 4, 6, 7, 15) / M 3 件 (8, 9, 12) / L 1 件 (13)。L の #17436 (queue pause/resume) のみ
+mkq driver にキュー pause 機構が無くインフラ層から要実装で大きい。残りは 1 PR / 数十〜百行で消化可。
+
+---
+
+## 1. SEC (fork) TOTP: 使用済 token の再利用防止 + validation window 5→1
+
+**sha**: `d323fe00d0`
+
+### Upstream 変更
+`UserAuthService.ts` の TOTP 検証を改修。(1) `OTPAuth.TOTP.validate` の `window` を **5→1** に縮小。(2) 検証成功後に
+Redis へ `2fa:used:<userId>:<step>` (step = `totp.counter()+delta`) を `SET EX <ttl> NX` で立て、既存なら
+authentication failed を投げる **replay 防止**を追加 (TTL=`timeStep*(window*2+1)`=90s)。固定 `now` で counter と
+validate を一貫させる。
+
+### mk-go 該当箇所
+- `internal/core/twofactor/totp_service.go:19` `totpSkew = 5` / `:66` `Validate` (Skew=5)
+- `internal/core/twofactor/replay.go:42` `defaultReplayTTL` / `:72` `MarkUsed` (`SetNX`) / `:100` `ValidateWithReplay`
+- `internal/api/i/handler_2fa.go:135`,`:258` 呼び出し
+
+### Gap
+**部分対応**。replay 防止は mk-go が #1555 で**先行実装済** (upstream に当時無かった機能)。drift 2 点: (a) window が
+**5 のまま** (upstream は 1 に縮小)。(b) replay キーが **raw code 単位** で upstream は **step 単位**。最終目的
+(replay 防止) は両者達成だが、`totp_service.go:15-18` / `replay.go:40-41` のコメントが「upstream window:5 に
+合わせる」と明記しており**事実と乖離**。
+
+### 推定実装
+`totpSkew` を 1 に変更 + コメントを upstream window:1 追従に更新。replay キーを step 単位に寄せるかは任意。
+**要確認**: skew=5 を入れた #1555 の動機 (drop-in 互換で緩めた可能性) と window:1 追従の優先度。時計ずれ端末を
+締め出すリスクがあるため安易に 1 に絞らない。
+
+**難易度**: **S**
+
+## 2. SEC (fork) URL Preview: proxy 未設定でも常に SSRF-safe agent を渡す
+
+**sha**: `1eac4ccf51`
+
+### Upstream 変更
+`UrlPreviewService.fetchSummary` で proxy 未設定時に `agent: undefined` で summaly を呼び SSRF 防御が抜けていた
+bug を、proxy 有無に関わらず常に SSRF-safe な custom agent を渡すよう修正。
+
+### mk-go 該当箇所
+- `internal/core/urlpreview/fetcher.go:79-82` `NewFetcher` — 常に `safehttp.NewSSRFSafeTransport(...)` で構築
+- `:152` `fetchAndParse` が常に `f.client` 使用 / `:99` `proxyClient` は summalyProxy (operator-trusted) 専用
+
+### Gap
+**影響なし**。mk-go は proxy 設定有無と独立に URL preview fetch を常に SSRF-safe transport 経由で行う。upstream の
+バグに対応する分岐自体が存在しない。
+
+**難易度**: **N/A**
+
+## 3. #17558 ActivityPub: actor 無し inbox activity を 400 で弾く (TypeError 防止)
+
+**sha**: `ae5d2d40d7`
+
+### Upstream 変更
+`ActivityPubServerService.inbox()` で enqueue 前に body 検証 (object でない/null/`actor` 欠落/`actor==null` なら
+400 を返し enqueue しない)。`InboxProcessorService` 側の actor null guard 削除。`getApId` を undefined 許容に。
+Fixes #17557。
+
+### mk-go 該当箇所
+- `internal/api/inbox/handler.go:160` `Inbox` / `:241` `admitInbox` (署名/host/digest 検証のみ、actor presence check 無し)
+- `internal/core/federation/processor.go:344-347` actor 空文字検出 → 通常 error
+- `internal/queue/processors/inbox.go:184` `authorizeActor` / `:165` `verifyPayload`
+
+### Gap
+**部分対応** (機能面は実質対応済)。Go では nil/型不一致が安全に処理され `processor.go:345` で actor 空を検出して
+error を返すため、upstream が直した crash は mk-go に存在しない。ただし「authenticate 不能な activity を
+enqueue しない」early-reject 最適化は未適用 (mk-go は admitInbox を通れば一旦 enqueue し worker で drop)。署名検証が
+actor 解決を要するため実際の無駄 retry は起きにくい。**注**: open #1959 (federation='none' 早期403) とは別系統
+(構造不正 vs federation mode gate)。
+
+### 推定実装
+parity 最適化として `Inbox` handler に「body を緩く parse し actor 欠落なら 400」を足せば挙動一致。fast-write 設計で
+JSON unmarshal を 1 回増やすコスト対効果は小。
+
+**難易度**: **S** (parity 最適化を入れる場合) / 機能面 N/A
+
+## 4. #17563 ActivityPub: 画像添付に width/height メタデータ (outbound)
+
+**sha**: `ec6b1cc6a8`
+
+### Upstream 変更
+`ApRendererService.renderDocument` に `width: file.properties?.width` / `height` を追加。送信する AP Document
+attachment に画像寸法を含める enhancement。
+
+### mk-go 該当箇所
+- `internal/activitypub/renderer.go:705-740` `addAttachments` — `Document` を組むが Width/Height 未 populate
+- `internal/activitypub/types.go:358-368` `Document` — `Width int`/`Height int` (omitempty) フィールドは**既存**
+- `internal/model/drive_file.go:16` `Properties datatypes.JSON` (`{"width":..,"height":..}`)
+
+### Gap
+**未対応**。型はあるが `addAttachments` で `f.Properties` から width/height を読んで詰める処理が無く常に omitempty で
+送出されない。`image_dimensions.go` は inbound (受信 probe) 用で本 commit (outbound) と無関係。
+
+### 推定実装
+`addAttachments` の Document 構築時に `f.Properties` を `{Width,Height int}` に unmarshal してセット (画像のみに限定が
+無難)。renderer_test.go に 1 ケース。
+
+**難易度**: **S**
+
+## 5. #16488 ActivityPub: self-hostname 付き acct で profile を引けない
+
+**sha**: `a75f3adc36`
+
+### Upstream 変更
+`/users/:acct` 系で `if (isSelfHost(acct.host)) acct.host = null;` を追加。`@user@self-host` で local user を
+解決できるよう host を正規化。
+
+### mk-go 該当箇所
+- `internal/api/ap/handler.go:340-369` `UserByAcct` — `:352-355` で username だけ抽出し host を完全に無視、
+  `ShowByUsername(username, nil)` で local-only lookup
+- `internal/api/ap/handler_test.go:981` `TestUserByAcct_WithHostSuffix` (host suffix 付きで local 解決を検証済)
+
+### Gap
+**影響なし**。mk-go は acct の host 部分を捨てて username のみで local lookup するため、self-host suffix で 404 になる
+upstream バグは元々存在しない。
+
+**難易度**: **N/A**
+
+## 6. #17576 ActivityPub: remote note の mention 制限を raw count で判定
+
+**sha**: `420d1f0f95`
+
+### Upstream 変更
+`ApNoteService` で `apMentionRawCount = new Set(extractApMentionObjects(note.tag).map(x=>x.href)).size` を算出し
+`NoteCreateService` へ渡す。`effectiveMentionCount = Math.max(mentionedUsers.length, apMentionRawCount ?? 0)` で
+`mentionLimit` を判定。狙いは「解決できたユーザー数」でなく「remote が宣言した raw mention 数」で制限すること。
+
+### mk-go 該当箇所
+- `internal/core/federation/resolver.go:1254-1265` — `note.Mentions` を作り `len(note.Mentions) > DefaultMentionLimit` で判定
+- `:1736-1761` `resolveMentionedUserIDs` — 未知 URI/解決失敗を skip / `:1709-1729` `extractMentionTags`
+
+### Gap
+**未対応**。制限判定が `len(note.Mentions)` (= 解決済ユニーク数) で、これは upstream 修正前のロジックそのもの。解決失敗を
+skip するため raw 数より小さくなり大量 mention をすり抜けうる。
+
+### 推定実装
+`extractMentionTags(apNote.Tag)` の href ユニーク数 (upstream の `new Set().size` 相当) を raw count として算出し、
+`max(len(note.Mentions), rawTagCount)` を制限判定に使う。upstream は AP tag の Mention href のみを raw count に
+する点に注意 (本文 @ は含めない)。IngestNote + 更新経路 (`resolver.go:1540` 付近) の両方に適用。
+
+**難易度**: **S**
+
+## 7. #15961 notes: followers note を direct 引用したとき direct を維持
+
+**sha**: `f17c93ec3b`
+
+### Upstream 変更
+renote visibility 調整 switch の `case 'followers':` で、従来無条件 `data.visibility='followers'` だったのを
+`if (visibility==='public'||'home') visibility='followers'` に変更。自分の followers note を direct/followers で
+引用したらユーザー選択の (狭い) 可視性を維持。
+
+### mk-go 該当箇所
+- `internal/core/note/note_create_service.go:578-588` `case NoteVisibilityFollowers:` で**無条件** followers 代入
+- `internal/core/note/note_create_service_test.go:680-687` `own followers target forces renote to followers` が旧挙動を固定
+
+### Gap
+**未対応**。upstream 修正前と完全一致。direct/specified で引用しても followers に上書きされる。修正時は既存テスト更新が必要。
+
+### 推定実装
+`case NoteVisibilityFollowers:` を `if visibility == Public || visibility == Home { visibility = Followers }` に変更。
+test を「specified/direct/followers は維持、public/home は降格」へ更新 + direct 維持ケース追加。local create のみ。
+
+**難易度**: **S**
+
+## 8. #16119 search: 投稿日時範囲 (rangeStartAt/rangeEndAt) でノート検索
+
+**sha**: `863046ba8c`
+
+### Upstream 変更
+`notes/search` に `rangeStartAt`/`rangeEndAt` (epoch ms, nullable) を追加。SQL 経路は range を **ID 境界に変換**
+(`note.id > gen(rangeStartAt-1)` / `< gen(rangeEndAt+1)`) して既存 cursor と AND 併用。Meilisearch 経路は
+`createdAt >= / <= ` filter。既存の `sinceDate`/`untilDate` (cursor 正規化) とは別物の独立フィルタ。
+
+### mk-go 該当箇所
+- `internal/api/notes/handler.go:777-788` `SearchRequest` (range param 無し) / `:791-835` `Search`
+- `internal/core/search/provider.go:43-50` `SearchOpts` (range 無し) / `sqllike_provider.go:64-75` / `meilisearch_provider.go:191` `buildFilter`
+- `internal/repository/note.go` `SearchByFilter` (range 境界未実装)
+
+### Gap
+**未対応**。range param 自体が無い。既存 `sinceDate`/`untilDate` は cursor 正規化用で意味論が異なり代替にならない。
+
+### 推定実装
+`SearchRequest` + `SearchOpts` + `NoteSearchFilter` に range を追加。sqllike は `note.id > idGen.Generate(start-1)` /
+`< gen(end+1)` を AND 追加、meilisearch は `createdAt` range filter。provider 2 系統 + repo + handler の横断改修。
+**要確認**: mk-go #1948 系の「投稿日時範囲検索」と重複するか (既存 issue があれば統合)。
+
+**難易度**: **M**
+
+## 9. #17463 antenna: antennas/remove-note 新 API
+
+**sha**: `89ae64b077`
+
+### Upstream 変更
+新規 `antennas/remove-note` (`requireCredential`/`prohibitMoved`/`write:account`、params `antennaId`+`noteId`、
+`NO_SUCH_ANTENNA`=`850926e0-...`)。所有者検証後 `FanoutTimelineService.remove('antennaTimeline:<id>', noteId)`
+(Redis `lrem`) で TL から削除。frontend は context menu + `noteRemovedFromAntenna` event (backend gap 無関係)。
+
+### mk-go 該当箇所
+- `internal/api/antennas/handler.go` — Create/Show/Update/Delete/List/Notes のみ、`RemoveNote` 無し
+- `internal/server/router.go:1997-2002` — `remove-note` ルート無し
+- `internal/core/antenna/antenna_service.go` — antenna TL は Redis **Stream** (`XADD`/`XRANGE`、entry id は push 時刻ベース)
+- `internal/api/clips/handler.go:377` `RemoveNote` — 近いテンプレ / error id `850926e0-...` は golden 一致済
+
+### Gap
+**未対応**。endpoint 自体が無い。さらに mk-go の antenna TL は Redis **Stream** のため upstream の `LREM` を直移植
+できず、noteId から entry を XRANGE 走査で特定し `XDEL` する追加ロジックが要る (entry id ≠ noteId)。
+
+### 推定実装
+`antenna_service.RemoveNote(ownerID, antennaID, noteId)` (所有者検証 → XRANGE 走査で `noteId` 一致 entry を XDel、
+存在しないノートは no-op 成功)。handler + router (`write:account` + RequireAuth + RequireNotMoved)。`clips/remove-note`
+をテンプレに。`AntennaNoteUnread` 整合は要確認。
+
+**難易度**: **M**
+
+## 10. #17499 chart: PerUserDriveChart で userId null の system file skip
+
+**sha**: `3246dad53e`
+
+### Upstream 変更
+`PerUserDriveChart.update` 冒頭に `if (file.userId == null) return;` を追加。所有者なし file (instance icon/banner、
+system avatar、custom emoji 等) の `group` NOT NULL 制約違反 crash を防止。
+
+### mk-go 該当箇所
+- `internal/core/chart/charts/per_user_drive.go:49-52` `Update` — `if file.UserID == nil || *file.UserID == ""` で先頭ガード済
+- `internal/core/chart/charthook/charthook.go:238` `OnFileUploaded` — caller でも `file.UserID != nil && != ""` を条件化 (二重ガード)
+
+### Gap
+**影響なし**。Update 内ガード + caller ガードの二重防御で所有者なし file は集計に到達せず crash しない。空文字も弾く
+分 upstream より厳しい。
+
+**難易度**: **N/A**
+
+## 11. #17580 OAuth: Token Grant エンドポイントの validation 堅牢化
+
+**sha**: `d7c11a61c5`
+
+### Upstream 変更
+`OAuth2ProviderService` で `firstValue` の型ガード追加 + `toRequestParameters` が string/URLSearchParams body も
+urlencoded として parse、object body は値が string/string[] のエントリのみ filter。不正型値が grant param に
+混入しないようにする。e2e は JSON/urlencoded 両方 200 を確認するのみ。
+
+### mk-go 該当箇所
+- `internal/api/oauth/provider.go:207-303` `Token` — `application/json` なら typed struct へ decode、他は `c.FormValue`
+
+### Gap
+**影響なし**。mk-go は JSON/urlencoded 両 body を既にサポート (`provider.go:216-232`)。JSON は string 型 field へ
+decode、urlencoded は `FormValue` が常に string を返すため、upstream の「非文字列値混入」は構造的に発生しない。
+grant_type/PKCE 検証も実装済。
+
+**難易度**: **N/A**
+
+## 12. #17389 upload: upload size を server 全体上限で cap + base-role aggregate
+
+**sha**: `e50603e30b`
+
+### Upstream 変更
+`RoleService.getUserPolicies` に 2 点。(1) **server cap**: `maxFileSizeMb` を `Math.min(serverMaxFileSizeMb, max(...))`
+で server 全体設定 (`config.maxFileSize`) で上限 cap。(2) **base-role-only バグ修正**: `roles.length === 0` で
+従来 `basePolicies[name]` 素通しだったのを `aggregate([basePolicies[name]])` に変更し base のみのユーザーでも cap を効かせる。
+
+### mk-go 該当箇所
+- `internal/core/role/role_service.go:544-583` `GetUserPolicies` — `len(roles)==0` で basePolicies 素通し (旧 upstream 挙動)
+- `:763-791` `aggregatePolicyValues` / `:869` `maxNumberAsInt` — `maxFileSizeMb` は単純 max のみ、server cap 無
+- `internal/core/drive/drive_service.go:297-303` — policy で gate するが server 上限と min を取らない
+- server `MaxFileSize` は `config.go:331` (利用は meta/url-upload cap のみ)
+
+### Gap
+**未対応**。`maxFileSizeMb` を server `MaxFileSize` で cap しない。role policy が server 上限超の値を持つと upstream は
+server 値に丸めるが mk-go は role 値をそのまま採用し gate がゆるい。base-role-only 素通しも旧挙動。
+
+### 推定実装
+`role.Service` に server `maxFileSize` を注入し `GetUserPolicies` の `maxFileSizeMb` 集約を `min(serverMaxFileSizeMb,
+aggregated)` で cap。`len(roles)==0` 経路も base 値を cap 対象に通す。**要確認**: `NewService` シグネチャ変更の影響範囲
+(呼出元多数)。drive gate は policy 経由なので RoleService を直せば自動で効く。
+
+**難易度**: **M**
+
+## 13. #17436 admin/queue: ジョブキューに pause/resume
+
+**sha**: `9f2e806c20`
+
+### Upstream 変更
+`admin/queue/pause` + `admin/queue/resume` 新設 (`requireModerator` + `write:admin:queue`、param `queue` は
+`QUEUE_TYPES` enum、204)。`QueueService` に `queuePause`/`queueResume` (BullMQ `queue.pause()`/`resume()`)。modlog
+`pauseQueue`/`resumeQueue` 追加。frontend は `queueInfo.isPaused` でボタン切替。
+
+### mk-go 該当箇所
+- `internal/api/admin/queue.go` — pause/resume 無し。`shapeQueueForFrontend:499` は `isPaused:false` ハードコード
+- `internal/server/router.go:2582-2593` — pause/resume ルート無し
+- `internal/queue/inspector.go` / `driver/driver.go:91-122` / `mkqdriver/` — Pause/Unpause method 無、`IsPaused` field 無
+- `internal/core/moderationlog/types.go` — `pauseQueue`/`resumeQueue` LogType 未定義
+
+### Gap
+**未対応**。endpoint・handler・queue pause 機構・modlog 種別すべて無し。mkq driver にキューを pause (worker dequeue 停止)
+して状態を永続化する仕組みが無く `InspectorInfo.IsPaused` も無いため frontend に状態を返せない。インフラ層から要実装。
+asynq は deprecated 方針のため mkq driver 側に実装。
+
+### 推定実装
+(1) `driver.Driver`/`Inspector` に `PauseQueue`/`UnpauseQueue` + `InspectorInfo.IsPaused` 追加、mkqdriver で Redis
+paused フラグ key を worker dequeue 側で参照。(2) handler + router (`write:admin:queue` + RequireModerator)。
+(3) `shapeQueueForFrontend.isPaused` を `info.IsPaused` から。(4) modlog 追加。worker 停止セマンティクスが肝で工数大。
+
+**難易度**: **L**
+
+## 14. #17513 admin/reset-password: エラーをダイアログ表示可能に
+
+**sha**: `eed6c3654f`
+
+### Upstream 変更
+`admin/reset-password.ts` の生 `throw new Error` を typed `ApiError` (`NO_SUCH_USER` /
+`CANNOT_RESET_PASSWORD_OF_ROOT_USER`) に置換 + `meta.errors` 登録。frontend は `apiWithDialog` でダイアログ表示。
+
+### mk-go 該当箇所
+- `internal/api/admin/password_reset.go:38-48` — 存在しない user は `NO_SUCH_USER`(404)、root は `ACCESS_DENIED`(403) を構造化エラーで返す
+
+### Gap
+**実質対応済**。両ケースを構造化 API エラー (code 付き) で返すため frontend ダイアログ要件は満たす。ただし root 拒否の
+code/id が upstream と不一致 (upstream `CANNOT_RESET_PASSWORD_OF_ROOT_USER`/`f28fc207-...` vs mk-go
+`ACCESS_DENIED`/`1fb7cb09-...`)。#1539 で他 admin guard と揃えた意図的選択。NO_SUCH_USER の id も upstream
+`ccafc7fe-...` と異なる (mk-go `2b730f78-...`)。frontend は scope 外。
+
+### 推定実装
+(任意 parity 強化) root 拒否を `CANNOT_RESET_PASSWORD_OF_ROOT_USER`/upstream id に、NO_SUCH_USER id を upstream に
+揃える。挙動互換は既に成立のため見送りも妥当。**要確認**: golden gate (error id/status) との整合。
+
+**難易度**: **S**
+
+## 15. migration: note_favorite / user_note_pining の noteId index
+
+**sha**: `bbcce5b49d` (#17577) / `2b016d670f` (#17511) / `7f00846779` (#17581)
+
+### Upstream 変更
+3 commit の正味結果は `note_favorite.noteId` と `user_note_pining.noteId` への単一カラム index 追加
+(`IDX_0e00498f...` / `IDX_68881008...`)。後続 2 件は CONCURRENTLY 対応の index 作成統合 + 冗長 recover migration 削除
+(TypeORM 履歴管理の都合)。最終状態は「両テーブルに noteId 単一 index が valid に存在」。
+
+### mk-go 該当箇所
+- `migration/000017_note_favorite.up.sql:9` — `IDX_note_favorite_noteId ON note_favorite("noteId")` **あり**
+- `migration/000003_user_note_pining.up.sql:8-9` — `userId` 単一 + `userId_noteId` 複合 unique のみ、**noteId 単一 index 無し**
+
+### Gap
+**部分対応**。`note_favorite` は noteId index 保持済 (影響なし)。`user_note_pining` は noteId 単一 index を欠く
+(複合 unique は先頭 `userId` なので noteId 単独検索に効かない = upstream #17511 が解消した gap)。upstream の index 統合・
+冗長 migration 削除は TypeORM 履歴固有なので追従不要、「同等 index を持つか」だけ判定対象。
+
+### 推定実装
+新規 migration で `CREATE INDEX IF NOT EXISTS "IDX_user_note_pining_noteId" ON "user_note_pining" ("noteId");`
+(down で DROP)。`note_favorite` は対応済のため不要。
+
+**難易度**: **S**
+
+---
+
+## N/A bucket (deps / refactor / test / TS-only / build — mk-go 影響なし)
+
+精読の上 mk-go の API/AP 互換性に影響しないと判定した backend commits:
+
+| sha | 内容 | 理由 |
+|---|---|---|
+| `00c6210a59` | #17606 fix tests | upstream の test 修正のみ |
+| `053e244582` | #17595 summaly version 埋め込みビルド | TS ビルド構成、mk-go は summaly 非依存 (自前 urlpreview) |
+| `c0a8c7f93a` | #17589 Summaly User-Agent 改善 | 同上 (summaly 固有) |
+| `e093b32aa9` | #17512 MemoryKVCache GC 修正 | TS 固有の in-memory cache 実装 bug |
+| `b125ce1eb2` | #17401 fastify listen/ready/close を logger 経由に | Fastify 固有 (mk-go は Echo) |
+| `81b182460e` | #17477 deps update | 依存更新 |
+| `e50603e30b`※ | (item 12 と別) — | — |
+| `43534d6213` | #17476 typeorm v1 update | ORM 依存 (mk-go は GORM) |
+| `623700119c` `d74b6462a8` | #17415 #17505 oauth2orize 削除 | TS 内部 lib 置換、外部 API 不変 (item 11 で oauth 挙動は確認済) |
+| `e7430057e6` | #17422 削除対象ノート検索クエリ簡略化 | 内部クエリ最適化、外部挙動不変 |
+
+---
+
+## Wave 推奨実行順
+
+upstream 取込本体 (submodule/version bump) は別 tracker scope のため、本 triage は**互換性 gap の解消**に絞る。
+
+- **Wave 1 (close 候補 / 影響なし — comment + 必要なら regression test で意思表明)**:
+  item 2 (URL preview SSRF) / 5 (self-host acct) / 10 (PerUserDrive null) / 11 (OAuth grant) / 14 (reset-password、
+  code/id 厳密 parity を狙うなら S 実装、見送りなら close)。
+- **Wave 2 (S — 1 PR / 1 sub-issue で順次)**:
+  item 4 (AP image width/height) → 6 (mention raw count) → 7 (followers direct quote) → 15 (user_note_pining noteId index) →
+  3 (inbox early-400 parity 最適化) → 1 (TOTP window/コメント整理、#1555 動機要確認)。
+- **Wave 3 (M — PR 1 本ずつ)**:
+  item 8 (date-range search、provider 横断) / 9 (antennas/remove-note、Stream XDEL) / 12 (upload size server cap)。
+- **Wave 4 (L)**:
+  item 13 (admin/queue pause/resume、mkq driver に pause 機構を要実装)。
+- **Final audit**: N/A bucket の commits も再突き合わせて drift が無いか確認し、結果を本 doc 末尾に追記。
+
+各 sub-issue は `#2069 sub-N (upstream #XXXXX): <要約>` で起票し、本 doc の該当 item を参照する
+(cross-repo link 回避のため upstream PR は plain text 表記)。


### PR DESCRIPTION
## Summary

upstream Misskey 2026.6.0 (2026-06-22 release) への backend 追従 triage doc を追加する
(`docs/update/20260622-2069-triage.md`)。先例 `20260512-947-triage.md` と同形式。

## 内容

- 対象: `packages/backend/src/` + `migration/` の no-merges 27 commits (2026.5.4 → 2026.6.0)。
- mk-go の API/ActivityPub 互換性に影響しうる **15 件**を精読 (diff + mk-go grep) し、Gap 判定
  (既対応/部分対応/未対応/影響なし) + 難易度 (S/M/L/N/A) + 推定実装方針を付与。
- deps/refactor/test/build の **12 件**は N/A bucket に整理。
- 末尾に Wave 1-4 の推奨実行順。

## 判定サマリ

- 未対応 7 (AP image width/height・mention raw count・followers direct quote・date-range search・
  antennas/remove-note・upload size server cap・queue pause/resume)
- 部分対応 3 (TOTP window・inbox early-400・user_note_pining noteId index)
- 実質対応 1 (reset-password code/id 差異) / 影響なし 4 (close 候補)

## 補足

docs 追加のみ (コード変更なし)。fork は `2026.6.0-mk.0` 配信済。本体の `MisskeyVersion` / dropin 版数 bump は
別 tracker scope。各 item の sub-issue 化・実装は Wave 順で後続。

## 関連

- tracker: #2069
