### PR TITLE
Misskey TS 2026.6.0 backend 追従 (#2069): parity gap 9 件 + version bump

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -732,11 +732,35 @@ func (r *Renderer) addAttachments(out *Note, n *model.Note) {
 			Name:      stringValue(f.Comment),
 			Sensitive: f.IsSensitive,
 		}
+		// upstream renderDocument は file.properties?.width / height を Document に
+		// 載せる (画像の寸法メタデータ、upstream #17563)。drive_file.properties は
+		// `{"width":..,"height":..}` jsonb。非画像は width/height を持たず omitempty で
+		// 出ない。
+		if w, h := driveImageDimensions([]byte(f.Properties)); w > 0 || h > 0 {
+			doc.Width = w
+			doc.Height = h
+		}
 		out.Attachment = append(out.Attachment, doc)
 		if f.IsSensitive {
 			out.Sensitive = true
 		}
 	}
+}
+
+// driveImageDimensions extracts width/height from a drive_file.properties jsonb
+// (`{"width":..,"height":..}`)。値が無い / parse 失敗 / 非画像なら 0,0 を返す (#2069)。
+func driveImageDimensions(props []byte) (int, int) {
+	if len(props) == 0 {
+		return 0, 0
+	}
+	var p struct {
+		Width  int `json:"width"`
+		Height int `json:"height"`
+	}
+	if err := json.Unmarshal(props, &p); err != nil {
+		return 0, 0
+	}
+	return p.Width, p.Height
 }
 
 // resolveNoteURI returns the canonical URI for a note (remote URI or local).

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -972,7 +972,8 @@ func TestRenderer_RenderNote_WithAttachment(t *testing.T) {
 	r := newRenderer()
 	comment := "photo"
 	r.SetFileResolver(&stubFileResolver{files: []*model.DriveFile{
-		{Type: "image/png", URL: "https://example.com/files/f1.png", Comment: &comment, IsSensitive: false},
+		{Type: "image/png", URL: "https://example.com/files/f1.png", Comment: &comment, IsSensitive: false,
+			Properties: datatypes.JSON(`{"width":800,"height":600}`)},
 		{Type: "video/mp4", URL: "https://example.com/files/f2.mp4", IsSensitive: true},
 	}})
 	idGen := newIDGen(t)
@@ -990,9 +991,15 @@ func TestRenderer_RenderNote_WithAttachment(t *testing.T) {
 	assert.Equal(t, "image/png", doc0.MediaType)
 	assert.Equal(t, "photo", doc0.Name)
 	assert.False(t, doc0.Sensitive)
+	// #2069 (upstream #17563): 画像の width/height を properties から付与。
+	assert.Equal(t, 800, doc0.Width)
+	assert.Equal(t, 600, doc0.Height)
 	doc1, ok := out.Attachment[1].(Document)
 	require.True(t, ok)
 	assert.True(t, doc1.Sensitive)
+	// 非画像 (properties 無し) は width/height 0 (omitempty)。
+	assert.Equal(t, 0, doc1.Width)
+	assert.Equal(t, 0, doc1.Height)
 	// sensitive ファイルがあるのでNote自体もsensitiveになる
 	assert.True(t, out.Sensitive)
 }

--- a/internal/api/antennas/handler.go
+++ b/internal/api/antennas/handler.go
@@ -292,6 +292,28 @@ func (h *Handler) Delete(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
+// RemoveNote handles POST /api/antennas/remove-note (upstream #17463, #2069).
+// antenna TL から特定ノートを除去する。upstream は findOneBy({id, userId}) で
+// not-found / not-owner を区別せず NO_SUCH_ANTENNA を返すので、mk-go も両方を
+// NO_SUCH_ANTENNA に倒す。
+func (h *Handler) RemoveNote(c echo.Context) error {
+	user := middleware.GetUser(c)
+	var req struct {
+		AntennaID string `json:"antennaId"`
+		NoteID    string `json:"noteId"`
+	}
+	if err := c.Bind(&req); err != nil || req.AntennaID == "" || req.NoteID == "" {
+		return apierr.JSONInvalidParam(c)
+	}
+	if err := h.svc.RemoveNote(user.ID, req.AntennaID, req.NoteID); err != nil {
+		if errors.Is(err, coreantenna.ErrAntennaNotFound) || errors.Is(err, coreantenna.ErrAccessDenied) {
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANTENNA", "No such antenna.", "850926e0-fd3b-49b6-b69a-b28a5dbd82fe"))
+		}
+		return apierr.JSONInternalError(c)
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
 // List handles POST /api/antennas/list.
 func (h *Handler) List(c echo.Context) error {
 	user := middleware.GetUser(c)

--- a/internal/api/antennas/handler_test.go
+++ b/internal/api/antennas/handler_test.go
@@ -810,3 +810,38 @@ func TestNotes_FollowersNote_VisibleToFollower(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "n-ok")
 }
+
+// #2069 (upstream #17463): antennas/remove-note の handler。
+func TestRemoveNote_Success(t *testing.T) {
+	h, repo, _ := newHandler(t)
+	repo.Antennas["a1"] = &model.Antenna{ID: "a1", UserID: "alice"}
+	c, rec := newReq(t, `{"antennaId":"a1","noteId":"n1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.RemoveNote(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code, "存在しないノート除去も 204 (no-op)")
+}
+
+func TestRemoveNote_NoSuchAntenna(t *testing.T) {
+	h, repo, _ := newHandler(t)
+	repo.Antennas["a1"] = &model.Antenna{ID: "a1", UserID: "bob"} // 他人所有
+	// not-owner → NO_SUCH_ANTENNA。
+	c, rec := newReq(t, `{"antennaId":"a1","noteId":"n1"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.RemoveNote(c))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "NO_SUCH_ANTENNA")
+	assert.Contains(t, rec.Body.String(), "850926e0-fd3b-49b6-b69a-b28a5dbd82fe")
+	// 未存在 antenna も NO_SUCH_ANTENNA。
+	c2, rec2 := newReq(t, `{"antennaId":"nope","noteId":"n1"}`)
+	setUser(c2, "alice")
+	require.NoError(t, h.RemoveNote(c2))
+	assert.Equal(t, http.StatusNotFound, rec2.Code)
+}
+
+func TestRemoveNote_BadParam(t *testing.T) {
+	h, _, _ := newHandler(t)
+	c, rec := newReq(t, `{"antennaId":"a1"}`) // noteId 欠落
+	setUser(c, "alice")
+	require.NoError(t, h.RemoveNote(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/internal/api/inbox/handler.go
+++ b/internal/api/inbox/handler.go
@@ -3,6 +3,7 @@ package inbox
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
@@ -177,6 +178,14 @@ func (h *Handler) Inbox(c echo.Context) error {
 		return c.NoContent(http.StatusUnauthorized)
 	}
 
+	// upstream ActivityPubServerService.inbox (#17558): actor を持たない activity は
+	// authenticate 不能なので enqueue せず 400 で弾く。mk-go は actor 欠落で worker 側が
+	// drop する (crash はしない) が、無駄な enqueue/retry を避けるため早期 reject する。
+	if !bodyHasActor(body) {
+		slog.Warn("inbox rejected: activity has no actor")
+		return c.NoContent(http.StatusBadRequest)
+	}
+
 	if h.enqueuer != nil {
 		// Fast write path. signature の crypto 検証は worker 側で再現する。
 		// admitInbox を上で通しているので handler 側の presence check は不要。
@@ -303,4 +312,17 @@ func (h *Handler) commitChart(actor *model.User) {
 		return
 	}
 	h.chartHook.OnInboxReceived(*actor.Host)
+}
+
+// bodyHasActor reports whether the inbox activity body is a JSON object with a
+// non-null `actor` field. upstream #17558: actor 無し activity は authenticate
+// 不能なので enqueue 前に弾く。actor は string ID / embedded object どちらも許容
+// (presence + 非 null のみ判定)。
+func bodyHasActor(body []byte) bool {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(body, &probe); err != nil {
+		return false // object でない (= 不正) → reject
+	}
+	actor, ok := probe["actor"]
+	return ok && len(actor) > 0 && string(actor) != "null"
 }

--- a/internal/api/inbox/handler_test.go
+++ b/internal/api/inbox/handler_test.go
@@ -614,3 +614,25 @@ func TestInbox_HostSignedAndMatchAccepted(t *testing.T) {
 	assert.Equal(t, http.StatusAccepted, rec.Code)
 	assert.Len(t, followingRepo.Followings, 1)
 }
+
+// #2069 (upstream #17558): bodyHasActor は actor を持つ object のみ true。
+func TestBodyHasActor(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"string actor", `{"type":"Create","actor":"https://r/u/a"}`, true},
+		{"embedded object actor", `{"type":"Create","actor":{"id":"https://r/u/a"}}`, true},
+		{"no actor key", `{"type":"Create","object":{}}`, false},
+		{"null actor", `{"type":"Create","actor":null}`, false},
+		{"not an object (array)", `[{"actor":"x"}]`, false},
+		{"not json", `garbage`, false},
+		{"empty actor string is present", `{"actor":""}`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, bodyHasActor([]byte(tc.body)))
+		})
+	}
+}

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -785,6 +785,10 @@ type SearchRequest struct {
 	UserID    string `json:"userId"`
 	ChannelID string `json:"channelId"`
 	Host      string `json:"host"`
+	// rangeStartAt / rangeEndAt は投稿日時範囲 (epoch ms、upstream #16119 #2069)。
+	// sinceDate/untilDate (cursor 正規化用) とは別物で、cursor と独立に AND される。
+	RangeStartAt *int64 `json:"rangeStartAt"`
+	RangeEndAt   *int64 `json:"rangeEndAt"`
 }
 
 // Search handles POST /api/notes/search.
@@ -822,10 +826,12 @@ func (h *Handler) Search(c echo.Context) error {
 		viewer,
 		req.Query,
 		search.SearchOpts{
-			UserID:    req.UserID,
-			ChannelID: req.ChannelID,
-			Host:      req.Host,
-			Offset:    req.Offset,
+			UserID:       req.UserID,
+			ChannelID:    req.ChannelID,
+			Host:         req.Host,
+			Offset:       req.Offset,
+			RangeStartAt: req.RangeStartAt,
+			RangeEndAt:   req.RangeEndAt,
 		},
 		search.Pagination{
 			UntilID: untilID,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,8 +19,8 @@ var MkGoVersion = "0.9.2"
 
 // MisskeyVersion is the compatible Misskey version. Override at build time via:
 //
-//	go build -ldflags "-X github.com/shiroha-a/mk/internal/config.MisskeyVersion=2026.5.4"
-var MisskeyVersion = "2026.5.4"
+//	go build -ldflags "-X github.com/shiroha-a/mk/internal/config.MisskeyVersion=2026.6.0"
+var MisskeyVersion = "2026.6.0"
 
 // RedisOptions represents Redis connection configuration.
 type RedisOptions struct {

--- a/internal/core/antenna/antenna_service.go
+++ b/internal/core/antenna/antenna_service.go
@@ -378,6 +378,40 @@ func (s *Service) Delete(ownerID, antennaID string) error {
 	return nil
 }
 
+// RemoveNote removes a specific note from an antenna's timeline (upstream
+// antennas/remove-note、#2069 #17463)。owner 検証後、Redis Stream を走査して
+// noteId 一致 entry を XDel する。upstream は List-based の LREM だが mk-go の
+// antenna TL は Stream (entry id = push 時刻ベース) なので noteId で照合して
+// 削除する。該当ノートが無い場合は no-op で成功 (upstream も同様)。
+func (s *Service) RemoveNote(ownerID, antennaID, noteID string) error {
+	a, err := s.repo.FindByID(antennaID)
+	if err != nil {
+		return ErrAntennaNotFound
+	}
+	if a.UserID != ownerID {
+		return ErrAccessDenied
+	}
+	ctx := context.Background()
+	key := streamKey(antennaID)
+	// MaxNotesPerAntenna で stream 長は bounded なので全件走査は許容範囲。
+	msgs, err := s.client.XRange(ctx, key, "-", "+").Result()
+	if err != nil {
+		return err
+	}
+	entryIDs := make([]string, 0, 1)
+	for _, m := range msgs {
+		if v, _ := m.Values["noteId"].(string); v == noteID {
+			entryIDs = append(entryIDs, m.ID)
+		}
+	}
+	if len(entryIDs) > 0 {
+		if err := s.client.XDel(ctx, key, entryIDs...).Err(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // ListByUser returns the antennas owned by userID.
 func (s *Service) ListByUser(userID string) ([]*model.Antenna, error) {
 	return s.repo.ListByUser(userID)

--- a/internal/core/antenna/antenna_service_test.go
+++ b/internal/core/antenna/antenna_service_test.go
@@ -1331,3 +1331,29 @@ func TestOnNoteCreated_NilPublisherIsNoOp(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"n1"}, rows)
 }
+
+// #2069 (upstream #17463): RemoveNote は antenna TL stream から noteId 一致 entry を
+// 削除する。owner 検証 (not-found / not-owner)、存在しないノートは no-op 成功。
+func TestRemoveNote(t *testing.T) {
+	svc, repo := newSvc(t)
+	repo.Antennas["a1"] = &model.Antenna{ID: "a1", UserID: "u1"}
+	ctx := context.Background()
+	for _, n := range []string{"n1", "n2", "n3"} {
+		require.NoError(t, testRedis.Client.XAdd(ctx, &redis.XAddArgs{
+			Stream: streamKey("a1"), Values: map[string]any{"noteId": n},
+		}).Err())
+	}
+
+	// n2 を削除 → n1, n3 が残る。
+	require.NoError(t, svc.RemoveNote("u1", "a1", "n2"))
+	rows, err := svc.Notes(ctx, "u1", "a1", 10, "", "")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"n1", "n3"}, rows, "n2 のみ削除される (#2069)")
+
+	// 存在しないノートは no-op 成功。
+	require.NoError(t, svc.RemoveNote("u1", "a1", "ghost"))
+
+	// not-owner は ErrAccessDenied、未存在 antenna は ErrAntennaNotFound。
+	assert.ErrorIs(t, svc.RemoveNote("other", "a1", "n1"), ErrAccessDenied)
+	assert.ErrorIs(t, svc.RemoveNote("u1", "nope", "n1"), ErrAntennaNotFound)
+}

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -1251,16 +1251,26 @@ func (r *Resolver) ingestNoteWithCreated(body []byte, deliveringActorURI string,
 	if note.Text != nil {
 		textMentions = r.resolveTextMentionUserIDs(corenote.ExtractMentionStructs(*note.Text))
 	}
-	tagMentions := r.resolveMentionedUserIDs(extractMentionTags(apNote.Tag))
+	tagHrefs := extractMentionTags(apNote.Tag)
+	tagMentions := r.resolveMentionedUserIDs(tagHrefs)
 	note.Mentions = mergeMentionIDs(textMentions, tagMentions)
 	// upstream Misskey #17167 (= 2026.5.0 fix / triage #1004): mentionLimit を
 	// 超える note は無効と扱い、保存せずに ErrContainsTooManyMentions を返す。
 	// caller (processor.handleCreate) が当該 sentinel を catch して queue retry
 	// 経路から除外することで、罠の inbox job が永続蓄積するのを防ぐ。
-	// limit 値は corenote.DefaultMentionLimit (= 20) を参照し、local create
-	// path (NoteCreateService.checkMentionLimit) と同じ policy を federation
-	// 受信側にも適用する。
-	if corenote.DefaultMentionLimit > 0 && len(note.Mentions) > corenote.DefaultMentionLimit {
+	// upstream #17576: 制限判定は「解決できたユーザー数」(= len(note.Mentions)) でなく、
+	// remote が宣言した raw mention 数 (AP tag の Mention href ユニーク数) との max で
+	// 行う。一部しか解決できなくても大量 mention をすり抜けさせない。limit 値は
+	// corenote.DefaultMentionLimit (= 20、local create path と同 policy)。
+	rawTagSet := make(map[string]struct{}, len(tagHrefs))
+	for _, h := range tagHrefs {
+		rawTagSet[h] = struct{}{}
+	}
+	effectiveMentions := len(note.Mentions)
+	if len(rawTagSet) > effectiveMentions {
+		effectiveMentions = len(rawTagSet)
+	}
+	if corenote.DefaultMentionLimit > 0 && effectiveMentions > corenote.DefaultMentionLimit {
 		return nil, false, corenote.ErrContainsTooManyMentions
 	}
 	// specified visibility では AP `to` 配列が宛先 actor URI 列。CanView の

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -4707,6 +4707,39 @@ func TestIngestNote_MentionLimitExceededReturnsSentinel(t *testing.T) {
 	require.Error(t, lookupErr, "limit exceed note should NOT be persisted")
 }
 
+// #2069 (upstream #17576): 解決できたユーザー数が少なくても、raw な AP tag mention
+// 数 (href ユニーク数) が limit を超えれば reject する。21 件の未知 remote mention URI
+// は resolveMentionedUserIDs で全て skip され note.Mentions=0 になるが、raw count=21 が
+// limit を超えるので ErrContainsTooManyMentions を返す (修正前は 0 ≤ 20 で受理されていた)。
+func TestIngestNote_MentionLimitRawCountExceeded(t *testing.T) {
+	repo := testutil.NewMockUserRepository()
+	noteRepo := testutil.NewMockNoteRepository()
+	urls := activitypub.NewURLBuilder("https://example.com")
+	idGen, _ := id.NewGenerator("aidx")
+	r := federation.NewResolver(repo, noteRepo, urls, &stubFetcher{body: []byte(sampleActor)}, idGen)
+
+	var tagJSON string
+	for i := 1; i <= corenote.DefaultMentionLimit+1; i++ {
+		if i > 1 {
+			tagJSON += ","
+		}
+		// 未知の remote URI (repo に無い) なので resolveMentionedUserIDs は skip する。
+		tagJSON += `{"type": "Mention", "href": "https://remote.example/users/m` + strconv.Itoa(i) + `"}`
+	}
+	body := []byte(`{ "@context": "https://www.w3.org/ns/activitystreams",
+		"id": "https://remote.example/notes/rawover",
+		"type": "Note",
+		"attributedTo": "https://remote.example/users/alice",
+		"content": "x",
+		"to": ["https://www.w3.org/ns/activitystreams#Public"],
+		"tag": [` + tagJSON + `]
+	}`)
+	_, err := r.IngestNote(body)
+	require.ErrorIs(t, err, corenote.ErrContainsTooManyMentions)
+	_, lookupErr := noteRepo.FindByURI("https://remote.example/notes/rawover")
+	require.Error(t, lookupErr, "raw mention 超過 note は保存されない")
+}
+
 // 境界条件 (= limit ぴったりの 20 件) は受理される。off-by-one 検出。
 func TestIngestNote_MentionLimitBoundaryAccepted(t *testing.T) {
 	repo := testutil.NewMockUserRepository()

--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -582,9 +582,12 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 				visibility = model.NoteVisibilityHome
 			}
 		case model.NoteVisibilityFollowers:
-			// ここに来るのは自分の followers note のみ (他人は上で reject)。
-			// upstream は renote 自身も followers に強制する。
-			visibility = model.NoteVisibilityFollowers
+			// ここに来るのは自分の followers note のみ (他人は上で reject)。upstream
+			// #15961: public / home の引用のみ followers に降格し、ユーザーが選んだより
+			// 狭い可視性 (specified / direct / followers) は維持する。
+			if visibility == model.NoteVisibilityPublic || visibility == model.NoteVisibilityHome {
+				visibility = model.NoteVisibilityFollowers
+			}
 		}
 		// local-only な対象を renote したら local-only にする (channel 外のみ、
 		// upstream `data.renote.localOnly && data.channel == null`)。

--- a/internal/core/note/note_create_service_test.go
+++ b/internal/core/note/note_create_service_test.go
@@ -677,13 +677,26 @@ func TestCreateService_RenoteVisibilityAdjustment(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, model.NoteVisibilityHome, created.Visibility, "home note の public renote は home に降格")
 	})
-	t.Run("own followers target forces renote to followers", func(t *testing.T) {
+	t.Run("own followers target downgrades public renote to followers", func(t *testing.T) {
 		svc, noteRepo, _ := newCreateServiceWithFollowing(t)
 		noteRepo.Notes["f"] = &model.Note{ID: "f", UserID: "u1", Visibility: model.NoteVisibilityFollowers}
 		rid := "f"
 		created, err := svc.Create(note.CreateInput{User: &model.User{ID: "u1"}, RenoteID: &rid, Visibility: model.NoteVisibilityPublic})
 		require.NoError(t, err)
-		assert.Equal(t, model.NoteVisibilityFollowers, created.Visibility, "自分の followers note の renote は followers に強制")
+		assert.Equal(t, model.NoteVisibilityFollowers, created.Visibility, "public 引用は followers に降格")
+	})
+	t.Run("own followers target keeps direct(specified) quote (#15961)", func(t *testing.T) {
+		// upstream #15961: followers note を direct で引用したら direct を維持する
+		// (public/home のみ followers に降格)。
+		svc, noteRepo, _ := newCreateServiceWithFollowing(t)
+		noteRepo.Notes["f2"] = &model.Note{ID: "f2", UserID: "u1", Visibility: model.NoteVisibilityFollowers}
+		rid := "f2"
+		created, err := svc.Create(note.CreateInput{
+			User: &model.User{ID: "u1"}, RenoteID: &rid,
+			Text: ptrString("quote"), Visibility: model.NoteVisibilitySpecified, VisibleUserIDs: []string{"u2"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, model.NoteVisibilitySpecified, created.Visibility, "direct 引用は specified を維持 (#15961)")
 	})
 	t.Run("localOnly target propagates to renote", func(t *testing.T) {
 		svc, noteRepo, _ := newCreateService(t)

--- a/internal/core/role/role_service.go
+++ b/internal/core/role/role_service.go
@@ -94,6 +94,10 @@ type Service struct {
 	assignmentRepo repository.RoleAssignmentRepository
 	metaRepo       repository.MetaRepository
 	idGen          id.Generator
+	// serverMaxFileSizeMb は config.maxFileSize を MB 換算した server 全体の
+	// upload 上限。GetUserPolicies の maxFileSizeMb を upstream #17389 同様に
+	// この値で cap する (0 なら cap しない、router で配線)。
+	serverMaxFileSizeMb int
 	// userRepo は drop-in 互換 (#785) のため optional に注入される。
 	// Misskey TS upstream で signup された root user は user.isRoot=true で
 	// 識別され meta.rootUserId は set されない。drop-in で TS DB を引き継いだ
@@ -541,6 +545,38 @@ type rolePolicyOverride struct {
 //
 // userID が "" の場合は base policies のみを返す (= upstream の userId==null
 // と同等)。
+// SetServerMaxFileSizeMb wires the server-wide upload size limit (MB) used to
+// cap the aggregated maxFileSizeMb policy (upstream #17389)。0 で cap 無効。
+func (s *Service) SetServerMaxFileSizeMb(mb int) { s.serverMaxFileSizeMb = mb }
+
+// capServerMaxFileSize caps the maxFileSizeMb policy at serverMaxFileSizeMb,
+// mirroring upstream `Math.min(serverMaxFileSizeMb, aggregated)` (#17389)。
+// base-only / role 集約どちらの経路でも適用するため、全 return 直前で呼ぶ。
+func (s *Service) capServerMaxFileSize(policies map[string]any) map[string]any {
+	if s.serverMaxFileSizeMb <= 0 || policies == nil {
+		return policies
+	}
+	if v, ok := policies["maxFileSizeMb"]; ok {
+		if cur, ok := policyIntValue(v); ok && cur > s.serverMaxFileSizeMb {
+			policies["maxFileSizeMb"] = s.serverMaxFileSizeMb
+		}
+	}
+	return policies
+}
+
+// policyIntValue extracts an int from a policy value (int / int64 / float64)。
+func policyIntValue(v any) (int, bool) {
+	switch x := v.(type) {
+	case int:
+		return x, true
+	case int64:
+		return int(x), true
+	case float64:
+		return int(x), true
+	}
+	return 0, false
+}
+
 func (s *Service) GetUserPolicies(userID string) map[string]any {
 	// applyMetaBasePolicies が basePolicies を mutate するため、共有 cache では
 	// なく clone を使う (DefaultPolicies の共有 map を壊さない、#1377)。
@@ -548,16 +584,18 @@ func (s *Service) GetUserPolicies(userID string) map[string]any {
 	s.applyMetaBasePolicies(basePolicies)
 
 	if userID == "" {
-		return basePolicies
+		return s.capServerMaxFileSize(basePolicies)
 	}
 	roles, err := s.GetUserRoles(userID)
 	if err != nil {
 		// role 取得失敗時は base policies で fallback (upstream は throw
 		// するが、mk-go は fail-soft で gate を default 値に倒す)。
-		return basePolicies
+		return s.capServerMaxFileSize(basePolicies)
 	}
 	if len(roles) == 0 {
-		return basePolicies
+		// upstream #17389: base role only でも server cap を効かせる (旧 upstream は
+		// 素通しだった base-role-only bug を aggregate([base]) で修正)。
+		return s.capServerMaxFileSize(basePolicies)
 	}
 
 	// 各 role の policies JSON を Unmarshal して一度だけ展開する。
@@ -579,7 +617,7 @@ func (s *Service) GetUserPolicies(userID string) map[string]any {
 	for key, baseVal := range basePolicies {
 		out[key] = computePolicy(key, baseVal, roleOverrides)
 	}
-	return out
+	return s.capServerMaxFileSize(out)
 }
 
 // applyMetaBasePolicies overlays `meta.policies` (admin UI 設定の base

--- a/internal/core/role/role_service_test.go
+++ b/internal/core/role/role_service_test.go
@@ -1623,3 +1623,26 @@ func TestService_ListByLastUsed(t *testing.T) {
 	require.Len(t, roles, 3)
 	assert.Equal(t, []string{"b", "c", "a"}, []string{roles[0].ID, roles[1].ID, roles[2].ID}, "lastUsedAt DESC (#2061)")
 }
+
+// #2069 (upstream #17389): maxFileSizeMb は server 全体上限 (SetServerMaxFileSizeMb)
+// で cap される。role が server 上限超の値を持っても cap 後の値になり、base-only
+// (role 無し) ユーザーでも cap が効く。
+func TestGetUserPolicies_MaxFileSizeServerCap(t *testing.T) {
+	svc, roleRepo, assignRepo, _ := newTestService(t)
+	svc.SetServerMaxFileSizeMb(100) // server 全体 100MB
+
+	// role が maxFileSizeMb=500 を要求 → server cap 100 に丸められる。
+	roleRepo.Roles["r1"] = &model.Role{
+		ID: "r1", Name: "Big",
+		Policies: datatypes.JSON([]byte(`{"maxFileSizeMb": {"useDefault": false, "priority": 0, "value": 500}}`)),
+	}
+	assignRepo.Assignments["user1:r1"] = &model.RoleAssignment{ID: "a1", UserID: "user1", RoleID: "r1"}
+	assert.Equal(t, 100, svc.GetUserPolicies("user1")["maxFileSizeMb"], "role 値 500 は server cap 100 に丸められる (#2069)")
+
+	// role 無し (base-only) でも cap が効く: default 30 < cap 100 なので default 維持。
+	assert.Equal(t, 30, svc.GetUserPolicies("user2")["maxFileSizeMb"], "base default 30 は cap 100 未満で維持")
+
+	// cap が default 未満なら default も cap される (base-role-only bug fix)。
+	svc.SetServerMaxFileSizeMb(10)
+	assert.Equal(t, 10, svc.GetUserPolicies("user2")["maxFileSizeMb"], "cap 10 < default 30 → base-only でも 10 に cap (#2069)")
+}

--- a/internal/core/search/meilisearch_provider.go
+++ b/internal/core/search/meilisearch_provider.go
@@ -196,6 +196,14 @@ func (p *MeilisearchProvider) buildFilter(opts SearchOpts, page Pagination) stri
 	if t := p.timestampOfID(page.SinceID); t != 0 {
 		clauses = append(clauses, fmt.Sprintf("(createdAt > %d)", t))
 	}
+	// 投稿日時範囲 (upstream #16119、#2069)。createdAt は epoch ms で index 済なので
+	// rangeStartAt/rangeEndAt (epoch ms) と直接比較する。cursor とは独立に AND。
+	if opts.RangeStartAt != nil {
+		clauses = append(clauses, fmt.Sprintf("(createdAt >= %d)", *opts.RangeStartAt))
+	}
+	if opts.RangeEndAt != nil {
+		clauses = append(clauses, fmt.Sprintf("(createdAt <= %d)", *opts.RangeEndAt))
+	}
 	if opts.UserID != "" {
 		clauses = append(clauses, fmt.Sprintf("(userId = %s)", quoteValue(opts.UserID)))
 	}

--- a/internal/core/search/provider.go
+++ b/internal/core/search/provider.go
@@ -47,6 +47,10 @@ type SearchOpts struct {
 	// Offset is the OFFSET-based pagination offset (upstream notes/search.ts:47
 	// `offset`). 0 = no offset (#1783)。
 	Offset int
+	// RangeStartAt / RangeEndAt は投稿日時範囲 (epoch ms、upstream #16119 #2069)。
+	// nil = 無制限。sinceId/untilId cursor とは独立に AND される。
+	RangeStartAt *int64
+	RangeEndAt   *int64
 }
 
 // Pagination wraps the keyset pagination parameters used by SearchNote.

--- a/internal/core/search/sqllike_provider.go
+++ b/internal/core/search/sqllike_provider.go
@@ -1,10 +1,30 @@
 package search
 
 import (
+	"time"
+
 	"github.com/shiroha-a/mk/internal/core/note"
+	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
 )
+
+// rangeStartID / rangeEndID convert a date-range bound (epoch ms) to an aidx
+// prefix id boundary, mirroring upstream `idService.gen(rangeStartAt-1)` /
+// `gen(rangeEndAt+1)` (#16119 #2069)。±1ms で範囲を inclusive にする。
+func rangeStartID(at *int64) string {
+	if at == nil {
+		return ""
+	}
+	return id.AidxCutoffPrefix(time.UnixMilli(*at - 1))
+}
+
+func rangeEndID(at *int64) string {
+	if at == nil {
+		return ""
+	}
+	return id.AidxCutoffPrefix(time.UnixMilli(*at + 1))
+}
 
 // SQLLikeProvider is the default backend that delegates to
 // `noteRepo.SearchByFilter`. It performs a case-insensitive substring match
@@ -62,16 +82,18 @@ func (p *SQLLikeProvider) SearchNote(viewer *model.User, query string, opts Sear
 		viewerID = viewer.ID
 	}
 	rows, err := p.noteRepo.SearchByFilter(model.NoteSearchFilter{
-		Query:     query,
-		UserID:    opts.UserID,
-		ChannelID: opts.ChannelID,
-		Host:      opts.Host,
-		UntilID:   page.UntilID,
-		SinceID:   page.SinceID,
-		Limit:     limit,
-		Offset:    opts.Offset,
-		ViewerID:  viewerID,
-		Pgroonga:  p.pgroonga,
+		Query:        query,
+		UserID:       opts.UserID,
+		ChannelID:    opts.ChannelID,
+		Host:         opts.Host,
+		UntilID:      page.UntilID,
+		SinceID:      page.SinceID,
+		RangeStartID: rangeStartID(opts.RangeStartAt),
+		RangeEndID:   rangeEndID(opts.RangeEndAt),
+		Limit:        limit,
+		Offset:       opts.Offset,
+		ViewerID:     viewerID,
+		Pgroonga:     p.pgroonga,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/core/search/sqllike_provider_test.go
+++ b/internal/core/search/sqllike_provider_test.go
@@ -3,6 +3,7 @@ package search
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/testutil"
@@ -129,4 +130,16 @@ func TestSQLLikeProvider_VisibilityFilterDropsHidden(t *testing.T) {
 	out, err := p.SearchNote(nil, "hello", SearchOpts{}, Pagination{Limit: 10})
 	require.NoError(t, err)
 	assert.Len(t, out, 1)
+}
+
+// #2069 (upstream #16119): rangeStartID/rangeEndID は epoch ms → aidx prefix 境界。
+// nil は空文字 (制限なし)、非 nil は AidxCutoffPrefix の値。
+func TestRangeBoundConversion(t *testing.T) {
+	assert.Equal(t, "", rangeStartID(nil))
+	assert.Equal(t, "", rangeEndID(nil))
+	at := time.Date(2022, 6, 1, 0, 0, 0, 0, time.UTC).UnixMilli()
+	assert.NotEmpty(t, rangeStartID(&at))
+	assert.NotEmpty(t, rangeEndID(&at))
+	// end は start より後ろの境界 (rangeEndAt+1 > rangeStartAt-1 で prefix も大)。
+	assert.Greater(t, rangeEndID(&at), rangeStartID(&at))
 }

--- a/internal/core/twofactor/replay.go
+++ b/internal/core/twofactor/replay.go
@@ -37,8 +37,10 @@ type ReplayGuard interface {
 // so the guard entry must survive at least that long after the first
 // acceptance — otherwise the code could be replayed during the residual
 // validity once the entry expires. We pad by one extra step for clock jitter.
-// 旧実装は Skew=1 前提の 120s 固定だったが、#1555 で Skew=5 に広げたため
-// totpSkew から導出して lockstep を保つ (Skew=5 → 11 steps = 330s + 30s pad)。
+// totpSkew から導出して lockstep を保つ。#2069 で totpSkew が 5→1 になった
+// (upstream #17580 validationWindow:1 追従) ため Skew=1 → 4 steps = 120s
+// (validity 90s + 30s jitter pad)。upstream ttl=timeStep*(window*2+1)=90s より 1 step
+// 保守的。
 const defaultReplayTTL = time.Duration(2*totpSkew+2) * 30 * time.Second
 
 // RedisReplayGuard implements ReplayGuard on top of go-redis. Keys are

--- a/internal/core/twofactor/totp_service.go
+++ b/internal/core/twofactor/totp_service.go
@@ -12,11 +12,12 @@ import (
 	"github.com/pquerna/otp/totp"
 )
 
-// totpSkew は許容する前後ステップ数。upstream Misskey は OTPAuth.TOTP.validate
-// を window:5 で呼ぶ (UserAuthService.ts / 2fa/done.ts) ため、pquerna の
-// デフォルト Skew=1 (±30s) ではなく ±5 ステップ (±150s) に合わせる。これにより
-// 端末の時計ずれが大きい環境でも upstream と同じコードを受理できる (#1555)。
-const totpSkew = 5
+// totpSkew は許容する前後ステップ数。upstream Misskey 2026.6.0 (#17580) で
+// UserAuthService の validationWindow が 5→1 に絞られた (replay surface 縮小)。
+// drop-in 互換のため mk-go も ±1 ステップ (±30s) に揃える。Misskey TS 側も
+// window:1 になったため両者 ±30s で時計ずれ許容も一致する (旧 #1555 の window:5
+// 追従は upstream 変更で陳腐化)。
+const totpSkew = 1
 
 // qrImageSize は frontend MkPoll 系コンポーネントが想定する QR コード画像
 // の 1 辺ピクセル数。Misskey TS upstream の `QRCode.toDataURL(url)` は

--- a/internal/core/twofactor/totp_service_test.go
+++ b/internal/core/twofactor/totp_service_test.go
@@ -34,20 +34,20 @@ func TestValidate_WrongCode(t *testing.T) {
 	assert.False(t, Validate("000000", secret))
 }
 
-// #1555 acceptance window は upstream (window:5 ≈ ±150s) に合わせる。
-// 旧 Skew=1 (±30s) では落ちる ±120s ずれのコードを受理できることを確認する。
-func TestValidate_WideWindow(t *testing.T) {
+// #2069 (upstream #17580): acceptance window は upstream validationWindow:1 に
+// 合わせ ±1 step (±30s)。±30s 内は受理、それを超えるずれは拒否する。
+func TestValidate_Window(t *testing.T) {
 	secret, _, err := GenerateSecret("Misskey", "testuser")
 	require.NoError(t, err)
-	// 120秒前 (4 steps) のコード。Skew=1 では拒否、Skew=5 では受理。
-	code, err := totp.GenerateCode(secret, time.Now().Add(-120*time.Second))
+	// 30秒前 (1 step) のコードは Skew=1 で受理。
+	code, err := totp.GenerateCode(secret, time.Now().Add(-30*time.Second))
 	require.NoError(t, err)
-	assert.True(t, Validate(code, secret), "code within ±150s window must be accepted")
+	assert.True(t, Validate(code, secret), "code within ±30s (1 step) window must be accepted")
 
-	// 窓外 (300秒前 = 10 steps) は拒否される。
-	farCode, err := totp.GenerateCode(secret, time.Now().Add(-300*time.Second))
+	// 120秒前 (4 steps) は窓外 (旧 Skew=5 では受理だったが #17580 追従で拒否)。
+	farCode, err := totp.GenerateCode(secret, time.Now().Add(-120*time.Second))
 	require.NoError(t, err)
-	assert.False(t, Validate(farCode, secret), "code far outside the window must be rejected")
+	assert.False(t, Validate(farCode, secret), "code outside ±30s window must be rejected (#2069)")
 }
 
 func TestValidate_EmptySecret(t *testing.T) {

--- a/internal/model/note.go
+++ b/internal/model/note.go
@@ -78,7 +78,12 @@ type NoteSearchFilter struct {
 	Host      string
 	UntilID   string
 	SinceID   string
-	Limit     int
+	// RangeStartID / RangeEndID は投稿日時範囲検索 (upstream #16119、#2069) の id
+	// 境界。rangeStartAt/rangeEndAt (epoch ms) を aidx prefix に変換したもので、
+	// sinceID/untilID cursor とは独立に AND される (空なら無視)。
+	RangeStartID string
+	RangeEndID   string
+	Limit        int
 	// Offset is the OFFSET-based pagination offset (upstream notes/search.ts:47)。
 	// 0 = no offset (#1783)。
 	Offset int

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -564,6 +564,13 @@ func (r *noteRepository) SearchByFilter(f model.NoteSearchFilter) ([]*model.Note
 	if f.SinceID != "" {
 		q = q.Where("id > ?", f.SinceID)
 	}
+	// 投稿日時範囲 (upstream #16119、#2069)。cursor とは独立に AND する。
+	if f.RangeStartID != "" {
+		q = q.Where("id > ?", f.RangeStartID)
+	}
+	if f.RangeEndID != "" {
+		q = q.Where("id < ?", f.RangeEndID)
+	}
 	limit := f.Limit
 	if limit <= 0 {
 		limit = 10

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/lib/pq"
+	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -3380,4 +3381,38 @@ func TestNoteRepository_ListPublicByUserID(t *testing.T) {
 	require.Len(t, sinceRows, 2)
 	assert.Equal(t, "obx_pub1", sinceRows[0].ID, "since-only is ASC")
 	assert.Equal(t, "obx_pub2", sinceRows[1].ID)
+}
+
+// #2069 (upstream #16119): SearchByFilter は RangeStartID/RangeEndID (投稿日時範囲を
+// aidx prefix に変換した境界) で cursor とは独立に絞り込む。
+func TestNoteRepository_SearchByFilter_DateRange(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	u := insertTestUser(t, "u_dr_1", "drangeuser")
+	defer cleanupUser(t, u.ID)
+	idGen, _ := id.NewGenerator("aidx")
+	txt := "drangesearchabletoken"
+	mk := func(ts time.Time) string {
+		nid := idGen.Generate(ts)
+		require.NoError(t, repo.Create(&model.Note{
+			ID: nid, UserID: u.ID, Text: &txt,
+			Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}")),
+		}))
+		t.Cleanup(func() { cleanupNote(t, nid) })
+		return nid
+	}
+	id2021 := mk(time.Date(2021, 6, 1, 0, 0, 0, 0, time.UTC))
+	id2022 := mk(time.Date(2022, 6, 1, 0, 0, 0, 0, time.UTC))
+	id2023 := mk(time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	// 2022 年のみを範囲指定 (start 2022-01-01 / end 2022-12-31)。
+	rangeStart := id.AidxCutoffPrefix(time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC))
+	rangeEnd := id.AidxCutoffPrefix(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
+	out, err := repo.SearchByFilter(model.NoteSearchFilter{
+		Query: "drangesearchabletoken", RangeStartID: rangeStart, RangeEndID: rangeEnd, Limit: 50,
+	})
+	require.NoError(t, err)
+	got := idsOf(out)
+	assert.Contains(t, got, id2022, "2022 の note は範囲内 (#2069)")
+	assert.NotContains(t, got, id2021, "2021 は範囲外")
+	assert.NotContains(t, got, id2023, "2023 は範囲外")
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2002,6 +2002,7 @@ func (s *Server) setupRoutes() {
 	api.POST("/antennas/delete", antennasHandler.Delete, middleware.RequireAuth(), middleware.RequireScope("write:account"))
 	api.POST("/antennas/list", antennasHandler.List, middleware.RequireAuth(), middleware.RequireScope("read:account"))
 	api.POST("/antennas/notes", antennasHandler.Notes, middleware.RequireAuth(), middleware.RequireScope("read:account"))
+	api.POST("/antennas/remove-note", antennasHandler.RemoveNote, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:account")) // #2069 #17463
 
 	// Clips endpoints (Phase 4.4)
 	clipsHandler := clips.NewHandler(clipService, idGen)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -211,6 +211,8 @@ func (s *Server) setupRoutes() {
 
 	// Core services
 	roleService := corerole.NewService(roleRepo, roleAssignmentRepo, metaRepo, idGen)
+	// server 全体の upload 上限 (MB) を role policy maxFileSizeMb の cap に使う (#2069/#17389)。
+	roleService.SetServerMaxFileSizeMb(int(s.config.MaxFileSize / (1024 * 1024)))
 	// drop-in 互換 (#785): Misskey TS は signup root user を user.isRoot=true で
 	// マークし meta.rootUserId は set しない。TS DB を引き継いだ mk-go では
 	// meta.rootUserId=nil となり admin paths で 403 が返る regression を防ぐ

--- a/migration/000063_user_note_pining_noteid_index.down.sql
+++ b/migration/000063_user_note_pining_noteid_index.down.sql
@@ -1,0 +1,3 @@
+-- CONCURRENTLY で作った index は CONCURRENTLY で drop して write block を避ける
+-- (DROP INDEX CONCURRENTLY も transaction 外・単一文でのみ実行可能)。
+DROP INDEX CONCURRENTLY IF EXISTS "IDX_user_note_pining_noteId";

--- a/migration/000063_user_note_pining_noteid_index.up.sql
+++ b/migration/000063_user_note_pining_noteid_index.up.sql
@@ -1,0 +1,10 @@
+-- #2069 (upstream 2026.6.0 #17511 追従): user_note_pining.noteId 単一 index を追加。
+-- upstream #17511 は note_favorite.noteId / user_note_pining.noteId に単一 index を
+-- 足した。mk-go は note_favorite 側は 000017 で既に持つが、user_note_pining は
+-- IDX("userId") と UNIQUE("userId","noteId") のみで、noteId 単独検索 (ノート削除時の
+-- pin 逆引き等) に使える index が無い (UNIQUE は第 1 カラムが userId のため効かない)。
+--
+-- CONCURRENTLY は transaction 外・単一文でのみ実行できるため 1 文のみで構成する。
+-- 失敗時の回復手順 (INVALID index の DROP + migrate dirty 解除) は 000054 の
+-- コメントを参照 (対象 index 名は読み替える)。
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_user_note_pining_noteId" ON "user_note_pining" ("noteId");


### PR DESCRIPTION
## Summary

upstream Misskey 2026.6.0 (2026-06-22) への backend 追従を 1 PR・項目ごとに別コミットで実施する
(triage: `docs/update/20260622-2069-triage.md`)。fork は `2026.6.0-mk.0` 配信済。

## 実装した gap items (各 = 1 commit)

| upstream | 内容 | 領域 |
|---|---|---|
| infra | MisskeyVersion 2026.5.4 → 2026.6.0 | config |
| #17563 | AP Document attachment に width/height (outbound) | activitypub |
| #15961 | followers note の direct 引用で direct 維持 (public/home のみ降格) | note create |
| #17511 | user_note_pining.noteId 単一 index (migration 000063) | migration |
| #17580 | TOTP validation window 5→1 (replay surface 縮小) | twofactor |
| #17576 | remote note mention 制限を raw count (= max(resolved, raw tag href)) で判定 | federation |
| #17558 | inbox の actor 欠落 activity を早期 400 で reject | inbox |
| #17389 | maxFileSizeMb を server 全体上限で cap + base-role aggregate | role |
| #17463 | antennas/remove-note 新 API (Stream XDEL) | antenna |
| #16119 | notes/search に投稿日時範囲 rangeStartAt/rangeEndAt | search |

## close 候補 (影響なし — 実装変更不要、triage に根拠記載)

- URL preview SSRF (常時 SSRF-safe transport) / self-host acct (host を無視する実装で元々救済) /
  PerUserDrive null userId (二重ガード済) / OAuth2 Token Grant validation (JSON/urlencoded 両対応済)。
- admin/reset-password エラー code/id 差異は #1539 の意図的 deviation のため変更しない。

## 残 (本 PR 非対象)

- **queue pause/resume (#17436、L)**: mkq driver に pause 機構が無く worker dequeue gate を新規実装する
  production-critical な infra feature のため、別 PR で dedicated に対応 (parity gap でなく新機能)。

## テスト

各 item に単体/統合テストを追加・更新 (旧挙動を pin していた test は upstream 新挙動へ付替)。
`make fmt` / `go vet ./...` / 全 touched package test / entitycompat golden gate green。敵対的レビューで
全 10 item の upstream parity・regression なし・migration/ security 安全を確認。

## 関連

- tracker: #2069
- triage: `docs/update/20260622-2069-triage.md`
