### PR TITLE
admin/queue pause/resume を追加 (#2069 Wave4, upstream #17436)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/pquerna/otp v1.5.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.18.0
-	github.com/shiroha-a/mkq v1.0.2
+	github.com/shiroha-a/mkq v1.0.3
 	github.com/shirou/gopsutil/v4 v4.26.3
 	github.com/spakin/netpbm v1.3.2
 	github.com/spf13/viper v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -293,8 +293,8 @@ github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd h1:CmH9+J6ZSsIjUK
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
-github.com/shiroha-a/mkq v1.0.2 h1:/yW4b6zsfbgQc8Mqb7Ehi/ZbMfOUWoHxBifSx4z06lY=
-github.com/shiroha-a/mkq v1.0.2/go.mod h1:rsssbhJCi7RO8RTCAXQwUAzGLEvQuxxgTrfdah9vs6U=
+github.com/shiroha-a/mkq v1.0.3 h1:9kamKncYsgB3u47i2mmAoQ1wvO0GmQRd/urQqVPKJxw=
+github.com/shiroha-a/mkq v1.0.3/go.mod h1:rsssbhJCi7RO8RTCAXQwUAzGLEvQuxxgTrfdah9vs6U=
 github.com/shirou/gopsutil/v4 v4.26.3 h1:2ESdQt90yU3oXF/CdOlRCJxrP+Am1aBYubTMTfxJ1qc=
 github.com/shirou/gopsutil/v4 v4.26.3/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -421,6 +421,9 @@ type QueueInspector interface {
 	DeleteTask(qname, taskID string) error
 	DeleteAllPendingTasks(qname string) (int, error)
 	RunTask(qname, taskID string) error
+	// PauseQueue / UnpauseQueue pause and resume a queue (#17436)。
+	PauseQueue(qname string) error
+	UnpauseQueue(qname string) error
 	// Task listing APIs. page is 1-indexed.
 	ListPendingTasks(qname string, page, pageSize int) ([]*QueueTaskSummary, error)
 	ListActiveTasks(qname string, page, pageSize int) ([]*QueueTaskSummary, error)
@@ -451,6 +454,7 @@ type QueueInfoResult struct {
 	Failed    int
 	Scheduled int
 	Retry     int
+	IsPaused  bool
 }
 
 // QueueTaskSummary mirrors queue.TaskSummary for handler responses without

--- a/internal/api/admin/queue.go
+++ b/internal/api/admin/queue.go
@@ -12,6 +12,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/api/apierr"
+	"github.com/shiroha-a/mk/internal/core/moderationlog"
 	"github.com/shiroha-a/mk/internal/queue"
 )
 
@@ -469,6 +470,75 @@ func (h *Handler) QueuePromoteJobs(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]any{"promoted": promoted})
 }
 
+// queuePauseResumeTypes mirrors upstream QueueService.QUEUE_TYPES (admin/queue/
+// pause・resume の param enum、#17436)。enum 外の queue は invalidParam で弾く。
+var queuePauseResumeTypes = map[string]struct{}{
+	"system": {}, "endedPollNotification": {}, "postScheduledNote": {}, "deliver": {},
+	"inbox": {}, "db": {}, "relationship": {}, "objectStorage": {},
+	"userWebhookDeliver": {}, "systemWebhookDeliver": {},
+}
+
+// QueuePause handles POST /api/admin/queue/pause (upstream #17436)。
+func (h *Handler) QueuePause(c echo.Context) error { return h.queuePauseResume(c, true) }
+
+// QueueResume handles POST /api/admin/queue/resume (upstream #17436)。
+func (h *Handler) QueueResume(c echo.Context) error { return h.queuePauseResume(c, false) }
+
+// queuePauseResume は pause / resume 共通処理。queue param を QUEUE_TYPES で検証し、
+// queueInspector の PauseQueue/UnpauseQueue を呼んで moderationLog に記録する。
+// upstream pause.ts / resume.ts と同じく res は無し (204)。
+func (h *Handler) queuePauseResume(c echo.Context, pause bool) error {
+	var req struct {
+		Queue string `json:"queue"`
+	}
+	if err := c.Bind(&req); err != nil || req.Queue == "" {
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("queue is required."))
+	}
+	if _, ok := queuePauseResumeTypes[req.Queue]; !ok {
+		return c.JSON(http.StatusBadRequest, apierr.InvalidParam("invalid queue."))
+	}
+	if h.queueInspector == nil {
+		return c.NoContent(http.StatusNoContent)
+	}
+	// mk-go が運用しない queue (QUEUE_TYPES enum だが worker 無し) は no-op 204。
+	// upstream は全 queue が実在するが mk-go は subset のみ運用するため、frontend が
+	// 全 QUEUE_TYPES のタブを出して未運用 queue を pause しようとしても、GetQueueInfo /
+	// queue-stats の zero-fill 同様 graceful に成功させる (500 を返さない)。
+	if !h.queueIsManaged(req.Queue) {
+		return c.NoContent(http.StatusNoContent)
+	}
+	var err error
+	logType := moderationlog.LogResumeQueue
+	if pause {
+		err = h.queueInspector.PauseQueue(req.Queue)
+		logType = moderationlog.LogPauseQueue
+	} else {
+		err = h.queueInspector.UnpauseQueue(req.Queue)
+	}
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
+	// upstream は moderationLog.log(me, 'pauseQueue') を detail 無し (空 object) で
+	// 記録するため、info も空にして parity を保つ。
+	h.logModeration(c, logType, map[string]any{})
+	return c.NoContent(http.StatusNoContent)
+}
+
+// queueIsManaged reports whether qname is a queue mk-go actually runs (= present
+// in Inspector.Queues())。判定不能 (Queues error) 時は通常経路へ倒す。
+func (h *Handler) queueIsManaged(qname string) bool {
+	queues, err := h.queueInspector.Queues()
+	if err != nil {
+		return true
+	}
+	for _, q := range queues {
+		if q == qname {
+			return true
+		}
+	}
+	return false
+}
+
 // shapeQueueForFrontend adapts a QueueInfoResult to the Misskey Bull-shaped
 // JSON expected by the admin/job-queue.vue page.
 //
@@ -496,7 +566,7 @@ func shapeQueueForFrontend(info *QueueInfoResult, completed, failed *QueueMetric
 	return map[string]any{
 		"name":          info.Queue,
 		"qualifiedName": info.Queue,
-		"isPaused":      false,
+		"isPaused":      info.IsPaused,
 		"counts": map[string]any{
 			"active":    info.Active,
 			"delayed":   delayed,

--- a/internal/api/admin/queue_test.go
+++ b/internal/api/admin/queue_test.go
@@ -73,9 +73,28 @@ type stubQueueInspector struct {
 	deleted       []string
 	runCalls      []string
 	deleteAllHits []string
+	pauseCalls    []string
+	resumeCalls   []string
+	pauseErr      error
 	queuesErr     error
 	runErr        error
 	deleteErr     error
+}
+
+func (s *stubQueueInspector) PauseQueue(q string) error {
+	if s.pauseErr != nil {
+		return s.pauseErr
+	}
+	s.pauseCalls = append(s.pauseCalls, q)
+	return nil
+}
+
+func (s *stubQueueInspector) UnpauseQueue(q string) error {
+	if s.pauseErr != nil {
+		return s.pauseErr
+	}
+	s.resumeCalls = append(s.resumeCalls, q)
+	return nil
 }
 
 func (s *stubQueueInspector) Queues() ([]string, error) { return s.queues, s.queuesErr }
@@ -1101,4 +1120,65 @@ func TestQueueJobs_SearchReturnsUpTo100(t *testing.T) {
 	var rows []map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
 	assert.Len(t, rows, 100, "search は最大 100 件 (RETURN_LIMIT)")
+}
+
+// #2069 (upstream #17436): admin/queue/pause・resume。
+func TestQueuePause_Success(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{queues: []string{"deliver", "inbox"}}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueuePause, `{"queue":"deliver"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, []string{"deliver"}, insp.pauseCalls)
+	assert.Empty(t, insp.resumeCalls)
+}
+
+func TestQueueResume_Success(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{queues: []string{"deliver", "inbox"}}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueueResume, `{"queue":"inbox"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, []string{"inbox"}, insp.resumeCalls)
+	assert.Empty(t, insp.pauseCalls)
+}
+
+func TestQueuePauseResume_Validation(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{queues: []string{"deliver"}}
+	h.SetQueueInspector(insp)
+	// queue 欠落 → 400。
+	assert.Equal(t, http.StatusBadRequest, doPost(h.QueuePause, `{}`, adminUser).Code)
+	// QUEUE_TYPES 外 → 400。
+	assert.Equal(t, http.StatusBadRequest, doPost(h.QueuePause, `{"queue":"bogus"}`, adminUser).Code)
+	assert.Equal(t, http.StatusBadRequest, doPost(h.QueueResume, `{"queue":"bogus"}`, adminUser).Code)
+	assert.Empty(t, insp.pauseCalls)
+	assert.Empty(t, insp.resumeCalls)
+}
+
+// #2069 H1: QUEUE_TYPES enum だが mk-go が運用しない queue (Queues() に無い) は
+// no-op 204 (frontend が全 QUEUE_TYPES タブを出すため 500 にしない)。
+func TestQueuePause_UnmanagedQueueNoOp(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{queues: []string{"deliver", "inbox"}}
+	h.SetQueueInspector(insp)
+	// "system" は enum だが managed でない → 204、PauseQueue は呼ばれない。
+	rec := doPost(h.QueuePause, `{"queue":"system"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Empty(t, insp.pauseCalls)
+}
+
+func TestQueuePause_InspectorError(t *testing.T) {
+	h, _, _, _ := newTestHandler(t)
+	insp := &stubQueueInspector{queues: []string{"deliver"}, pauseErr: assert.AnError}
+	h.SetQueueInspector(insp)
+	rec := doPost(h.QueuePause, `{"queue":"deliver"}`, adminUser)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestQueuePause_NoInspector(t *testing.T) {
+	// queueInspector 未配線時は no-op 204 (QueueClear と同パターン)。
+	h, _, _, _ := newTestHandler(t)
+	rec := doPost(h.QueuePause, `{"queue":"deliver"}`, adminUser)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
 }

--- a/internal/core/moderationlog/types.go
+++ b/internal/core/moderationlog/types.go
@@ -10,7 +10,8 @@
 //     spec even if the UI falls back to the generic display).
 //
 // Types defined in upstream but skipped for now:
-//   - clearQueue / promoteQueue: tooling-only, no UI branch
+//   - clearQueue / promoteQueue: tooling-only, no UI branch (pauseQueue /
+//     resumeQueue は admin/queue/pause・resume で記録するため下に定義済み)
 //   - markSensitiveDriveFile / unmarkSensitiveDriveFile / deleteDriveFile:
 //     mk-go admin/drive write handlers are not implemented
 //   - deleteNote / deletePage / deleteFlash / deleteGalleryPost / deleteChatRoom:
@@ -94,6 +95,10 @@ const (
 	LogDeleteGalleryPost LogType = "deleteGalleryPost"
 	LogDeleteFlash       LogType = "deleteFlash"
 	LogDeleteChatRoom    LogType = "deleteChatRoom"
+
+	// Queue (admin/queue/pause・resume、upstream #17436)
+	LogPauseQueue  LogType = "pauseQueue"
+	LogResumeQueue LogType = "resumeQueue"
 
 	// Misc
 	LogUpdateProxyAccountDescription LogType = "updateProxyAccountDescription"

--- a/internal/queue/driver/asynqdriver/inspector.go
+++ b/internal/queue/driver/asynqdriver/inspector.go
@@ -37,7 +37,18 @@ func (i *Inspector) GetQueueInfo(qname string) (*driver.InspectorInfo, error) {
 		Failed:    info.Failed,
 		Scheduled: info.Scheduled,
 		Retry:     info.Retry,
+		IsPaused:  info.Paused,
 	}, nil
+}
+
+// PauseQueue pauses the named queue via asynq's native PauseQueue (#17436)。
+func (i *Inspector) PauseQueue(qname string) error {
+	return i.inner.PauseQueue(qname)
+}
+
+// UnpauseQueue resumes the named queue via asynq's native UnpauseQueue。
+func (i *Inspector) UnpauseQueue(qname string) error {
+	return i.inner.UnpauseQueue(qname)
 }
 
 // DeleteTask deletes the named task from the named queue.

--- a/internal/queue/driver/asynqdriver/integration_test.go
+++ b/internal/queue/driver/asynqdriver/integration_test.go
@@ -289,3 +289,28 @@ func TestScheduler_RegisterAndStart(t *testing.T) {
 	require.NoError(t, sched.Start())
 	sched.Shutdown()
 }
+
+// #2069 (upstream #17436): Inspector.PauseQueue/UnpauseQueue + GetQueueInfo.IsPaused が
+// asynq native pause に wire されていることを検証。
+func TestInspector_PauseResume(t *testing.T) {
+	testutil.SkipIfNoDocker(t)
+	flushRedis(t)
+
+	d := newDriver()
+	t.Cleanup(func() { _ = d.Close() })
+
+	// queue を実体化するため 1 件 enqueue。
+	require.NoError(t, d.Client().Enqueue(context.Background(),
+		"pause:probe", []byte("x"), driver.WithQueue("deliver")))
+
+	ins := d.Inspector()
+	require.NoError(t, ins.PauseQueue("deliver"))
+	info, err := ins.GetQueueInfo("deliver")
+	require.NoError(t, err)
+	assert.True(t, info.IsPaused, "pause 後は IsPaused=true")
+
+	require.NoError(t, ins.UnpauseQueue("deliver"))
+	info, err = ins.GetQueueInfo("deliver")
+	require.NoError(t, err)
+	assert.False(t, info.IsPaused, "resume 後は IsPaused=false")
+}

--- a/internal/queue/driver/driver.go
+++ b/internal/queue/driver/driver.go
@@ -37,6 +37,9 @@ type InspectorInfo struct {
 	Failed    int
 	Scheduled int
 	Retry     int
+	// IsPaused reports whether the queue is paused (BullMQ meta.paused)。
+	// upstream admin/queue は queueInfo.isPaused でボタンを切り替える (#17436)。
+	IsPaused bool
 }
 
 // MetricsResult is the BullMQ-compatible per-minute history of
@@ -95,6 +98,13 @@ type Inspector interface {
 	DeleteTask(qname, taskID string) error
 	DeleteAllPendingTasks(qname string) (int, error)
 	RunTask(qname, taskID string) error
+
+	// PauseQueue / UnpauseQueue pause and resume a queue (BullMQ
+	// Queue.pause()/resume()、upstream admin/queue/pause・resume #17436)。
+	// paused 中は worker が job を fetch しない。enqueue された job は drop
+	// されず resume で再開される (driver の保証)。
+	PauseQueue(qname string) error
+	UnpauseQueue(qname string) error
 
 	ListPendingTasks(qname string, page, pageSize int) ([]*TaskSummary, error)
 	ListActiveTasks(qname string, page, pageSize int) ([]*TaskSummary, error)

--- a/internal/queue/driver/mkqdriver/inspector.go
+++ b/internal/queue/driver/mkqdriver/inspector.go
@@ -97,6 +97,10 @@ func (i *Inspector) GetQueueInfo(qname string) (*driver.InspectorInfo, error) {
 	// #1187 で内訳が変わったが合計値は不変: scheduledCount + retryCount ==
 	// counts.Delayed (= 同じ delayed bucket を partition しただけ) なので、
 	// Size 計算では partition 前の counts.Delayed をそのまま使える。
+	// paused 状態 (meta.paused) は best-effort で取得 (失敗しても info 全体は
+	// 返す、admin panel を真っ白にしない方針)。
+	paused, _ := q.IsPaused(inspectorCtx())
+
 	return &driver.InspectorInfo{
 		Queue:     qname,
 		Size:      int(counts.Wait+counts.Active+counts.Delayed+counts.Prioritized+counts.Failed) + int(repeatCount),
@@ -106,7 +110,35 @@ func (i *Inspector) GetQueueInfo(qname string) (*driver.InspectorInfo, error) {
 		Failed:    int(counts.Failed),
 		Scheduled: scheduledCount + int(repeatCount),
 		Retry:     retryCount,
+		IsPaused:  paused,
 	}, nil
+}
+
+// PauseQueue pauses the named queue via mkq's BullMQ-compatible Queue.Pause
+// (meta.paused フラグ + wait→paused list 移動)。paused 中の enqueue も paused に
+// 入り orphan しない (mkq v1.0.3 #70)。
+func (i *Inspector) PauseQueue(qname string) error {
+	q := i.driver.queueFor(qname)
+	if q == nil {
+		return fmt.Errorf("mkqdriver: unknown queue %q", qname)
+	}
+	if err := q.Pause(inspectorCtx()); err != nil {
+		return fmt.Errorf("mkqdriver: pause %q: %w", qname, err)
+	}
+	return nil
+}
+
+// UnpauseQueue resumes the named queue via mkq's Queue.Resume (paused→wait に
+// 戻し marker を poke して blocking worker を起こす)。
+func (i *Inspector) UnpauseQueue(qname string) error {
+	q := i.driver.queueFor(qname)
+	if q == nil {
+		return fmt.Errorf("mkqdriver: unknown queue %q", qname)
+	}
+	if err := q.Resume(inspectorCtx()); err != nil {
+		return fmt.Errorf("mkqdriver: resume %q: %w", qname, err)
+	}
+	return nil
 }
 
 // partitionDelayedByAttempts inspects mkq's delayed bucket and partitions

--- a/internal/queue/driver/mkqdriver/integration_test.go
+++ b/internal/queue/driver/mkqdriver/integration_test.go
@@ -1268,3 +1268,47 @@ func TestServer_Resize_ToZeroStopsAll(t *testing.T) {
 		}
 	}
 }
+
+// #2069 (upstream #17436): Inspector.PauseQueue/UnpauseQueue + GetQueueInfo.IsPaused の
+// wiring と、pause 中 enqueue した job が resume で処理される (orphan しない) ことを検証。
+func TestPauseResume_EndToEnd(t *testing.T) {
+	d := newDriver(t)
+	insp := d.Inspector()
+
+	// wiring: pause → IsPaused true、resume → false。
+	require.NoError(t, insp.PauseQueue("deliver"))
+	info, err := insp.GetQueueInfo("deliver")
+	require.NoError(t, err)
+	assert.True(t, info.IsPaused, "pause 後は IsPaused=true")
+
+	// worker を起動。pause 中は fetch されない。
+	var received int32
+	var wg sync.WaitGroup
+	wg.Add(1)
+	srv := d.Server()
+	srv.Handle("test:pause", func(_ context.Context, _ driver.Task) error {
+		atomic.AddInt32(&received, 1)
+		wg.Done()
+		return nil
+	})
+	require.NoError(t, srv.Start())
+	t.Cleanup(srv.Shutdown)
+
+	// pause 中に enqueue。
+	require.NoError(t, d.Client().Enqueue(context.Background(), "test:pause", []byte(`{}`),
+		driver.WithQueue("deliver")))
+
+	// pause 中は処理されない (1s 待っても handler 未起動 = lua gate が wait を fetch しない)。
+	time.Sleep(1 * time.Second)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&received), "pause 中は job が処理されない")
+
+	// resume → IsPaused false + parked job が処理される (orphan しない)。
+	require.NoError(t, insp.UnpauseQueue("deliver"))
+	info, err = insp.GetQueueInfo("deliver")
+	require.NoError(t, err)
+	assert.False(t, info.IsPaused, "resume 後は IsPaused=false")
+	if !waitGroupTimeout(&wg, 5*time.Second) {
+		t.Fatal("resume 後に parked job が処理されなかった (orphan)")
+	}
+	assert.Equal(t, int32(1), atomic.LoadInt32(&received))
+}

--- a/internal/queue/inspector.go
+++ b/internal/queue/inspector.go
@@ -39,6 +39,16 @@ func (i *Inspector) GetQueueInfo(qname string) (*InspectorInfo, error) {
 	return i.inner.GetQueueInfo(qname)
 }
 
+// PauseQueue pauses the named queue (#17436)。
+func (i *Inspector) PauseQueue(qname string) error {
+	return i.inner.PauseQueue(qname)
+}
+
+// UnpauseQueue resumes the named queue (#17436)。
+func (i *Inspector) UnpauseQueue(qname string) error {
+	return i.inner.UnpauseQueue(qname)
+}
+
 // DeleteTask deletes a task by queue and ID.
 func (i *Inspector) DeleteTask(qname, taskID string) error {
 	return i.inner.DeleteTask(qname, taskID)

--- a/internal/queue/metrics/metrics_test.go
+++ b/internal/queue/metrics/metrics_test.go
@@ -63,6 +63,8 @@ func (i *fakeInspector) GetQueueInfo(qname string) (*driver.InspectorInfo, error
 }
 func (i *fakeInspector) DeleteTask(qname, taskID string) error           { return nil }
 func (i *fakeInspector) DeleteAllPendingTasks(qname string) (int, error) { return 0, nil }
+func (i *fakeInspector) PauseQueue(qname string) error                   { return nil }
+func (i *fakeInspector) UnpauseQueue(qname string) error                 { return nil }
 func (i *fakeInspector) RunTask(qname, taskID string) error              { return nil }
 func (i *fakeInspector) ListPendingTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
 	return nil, nil

--- a/internal/server/autoscale_wiring_test.go
+++ b/internal/server/autoscale_wiring_test.go
@@ -92,6 +92,8 @@ func (i *scriptableInspector) DeleteAllPendingTasks(qname string) (int, error) {
 	return 0, nil
 }
 func (i *scriptableInspector) RunTask(qname, taskID string) error { return nil }
+func (i *scriptableInspector) PauseQueue(qname string) error      { return nil }
+func (i *scriptableInspector) UnpauseQueue(qname string) error    { return nil }
 func (i *scriptableInspector) ListPendingTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
 	return nil, nil
 }

--- a/internal/server/metrics_route_test.go
+++ b/internal/server/metrics_route_test.go
@@ -73,6 +73,8 @@ func (i *fakeMetricsInspector) DeleteAllPendingTasks(qname string) (int, error) 
 	return 0, nil
 }
 func (i *fakeMetricsInspector) RunTask(qname, taskID string) error { return nil }
+func (i *fakeMetricsInspector) PauseQueue(qname string) error      { return nil }
+func (i *fakeMetricsInspector) UnpauseQueue(qname string) error    { return nil }
 func (i *fakeMetricsInspector) ListPendingTasks(qname string, page, pageSize int) ([]*driver.TaskSummary, error) {
 	return nil, nil
 }

--- a/internal/server/queue_adapter.go
+++ b/internal/server/queue_adapter.go
@@ -65,7 +65,16 @@ func (a *queueInspectorAdapter) GetQueueInfo(qname string) (*apiadmin.QueueInfoR
 		Failed:    info.Failed,
 		Scheduled: info.Scheduled,
 		Retry:     info.Retry,
+		IsPaused:  info.IsPaused,
 	}, nil
+}
+
+func (a *queueInspectorAdapter) PauseQueue(qname string) error {
+	return a.inner.PauseQueue(qname)
+}
+
+func (a *queueInspectorAdapter) UnpauseQueue(qname string) error {
+	return a.inner.UnpauseQueue(qname)
 }
 
 func (a *queueInspectorAdapter) DeleteTask(qname, taskID string) error {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2587,6 +2587,8 @@ func (s *Server) setupRoutes() {
 	api.POST("/admin/queue/inbox-delayed", adminHandler.QueueInboxDelayed, middleware.RequireModerator(roleService), middleware.RequireScope("read:admin:queue"))
 	api.POST("/admin/queue/jobs", adminHandler.QueueJobs, middleware.RequireModerator(roleService), middleware.RequireScope("read:admin:queue"))
 	api.POST("/admin/queue/promote-jobs", adminHandler.QueuePromoteJobs, middleware.RequireModerator(roleService), middleware.RequireScope("write:admin:queue"))
+	api.POST("/admin/queue/pause", adminHandler.QueuePause, middleware.RequireModerator(roleService), middleware.RequireScope("write:admin:queue"))   // #2069 #17436
+	api.POST("/admin/queue/resume", adminHandler.QueueResume, middleware.RequireModerator(roleService), middleware.RequireScope("write:admin:queue")) // #2069 #17436
 	api.POST("/admin/queue/queue-stats", adminHandler.QueueQueueStats, middleware.RequireModerator(roleService), middleware.RequireScope("read:admin:queue"))
 	api.POST("/admin/queue/queues", adminHandler.QueueQueues, middleware.RequireModerator(roleService), middleware.RequireScope("read:admin:queue"))
 	api.POST("/admin/queue/remove-job", adminHandler.QueueRemoveJob, middleware.RequireModerator(roleService), middleware.RequireScope("write:admin:queue"))


### PR DESCRIPTION
## Summary

2026.6.0 追従の残 item **admin/queue pause/resume (upstream #17436、#2069 Wave 4)** を実装する。
queue driver の mkq に公開 Pause/Resume API が無くブロックされていたが、mkq v1.0.3 (mkq#70) で
`Queue.Pause`/`Resume`/`IsPaused` が追加されたため、これに wire する。

## 主な変更点

- **mkq v1.0.2 → v1.0.3** (BullMQ `Queue.pause()`/`resume()` 互換の公開 API。meta.paused + wait↔paused
  list 移動 + marker poke で、pause 中 enqueue した job も orphan しない)。
- `driver.Inspector` に `PauseQueue`/`UnpauseQueue` + `InspectorInfo.IsPaused` を追加。
  - mkqdriver: mkq `Queue.Pause`/`Resume`/`IsPaused` に委譲 (恒久 driver)。
  - asynqdriver: asynq native `PauseQueue`/`UnpauseQueue` + `QueueInfo.Paused` に委譲。
- `queue.Inspector` → `server/queue_adapter` → `admin.QueueInspector` の各層に透過 + `QueueInfoResult.IsPaused`、
  `shapeQueueForFrontend.isPaused` を info から返す。
- admin handler `QueuePause`/`QueueResume` (param を QUEUE_TYPES enum で検証、`write:admin:queue` +
  `RequireModerator`、modlog `pauseQueue`/`resumeQueue`、204)。router routes 追加。

## レビュー指摘の反映

- **(HIGH) 未運用 queue の 500 回避**: mkq driver が運用するのは QUEUE_TYPES の subset のみ。frontend は全
  QUEUE_TYPES のタブを出すため、未運用 queue (system/db 等) の pause で `queueFor==nil` → 500 になりうる
  問題を、`Queues()` に無い queue は **no-op 204** に倒して解消 (GetQueueInfo / queue-stats の zero-fill
  graceful degrade と同方針)。
- **(MEDIUM) modlog info parity**: upstream は detail 無し (空 object) で記録するため info も空にした。
- **(既知)** asynq driver は二重 pause/resume で asynq native が error を返し非冪等 (mkq は冪等)。asynq は
  deprecated 方針のため現状維持。

## テスト

- mkqdriver 統合テスト (`TestPauseResume_EndToEnd`): pause 中 enqueue した job が処理されず、resume 後に
  処理される (orphan しない) ことを実 Redis で検証。
- asynqdriver 統合テスト (`TestInspector_PauseResume`): pause/resume → IsPaused の wire を検証。
- admin handler テスト: 成功 / QUEUE_TYPES 検証 / 未運用 queue の no-op 204 / inspector error 500 / nil no-op。
- `make fmt` / `go vet ./...` / 全 touched package test green (mkqdriver 90.2% / asynqdriver 90.9% / admin 89.8%)。
  敵対的レビューで parity・regression・queue stall risk なしを確認 (HIGH 1 件修正済)。

## 関連

- mkq 側 API: shiroha-a/mkq#70 (v1.0.3 で対応済)
- Closes #2069
