### PR TITLE
streaming renote.myReaction: pair cache を note_reaction から埋める (#2067)

### DIFF
--- a/internal/repository/note_reaction.go
+++ b/internal/repository/note_reaction.go
@@ -21,6 +21,13 @@ type NoteReactionRepository interface {
 	// noteIDをキーとしたmapを返す。
 	FindByUserAndNoteIDs(userID string, noteIDs []string) (map[string]*model.NoteReaction, error)
 	ListByNoteID(noteID string, untilID, sinceID string, limit int, reactions []string) ([]*model.NoteReaction, error)
+	// ListReactionPairs returns up to `limit` "<userId>/<reaction>" pairs for a
+	// note (oldest first), mirroring upstream's reactionAndUserPairCache capped at
+	// PER_NOTE_REACTION_USER_PAIR_CACHE_MAX. Used by the streaming note publisher
+	// to fill the renote embed pair cache for per-subscriber renote.myReaction
+	// (#2067)。note_reaction 行は reaction 時に即 persist されるため count buffer 中の
+	// reaction も含まれる。User は preload しない (userId だけ要るため)。
+	ListReactionPairs(noteID string, limit int) ([]string, error)
 	// ListByUserID returns reactions made by the given user, with User and Note
 	// preloaded for packing. upstream Misskey TS の users/reactions endpoint
 	// 用 (reactor 視点の reaction list)。viewerID は閲覧者 (空文字列で匿名) で、
@@ -98,6 +105,30 @@ func (r *noteReactionRepository) ListByNoteID(noteID string, untilID, sinceID st
 		return nil, err
 	}
 	return rows, nil
+}
+
+func (r *noteReactionRepository) ListReactionPairs(noteID string, limit int) ([]string, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	var rows []struct {
+		UserID   string `gorm:"column:userId"`
+		Reaction string `gorm:"column:reaction"`
+	}
+	// User を preload せず userId / reaction の 2 列だけを引く (publish path の軽量化)。
+	if err := r.db.Model(&model.NoteReaction{}).
+		Select(`"userId", reaction`).
+		Where(`"noteId" = ?`, noteID).
+		Order("id").
+		Limit(limit).
+		Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	pairs := make([]string, 0, len(rows))
+	for _, row := range rows {
+		pairs = append(pairs, row.UserID+"/"+row.Reaction)
+	}
+	return pairs, nil
 }
 
 // ListByUserID returns reactions made by the given user. upstream Misskey TS

--- a/internal/repository/note_reaction_test.go
+++ b/internal/repository/note_reaction_test.go
@@ -314,3 +314,46 @@ func TestNoteReactionRepository_QueryErrors(t *testing.T) {
 	_, err = repo.ListByNoteID("n", "", "", 10, nil)
 	assert.Error(t, err)
 }
+
+// #2067: ListReactionPairs は "<userId>/<reaction>" を id 昇順 (oldest first) で
+// 最大 limit 件返す。note_reaction 行が即 persist されるため buffered count とは独立。
+func TestNoteReactionRepository_ListReactionPairs(t *testing.T) {
+	repo := NewNoteReactionRepository(testDB)
+	u1 := insertTestUser(t, "u_lrp_1", "lrpuser1")
+	defer cleanupUser(t, u1.ID)
+	u2 := insertTestUser(t, "u_lrp_2", "lrpuser2")
+	defer cleanupUser(t, u2.ID)
+
+	noteRepo := NewNoteRepository(testDB)
+	note := &model.Note{ID: "n_lrp_1", UserID: u1.ID, Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}"))}
+	require.NoError(t, noteRepo.Create(note))
+	defer cleanupNote(t, note.ID)
+
+	// id 昇順で rx_lrp_1 (u1/👍) → rx_lrp_2 (u2/❤)。
+	for _, rec := range []*model.NoteReaction{
+		{ID: "rx_lrp_1", UserID: u1.ID, NoteID: note.ID, Reaction: "👍"},
+		{ID: "rx_lrp_2", UserID: u2.ID, NoteID: note.ID, Reaction: "❤"},
+	} {
+		require.NoError(t, repo.Create(rec))
+		defer cleanupReaction(t, rec.ID)
+	}
+
+	pairs, err := repo.ListReactionPairs(note.ID, 16)
+	require.NoError(t, err)
+	assert.Equal(t, []string{u1.ID + "/👍", u2.ID + "/❤"}, pairs, "oldest first")
+
+	// limit でキャップされる (oldest 1 件のみ)。
+	capped, err := repo.ListReactionPairs(note.ID, 1)
+	require.NoError(t, err)
+	assert.Equal(t, []string{u1.ID + "/👍"}, capped)
+
+	// limit <= 0 は nil。
+	none, err := repo.ListReactionPairs(note.ID, 0)
+	require.NoError(t, err)
+	assert.Nil(t, none)
+
+	// reaction の無い note は空。
+	empty, err := repo.ListReactionPairs("n_lrp_nonexistent", 16)
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2159,6 +2159,7 @@ func (s *Server) setupRoutes() {
 	notePublisher.SetEmojiLookup(emojiRepo)
 	notePublisher.SetInstanceLookup(instanceRepo)
 	notePublisher.SetReactionReader(reactionCountWriter)
+	notePublisher.SetReactionPairReader(reactionRepo) // #2067: renote embed の pair cache を note_reaction から埋める
 	notePublisher.SetFieldResolver(noteFieldResolver)
 	notificationPublisher := stream.NewNotificationPublisher(streamPubSub)
 	notificationPublisher.SetRepos(userRepo, noteRepo, idGen)

--- a/internal/stream/note_publisher.go
+++ b/internal/stream/note_publisher.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	coredrive "github.com/shiroha-a/mk/internal/core/drive"
+	corenote "github.com/shiroha-a/mk/internal/core/note"
 	corenotification "github.com/shiroha-a/mk/internal/core/notification"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -31,6 +32,10 @@ type NotePublisher struct {
 	emojiLookup    entity.EmojiLookup
 	instanceLookup entity.InstanceLookup
 	reactionReader entity.BufferedReactionsReader
+	// reactionPairReader は pure renote の renote embed の reactionAndUserPairCache
+	// を note_reaction から埋めるために使う (#2067)。nil 時は DB の (通常空の) cache
+	// をそのまま使う = #2058 の streaming renote.myReaction は事実上発火しない。
+	reactionPairReader ReactionPairReader
 	// fieldResolver は Files / Channel など PackNoteWithInstance では
 	// 解決されない後段 field を埋める。未設定時は従来通り Files が
 	// 空配列のまま publish される (旧挙動)。SetFieldResolver で配線。
@@ -66,6 +71,38 @@ func (p *NotePublisher) SetInstanceLookup(lookup entity.InstanceLookup) {
 // nil 配線時は DB の note.Reactions のみ反映 (旧挙動)。
 func (p *NotePublisher) SetReactionReader(r entity.BufferedReactionsReader) {
 	p.reactionReader = r
+}
+
+// ReactionPairReader lists up to `limit` "<userId>/<reaction>" pairs for a note,
+// backed by note_reaction (#2067)。
+type ReactionPairReader interface {
+	ListReactionPairs(noteID string, limit int) ([]string, error)
+}
+
+// reactionPairCacheMax は renote embed の reactionAndUserPairCache に載せる pair の
+// 上限。upstream PER_NOTE_REACTION_USER_PAIR_CACHE_MAX (16) と揃える。これを超える
+// reaction 数の renote は injectRenoteMyReaction が truncated skip する (#2067)。
+const reactionPairCacheMax = 16
+
+// SetReactionPairReader attaches a ReactionPairReader so that pure-renote streaming
+// payloads carry the renote's reaction/user pairs, letting subscribers resolve
+// renote.myReaction in-memory (#2067)。
+func (p *NotePublisher) SetReactionPairReader(r ReactionPairReader) {
+	p.reactionPairReader = r
+}
+
+// reactionsNonEmpty reports whether a packed reactions JSON object has at least
+// one entry (`{}` / null / empty → false)。pair cache を埋めるか (= note_reaction を
+// 引くか) の gate に使う。
+func reactionsNonEmpty(raw []byte) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var m map[string]json.RawMessage
+	if json.Unmarshal(raw, &m) != nil {
+		return false
+	}
+	return len(m) > 0
 }
 
 // SetFieldResolver attaches a NoteFieldResolver so that streaming payloads
@@ -130,10 +167,22 @@ func (p *NotePublisher) packNote(n *model.Note, author *model.User) []byte {
 	pn.ReactionAndUserPairCache = &pairs
 	// pure renote の renote embed にも reactionAndUserPairCache を載せ、subscriber 側の
 	// timeline channel が renote.myReaction を per-viewer に in-memory 算出できるように
-	// する (upstream populateMyReaction の cache 経路、#2058)。renote model が preload
-	// されていれば DB の cache をそのまま渡す。
+	// する (upstream populateMyReaction の cache 経路、#2058)。
 	if pn.Renote != nil && noteForPack.Renote != nil {
-		rpairs := []string(noteForPack.Renote.ReactionAndUserPairCache)
+		var rpairs []string
+		// mk-go は note.reactionAndUserPairCache を維持しない (DB は常に空) ため、上位 note が
+		// pure renote で renote に reaction がある場合のみ note_reaction から pair を引いて埋める
+		// (#2067)。note_reaction 行は reaction 時に即 persist されるので count buffer 中の reaction
+		// も含まれる = buffered reaction をした viewer の renote.myReaction も streaming で拾える。
+		if p.reactionPairReader != nil && reactionsNonEmpty(pn.Renote.Reactions) && corenote.IsPureRenote(&noteForPack) {
+			if pairs, err := p.reactionPairReader.ListReactionPairs(noteForPack.Renote.ID, reactionPairCacheMax); err == nil {
+				rpairs = pairs
+			}
+		}
+		if rpairs == nil {
+			// fallback: DB cache (通常空) をそのまま使う。
+			rpairs = []string(noteForPack.Renote.ReactionAndUserPairCache)
+		}
 		if rpairs == nil {
 			rpairs = []string{}
 		}

--- a/internal/stream/note_publisher_test.go
+++ b/internal/stream/note_publisher_test.go
@@ -838,3 +838,85 @@ func TestNotePublisher_EmitsRenoteReactionAndUserPairCache(t *testing.T) {
 	require.Contains(t, renoteObj, "reactionAndUserPairCache", "renote embed に cache を載せる (#2058)")
 	assert.JSONEq(t, `["userA/👍"]`, string(renoteObj["reactionAndUserPairCache"]))
 }
+
+// stubReactionPairReader records ListReactionPairs calls and returns canned pairs.
+type stubReactionPairReader struct {
+	pairs map[string][]string
+	calls []string
+}
+
+func (s *stubReactionPairReader) ListReactionPairs(noteID string, _ int) ([]string, error) {
+	s.calls = append(s.calls, noteID)
+	return s.pairs[noteID], nil
+}
+
+// #2067: pure renote で renote に reaction がある場合、renote embed の
+// reactionAndUserPairCache を note_reaction (reader) から埋める。
+func TestNotePublisher_RenotePairCacheFromReader(t *testing.T) {
+	pub := &stubPublisher{}
+	idGen, _ := id.NewGenerator("aidx")
+	np := NewNotePublisher(pub, idGen)
+	renoteID := idGen.Generate(time.Now())
+	noteID := idGen.Generate(time.Now())
+	reader := &stubReactionPairReader{pairs: map[string][]string{renoteID: {"alice/👍", "bob/❤"}}}
+	np.SetReactionPairReader(reader)
+
+	n := &model.Note{
+		ID: noteID, UserID: "u1", RenoteID: &renoteID, Visibility: model.NoteVisibilityPublic,
+		Renote: &model.Note{
+			ID: renoteID, UserID: "u2", Visibility: model.NoteVisibilityPublic,
+			Reactions: datatypes.JSON([]byte(`{"👍":2}`)),
+			User:      &model.User{ID: "u2", Username: "author2"},
+		},
+	}
+	np.PublishNote("homeTimeline:u1", n, &model.User{ID: "u1", Username: "alice"})
+
+	require.Len(t, pub.payloads, 1)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(pub.payloads[0].(json.RawMessage), &body))
+	renote := body["renote"].(map[string]any)
+	assert.Equal(t, []any{"alice/👍", "bob/❤"}, renote["reactionAndUserPairCache"])
+	assert.Equal(t, []string{renoteID}, reader.calls, "pure renote + reactions のときだけ reader を引く")
+}
+
+// quote renote (text あり = 非 pure) では reader を引かない。
+func TestNotePublisher_QuoteRenoteSkipsPairReader(t *testing.T) {
+	pub := &stubPublisher{}
+	idGen, _ := id.NewGenerator("aidx")
+	np := NewNotePublisher(pub, idGen)
+	renoteID := idGen.Generate(time.Now())
+	reader := &stubReactionPairReader{pairs: map[string][]string{renoteID: {"alice/👍"}}}
+	np.SetReactionPairReader(reader)
+	quoteText := "quote"
+	n := &model.Note{
+		ID: idGen.Generate(time.Now()), UserID: "u1", RenoteID: &renoteID, Text: &quoteText,
+		Visibility: model.NoteVisibilityPublic,
+		Renote: &model.Note{
+			ID: renoteID, UserID: "u2", Visibility: model.NoteVisibilityPublic,
+			Reactions: datatypes.JSON([]byte(`{"👍":1}`)),
+			User:      &model.User{ID: "u2", Username: "author2"},
+		},
+	}
+	np.PublishNote("homeTimeline:u1", n, &model.User{ID: "u1", Username: "alice"})
+	assert.Empty(t, reader.calls, "非 pure renote では reader を引かない")
+}
+
+// reaction の無い renote では reader を引かない。
+func TestNotePublisher_NoReactionsSkipsPairReader(t *testing.T) {
+	pub := &stubPublisher{}
+	idGen, _ := id.NewGenerator("aidx")
+	np := NewNotePublisher(pub, idGen)
+	renoteID := idGen.Generate(time.Now())
+	reader := &stubReactionPairReader{}
+	np.SetReactionPairReader(reader)
+	n := &model.Note{
+		ID: idGen.Generate(time.Now()), UserID: "u1", RenoteID: &renoteID, Visibility: model.NoteVisibilityPublic,
+		Renote: &model.Note{
+			ID: renoteID, UserID: "u2", Visibility: model.NoteVisibilityPublic,
+			Reactions: datatypes.JSON([]byte(`{}`)),
+			User:      &model.User{ID: "u2", Username: "author2"},
+		},
+	}
+	np.PublishNote("homeTimeline:u1", n, &model.User{ID: "u1", Username: "alice"})
+	assert.Empty(t, reader.calls, "reaction 無しの renote では reader を引かない")
+}

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1846,6 +1846,29 @@ func (m *MockNoteReactionRepository) ListByNoteID(noteID, untilID, sinceID strin
 	return rows, nil
 }
 
+// ListReactionPairs returns up to `limit` "<userId>/<reaction>" pairs for a note,
+// oldest (smallest id) first, mirroring the production repo (#2067)。
+func (m *MockNoteReactionRepository) ListReactionPairs(noteID string, limit int) ([]string, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	var matched []*model.NoteReaction
+	for _, r := range m.Reactions {
+		if r.NoteID == noteID {
+			matched = append(matched, r)
+		}
+	}
+	sort.Slice(matched, func(i, j int) bool { return matched[i].ID < matched[j].ID })
+	if len(matched) > limit {
+		matched = matched[:limit]
+	}
+	pairs := make([]string, 0, len(matched))
+	for _, r := range matched {
+		pairs = append(pairs, r.UserID+"/"+r.Reaction)
+	}
+	return pairs, nil
+}
+
 // ListByUserID returns reactions made by a user. paginationOrder と同じく
 // sinceID 単独指定時のみ ASC、それ以外 DESC (ListByNoteID と同 logic)。
 func (m *MockNoteReactionRepository) ListByUserID(userID, viewerID, untilID, sinceID string, limit int) ([]*model.NoteReaction, error) {


### PR DESCRIPTION
## Summary

streaming の `renote.myReaction` 算出 (#2058) を実際に機能させる修正。#2058 派生 (#2067)。

## 背景 (調査で判明した前提)

#2058 は subscriber 側 (`injectRenoteMyReaction`) で renote embed の `reactionAndUserPairCache` から
viewer の myReaction を in-memory 算出するが、**mk-go は `note.reactionAndUserPairCache` を一切 maintain
しない** (DB 常に空 `{}`、upstream は ReactionService が array_append で維持)。そのため cache が空のまま
truncated guard に当たり、streaming の renote.myReaction は **production で発火していなかった**。

pair の実体は `note_reaction` テーブル (reaction 時に即 persist、count は別途 buffer されうる) にある。

## 主な変更点

- `NoteReactionRepository.ListReactionPairs(noteID, limit)` を追加 (userId/reaction を id 昇順で最大
  limit 件、User preload せず 2 列だけ引く軽量 query)。
- `note_publisher` が **pure renote かつ renote に reaction がある場合のみ** `ListReactionPairs(renoteID, 16)`
  で pair を引いて renote embed の cache を埋める (cap 16 = upstream `PER_NOTE_REACTION_USER_PAIR_CACHE_MAX`)。
  - `note_reaction` 行は count buffer とは独立に即 persist されるため、**buffered reaction をした viewer の
    renote.myReaction も streaming で拾える** (= #2067 の本来の狙い)。
  - reaction 数 > 16 の renote は consumer (`injectRenoteMyReaction`) が truncated skip → REST reload で復旧
    (upstream は DB fallback、mk-go は cache-only という #2058 の設計を踏襲)。
- gate (`reactionsNonEmpty` + `IsPureRenote`) で quote renote / reaction 無し renote は query しない。fanout の
  複数 topic publish は `cachedBody` で 1 note 1 query に抑制 (note 作成経路、timeline read の hot path ではない)。

## テスト

- repository: `ListReactionPairs` の oldest-first / cap / limit<=0 / 空 note を統合テスト。
- publisher: pure renote + reaction で reader から cache を埋める / quote renote・reaction 無しで reader を引かない。
- `make fmt` / `go vet ./...` / 全 touched package test green (repository 90.0% / stream 90.7%)。敵対的レビューで
  correctness・parity (cap16 / guard 境界 `<=` 一致)・perf・regression に HIGH 指摘なしを確認。

## Closes

Closes #2067
