### PR TITLE
AP inbox に 64KB body limit を追加 (#1958)

### DIFF
--- a/internal/api/inbox/handler.go
+++ b/internal/api/inbox/handler.go
@@ -161,6 +161,14 @@ func captureSignatureHeaders(req *http.Request) map[string]string {
 func (h *Handler) Inbox(c echo.Context) error {
 	body, err := io.ReadAll(c.Request().Body)
 	if err != nil {
+		// BodyLimit (#1958) が wrap した limitedReader は 64KB 超過時に 413 HTTPError を
+		// 返す。ContentLength での即時 reject は handler に到達しないが、chunked 超過は
+		// ここで read error になるため echo.HTTPError を伝播して upstream fastify と同じ
+		// 413 を返す (それ以外の read error は従来通り 400)。
+		var he *echo.HTTPError
+		if errors.As(err, &he) {
+			return he
+		}
 		return c.NoContent(http.StatusBadRequest)
 	}
 

--- a/internal/api/inbox/handler_test.go
+++ b/internal/api/inbox/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	emiddleware "github.com/labstack/echo/v4/middleware"
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/core/federation"
 	corefollowing "github.com/shiroha-a/mk/internal/core/following"
@@ -635,4 +636,42 @@ func TestBodyHasActor(t *testing.T) {
 			assert.Equal(t, tc.want, bodyHasActor([]byte(tc.body)))
 		})
 	}
+}
+
+// #1958: inbox route の 64KB body limit。upstream ActivityPubServerService の
+// bodyLimit: 1024*64 相当。署名検証前に巨大 body を弾く DoS 対策で、超過時は
+// upstream fastify と同じ 413 を返す。
+func TestInbox_BodyLimit(t *testing.T) {
+	_, pub, err := activitypub.GenerateRSAKeypair()
+	require.NoError(t, err)
+	h, _, _ := newHandler(t, pub)
+
+	e := echo.New()
+	// router.go と同じ wiring (BodyLimit("64KiB")=65536 + handler)。
+	e.POST("/inbox", h.Inbox, emiddleware.BodyLimit("64KiB"))
+
+	serve := func(body []byte, chunked bool) int {
+		req := httptest.NewRequest(http.MethodPost, "https://example.com/inbox", bytes.NewReader(body))
+		req.Header.Set("Host", "example.com")
+		if chunked {
+			// Content-Length を消して limitedReader 経路 (read 中の 413) を通す。
+			req.ContentLength = -1
+		}
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	big := bytes.Repeat([]byte("a"), 64*1024+1)   // 64KB 超
+	atLimit := bytes.Repeat([]byte("a"), 64*1024) // ちょうど 64KB (許容)
+	small := []byte(`{"actor":"https://remote.example/users/x"}`)
+
+	// Content-Length > 64KB → BodyLimit が即時 413 (handler 未到達)。
+	assert.Equal(t, http.StatusRequestEntityTooLarge, serve(big, false), "Content-Length 超過は 413")
+	// chunked (Content-Length 不明) で 64KB 超 → handler が limitedReader の 413 を伝播。
+	assert.Equal(t, http.StatusRequestEntityTooLarge, serve(big, true), "chunked 超過も 413")
+	// ちょうど 64KB は通過 (413 にならない、署名なしで admission が 401 になるが 413 ではない)。
+	assert.NotEqual(t, http.StatusRequestEntityTooLarge, serve(atLimit, false), "64KB ちょうどは許容")
+	// 小さい body は 413 にならない。
+	assert.NotEqual(t, http.StatusRequestEntityTooLarge, serve(small, false))
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	emiddleware "github.com/labstack/echo/v4/middleware"
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/activitypub/ld"
 	apiadmin "github.com/shiroha-a/mk/internal/api/admin"
@@ -1937,8 +1938,14 @@ func (s *Server) setupRoutes() {
 	// #534: signature 検証成功後の Process(body) を inbox queue に逃がす。
 	// 未配線時は legacy 同期処理にフォールバック (テスト互換)。
 	inboxHandler.SetEnqueuer(s.queueClient)
-	s.echo.POST("/inbox", inboxHandler.Inbox)
-	s.echo.POST("/users/:id/inbox", inboxHandler.Inbox)
+	// upstream ActivityPubServerService は両 inbox route に bodyLimit: 1024*64 を設定する
+	// (#1958)。未認証で巨大 body を投げられる DoS surface を防ぐため、署名検証前に 64KB で
+	// 弾く。超過時は upstream fastify と同じ 413 (echo BodyLimit は ContentLength 即時 reject /
+	// chunked は limitedReader が 413 error を返し handler が伝播)。"64KiB" = 65536 で
+	// upstream の 1024*64 と厳密一致 (gommon の "64K"/"64KB" は decimal 64000 になる罠)。
+	inboxBodyLimit := emiddleware.BodyLimit("64KiB")
+	s.echo.POST("/inbox", inboxHandler.Inbox, inboxBodyLimit)
+	s.echo.POST("/users/:id/inbox", inboxHandler.Inbox, inboxBodyLimit)
 
 	// Federation endpoints
 	federationHandler := apifederation.NewHandler(instanceService)


### PR DESCRIPTION
## Summary

AP inbox の未認証 DoS surface を塞ぐ。#1948 (全面互換性再監査) 派生、#1949 の敵対的レビューで発見。

upstream `ActivityPubServerService` は両 inbox route に `bodyLimit: 1024 * 64` (=65536) を設定するが
(`ActivityPubServerService.ts:637-638`)、mk-go の inbox route には body limit が無く、`inbox/handler.go` の
`io.ReadAll(c.Request().Body)` が**署名検証前**に無制限に body を読むため、未認証で巨大 body を投げると
memory を消費する DoS surface だった。

## 主な変更点

- `router.go`: `/inbox` と `/users/:id/inbox` に echo `BodyLimit("64KiB")` を適用。
  - **"64KiB" = 65536** で upstream `1024*64` と厳密一致。gommon の `"64K"`/`"64KB"` は decimal 64000 になる罠を
    回避するため意図的に `"64KiB"` (binary) を選択。
- `inbox/handler.go`: `io.ReadAll` の error が `*echo.HTTPError` (= BodyLimit limitedReader の 413) なら伝播、
  それ以外 (connection drop 等) は従来通り 400。

## 挙動 (upstream fastify と一致)

- `Content-Length > 64KB` → middleware が即時 413 (handler 未到達)。
- chunked (`Content-Length` 不明) で 64KB 超過 → limitedReader が実 read を 65536 で打ち切り 413 error → handler 伝播。
- `Content-Length` 詐称 (小さい値で実 body 巨大) も limitedReader が実累積 read を見るため memory capped。
- ちょうど 64KB は許容 / 65537 は reject (strict `>`、upstream と一致)。
- 正常 (<64KB, 署名あり) リクエストは無影響 (digest = sha256(body) は handler が読んだ same bytes、再 read なし)。

## テスト

- `TestInbox_BodyLimit`: ContentLength 超過 / chunked 超過 / ちょうど 64KB / 小 body の 4 ケースを ServeHTTP で検証。
- `make fmt` / `go vet ./...` / inbox package test green (95.1%)。敵対的レビューで parity・DoS 実効性 (詐称耐性)・
  regression (両 path 保護・digest 不変) に HIGH 指摘なしを確認。

## Closes

Closes #1958
