### PR TITLE
API/inbox に global pre-auth body limit を追加 (#2075, #1958 bypass 修正)

### DIFF
--- a/internal/server/middleware/bodylimit.go
+++ b/internal/server/middleware/bodylimit.go
@@ -1,0 +1,63 @@
+package middleware
+
+import (
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	emiddleware "github.com/labstack/echo/v4/middleware"
+)
+
+// BodyLimitByPath returns a GLOBAL middleware that caps the request body size by
+// path, matching upstream's per-route bodyLimit:
+//
+//   - /api/*  → 1MiB (upstream ApiServerService の bodyLimit: 1024*1024)
+//   - /inbox, /users/:id/inbox → 64KiB (upstream ActivityPubServerService の bodyLimit: 1024*64)
+//   - その他 → 制限なし
+//
+// これは **auth.Authenticate より前** (global pre-auth) に登録する必要がある。
+// auth.Authenticate は token 抽出のため body を io.ReadAll する (extractToken) が、
+// echo の middleware 順は global → group → route なので、route/group に BodyLimit を
+// 置いても auth の read が先に走って無制限に body を消費し bypass される (#1958 / #2075)。
+// 本 middleware を auth より前に置くことで auth・JSONBodyParse・handler の全 read が
+// limitedReader 経由になり cap される。
+//
+// 超過時は upstream fastify と同じ 413 (echo BodyLimit が ContentLength 即時 reject /
+// chunked は limitedReader が 413 error を返す。後者は JSONBodyParse / inbox handler が
+// echo.HTTPError を伝播する)。
+//
+// upload endpoint (drive/files/create) **のみ** 1MiB 制限から除外する。これは唯一の
+// multipart upload route で RequireAuth + write:drive 保護され、file サイズは drive handler の
+// maxFileSize が別途 bound する。content-type が multipart というだけで /api 全体を除外すると、
+// 非 upload endpoint (例: 未認証到達可能な /api/meta) に multipart を投げて 1MiB を bypass し
+// ParseMultipartForm に disk spill させる DoS 穴になる。upstream も requireFile endpoint だけ
+// multipart parser を起動し、他の endpoint は bodyLimit:1024*1024 が raw body に効く。
+func BodyLimitByPath() echo.MiddlewareFunc {
+	apiBL := emiddleware.BodyLimit("1MiB")    // = 1024*1024 = 1048576
+	inboxBL := emiddleware.BodyLimit("64KiB") // = 1024*64   = 65536
+	const driveUploadPath = "/api/drive/files/create"
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		// limitedReader pool は per-route で 1 度だけ構築する (BodyLimit の
+		// MiddlewareFunc を next で 1 回 wrap)。本 middleware は global なので
+		// next は router dispatch、pool 構築も 1 度きり。
+		apiNext := apiBL(next)
+		inboxNext := inboxBL(next)
+		return func(c echo.Context) error {
+			p := c.Request().URL.Path
+			switch {
+			case p == driveUploadPath:
+				return next(c) // 唯一の multipart upload endpoint のみ除外 (auth + maxFileSize 保護)
+			case p == "/api" || strings.HasPrefix(p, "/api/"):
+				return apiNext(c)
+			case isInboxPath(p):
+				return inboxNext(c)
+			}
+			return next(c)
+		}
+	}
+}
+
+// isInboxPath reports whether p is an ActivityPub inbox route (/inbox or
+// /users/:id/inbox)。
+func isInboxPath(p string) bool {
+	return p == "/inbox" || (strings.HasPrefix(p, "/users/") && strings.HasSuffix(p, "/inbox"))
+}

--- a/internal/server/middleware/bodylimit_test.go
+++ b/internal/server/middleware/bodylimit_test.go
@@ -1,0 +1,73 @@
+package middleware
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// #2075: BodyLimitByPath は path 別に body size を cap する (/api 1MiB / inbox 64KiB /
+// multipart 除外 / その他 無制限)。超過は 413。
+func TestBodyLimitByPath(t *testing.T) {
+	e := echo.New()
+	e.Use(BodyLimitByPath())
+	// body を読む handler。chunked 超過時に limitedReader の 413 を伝播する。
+	h := func(c echo.Context) error {
+		if _, err := io.ReadAll(c.Request().Body); err != nil {
+			var he *echo.HTTPError
+			if errors.As(err, &he) {
+				return he
+			}
+			return c.NoContent(http.StatusBadRequest)
+		}
+		return c.NoContent(http.StatusOK)
+	}
+	e.POST("/api/meta", h)
+	e.POST("/api/drive/files/create", h)
+	e.POST("/inbox", h)
+	e.POST("/users/:id/inbox", h)
+	e.POST("/nolimit", h)
+
+	post := func(path, ct string, n int, chunked bool) int {
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(bytes.Repeat([]byte("a"), n)))
+		if ct != "" {
+			req.Header.Set(echo.HeaderContentType, ct)
+		}
+		if chunked {
+			req.ContentLength = -1 // limitedReader 経路 (read 中の 413) を通す
+		}
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	const mb = 1024 * 1024
+	const kb = 1024
+
+	// /api → 1MiB (= 1048576)。境界: ちょうどは許容、+1 は 413。
+	assert.Equal(t, http.StatusRequestEntityTooLarge, post("/api/meta", "application/json", mb+1, false), "/api > 1MiB は 413")
+	assert.Equal(t, http.StatusOK, post("/api/meta", "application/json", mb, false), "/api ちょうど 1MiB は許容")
+	assert.Equal(t, http.StatusOK, post("/api/meta", "application/json", 500*kb, false))
+	// /api chunked 超過 → handler の read で 413 伝播。
+	assert.Equal(t, http.StatusRequestEntityTooLarge, post("/api/meta", "application/json", mb+1, true), "/api chunked 超過も 413")
+
+	// upload endpoint (drive/files/create) は除外 → 2MB multipart でも通過。
+	assert.Equal(t, http.StatusOK, post("/api/drive/files/create", "multipart/form-data; boundary=x", 2*mb, false), "upload endpoint は除外")
+	// HIGH-1 regression: 非 upload endpoint への multipart は 1MiB が効く (DoS bypass 防止)。
+	assert.Equal(t, http.StatusRequestEntityTooLarge, post("/api/meta", "multipart/form-data; boundary=x", 2*mb, false), "非 upload endpoint の multipart は 1MiB cap")
+	assert.Equal(t, http.StatusOK, post("/api/meta", "multipart/form-data; boundary=x", 500*kb, false), "非 upload endpoint の小 multipart は通過")
+
+	// inbox → 64KiB (= 65536)。
+	assert.Equal(t, http.StatusRequestEntityTooLarge, post("/inbox", "application/activity+json", 64*kb+1, false), "inbox > 64KiB は 413")
+	assert.Equal(t, http.StatusOK, post("/inbox", "application/activity+json", 64*kb, false), "inbox ちょうど 64KiB は許容")
+	assert.Equal(t, http.StatusRequestEntityTooLarge, post("/users/u1/inbox", "application/activity+json", 64*kb+1, false), "/users/:id/inbox も 64KiB")
+
+	// 制限対象外 path は無制限。
+	assert.Equal(t, http.StatusOK, post("/nolimit", "application/json", 2*mb, false), "対象外 path は無制限")
+}

--- a/internal/server/middleware/jsonbody.go
+++ b/internal/server/middleware/jsonbody.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"mime"
 	"net/http"
@@ -84,6 +85,14 @@ func JSONBodyParse() echo.MiddlewareFunc {
 
 			body, err := io.ReadAll(req.Body)
 			if err != nil {
+				// BodyLimitByPath (#2075) が wrap した limitedReader は body 超過時に
+				// 413 HTTPError を返す。ContentLength 経路は middleware 段で 413 に
+				// なるが、chunked 超過はここで read error になるため echo.HTTPError を
+				// 伝播して upstream fastify と同じ 413 を返す (その他 read error は 400)。
+				var he *echo.HTTPError
+				if errors.As(err, &he) {
+					return he
+				}
 				return c.JSON(http.StatusBadRequest, errInvalidJSONBody)
 			}
 			if len(body) == 0 {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
-	emiddleware "github.com/labstack/echo/v4/middleware"
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/activitypub/ld"
 	apiadmin "github.com/shiroha-a/mk/internal/api/admin"
@@ -1938,14 +1937,11 @@ func (s *Server) setupRoutes() {
 	// #534: signature 検証成功後の Process(body) を inbox queue に逃がす。
 	// 未配線時は legacy 同期処理にフォールバック (テスト互換)。
 	inboxHandler.SetEnqueuer(s.queueClient)
-	// upstream ActivityPubServerService は両 inbox route に bodyLimit: 1024*64 を設定する
-	// (#1958)。未認証で巨大 body を投げられる DoS surface を防ぐため、署名検証前に 64KB で
-	// 弾く。超過時は upstream fastify と同じ 413 (echo BodyLimit は ContentLength 即時 reject /
-	// chunked は limitedReader が 413 error を返し handler が伝播)。"64KiB" = 65536 で
-	// upstream の 1024*64 と厳密一致 (gommon の "64K"/"64KB" は decimal 64000 になる罠)。
-	inboxBodyLimit := emiddleware.BodyLimit("64KiB")
-	s.echo.POST("/inbox", inboxHandler.Inbox, inboxBodyLimit)
-	s.echo.POST("/users/:id/inbox", inboxHandler.Inbox, inboxBodyLimit)
+	// inbox の 64KB body limit は global pre-auth な middleware.BodyLimitByPath で適用する
+	// (#1958 / #2075)。route-level に置くと global な auth.Authenticate の token 抽出 read が
+	// 先に走って bypass されるため、ここでは limit を付けない。
+	s.echo.POST("/inbox", inboxHandler.Inbox)
+	s.echo.POST("/users/:id/inbox", inboxHandler.Inbox)
 
 	// Federation endpoints
 	federationHandler := apifederation.NewHandler(instanceService)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -203,6 +203,11 @@ func New(cfg *config.Config, db *gorm.DB, redis *cache.RedisClients) (*Server, e
 	userRepo := repository.NewCachedUserRepository(repository.NewUserRepository(db))
 	accessTokenRepo := repository.NewAccessTokenRepository(db)
 
+	// body size 制限は auth.Authenticate より前に置く: auth は token 抽出のため
+	// body を io.ReadAll するので、後に置くと巨大 body が auth で先に読まれて
+	// bypass される (#1958 / #2075)。/api → 1MiB / inbox → 64KiB / multipart 除外。
+	e.Use(middleware.BodyLimitByPath())
+
 	auth := middleware.NewAuthMiddleware(userRepo, accessTokenRepo)
 	e.Use(auth.Authenticate())
 


### PR DESCRIPTION
## Summary

`/api` の未認証 body-size DoS surface を塞ぐ。あわせて #1958 (inbox 64KB limit) が bypass されていた
バグも修正する。#1948 (全面互換性再監査) 派生、#1958 の敵対的レビューで発見。

## 背景: route-level limit は bypass されていた

upstream は `/api/<endpoint>` に `bodyLimit: 1024*1024`、inbox に `1024*64` を設定する。mk-go は前者が無く、
**後者 (#1958 で route-level に追加したもの) も bypass されていた**: global な `auth.Authenticate` が token 抽出の
ため body を `io.ReadAll` する (`extractToken`) のが、echo の middleware 順 (global → group → route) で
route/group の BodyLimit より**先に**走るため、route-level に置いた limit は auth の read で無効化されていた
(empirical に `ORDER=[global route-mw handler]` を確認)。

## 主な変更点

- **`middleware.BodyLimitByPath`** を新規追加し、`auth.Authenticate` の**前** (global pre-auth) に登録。
  path 別に cap する:
  - `/api/*` → **1MiB** (=1048576, upstream `1024*1024`)
  - `/inbox`, `/users/:id/inbox` → **64KiB** (=65536, upstream `1024*64`)
  - `/api/drive/files/create` (唯一の multipart upload endpoint、RequireAuth + write:drive) → 除外
  - その他 → 無制限
  - これで auth・JSONBodyParse・handler の全 body read が limitedReader 経由になり cap される。
- `router.go`: #1958 の route-level inbox BodyLimit を削除 (bypass される dead code)。
- `jsonbody.go`: `io.ReadAll` error が `*echo.HTTPError` なら伝播 (chunked /api 413)。inbox handler の 413
  伝播 (#1958) は維持。

## 挙動 (upstream fastify と一致、413)

- Content-Length 超過 → middleware が即時 413 (auth より前)。
- chunked / Content-Length 詐称 → limitedReader が実 read を cap、超過で 413。
- multipart は **upload endpoint のみ除外**。非 upload endpoint (例: 未認証到達可能な `/api/meta`) への大 multipart
  は 1MiB が効く (敵対的レビュー HIGH 指摘: content-type 一律除外だと multipart 経由で DoS bypass する問題を、
  path 限定除外に修正)。
- `"1MiB"`/`"64KiB"` は binary で upstream `1024*1024`/`1024*64` と厳密一致 (gommon の `"1M"`/`"64K"` は decimal の罠)。

## テスト

- `TestBodyLimitByPath`: /api 1MiB (境界含む) / inbox 64KiB / upload endpoint 除外 / 非 upload endpoint の
  multipart cap (HIGH regression) / chunked 超過 413 / 対象外 path 無制限 を網羅。
- `make fmt` / `go vet ./...` / middleware (96.6%) ・ inbox (95.1%) test green。敵対的レビュー 2 巡で HIGH
  (multipart bypass) を発見・修正し、解消を再確認。

## 補足 (別レイヤ)

`/api/drive/files/create` は authenticated (write:drive)。upload サイズの最終 bound は drive handler の
maxFileSize に委ねる (upstream も requireFile endpoint は bodyLimit を外し multipart parser の fileSize limit に
委ねる設計)。ParseMultipartForm の parse-time spill を middleware で bound するかは別途検討余地 (認証済みのため
本 PR scope 外)。

## Closes

Closes #2075
