### PR TITLE
AP inbox に federation=none の早期 403 gate を追加 (#1959)

### DIFF
--- a/internal/api/inbox/handler.go
+++ b/internal/api/inbox/handler.go
@@ -25,6 +25,11 @@ type HostBlockChecker interface {
 	// the current admin federation mode (none / specified / all) and the
 	// host is not in blockedHosts.
 	IsAllowed(host string) bool
+	// FederationDisabled reports whether the instance federation mode is
+	// "none". upstream ActivityPubServerService.inbox は federation==='none' の
+	// とき body を読む前に 403 を即返す (#1959)。per-actor の IsAllowed は actor が
+	// local 扱い (host nil) のとき素通る余地があるため、最前段の mode gate を別途置く。
+	FederationDisabled() bool
 }
 
 // InstanceTracker is invoked after a successfully verified inbound request so
@@ -159,6 +164,13 @@ func captureSignatureHeaders(req *http.Request) map[string]string {
 // 単体テスト / 旧来配線を維持するためのもので、production 配線では
 // SetEnqueuer 経由の async path を踏む。
 func (h *Handler) Inbox(c echo.Context) error {
+	// upstream ActivityPubServerService.inbox と同じく、federation mode が "none" なら
+	// body を読む前に 403 を即返す (#1959)。per-actor の IsAllowed gate は actor が
+	// local 扱い (host nil) や async enqueue 後にしか効かない経路があるため、最前段で弾く。
+	if h.hostBlocker != nil && h.hostBlocker.FederationDisabled() {
+		return c.NoContent(http.StatusForbidden)
+	}
+
 	body, err := io.ReadAll(c.Request().Body)
 	if err != nil {
 		// BodyLimit (#1958) が wrap した limitedReader は 64KB 超過時に 413 HTTPError を

--- a/internal/api/inbox/handler_test.go
+++ b/internal/api/inbox/handler_test.go
@@ -258,12 +258,14 @@ func TestInbox_PublicKeyMissing(t *testing.T) {
 // disallowed simulates federation mode "specified" / "none". 既定 (zero-value)
 // では allow-all。
 type stubBlocker struct {
-	blocked    map[string]bool
-	disallowed map[string]bool
+	blocked     map[string]bool
+	disallowed  map[string]bool
+	fedDisabled bool
 }
 
 func (s *stubBlocker) IsBlocked(host string) bool { return s.blocked[host] }
 func (s *stubBlocker) IsAllowed(host string) bool { return !s.disallowed[host] }
+func (s *stubBlocker) FederationDisabled() bool   { return s.fedDisabled }
 
 func TestInbox_BlockedHost(t *testing.T) {
 	priv, pub, err := activitypub.GenerateRSAKeypair()
@@ -674,4 +676,42 @@ func TestInbox_BodyLimit(t *testing.T) {
 	assert.NotEqual(t, http.StatusRequestEntityTooLarge, serve(atLimit, false), "64KB ちょうどは許容")
 	// 小さい body は 413 にならない。
 	assert.NotEqual(t, http.StatusRequestEntityTooLarge, serve(small, false))
+}
+
+// #1959: federation mode が "none" のとき inbox は最前段で 403 を返す (upstream
+// ActivityPubServerService.inbox の federation==='none' gate)。署名の有無に依らず、
+// body を読む前に gate する (per-actor IsAllowed より前)。
+func TestInbox_FederationDisabled(t *testing.T) {
+	_, pub, err := activitypub.GenerateRSAKeypair()
+	require.NoError(t, err)
+	h, _, _ := newHandler(t, pub)
+	h.SetHostBlockChecker(&stubBlocker{fedDisabled: true})
+
+	// 署名なしの素の body でも、federation gate が先に効いて 403 (401 ではない)。
+	body := []byte(`{"type":"Follow","actor":"https://remote.example/users/alice","object":"https://example.com/users/bob"}`)
+	c, rec := newPost(t, body)
+	c.Request().Host = "example.com"
+	require.NoError(t, h.Inbox(c))
+	assert.Equal(t, http.StatusForbidden, rec.Code, "federation=none は最前段で 403")
+}
+
+// federation 有効時 (fedDisabled=false) は gate を素通りし通常の admission に進む
+// (gate が誤って常時 403 にしないことの確認)。
+func TestInbox_FederationEnabled_NotGated(t *testing.T) {
+	priv, pub, err := activitypub.GenerateRSAKeypair()
+	require.NoError(t, err)
+	key, err := activitypub.NewPrivateKey("https://remote.example/users/alice#main-key", priv)
+	require.NoError(t, err)
+	h, repo, _ := newHandler(t, pub)
+	bobURI := "https://example.com/users/bob"
+	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob", URI: &bobURI}
+	h.SetHostBlockChecker(&stubBlocker{fedDisabled: false})
+
+	body := []byte(`{"type":"Follow","actor":"https://remote.example/users/alice","object":"https://example.com/users/bob"}`)
+	c, rec := newPost(t, body)
+	req := c.Request()
+	require.NoError(t, activitypub.SignRequest(req, key, activitypub.SHA256Digest(body), []string{"(request-target)", "date", "host", "digest"}))
+	req.Host = "example.com"
+	require.NoError(t, h.Inbox(c))
+	assert.NotEqual(t, http.StatusForbidden, rec.Code, "federation 有効時は gate を素通り")
 }


### PR DESCRIPTION
## Summary

AP inbox に `federation==='none'` の早期 403 gate を追加する。#1948 (全面互換性再監査) 派生、#1949 の
敵対的レビューで発見。

upstream `ActivityPubServerService.inbox` は最前段で `if (meta.federation === 'none') { reply.code(403); return; }`
を行うが、mk-go の inbox handler にはこの gate が無かった。federation `none` は per-actor の `IsAllowed` でしか
弾かれず、(1) async path では enqueue 後、(2) actor が local 扱い (`actor.Host == nil`) のとき素通る余地があった。
`/ap` resolve handler には #1879 で `FederationDisabled` gate が入っていたが inbox には未配線だった。

## 主な変更点

- inbox handler の `HostBlockChecker` interface に `FederationDisabled() bool` を追加 (production の
  `instance.Service` が既に実装、`/ap` handler と同じ method)。
- `Inbox()` admission の**最前段** (body read / enqueue より前) で `mode==none` なら 403 を返す。
- `/inbox` と `/users/:id/inbox` は同一 handler なので両方カバー。`SetHostBlockChecker(instanceService)` は
  router.go で配線済のため追加配線は不要。

## 挙動 (upstream と一致)

- federation `none` → body を読まず・署名検証せず・enqueue せず 403 (最安価で遮断、async enqueue 後問題を解消)。
- `specified` は front gate を素通りし従来通り per-host `IsAllowed` で判定 (upstream も specified は inbox 全体を
  403 にせず per-actor)。
- federation 有効 (`all`) → gate 素通り、正常 inbound 不変。

## テスト

- `TestInbox_FederationDisabled` (none → 署名なしでも 403)、`TestInbox_FederationEnabled_NotGated` (有効時は非 403)。
- `make fmt` / `go vet ./...` / inbox test green (95.2%)。敵対的レビューで parity (403/最前段/specified 非全 403)・
  regression・wiring 有効性に HIGH 指摘なしを確認。

## 補足 (別レイヤ)

worker (InboxProcessor) 側には federation=none の独立 gate は無いが、本 front gate が全 HTTP inbound を遮断する
ため実害なし。HTTP handler を経由しない direct enqueue 経路が将来増えた場合の defense-in-depth は別途検討
(本 PR scope 外)。

## Closes

Closes #1959
