### PR TITLE
oauth/authorize に response_type 検証を追加 (#2079)

### DIFF
--- a/internal/api/oauth/provider.go
+++ b/internal/api/oauth/provider.go
@@ -94,6 +94,14 @@ func (h *Handler) Authorize(c echo.Context) error {
 	codeChallengeMethod := q.Get("code_challenge_method")
 	state := q.Get("state")
 
+	// 0. response_type 検証。upstream OAuth2ProviderService は client_id 検証より前に
+	// response_type を見て、code 以外なら 501 unsupported_response_type を直接返す
+	// (redirect しない、#2079)。implicit grant 等を弾く。
+	if q.Get("response_type") != "code" {
+		applyOAuthNoStore(c)
+		return c.JSON(http.StatusNotImplemented, map[string]any{"error": "unsupported_response_type"})
+	}
+
 	// 1. client_id 検証 (失敗時は信頼できる redirect 先が無いので直接 400)。
 	cu, err := validateClientID(clientID, h.allowHTTP)
 	if err != nil {
@@ -386,6 +394,13 @@ func directError(c echo.Context, desc string) error {
 		"error":             "invalid_request",
 		"error_description": desc,
 	})
+}
+
+// applyOAuthNoStore sets the no-cache headers upstream's applyNoStore applies to
+// authorization-endpoint responses (#2079)。
+func applyOAuthNoStore(c echo.Context) {
+	c.Response().Header().Set("Cache-Control", "no-store")
+	c.Response().Header().Set("Pragma", "no-cache")
 }
 
 // redirectError redirects to the (validated) client redirect_uri with the OAuth

--- a/internal/api/oauth/provider_test.go
+++ b/internal/api/oauth/provider_test.go
@@ -527,7 +527,8 @@ func TestAuthorize_DiscoveryFailure(t *testing.T) {
 		func(c echo.Context, _ ConsentMeta) error { return c.HTML(http.StatusOK, "x") })
 	e := echo.New()
 	q := url.Values{
-		"client_id": {srv.URL + "/"}, "redirect_uri": {srv.URL + "/cb"},
+		"response_type": {"code"},
+		"client_id":     {srv.URL + "/"}, "redirect_uri": {srv.URL + "/cb"},
 		"scope": {"read:account"}, "code_challenge": {challengeFor("v")}, "code_challenge_method": {"S256"},
 	}
 	req := httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+q.Encode(), nil)
@@ -592,4 +593,28 @@ func TestNotFound(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	errObj := resp["error"].(map[string]any)
 	assert.Equal(t, "UNKNOWN_OAUTH_ENDPOINT", errObj["code"])
+}
+
+// #2079: response_type が code 以外 / 欠落のとき、client_id 検証より前に 501
+// unsupported_response_type を直接返す (redirect しない、upstream OAuth2ProviderService)。
+func TestAuthorize_UnsupportedResponseType(t *testing.T) {
+	hn := newHarness(t)
+	for _, rt := range []string{"token", "", "id_token"} {
+		q := validAuthorizeQuery(hn, challengeFor("verifier-abc"))
+		q.Set("response_type", rt)
+		if rt == "" {
+			q.Del("response_type")
+		}
+		rec := hn.authorize(t, q)
+		require.Equal(t, http.StatusNotImplemented, rec.Code, "response_type=%q は 501", rt)
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+		assert.Equal(t, "unsupported_response_type", body["error"], "response_type=%q", rt)
+		// redirect していないこと (consent も発行されない)。
+		assert.Empty(t, rec.Header().Get("Location"))
+		assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+	}
+	// code は従来通り consent。
+	rec := hn.authorize(t, validAuthorizeQuery(hn, challengeFor("verifier-abc")))
+	assert.Equal(t, http.StatusOK, rec.Code)
 }


### PR DESCRIPTION
## Summary

`/oauth/authorize` に `response_type` 検証を追加する。#2078 (網羅性ギャップ追加監査) の OAuth audit で発見。

upstream `OAuth2ProviderService` は authorization endpoint で **client_id 検証より前**に `response_type` を見て、
`code` 以外なら **501 `unsupported_response_type` を直接返す** (redirect しない):
`OAuth2ProviderService.ts:433-434` (`if (responseType !== 'code') throw ...` status 501) + `:568`
(`error !== 'unsupported_response_type'` のときのみ redirect)。

mk-go の `Authorize` は `response_type` を一切読まず、`response_type=token` や欠落でもそのまま consent → code
発行に進んでいた (implicit grant 等を弾けない、OAuth 適合性ギャップ)。

## 主な変更点

- `Authorize` 冒頭 (client_id 検証より前) で `response_type` を検証し、`code` 以外なら `applyOAuthNoStore` +
  `501 {"error": "unsupported_response_type"}` を直接返す (redirect しない)。
- `applyOAuthNoStore` helper を追加 (upstream `applyNoStore` 相当: Cache-Control no-store + Pragma no-cache)。

## テスト

- `TestAuthorize_UnsupportedResponseType` (`token` / 欠落 / `id_token` → 501、redirect なし、no-store、`code` → consent)。
- 既存 `TestAuthorize_DiscoveryFailure` は manual query に `response_type=code` を補完 (新 gate を通すため)。
- `make fmt` / `go vet ./...` / oauth test green (92.4%)。

## Closes

Closes #2079
