### PR TITLE
signup の username error を upstream に揃える (used_usernames + DENIED_USERNAME) (#2080)

### DIFF
--- a/internal/api/signup/handler.go
+++ b/internal/api/signup/handler.go
@@ -207,8 +207,13 @@ func (h *Handler) Signup(c echo.Context) error {
 			if errors.Is(perr, coresignup.ErrInvalidUsername) {
 				return apierr.FastifyReply(c, http.StatusBadRequest, "INVALID_PARAM")
 			}
-			if errors.Is(perr, coresignup.ErrUsernameReserved) {
+			if errors.Is(perr, coresignup.ErrUsernameUsed) {
 				return apierr.FastifyReply(c, http.StatusBadRequest, "USED_USERNAME")
+			}
+			if errors.Is(perr, coresignup.ErrUsernameReserved) {
+				// upstream SignupApiService の email-required path は preserved を
+				// DENIED_USERNAME で返す (非 email path の USED_USERNAME とは異なる、#2080)。
+				return apierr.FastifyReply(c, http.StatusBadRequest, "DENIED_USERNAME")
 			}
 			if errors.Is(perr, coresignup.ErrPasswordTooLong) {
 				return apierr.FastifyReply(c, http.StatusBadRequest, "PASSWORD_TOO_LONG")
@@ -249,7 +254,11 @@ func (h *Handler) Signup(c echo.Context) error {
 		if errors.Is(err, coresignup.ErrInvalidUsername) {
 			return apierr.FastifyReply(c, http.StatusBadRequest, "INVALID_PARAM")
 		}
+		if errors.Is(err, coresignup.ErrUsernameUsed) {
+			return apierr.FastifyReply(c, http.StatusBadRequest, "USED_USERNAME")
+		}
 		if errors.Is(err, coresignup.ErrUsernameReserved) {
+			// 非 email path は upstream SignupService と同じく preserved も USED_USERNAME (#2080)。
 			return apierr.FastifyReply(c, http.StatusBadRequest, "USED_USERNAME")
 		}
 		if errors.Is(err, coresignup.ErrPasswordTooLong) {

--- a/internal/api/signup/handler_test.go
+++ b/internal/api/signup/handler_test.go
@@ -680,13 +680,14 @@ func TestSignup_EmailRequired_InvalidUsername(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
-// preserved username が email-required path で USED_USERNAME を返すこと。
+// #2080: preserved username が email-required path で DENIED_USERNAME を返すこと
+// (upstream SignupApiService。非 email path の USED_USERNAME とは異なる)。
 func TestSignup_EmailRequired_ReservedUsername(t *testing.T) {
 	h, _, metaRepo := newTestHandler(t)
 	metaRepo.Meta.EmailRequiredForSignup = true
 	metaRepo.Meta.PreservedUsernames = []string{"admin"}
 	rec := doPost(h.Signup, `{"username":"admin","password":"pass","emailAddress":"x@example.com"}`)
-	testutil.AssertFastifyError(t, rec, http.StatusBadRequest, "USED_USERNAME")
+	testutil.AssertFastifyError(t, rec, http.StatusBadRequest, "DENIED_USERNAME")
 }
 
 // 注: SignupPending の ErrInvitationAlreadyUsed / ErrInvitationRevoked は

--- a/internal/core/signup/signup_service.go
+++ b/internal/core/signup/signup_service.go
@@ -60,6 +60,10 @@ var (
 	// meta.preservedUsernames (case-insensitive). 初回セットアップ時は root
 	// ユーザー作成を妨げないため、このチェックはスキップする。
 	ErrUsernameReserved = errors.New("username is reserved")
+	// ErrUsernameUsed is returned when the username matches a deleted account's
+	// username recorded in used_usernames (再利用防止)。upstream SignupService /
+	// SignupApiService の usedUsernamesRepository.exists 相当 (#2080)。
+	ErrUsernameUsed = errors.New("username was used by a deleted account")
 	// ErrPendingNotFound is returned when no user_pending row matches the code.
 	ErrPendingNotFound = errors.New("pending signup not found")
 	// ErrPendingExpired is returned when the pending signup is past its TTL.
@@ -103,6 +107,9 @@ type Service struct {
 	keypairExtraRepo repository.UserKeypairExtraRepository
 	pendingRepo      repository.UserPendingRepository
 	ticketRepo       repository.RegistrationTicketRepository
+	// usedUsernameRepo は削除済 account の username 再利用を弾く (#2080)。
+	// optional (nil なら used_usernames チェックを skip、後方互換)。
+	usedUsernameRepo repository.UsedUsernameRepository
 	// db は PromotePending を transaction 化して partial failure rollback と
 	// invitation ticket の SELECT FOR UPDATE ロックを実現する用途。未設定 (nil)
 	// なら従来の repo-based 非 tx パスにフォールバックする (mock テスト用)。
@@ -121,6 +128,24 @@ func NewService(userRepo repository.UserRepository, metaRepo repository.MetaRepo
 // 非 tx パスで動作する (mock テスト用)。
 func (s *Service) SetDB(db *gorm.DB) {
 	s.db = db
+}
+
+// SetUsedUsernameRepo wires the UsedUsernameRepository so Signup / CreatePending
+// reject usernames of deleted accounts (#2080)。未設定なら used_usernames チェックを
+// skip する (後方互換)。
+func (s *Service) SetUsedUsernameRepo(r repository.UsedUsernameRepository) {
+	s.usedUsernameRepo = r
+}
+
+// isUsedUsername reports whether lower (already lowercased) is recorded in
+// used_usernames (削除済 account)。repo 未配線 / 照合失敗時は false (fail-open、
+// オンライン性優先で既存 preserved/duplicate ガードに委ねる)。
+func (s *Service) isUsedUsername(lower string) bool {
+	if s.usedUsernameRepo == nil {
+		return false
+	}
+	used, err := s.usedUsernameRepo.Exists(lower)
+	return err == nil && used
 }
 
 // SetTicketRepo wires the RegistrationTicketRepository so PromotePending tx
@@ -234,6 +259,12 @@ func (s *Service) Signup(username, password string, isInitialSetup bool) (*Signu
 	lower := strings.ToLower(username)
 	if _, err := s.userRepo.FindByUsernameLower(lower, nil); err == nil {
 		return nil, ErrUsernameAlreadyExists
+	}
+
+	// 削除済 account の username 再利用を弾く (upstream SignupService:87、existing →
+	// used → preserved の順、#2080)。
+	if s.isUsedUsername(lower) {
+		return nil, ErrUsernameUsed
 	}
 
 	// meta.preservedUsernames チェック。初回セットアップ (root ユーザー作成) は
@@ -360,6 +391,10 @@ func (s *Service) CreatePending(username, email, password string, invitationTick
 	// PromotePending 直前まで気付けず無駄なメール送信になる)。
 	if _, err := s.userRepo.FindByUsernameLower(lower, nil); err == nil {
 		return nil, ErrUsernameAlreadyExists
+	}
+	// 削除済 account の username 再利用を弾く (upstream SignupApiService:178、#2080)。
+	if s.isUsedUsername(lower) {
+		return nil, ErrUsernameUsed
 	}
 	if meta, err := s.metaRepo.Fetch(); err == nil && isReservedUsername(lower, meta.PreservedUsernames) {
 		return nil, ErrUsernameReserved

--- a/internal/core/signup/signup_service_test.go
+++ b/internal/core/signup/signup_service_test.go
@@ -541,3 +541,24 @@ func TestPromotePending_NoTicketIDReturnsNil(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, result.InvitationTicketID, "non-invitation pending では nil で伝搬する")
 }
+
+// #2080: used_usernames (削除済 account の username) は Signup で ErrUsernameUsed を
+// 返す (existing → used → preserved の順、upstream SignupService:87 相当)。
+func TestSignup_UsedUsername(t *testing.T) {
+	svc, _, _ := newTestService(t)
+	usedRepo := testutil.NewMockUsedUsernameRepository()
+	usedRepo.Usernames["taken"] = true
+	svc.SetUsedUsernameRepo(usedRepo)
+
+	_, err := svc.Signup("taken", "password123", false)
+	assert.ErrorIs(t, err, signup.ErrUsernameUsed)
+
+	// 大文字違いも lowercase 照合で弾く。
+	_, err = svc.Signup("TAKEN", "password123", false)
+	assert.ErrorIs(t, err, signup.ErrUsernameUsed)
+
+	// repo 未配線なら skip (後方互換) — 別 svc で確認。
+	svc2, _, _ := newTestService(t)
+	_, err = svc2.Signup("taken", "password123", false)
+	assert.NoError(t, err, "repo 未配線時は used_usernames を見ない")
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1216,6 +1216,7 @@ func (s *Server) setupRoutes() {
 	// localUsernameSchema で format 検証する (#1551)。format 不正は paramDef レベルで
 	// 弾かれるため INVALID_PARAM を返す。
 	usedUsernameRepo := repository.NewUsedUsernameRepository(s.db)
+	signupService.SetUsedUsernameRepo(usedUsernameRepo) // #2080: 削除済 username 再利用を弾く
 	api.POST("/username/available", func(c echo.Context) error {
 		var req struct {
 			Username string `json:"username"`


### PR DESCRIPTION
## Summary

signup の username 重複系エラーを upstream に揃える。#2078 の signup audit で発見。

upstream の username 検証 (`SignupService.signup` / `SignupApiService`) は:
- existing user → `DUPLICATED_USERNAME`
- used_usernames (削除済 account) → `USED_USERNAME`
- preserved (予約語) → **non-email path: `USED_USERNAME` / email-required path: `DENIED_USERNAME`**

mk-go は (1) used_usernames 照合が無く、(2) email-required path で preserved を `USED_USERNAME` (DENIED であるべき)
として返していた。

## 主な変更点

- core `signup.Service` に `UsedUsernameRepository` を注入 (`SetUsedUsernameRepo`)。`Signup` / `CreatePending` で
  existing→used→preserved の順 (upstream `SignupService:87` / `SignupApiService:178` 相当) に used_usernames を照合し
  `ErrUsernameUsed` → `USED_USERNAME`。repo 未配線時は skip (後方互換)。
- email-required path の preserved を `DENIED_USERNAME` に修正 (非 email path は upstream 同様 `USED_USERNAME` 維持)。
- router で `signupService.SetUsedUsernameRepo(usedUsernameRepo)` を配線。

## テスト

- core: `TestSignup_UsedUsername` (used_usernames → ErrUsernameUsed、大小文字、repo 未配線時 skip)。
- handler: `TestSignup_EmailRequired_ReservedUsername` を `DENIED_USERNAME` 期待に更新。
- `make fmt` / `go vet ./...` / signup test green (core 90.1% / api 93.6%)。

## 補足

ticket `usedAt` 30分再送防止窓 (`disableRegistration && emailRequiredForSignup` 併用時) は invitation
lifecycle 変更が要るため **#2083 に分離**。

## Closes

Closes #2080
