### PR TITLE
signup/signin parity 微差: INVALID_USERNAME + passkey error id (#2081)

### DIFF
--- a/internal/api/signin/helpers_test.go
+++ b/internal/api/signin/helpers_test.go
@@ -168,6 +168,10 @@ func TestFinishPasskeySignin_NilUser(t *testing.T) {
 	rec := c.Response().Writer.(*httptest.ResponseRecorder)
 	require.NoError(t, h.finishPasskeySignin(c, nil, nil))
 	assert.Equal(t, http.StatusForbidden, rec.Code)
+	// #2081: user==null は upstream SigninWithPasskeyApiService:155 の 652f899f。
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "652f899f-66d4-490e-993e-6606c8ec04c3", resp["error"].(map[string]any)["id"])
 }
 
 func TestFinishPasskeySignin_Suspended(t *testing.T) {

--- a/internal/api/signin/passkey.go
+++ b/internal/api/signin/passkey.go
@@ -102,7 +102,10 @@ func (h *Handler) resolvePasskeyUser(_, userHandle []byte) (*model.User, []*mode
 // しやすくするため。
 func (h *Handler) finishPasskeySignin(c echo.Context, user *model.User, cred *webauthn.Credential) error {
 	if user == nil {
-		return c.JSON(http.StatusForbidden, errBody("932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
+		// upstream SigninWithPasskeyApiService:155 の user==null ケースは 652f899f
+		// (authorizedUserId は得たが user row が無い)。932c904e は upstream の
+		// !authorizedUserId (challenge 未解決) 用で別ステージ (#2081)。
+		return c.JSON(http.StatusForbidden, errBody("652f899f-66d4-490e-993e-6606c8ec04c3"))
 	}
 	if user.IsSuspended {
 		return c.JSON(http.StatusForbidden, errBody("e03a5f46-d309-4865-9b69-56282d94e1eb"))

--- a/internal/api/signup/handler.go
+++ b/internal/api/signup/handler.go
@@ -205,7 +205,8 @@ func (h *Handler) Signup(c echo.Context) error {
 				return duplicatedUsernameError(c)
 			}
 			if errors.Is(perr, coresignup.ErrInvalidUsername) {
-				return apierr.FastifyReply(c, http.StatusBadRequest, "INVALID_PARAM")
+				// upstream SignupService は INVALID_USERNAME を投げる (#2081)。
+				return apierr.FastifyReply(c, http.StatusBadRequest, "INVALID_USERNAME")
 			}
 			if errors.Is(perr, coresignup.ErrUsernameUsed) {
 				return apierr.FastifyReply(c, http.StatusBadRequest, "USED_USERNAME")
@@ -252,7 +253,8 @@ func (h *Handler) Signup(c echo.Context) error {
 			return duplicatedUsernameError(c)
 		}
 		if errors.Is(err, coresignup.ErrInvalidUsername) {
-			return apierr.FastifyReply(c, http.StatusBadRequest, "INVALID_PARAM")
+			// upstream SignupService は INVALID_USERNAME を投げる (#2081)。
+			return apierr.FastifyReply(c, http.StatusBadRequest, "INVALID_USERNAME")
 		}
 		if errors.Is(err, coresignup.ErrUsernameUsed) {
 			return apierr.FastifyReply(c, http.StatusBadRequest, "USED_USERNAME")

--- a/internal/api/signup/handler_test.go
+++ b/internal/api/signup/handler_test.go
@@ -671,13 +671,14 @@ func TestSignupPending_MarksInvitationTicketUsed(t *testing.T) {
 // --- coverage 補完 (#739): Signup / SignupPending の error 分岐を network 化 ---
 
 // 129 文字 username → service が ErrInvalidUsername を返す。email-required path
-// 経由で 400 INVALID_PARAM が返ることを確認する。
+// 経由で 400 INVALID_USERNAME が返ることを確認する (#2081: upstream SignupService の
+// INVALID_USERNAME に揃える、旧 INVALID_PARAM)。
 func TestSignup_EmailRequired_InvalidUsername(t *testing.T) {
 	h, _, metaRepo := newTestHandler(t)
 	metaRepo.Meta.EmailRequiredForSignup = true
 	long := strings.Repeat("a", 129)
 	rec := doPost(h.Signup, `{"username":"`+long+`","password":"pass","emailAddress":"x@example.com"}`)
-	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	testutil.AssertFastifyError(t, rec, http.StatusBadRequest, "INVALID_USERNAME")
 }
 
 // #2080: preserved username が email-required path で DENIED_USERNAME を返すこと


### PR DESCRIPTION
## Summary

#2078 の signup/signin audit で発見した LOW parity 微差まとめ (#2081)。triage の結果、明確で安全な乖離 2 件を
修正し、残りは intentional / no-impact / feature と判断して文書化する。

## 修正 (本 PR)

- **invalid username message**: signup の `ErrInvalidUsername` を `INVALID_PARAM` → **`INVALID_USERNAME`** に
  (upstream `SignupService` が `INVALID_USERNAME` を投げる、email/non-email 両 path)。mk-go は param 層に
  username pattern を持たず service 検証が一次なので到達する。
- **passkey no-such-user error id**: `signin-with-passkey` の `finishPasskeySignin` の user==null error id を
  `932c904e` → **`652f899f`** に (upstream `SigninWithPasskeyApiService:155`。`932c904e` は `!authorizedUserId`
  = challenge 未解決の別ステージ用)。

## 変更しない (triage 結果)

- **message `Error:` prefix**: mk-go は #802 で全 path 一貫の `Error:` prefix に**意図的に normalize** 済
  (upstream 自身が email/non-email path で prefix の有無が不一致)。mk-go の一貫性を維持。
- **signup gate 検証順序** (captcha→email→invitation vs invitation→captcha→email): status 不変、error
  precedence の微差のみで legit client に observable でない。reorder の risk に見合わないため維持。
- **signin CORS header**: signin token は JSON body 経由で cookie 認証ではなく、global CORS (`*`) で実害なし。
- **new-login email**: API surface 無しの security 通知 feature (parity 非互換ではない)。優先度低のため defer
  (必要なら別 issue)。

## テスト

- `TestSignup_EmailRequired_InvalidUsername` を `INVALID_USERNAME` assert に強化。
- `TestFinishPasskeySignin_NilUser` を `652f899f` assert に強化。
- `make fmt` / `go vet ./...` / signin (94.7%) ・ signup (93.6%) test green。

## Closes

Closes #2081
