### PR TITLE
invitation ticket の確認メール 30分再送防止窓を実装 (#2083)

### DIFF
--- a/internal/api/signup/handler.go
+++ b/internal/api/signup/handler.go
@@ -3,6 +3,7 @@ package signup
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -24,6 +25,9 @@ import (
 type TicketStore interface {
 	FindByCode(code string) (*model.RegistrationTicket, error)
 	MarkUsed(ticketID, userID string) error
+	// MarkPending records usedAt + pendingUserId for an email-confirmation
+	// signup (確認メール再送防止窓、#2083)。
+	MarkPending(ticketID, pendingID string) error
 }
 
 // SigninRecorder fires the side-effects of a successful login (signin history,
@@ -153,7 +157,7 @@ func (h *Handler) Signup(c echo.Context) error {
 	// 登録無効時はinvitation code必須 (テストモードではバイパス — 本家 TS 互換)
 	var ticket *model.RegistrationTicket
 	if !h.testMode && meta.DisableRegistration {
-		t, vErr := h.validateInvitationCode(req.InvitationCode)
+		t, vErr := h.validateInvitationCode(req.InvitationCode, meta.EmailRequiredForSignup)
 		if vErr != nil {
 			return c.JSON(http.StatusBadRequest, apierr.Error("INVITATION_CODE_INVALID", "Invalid invitation code.", "11e71a03-43c4-4a99-92cf-bb7e2c581998"))
 		}
@@ -220,6 +224,17 @@ func (h *Handler) Signup(c echo.Context) error {
 				return apierr.FastifyReply(c, http.StatusBadRequest, "PASSWORD_TOO_LONG")
 			}
 			return apierr.FastifyReply(c, http.StatusInternalServerError, "INTERNAL_ERROR")
+		}
+		// 招待制併用時は ticket に usedAt + pendingId をセットし、確認メール送信から
+		// 30 分間の再送を validateInvitationCode で弾く (upstream SignupApiService の
+		// update({usedAt, pendingUserId})、#2083)。確認完了時に PromotePending が
+		// MarkUsed で usedById を立てる。
+		if ticket != nil && h.ticketStore != nil {
+			if merr := h.ticketStore.MarkPending(ticket.ID, pending.ID); merr != nil {
+				// best-effort (pending は作成済) だが、失敗すると再送防止窓が効かないので
+				// observability のため warn を残す (#2083)。
+				slog.Warn("signup: failed to mark invitation ticket pending", "ticketId", ticket.ID, "err", merr)
+			}
 		}
 		if h.emailSender != nil {
 			siteName := "Misskey"
@@ -350,7 +365,10 @@ func validateEmailWithMeta(ctx context.Context, meta *model.Meta, addr string, c
 }
 
 // validateInvitationCode checks the ticket store for a valid invitation code.
-func (h *Handler) validateInvitationCode(code string) (*model.RegistrationTicket, error) {
+// emailRequired は emailRequiredForSignup。upstream SignupApiService の usedAt
+// gate (#2083) を再現する: email 確認制では確認メール送信から 30 分以内の ticket を
+// 弾き (再送防止)、非 email 制では usedAt が立っている ticket を弾く。
+func (h *Handler) validateInvitationCode(code string, emailRequired bool) (*model.RegistrationTicket, error) {
 	if code == "" || h.ticketStore == nil {
 		return nil, errInvalidCode
 	}
@@ -362,6 +380,15 @@ func (h *Handler) validateInvitationCode(code string) (*model.RegistrationTicket
 		return nil, errInvalidCode
 	}
 	if ticket.ExpiresAt != nil && ticket.ExpiresAt.Before(time.Now()) {
+		return nil, errInvalidCode
+	}
+	if emailRequired {
+		// 確認メール送信 (= MarkPending で usedAt セット) から 30 分以内は再送不可。
+		if ticket.UsedAt != nil && ticket.UsedAt.Add(30*time.Minute).After(time.Now()) {
+			return nil, errInvalidCode
+		}
+	} else if ticket.UsedAt != nil {
+		// 非 email 制では usedAt が立っていれば使用済 (upstream の else if 分岐)。
 		return nil, errInvalidCode
 	}
 	return ticket, nil

--- a/internal/api/signup/handler_test.go
+++ b/internal/api/signup/handler_test.go
@@ -25,15 +25,17 @@ import (
 
 // mockTicketStore is a test double for signup.TicketStore.
 type mockTicketStore struct {
-	tickets  map[string]*model.RegistrationTicket // keyed by code
-	markUsed map[string]string                    // ticketID → userID
-	markErr  error
+	tickets     map[string]*model.RegistrationTicket // keyed by code
+	markUsed    map[string]string                    // ticketID → userID
+	markPending map[string]string                    // ticketID → pendingID
+	markErr     error
 }
 
 func newMockTicketStore() *mockTicketStore {
 	return &mockTicketStore{
-		tickets:  make(map[string]*model.RegistrationTicket),
-		markUsed: make(map[string]string),
+		tickets:     make(map[string]*model.RegistrationTicket),
+		markUsed:    make(map[string]string),
+		markPending: make(map[string]string),
 	}
 }
 
@@ -50,6 +52,23 @@ func (m *mockTicketStore) MarkUsed(ticketID, userID string) error {
 		return m.markErr
 	}
 	m.markUsed[ticketID] = userID
+	return nil
+}
+
+func (m *mockTicketStore) MarkPending(ticketID, pendingID string) error {
+	if m.markErr != nil {
+		return m.markErr
+	}
+	m.markPending[ticketID] = pendingID
+	// validateInvitationCode の 30分窓検証で参照されるよう、ticket の usedAt/pendingId も更新。
+	for _, t := range m.tickets {
+		if t.ID == ticketID {
+			now := time.Now()
+			t.UsedAt = &now
+			pid := pendingID
+			t.PendingID = &pid
+		}
+	}
 	return nil
 }
 
@@ -695,3 +714,35 @@ func TestSignup_EmailRequired_ReservedUsername(t *testing.T) {
 // service.PromotePending の **tx 経路** (db + ticketRepo wired) でのみ発火し、
 // mock ベース handler test では再現不可。これらの coverage は repository /
 // service integration test 側で別途担保する想定で本 handler test では skip。
+
+// #2083: email-required + invitation 併用時、確認メール送信 (MarkPending) から 30 分以内の
+// 同一 code 再送は弾き、30 分経過後は再び許可する (upstream SignupApiService の usedAt 窓)。
+func TestSignup_EmailRequired_TicketResendWindow(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "x", EmailRequiredForSignup: true, DisableRegistration: true}
+	pendingRepo := testutil.NewMockUserPendingRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := coresignup.NewService(userRepo, metaRepo, idGen)
+	svc.SetUserPendingRepo(pendingRepo)
+	h := apisignup.NewHandler(svc, metaRepo, idGen)
+	store := newMockTicketStore()
+	store.tickets["code1"] = &model.RegistrationTicket{ID: "t1", Code: "code1"}
+	h.SetTicketStore(store)
+
+	// 1 回目: fresh ticket → 204 + MarkPending (usedAt セット)。
+	rec := doPost(h.Signup, `{"username":"alice","password":"pass1234","emailAddress":"a@example.com","invitationCode":"code1"}`)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	assert.NotEmpty(t, store.markPending["t1"], "ticket が pending として予約される")
+	require.NotNil(t, store.tickets["code1"].UsedAt)
+
+	// 2 回目 (30分以内): 同一 code は弾かれる。
+	rec2 := doPost(h.Signup, `{"username":"bob","password":"pass1234","emailAddress":"b@example.com","invitationCode":"code1"}`)
+	assert.Equal(t, http.StatusBadRequest, rec2.Code, "30分以内の再送は INVITATION_CODE_INVALID")
+
+	// usedAt を 31 分前にすると窓が空けて再送可能。
+	old := time.Now().Add(-31 * time.Minute)
+	store.tickets["code1"].UsedAt = &old
+	rec3 := doPost(h.Signup, `{"username":"carol","password":"pass1234","emailAddress":"c@example.com","invitationCode":"code1"}`)
+	assert.Equal(t, http.StatusNoContent, rec3.Code, "30分経過後は再送可能")
+}

--- a/internal/repository/registration_ticket.go
+++ b/internal/repository/registration_ticket.go
@@ -43,6 +43,12 @@ type RegistrationTicketRepository interface {
 	// PromotePending tx 経路で SELECT FOR UPDATE ロック中に使うので、
 	// commit までロックを保持して race を完全に閉じる。
 	MarkUsedTx(tx *gorm.DB, ticketID, userID string) error
+	// MarkPending records that a ticket has been used to create a pending
+	// signup (email 確認待ち): usedAt + pendingUserId をセットする (usedById は
+	// 立てない)。upstream SignupApiService の email path で確認メール送信時に
+	// `update({usedAt, pendingUserId})` する挙動と一致 (#2083)。確認完了時に
+	// MarkUsed で usedById が立つ。
+	MarkPending(ticketID, pendingID string) error
 	// List returns tickets matching the filter, paginated with limit/offset.
 	// Unknown filter values are treated as "all".
 	// `now` is passed by callers so tests can supply a deterministic clock
@@ -112,6 +118,14 @@ func (r *registrationTicketRepository) markUsedOn(db *gorm.DB, ticketID, userID 
 	return db.Model(&model.RegistrationTicket{}).Where(`"id" = ?`, ticketID).Updates(map[string]any{
 		"usedById": userID,
 		"usedAt":   now,
+	}).Error
+}
+
+func (r *registrationTicketRepository) MarkPending(ticketID, pendingID string) error {
+	// usedAt + pendingUserId のみ更新 (usedById は確認完了時に MarkUsed が立てる)。
+	return r.db.Model(&model.RegistrationTicket{}).Where(`"id" = ?`, ticketID).Updates(map[string]any{
+		"usedAt":        time.Now(),
+		"pendingUserId": pendingID,
 	}).Error
 }
 

--- a/internal/repository/registration_ticket_test.go
+++ b/internal/repository/registration_ticket_test.go
@@ -302,3 +302,23 @@ func TestRegistrationTicketRepository_ListSorted(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"rts_c", "rts_a", "rts_b"}, only(uAsc))
 }
+
+// #2083: MarkPending は usedAt + pendingUserId をセットし usedById は立てない
+// (確認メール再送防止 ticket 予約)。pendingUserId は user_pending 行の ID で user に
+// 存在しないため、000064 で FK を撤去済 (FK が残っていると本テストが FK 違反で落ちる)。
+func TestRegistrationTicketRepository_MarkPending(t *testing.T) {
+	repo := NewRegistrationTicketRepository(testDB)
+	cleanupInvite(t, "rt_mp")
+	defer cleanupInvite(t, "rt_mp")
+	require.NoError(t, repo.Create(&model.RegistrationTicket{ID: "rt_mp", Code: "rtmp_code"}))
+
+	// pendingID は user に存在しない user_pending ID (FK 撤去後なので書ける)。
+	require.NoError(t, repo.MarkPending("rt_mp", "pending_xyz"))
+
+	got, err := repo.FindByCode("rtmp_code")
+	require.NoError(t, err)
+	require.NotNil(t, got.UsedAt, "usedAt がセットされる")
+	require.NotNil(t, got.PendingID)
+	assert.Equal(t, "pending_xyz", *got.PendingID)
+	assert.Nil(t, got.UsedByID, "MarkPending は usedById を立てない")
+}

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -8108,3 +8108,17 @@ func (m *MockRegistrationTicketRepository) MarkUsed(ticketID, userID string) err
 func (m *MockRegistrationTicketRepository) MarkUsedTx(_ *gorm.DB, ticketID, userID string) error {
 	return m.MarkUsed(ticketID, userID)
 }
+
+// MarkPending sets usedAt + pendingUserId (not usedById)。email 確認待ち ticket
+// の予約 (#2083)。
+func (m *MockRegistrationTicketRepository) MarkPending(ticketID, pendingID string) error {
+	t, ok := m.Tickets[ticketID]
+	if !ok {
+		return ErrNotFound
+	}
+	now := time.Now()
+	t.UsedAt = &now
+	pid := pendingID
+	t.PendingID = &pid
+	return nil
+}

--- a/migration/000064_drop_registration_ticket_pending_fk.down.sql
+++ b/migration/000064_drop_registration_ticket_pending_fk.down.sql
@@ -1,0 +1,5 @@
+-- FK を復元する (000026 と同じ user(id) 参照 / ON DELETE SET NULL)。down 適用後は
+-- MarkPending が再び FK 違反になる点に注意 (元の bug 状態に戻る)。
+ALTER TABLE "registration_ticket"
+    ADD CONSTRAINT "registration_ticket_pendingUserId_fkey"
+    FOREIGN KEY ("pendingUserId") REFERENCES "user"("id") ON DELETE SET NULL;

--- a/migration/000064_drop_registration_ticket_pending_fk.up.sql
+++ b/migration/000064_drop_registration_ticket_pending_fk.up.sql
@@ -1,0 +1,9 @@
+-- #2083: registration_ticket.pendingUserId の余分な FK を撤去する。
+-- 000026 で `"pendingUserId" varchar(32) REFERENCES "user"("id") ON DELETE SET NULL`
+-- と user(id) への FK を張っていたが、pendingUserId には **user_pending 行の ID**
+-- (= user テーブルには存在しない) が入るため、確認メール再送防止 (MarkPending) で
+-- 必ず FK 違反になり機能が production で no-op になっていた。upstream Misskey の
+-- registration_ticket.pendingUserId は無制約の varchar (refactor-invite-system
+-- 1688720440658 / RegistrationTicket.ts の bare @Column) なので、それに揃えて FK を
+-- 落とす。usedById / createdById の FK は upstream にもあるので残す。
+ALTER TABLE "registration_ticket" DROP CONSTRAINT IF EXISTS "registration_ticket_pendingUserId_fkey";


### PR DESCRIPTION
## Summary

invitation ticket の確認メール 30分再送防止窓を実装する (#2080 から分離、#2078 系)。

upstream `SignupApiService` は `disableRegistration && emailRequiredForSignup` 併用時、確認メール送信時に
ticket へ `usedAt + pendingUserId` をセットし、`usedAt` から 30 分以内の同一 code 再送を弾く (再送防止)。
非 email 制では `usedAt` が立っていれば使用済とする。mk-go は CreatePending 時に ticket を予約せず、
`validateInvitationCode` も `usedByID`/`expiresAt` しか見ていなかった。

## 主な変更点

- `RegistrationTicketRepository` / signup `TicketStore` に **`MarkPending`** (usedAt + pendingUserId を立て
  usedById は立てない) を追加。email path で `CreatePending` 成功後に呼ぶ (失敗は `slog.Warn`)。
- `validateInvitationCode(code, emailRequired)`: emailRequired 時は `usedAt + 30分` 窓、非 email 時は `usedAt` を
  検証 (upstream の usedAt gate)。確認完了時は従来通り `PromotePending` の `MarkUsed` が usedById を立てる。

## 敵対的レビューで HIGH を発見・修正

- **(HIGH) `registration_ticket.pendingUserId` の余分な FK**: migration 000026 が `pendingUserId varchar(32)
  REFERENCES "user"("id")` と FK を張っていたが、pendingUserId には **user_pending 行の ID** (user に存在しない)
  が入るため、`MarkPending` が必ず FK 違反 → error 握り潰しで **機能が production で no-op** になっていた
  (mock test では FK 非 enforce で発覚せず)。**migration 000064** で FK を撤去 (upstream は無制約 varchar)。
- **(HIGH) MarkPending の実 DB テスト欠如**: `repository` に `TestRegistrationTicketRepository_MarkPending`
  (実 Postgres) を追加。FK 撤去後に usedAt/pendingUserId がセットされ usedById は nil のままを検証
  (= FK regression guard)。

## テスト

- handler: `TestSignup_EmailRequired_TicketResendWindow` (30分以内再送→reject、30分経過→許可、MarkPending 確認)。
- repository: `TestRegistrationTicketRepository_MarkPending` (実 DB)。
- `make fmt` / `go vet ./...` / signup (93.2%) ・ core/signup (90.1%) ・ repository (90.0%) green。

## Closes

Closes #2083
