### PR TITLE
inbox 署名の必須 signed headers に (request-target)/date を追加 (#2087)

### DIFF
--- a/internal/activitypub/inbox_admission.go
+++ b/internal/activitypub/inbox_admission.go
@@ -11,6 +11,15 @@ import (
 // Inbox admission errors mirror the 401 conditions Misskey's
 // ActivityPubServerService.inbox enforces before queueing an inbound activity.
 var (
+	// ErrInboxRequestTargetUnsigned is returned when `(request-target)` is not
+	// part of the signed header set. upstream の parseRequest は
+	// `headers: ['(request-target)', 'host', 'date']` を必須にするため、これが
+	// 署名されていないと 401 になる。署名が HTTP method/path に束縛されない
+	// 非準拠署名を弾く (#2087)。
+	ErrInboxRequestTargetUnsigned = errors.New("inbox: (request-target) is not signed")
+	// ErrInboxDateUnsigned is returned when `date` is not part of the signed
+	// header set (upstream parseRequest の必須 header、#2087)。
+	ErrInboxDateUnsigned = errors.New("inbox: date header is not signed")
 	// ErrInboxHostUnsigned is returned when `host` is not part of the signed
 	// header set. Upstream requires the Host header to be covered by the
 	// signature so it cannot be swapped after signing.
@@ -54,6 +63,17 @@ var (
 func VerifyInboxAdmission(parsed *ParsedSignature, hostHeader, expectedHost, digestHeader string, body []byte) error {
 	if parsed == nil {
 		return errors.New("inbox: missing parsed signature")
+	}
+
+	// (request-target) / date: 署名対象であること (upstream parseRequest の必須
+	// header ['(request-target)', 'host', 'date'] 相当、#2087)。host と違い configured
+	// host への依存が無いので expectedHost に関わらず必須。production の正規 peer
+	// (Misskey/Mastodon 等) も mk-go 自身の deliver も 4 header を署名する。
+	if !containsHeaderFold(parsed.Headers, "(request-target)") {
+		return ErrInboxRequestTargetUnsigned
+	}
+	if !containsHeaderFold(parsed.Headers, "date") {
+		return ErrInboxDateUnsigned
 	}
 
 	// host: 署名対象 + 自ホスト一致。expectedHost が未設定の呼び出し元

--- a/internal/activitypub/inbox_admission_test.go
+++ b/internal/activitypub/inbox_admission_test.go
@@ -79,6 +79,26 @@ func TestVerifyInboxAdmission(t *testing.T) {
 			wantErr:      ErrInboxDigestAlgo,
 		},
 		{
+			// #2087: (request-target) 未署名は upstream parseRequest 同様 reject。
+			name:         "request-target not signed",
+			parsed:       sig("date", "host", "digest"),
+			hostHeader:   host,
+			expectedHost: host,
+			digestHeader: goodDigest,
+			body:         body,
+			wantErr:      ErrInboxRequestTargetUnsigned,
+		},
+		{
+			// #2087: date 未署名も reject (expectedHost 未設定でも必須)。
+			name:         "date not signed (even when expectedHost empty)",
+			parsed:       sig("(request-target)", "host", "digest"),
+			hostHeader:   host,
+			expectedHost: "",
+			digestHeader: goodDigest,
+			body:         body,
+			wantErr:      ErrInboxDateUnsigned,
+		},
+		{
 			name:         "host not signed when expectedHost set",
 			parsed:       sig("(request-target)", "date", "digest"),
 			hostHeader:   host,


### PR DESCRIPTION
## Summary

inbox の HTTP Signature 検証で必須にする signed headers を upstream に揃える。#2078 の AP signature audit で発見。

upstream `ActivityPubServerService.inbox` は `(request-target) / host / date / digest` の **4 つを署名必須**にする:
- `ActivityPubServerService.ts:118` `parseRequest({headers:['(request-target)','host','date']})` (どれか未署名なら throw → 401)
- 同 `:131` digest 署名 check

mk-go の `VerifyInboxAdmission` は **host + digest しか必須にしておらず**、`(request-target)` / `date` 未署名の
非準拠署名を受理していた (upstream は 401 拒否)。

## 主な変更点

- `VerifyInboxAdmission` に `(request-target)` / `date` が署名対象であることの必須チェックを追加
  (`ErrInboxRequestTargetUnsigned` / `ErrInboxDateUnsigned`)。host と違い configured host への依存が無いので
  `expectedHost` に関わらず必須。

## 互換性 (federation 影響なし)

- 正規 AP peer (Misskey TS / Mastodon 等) は `(request-target)/host/date/digest` を標準で署名する。upstream 自身が
  これらを必須にするため、**Misskey TS と連合できる peer は元々 4 header を署名済**で mk-go でも pass する。
- mk-go 自身の outbound 署名も該当 (`client.go:101` の POST は 4 header、GET は body 無しで 3)。
- 実害は限定的だった (digest が body を、`authorizeActor` #1779 が actor を束縛) が、conformance を upstream に揃える。

## テスト

- `(request-target)` 未署名 → reject、`date` 未署名 → reject (expectedHost 未設定でも) のケースを追加。既存ケースは
  全て 4 header を署名済で不変。
- `make fmt` / `go vet ./...` / activitypub (92.6%) ・ inbox (95.2%) test green。federation regression は nightly
  drop-in e2e でも担保。

## Closes

Closes #2087
