### PR TITLE
e2e 差分比較ハーネスの整備: mk-go ↔ Misskey-TS の値レベル diff (#2089)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@
 	uds-init uds-frontend-build uds-build uds-up uds-down uds-down-v uds-logs uds-ps \
 	bench-up bench-run bench-down bench-logs \
 	apicompat apicompat-routes apicompat-render \
-	shapecheck shapecheck-gen shapecheck-report errorid-check limitspec-check perm-check
+	shapecheck shapecheck-gen shapecheck-report errorid-check limitspec-check perm-check \
+	diff-up diff-test diff-down diff-logs
 
 # Binary output
 BINARY=misskey
@@ -390,6 +391,24 @@ playwright-ts-test:
 
 playwright-ts-down:
 	docker compose -f $(PLAYWRIGHT_COMPOSE) -f $(PLAYWRIGHT_TS_OVERLAY) down -v
+
+# Differential e2e diff harness (#2089) ― mk-go (2026.6.0) と Misskey TS
+# (2026.5.4) を並列に立て、同一 endpoint のレスポンスを diff して entitycompat
+# golden gate がカバーしない値レベル乖離を検出する。詳細は docs/diff-e2e.md。
+# 隔離 stack (own network/volumes)、production UDS には触れない。
+DIFF_COMPOSE=docker-compose.diff.yml
+
+diff-up:
+	docker compose -f $(DIFF_COMPOSE) up -d --build
+
+diff-test:
+	docker compose -f $(DIFF_COMPOSE) --profile test run --rm --build diff-runner
+
+diff-down:
+	docker compose -f $(DIFF_COMPOSE) down -v
+
+diff-logs:
+	docker compose -f $(DIFF_COMPOSE) logs -f
 
 # API compatibility matrix ― mk-go と Misskey TS の API endpoint 実装状況を
 # 突き合わせて docs/api-compat.md を生成する。

--- a/docker-compose.diff.yml
+++ b/docker-compose.diff.yml
@@ -1,0 +1,100 @@
+# Differential e2e diff stack (#2089): runs mk-go (2026.6.0) and Misskey TS
+# (2026.5.4) side-by-side with independent DB/Redis, plus a pytest diff-runner
+# that calls identical endpoints on both and reports value-level deviations the
+# entitycompat golden gate cannot catch.
+#
+# API-only (HTTP, no TLS/federation) — the runner hits the backends directly on
+# :3000. Fully isolated stack (own project/network/volumes); NEVER touches the
+# UDS production. Tear down with `make diff-down` (-v drops volumes).
+#
+#   make diff-up      # build + start mkgo + ts (+ their DB/Redis)
+#   make diff-test    # run the diff-runner (pytest) against both
+#   make diff-down    # stop + remove (incl. volumes)
+
+# 専用 project name で隔離する。これが無いと compose の default project は
+# directory 名 `mk` になり、本番 UDS stack (compose.uds.yaml, 同じ project `mk`)
+# の `mkgo` サービスと衝突して本番コンテナを recreate してしまう (実際に踏んだ)。
+name: mkdiff
+
+services:
+  # --- mk-go side ---
+  postgres-mk:
+    image: postgres:16-alpine
+    environment: {POSTGRES_DB: misskey, POSTGRES_USER: misskey, POSTGRES_PASSWORD: testpass}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U misskey"]
+      interval: 3s
+      timeout: 3s
+      retries: 30
+    networks: [diff]
+  redis-mk:
+    image: redis:7-alpine
+    healthcheck: {test: ["CMD", "redis-cli", "ping"], interval: 3s, timeout: 3s, retries: 30}
+    networks: [diff]
+  mkgo:
+    build:
+      context: .
+      dockerfile: tests/federation/common/Dockerfile.mkgo
+    environment: {TZ: Asia/Tokyo}
+    volumes:
+      - ./tests/diff/mkgo.yml:/app/.config/default.yml:ro
+    healthcheck:
+      test: ["CMD", "/app/misskey", "-healthcheck", "-config", ".config/default.yml"]
+      interval: 5s
+      timeout: 5s
+      retries: 40
+      start_period: 30s
+    depends_on:
+      postgres-mk: {condition: service_healthy}
+      redis-mk: {condition: service_healthy}
+    networks: [diff]
+
+  # --- Misskey TS side (version-matched-ish: 2026.5.4 vs mk-go 2026.6.0) ---
+  postgres-ts:
+    image: postgres:16-alpine
+    environment: {POSTGRES_DB: misskey, POSTGRES_USER: misskey, POSTGRES_PASSWORD: testpass}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U misskey"]
+      interval: 3s
+      timeout: 3s
+      retries: 30
+    networks: [diff]
+  redis-ts:
+    image: redis:7-alpine
+    healthcheck: {test: ["CMD", "redis-cli", "ping"], interval: 3s, timeout: 3s, retries: 30}
+    networks: [diff]
+  ts:
+    image: misskey/misskey:2026.5.4
+    volumes:
+      - ./tests/diff/ts.yml:/misskey/.config/default.yml:ro
+    healthcheck:
+      # Misskey image has curl (not wget); /api/ping は JSON body 必須 (空 POST は 400)。
+      test: ["CMD-SHELL", "curl -fsS -X POST -H 'Content-Type: application/json' -d '{}' http://localhost:3000/api/ping || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 40
+      start_period: 60s
+    depends_on:
+      postgres-ts: {condition: service_healthy}
+      redis-ts: {condition: service_healthy}
+    networks: [diff]
+
+  # --- diff runner (pytest) ---
+  diff-runner:
+    profiles: [test]
+    build:
+      context: ./tests/diff
+      dockerfile: Dockerfile.runner
+    environment:
+      MKGO_URL: http://mkgo:3000
+      TS_URL: http://ts:3000
+    volumes:
+      - ./tests/diff:/work
+    working_dir: /work
+    depends_on:
+      mkgo: {condition: service_healthy}
+      ts: {condition: service_healthy}
+    networks: [diff]
+
+networks:
+  diff:

--- a/docs/diff-e2e.md
+++ b/docs/diff-e2e.md
@@ -1,0 +1,116 @@
+# Differential e2e diff harness (#2089)
+
+mk-go と Misskey TS の**実 API レスポンスを並べて diff** し、静的コード比較や
+entitycompat golden gate では拾えない**値レベルの乖離**を検出するハーネス。
+
+## なぜ必要か
+
+既存の互換性検証には次の層がある:
+
+- **entitycompat golden gate**: error code/id/HTTP status と entity field の
+  **presence (shape)** を golden と突き合わせる。
+- **dropin / playwright e2e**: TS ↔ mk-go 切替が成立するか、フロントから見た
+  挙動が壊れないかを検証する。
+
+これらは「field が**存在するか**」「shape が合うか」は見るが、「field の**値**が
+upstream と一致するか」(計算結果・正規化・順序・条件分岐の差) は検証しない。
+本ハーネスはそこを埋める: **同一の入力に対する mk-go と TS の出力 JSON を field
+単位で diff** し、instance 固有のノイズ (id/時刻/host 等) を除いた残差を parity
+乖離の候補として報告する。
+
+## アーキテクチャ
+
+```
+docker-compose.diff.yml  (隔離 stack、production UDS には触れない)
+├─ mkgo  (build: tests/federation/common/Dockerfile.mkgo, config: tests/diff/mkgo.yml)
+│   ├─ postgres-mk / redis-mk
+├─ ts    (image: misskey/misskey:2026.5.4, config: tests/diff/ts.yml)
+│   ├─ postgres-ts / redis-ts
+└─ diff-runner (profiles:[test], pytest + requests)
+     MKGO_URL=http://mkgo:3000  TS_URL=http://ts:3000
+```
+
+- **API-only (HTTP, no TLS/federation)**: runner は両 backend を `:3000` で直接
+  叩く。WebAuthn/secure-context は不要なので nginx TLS 層は省く。
+- **version**: mk-go は現行 2026.6.0、TS は入手可能な最寄りの公式 image
+  2026.5.4。1 minor 差 (= 直近の 2026.6.0 追従分) のノイズは ignore-list と
+  endpoint 選定で吸収する。
+- **隔離 (重要)**: compose 先頭で `name: mkdiff` を指定し専用 project に固定する。
+  これが無いと default project は directory 名 `mk` になり、**本番 UDS stack
+  (compose.uds.yaml, 同じ project `mk`) の `mkgo` サービスと衝突して本番コンテナを
+  recreate してしまう** (整備中に実際に踏んで本番 mkgo を一時 clobber → 即復旧した)。
+  `mkdiff-*` という別 namespace で own network/volumes を持ち、`make diff-down`
+  (`down -v`) で完全破棄。本番 (UDS) には一切触れない。
+
+- **one-shot**: seed は Misskey の bootstrap (admin/accounts/create が無認証で通るのは
+  user 0 件のときだけ) を使うので、`make diff-test` は `make diff-up` 直後の fresh
+  state に対して 1 回流す前提。再実行は `make diff-down && make diff-up` で作り直す。
+
+## 使い方
+
+```bash
+make diff-up      # mkgo + ts (+ それぞれの DB/Redis) を build + 起動
+make diff-test    # diff-runner (pytest) を両 instance に対して実行
+make diff-logs    # ログ追尾
+make diff-down    # stop + volume ごと破棄
+```
+
+`make diff-test` 失敗時、pytest の assertion message に `format_diffs` が
+`[kind] $.path: mkgo=... ts=...` 形式で乖離を列挙する。
+
+## 構成要素
+
+| ファイル | 役割 |
+|---|---|
+| `tests/diff/diff_core.py` | JSON 値 diff の中核。ignore-list 付き再帰比較。**stdlib のみ**で unit-test 可能 |
+| `tests/diff/test_diff_core.py` | diff-core の unit test (`python3 tests/diff/test_diff_core.py` で単体実行) |
+| `tests/diff/conftest.py` | `mkgo` / `ts` fixture (Client) + health 待ち。env URL から接続 |
+| `tests/diff/test_endpoints.py` | endpoint 別の差分テスト (現状 meta + note packing の PoC) |
+| `tests/diff/{mkgo,ts}.yml` | 各 instance の config |
+| `tests/diff/Dockerfile.runner` | pytest + requests の runner image |
+| `docker-compose.diff.yml` | 2 backend + DB/Redis + runner |
+
+## ignore-list 戦略
+
+`diff_core.DEFAULT_IGNORE_KEYS` は 2 instance 間で必然的に異なる field を除外する
+(id / createdAt / updatedAt / host / uri / url / token / publicKey / version 等)。
+endpoint 固有のノイズ (meta の operator 設定、note の user オブジェクト等) は
+各テストで `ignore_keys=` / `ignore_paths=` を足して吸収する。
+
+方針は**保守的**: 「取りこぼし (本物の乖離を見逃す)」より「ノイズで埋もれて
+本物が見えなくなる」方が害が大きいので、確実に instance 固有な field のみ無視し、
+残差は人間が確認する。
+
+## 検出した乖離の扱い
+
+確認された値レベル乖離は **#2078 の sub-issue** として個別に起票し、通常の
+issue 消化ワークフロー (実装 → 敵対的レビュー → PR → CI → squash-merge) で潰す。
+ハーネス自体の endpoint coverage 拡張は #2089 で追う。
+
+## CI 方針
+
+dropin/playwright 同様、**PR の required check には含めない** (2 backend 起動 +
+image pull で重く、external image の flaky 要素もある)。nightly か手動
+(`make diff-test`) 運用とする。diff-core の unit test だけは軽いので、必要なら
+別途 lint/test に組み込める。
+
+## 検証状況
+
+初回 bring-up で end-to-end 動作を確認済 (fresh stack):
+
+- diff-core unit test 13 件 + `test_meta_value_parity` + `test_note_packing_parity`
+  = **15 passed**。
+- `test_note_packing_parity`: mk-go と TS の packed note が (instance noise を除き)
+  **値レベルで一致** することを確認。
+- `test_meta_value_parity`: meta は version-gap (2026.6.0 で増えた field) と instance
+  state (mediaProxy host / proxyAccountName) のノイズを `META_IGNORE` で吸収した上で
+  pass。これらは harness が初回に検出した差分で、version-matched TS に切替えたら見直す。
+
+## 既知の制約・今後
+
+- TS image が 2026.5.4 のため 1 minor 分のノイズが出る。完全 version 一致が必要に
+  なれば third_party/misskey (2026.6.0) からの source build に切り替える。
+- 初回 `make diff-test` は ignore-path の調整 (endpoint 固有ノイズの洗い出し) を
+  伴う。PoC endpoint で当たりを付けてから coverage を広げる。
+- auth が要る endpoint は `Client.ensure_admin` の token を使う。複雑な seed
+  (follow/反応/連合) が要る endpoint は fixture を足して対応する。

--- a/tests/diff/Dockerfile.runner
+++ b/tests/diff/Dockerfile.runner
@@ -1,0 +1,6 @@
+# Diff-runner: pytest + requests against the mk-go and TS instances (#2089).
+FROM python:3.12-alpine
+RUN pip install --no-cache-dir pytest==8.3.3 requests==2.32.3
+WORKDIR /work
+# diff_core.py / conftest.py / test_*.py are bind-mounted at run time.
+CMD ["pytest", "-q"]

--- a/tests/diff/conftest.py
+++ b/tests/diff/conftest.py
@@ -1,0 +1,97 @@
+"""Fixtures for the mk-go <-> Misskey-TS differential e2e harness (#2089).
+
+Two independent instances are reached via env URLs (set by docker-compose.diff.yml):
+  MKGO_URL (mk-go 2026.6.0)  /  TS_URL (misskey/misskey:2026.5.4)
+
+Each test seeds equivalent state on both, calls the same endpoint, and asserts
+the JSON responses match modulo instance noise (see diff_core).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import pytest
+import requests
+
+MKGO_URL = os.environ.get("MKGO_URL", "http://mkgo:3000")
+TS_URL = os.environ.get("TS_URL", "http://ts:3000")
+
+
+class Client:
+    """Minimal Misskey API client: POST /api/<endpoint> with an optional token."""
+
+    def __init__(self, base_url: str, label: str) -> None:
+        self.base = base_url.rstrip("/")
+        self.label = label
+        self.token: str | None = None
+        self.session = requests.Session()
+
+    def call(self, endpoint: str, body: dict | None = None, *, token: str | None = None) -> requests.Response:
+        payload = dict(body or {})
+        tok = token if token is not None else self.token
+        if tok:
+            payload["i"] = tok
+        return self.session.post(f"{self.base}/api/{endpoint}", json=payload, timeout=30)
+
+    def json(self, endpoint: str, body: dict | None = None, *, token: str | None = None) -> dict:
+        resp = self.call(endpoint, body, token=token)
+        resp.raise_for_status()
+        return resp.json() if resp.content else {}
+
+    def ensure_admin(self, username: str, password: str) -> str:
+        """Create the first (admin) account and store its token.
+
+        Uses Misskey's bootstrap path (admin/accounts/create needs no auth while
+        the instance has no users). The harness is therefore one-shot per fresh
+        `make diff-up`: re-running against an instance that already has users
+        fails here with a clear hint to recreate the stack (`make diff-down &&
+        make diff-up`). This keeps seeding simple and version-independent.
+        """
+        resp = self.call("admin/accounts/create", {"username": username, "password": password})
+        if resp.status_code == 200:
+            self.token = resp.json()["token"]
+            return self.token
+        raise RuntimeError(
+            f"{self.label}: bootstrap admin create failed (status {resp.status_code}). "
+            "The instance likely already has users — recreate the stack: "
+            "`make diff-down && make diff-up`."
+        )
+        return self.token
+
+
+def _wait_healthy(url: str) -> None:
+    deadline = time.time() + 120
+    last = None
+    while time.time() < deadline:
+        try:
+            # /api/ping は JSON body 必須 (空 POST は 400)。
+            r = requests.post(f"{url}/api/ping", json={}, timeout=5)
+            if r.status_code == 200:
+                return
+            last = r.status_code
+        except requests.RequestException as e:  # noqa: PERF203
+            last = e
+        time.sleep(2)
+    raise RuntimeError(f"instance {url} not healthy (last={last})")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _wait_for_instances() -> None:
+    _wait_healthy(MKGO_URL)
+    _wait_healthy(TS_URL)
+
+
+@pytest.fixture(scope="session")
+def mkgo() -> Client:
+    c = Client(MKGO_URL, "mkgo")
+    c.ensure_admin("alice", "test-password-1234")
+    return c
+
+
+@pytest.fixture(scope="session")
+def ts() -> Client:
+    c = Client(TS_URL, "ts")
+    c.ensure_admin("alice", "test-password-1234")
+    return c

--- a/tests/diff/diff_core.py
+++ b/tests/diff/diff_core.py
@@ -1,0 +1,119 @@
+"""Differential JSON comparison for the mk-go <-> Misskey-TS e2e diff harness (#2089).
+
+The entitycompat golden gate covers error code/id/status and field *presence*
+(shape). It cannot check field *values* (computed results, normalization,
+ordering, conditional branches). This module compares two API responses
+field-by-field, ignoring instance-specific keys (ids, timestamps, host/uri/url,
+tokens, etc.) so the remaining diffs are value-level parity candidates between
+mk-go (2026.6.0) and Misskey TS (2026.5.4).
+
+Pure stdlib so it is unit-testable without the running stack
+(`python3 tests/diff/test_diff_core.py`).
+"""
+
+from __future__ import annotations
+
+# Keys whose values legitimately differ between two independent instances and
+# therefore must not be reported as parity diffs. Conservative by design: better
+# to under-report (miss a diff) than drown real findings in instance noise.
+# Extend per-endpoint via the `ignore_keys` / `ignore_paths` args when needed.
+DEFAULT_IGNORE_KEYS = frozenset({
+    # identity / time — always instance-specific
+    "id", "createdAt", "updatedAt", "lastFetchedAt", "fetchedAt", "expiresAt",
+    "lastActiveDate", "updatedAtHistory", "lastNotedAt", "approvalDate",
+    # host / addressing — differ by instance domain
+    "host", "uri", "url", "avatarUrl", "bannerUrl", "backgroundUrl",
+    "avatarBlurhash", "bannerBlurhash", "src", "thumbnailUrl", "webpublicUrl",
+    # secrets / per-instance tokens & keys
+    "token", "i", "publicKey", "sshKey", "secret", "password",
+    # version / build identifiers (mk-go reports its own version string)
+    "version", "clientEntry", "clientManifestExists",
+})
+
+
+class Diff:
+    """A single field-level discrepancy.
+
+    kind is one of:
+      - "value":           same path, different scalar value
+      - "type":            different JSON types at the same path
+      - "length":          arrays of different length
+      - "missing_in_mkgo": key present in TS but absent in mk-go
+      - "missing_in_ts":   key present in mk-go but absent in TS
+    """
+
+    __slots__ = ("path", "kind", "mkgo", "ts")
+
+    def __init__(self, path: str, kind: str, mkgo: object, ts: object) -> None:
+        self.path = path
+        self.kind = kind
+        self.mkgo = mkgo
+        self.ts = ts
+
+    def __repr__(self) -> str:
+        return f"Diff({self.path!r}, {self.kind!r}, mkgo={self.mkgo!r}, ts={self.ts!r})"
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Diff) and (self.path, self.kind, self.mkgo, self.ts) == (
+            other.path, other.kind, other.mkgo, other.ts,
+        )
+
+
+def diff_json(mkgo, ts, *, ignore_keys=DEFAULT_IGNORE_KEYS, ignore_paths=frozenset(), path="$"):
+    """Return the list of field-level diffs between mkgo and ts responses.
+
+    ignore_keys: object keys to skip anywhere they appear (default instance noise).
+    ignore_paths: fully-qualified `$.a.b[0].c` paths to skip (per-endpoint tuning).
+    """
+    out: list[Diff] = []
+    _walk(mkgo, ts, path, ignore_keys, ignore_paths, out)
+    return out
+
+
+def _walk(a, b, path, ignore_keys, ignore_paths, out):
+    if path in ignore_paths:
+        return
+    # int/float are interchangeable JSON numbers; bool is NOT a number here.
+    if not _same_kind(a, b):
+        out.append(Diff(path, "type", a, b))
+        return
+    if isinstance(a, dict):
+        for key in sorted(set(a.keys()) | set(b.keys())):
+            if key in ignore_keys:
+                continue
+            child = f"{path}.{key}"
+            if child in ignore_paths:
+                continue
+            if key not in a:
+                out.append(Diff(child, "missing_in_mkgo", None, b[key]))
+            elif key not in b:
+                out.append(Diff(child, "missing_in_ts", a[key], None))
+            else:
+                _walk(a[key], b[key], child, ignore_keys, ignore_paths, out)
+    elif isinstance(a, list):
+        if len(a) != len(b):
+            out.append(Diff(path, "length", len(a), len(b)))
+        for i in range(min(len(a), len(b))):
+            _walk(a[i], b[i], f"{path}[{i}]", ignore_keys, ignore_paths, out)
+    else:
+        if a != b:
+            out.append(Diff(path, "value", a, b))
+
+
+def _same_kind(a, b) -> bool:
+    """Whether a and b are the same JSON kind. int/float unified; bool distinct."""
+    if isinstance(a, bool) or isinstance(b, bool):
+        return isinstance(a, bool) and isinstance(b, bool)
+    if isinstance(a, (int, float)) and isinstance(b, (int, float)):
+        return True
+    return type(a) is type(b)
+
+
+def format_diffs(diffs) -> str:
+    """Human-readable report (one line per diff) for test failure messages."""
+    if not diffs:
+        return "(no diffs)"
+    lines = [f"{len(diffs)} value-level diff(s):"]
+    for d in diffs:
+        lines.append(f"  [{d.kind}] {d.path}: mkgo={d.mkgo!r} ts={d.ts!r}")
+    return "\n".join(lines)

--- a/tests/diff/mkgo.yml
+++ b/tests/diff/mkgo.yml
@@ -1,0 +1,31 @@
+# mk-go config for the differential e2e diff stack (#2089). API-only (HTTP, no
+# TLS/federation): the diff-runner hits http://mkgo:3000 directly.
+url: http://mkgo:3000/
+port: 3000
+db:
+  host: postgres-mk
+  port: 5432
+  db: misskey
+  user: misskey
+  pass: testpass
+redis:
+  host: redis-mk
+  port: 6379
+redisForPubsub:
+  host: redis-mk
+  port: 6379
+redisForJobQueue:
+  host: redis-mk
+  port: 6379
+redisForTimelines:
+  host: redis-mk
+  port: 6379
+id: aidx
+jobQueueDriver: mkq
+disableEndpointRateLimits: true
+enableIpRateLimit: false
+allowedPrivateNetworks:
+  - 127.0.0.0/8
+  - 10.0.0.0/8
+  - 172.16.0.0/12
+  - 192.168.0.0/16

--- a/tests/diff/test_diff_core.py
+++ b/tests/diff/test_diff_core.py
@@ -1,0 +1,107 @@
+"""Unit tests for diff_core (#2089). Runnable standalone (no pytest needed):
+
+    python3 tests/diff/test_diff_core.py
+
+Also collected by pytest inside the diff-runner container.
+"""
+
+from __future__ import annotations
+
+from diff_core import DEFAULT_IGNORE_KEYS, Diff, diff_json, format_diffs
+
+
+def test_identical_no_diffs():
+    a = {"name": "x", "count": 3, "nested": {"a": [1, 2]}}
+    assert diff_json(a, dict(a)) == []
+
+
+def test_scalar_value_diff():
+    diffs = diff_json({"k": "mk"}, {"k": "ts"})
+    assert diffs == [Diff("$.k", "value", "mk", "ts")]
+
+
+def test_ignore_keys_skipped():
+    # id / createdAt / host differ per instance but must be ignored.
+    mk = {"id": "aaa", "createdAt": "2026-01-01", "host": "mk.local", "name": "alice"}
+    ts = {"id": "bbb", "createdAt": "2026-02-02", "host": "ts.local", "name": "alice"}
+    assert diff_json(mk, ts) == []
+
+
+def test_ignore_keys_skipped_when_value_actually_differs():
+    # even differing name is caught, but id/host noise is not.
+    mk = {"id": "a", "host": "m", "name": "alice"}
+    ts = {"id": "b", "host": "t", "name": "ALICE"}
+    assert diff_json(mk, ts) == [Diff("$.name", "value", "alice", "ALICE")]
+
+
+def test_missing_in_each_direction():
+    diffs = diff_json({"only_mk": 1, "shared": 2}, {"only_ts": 9, "shared": 2})
+    by_path = {d.path: d for d in diffs}
+    assert by_path["$.only_mk"].kind == "missing_in_ts"
+    assert by_path["$.only_ts"].kind == "missing_in_mkgo"
+    assert "$.shared" not in by_path
+
+
+def test_type_mismatch():
+    diffs = diff_json({"k": "3"}, {"k": 3})
+    assert diffs == [Diff("$.k", "type", "3", 3)]
+
+
+def test_int_float_unified():
+    # JSON numbers: 3 and 3.0 are equal, no diff.
+    assert diff_json({"k": 3}, {"k": 3.0}) == []
+
+
+def test_bool_not_a_number():
+    diffs = diff_json({"k": True}, {"k": 1})
+    assert len(diffs) == 1 and diffs[0].kind == "type"
+
+
+def test_list_length_and_elementwise():
+    diffs = diff_json({"xs": [1, 2, 3]}, {"xs": [1, 9]})
+    kinds = {(d.path, d.kind) for d in diffs}
+    assert ("$.xs", "length") in kinds
+    assert ("$.xs[1]", "value") in kinds
+
+
+def test_nested_path():
+    diffs = diff_json({"a": {"b": {"c": 1}}}, {"a": {"b": {"c": 2}}})
+    assert diffs == [Diff("$.a.b.c", "value", 1, 2)]
+
+
+def test_ignore_paths():
+    mk = {"meta": {"flaky": "x", "stable": "v"}}
+    ts = {"meta": {"flaky": "y", "stable": "v"}}
+    assert diff_json(mk, ts, ignore_paths={"$.meta.flaky"}) == []
+
+
+def test_extra_ignore_keys_param():
+    mk = {"custom": "a", "name": "n"}
+    ts = {"custom": "b", "name": "n"}
+    assert diff_json(mk, ts, ignore_keys=DEFAULT_IGNORE_KEYS | {"custom"}) == []
+
+
+def test_format_diffs_readable():
+    out = format_diffs([Diff("$.k", "value", "m", "t")])
+    assert "$.k" in out and "value" in out
+    assert format_diffs([]) == "(no diffs)"
+
+
+def _run_standalone():
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {fn.__name__}: {e}")
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    return failed
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(1 if _run_standalone() else 0)

--- a/tests/diff/test_endpoints.py
+++ b/tests/diff/test_endpoints.py
@@ -1,0 +1,53 @@
+"""Differential endpoint tests (#2089): call the same endpoint on mk-go and TS,
+diff the JSON responses, fail on value-level deviations.
+
+This is the PoC coverage (meta + note packing). Extend with more endpoints as
+the harness matures; each confirmed deviation should become a #2078 sub-issue.
+
+Run via the diff-runner container: `make diff-test`.
+"""
+
+from __future__ import annotations
+
+from diff_core import DEFAULT_IGNORE_KEYS, diff_json, format_diffs
+
+# meta carries a lot of operator-specific config (names, urls, versions, limits
+# that depend on the instance config). Ignore those so the diff focuses on
+# structural/value parity of the shared fields.
+META_IGNORE = DEFAULT_IGNORE_KEYS | {
+    # operator config strings / theming
+    "name", "shortName", "description", "maintainerName", "maintainerEmail",
+    "tosUrl", "privacyPolicyUrl", "inquiryUrl", "repositoryUrl", "feedbackUrl",
+    "serverRules", "themeColor", "bannerUrl", "backgroundImageUrl", "logoImageUrl",
+    "iconUrl", "infoImageUrl", "notFoundImageUrl", "serverErrorImageUrl",
+    "defaultLightTheme", "defaultDarkTheme", "mascotImageUrl", "languages",
+    # instance-specific addressing / state (host-derived URL, per-instance proxy account)
+    "mediaProxy", "proxyAccountName", "proxyAccountId",
+    # version-gap (mk-go 2026.6.0 が持ち TS 2026.5.4 に無い field)。golden gate が
+    # 2026.6.0 golden で presence を担保済なので diff harness では noise として無視。
+    # version-matched TS に切替えたら見直す。
+    "app192IconUrl", "app512IconUrl", "singleUserMode",
+    "globalTimeline", "localTimeline",
+}
+
+
+def test_meta_value_parity(mkgo, ts):
+    mk = mkgo.json("meta", {"detail": True})
+    tj = ts.json("meta", {"detail": True})
+    diffs = diff_json(mk, tj, ignore_keys=META_IGNORE)
+    assert not diffs, format_diffs(diffs)
+
+
+def test_note_packing_parity(mkgo, ts):
+    # Create an equivalent note on each instance and compare the packed object.
+    text = "diff-harness parity probe"
+    mk_note = mkgo.json("notes/create", {"text": text, "visibility": "public"})["createdNote"]
+    ts_note = ts.json("notes/create", {"text": text, "visibility": "public"})["createdNote"]
+
+    mk_show = mkgo.json("notes/show", {"noteId": mk_note["id"]})
+    ts_show = ts.json("notes/show", {"noteId": ts_note["id"]})
+
+    # user / author objects are entirely instance-specific (id/host/keys/dates).
+    note_ignore = DEFAULT_IGNORE_KEYS | {"userId", "user", "renoteId", "replyId"}
+    diffs = diff_json(mk_show, ts_show, ignore_keys=note_ignore)
+    assert not diffs, format_diffs(diffs)

--- a/tests/diff/ts.yml
+++ b/tests/diff/ts.yml
@@ -1,0 +1,28 @@
+# Misskey TS (misskey/misskey:2026.5.4) config for the differential e2e diff
+# stack (#2089). API-only (HTTP, no TLS): the diff-runner hits http://ts:3000.
+url: http://ts:3000/
+port: 3000
+db:
+  host: postgres-ts
+  port: 5432
+  db: misskey
+  user: misskey
+  pass: testpass
+redis:
+  host: redis-ts
+  port: 6379
+redisForPubsub:
+  host: redis-ts
+  port: 6379
+redisForJobQueue:
+  host: redis-ts
+  port: 6379
+redisForTimelines:
+  host: redis-ts
+  port: 6379
+id: aidx
+allowedPrivateNetworks:
+  - 127.0.0.0/8
+  - 10.0.0.0/8
+  - 172.16.0.0/12
+  - 192.168.0.0/16


### PR DESCRIPTION
## Summary

#2078 の e2e 動的検証領域に向けて、**mk-go ↔ Misskey-TS の実 API レスポンスを field 単位で diff** して
entitycompat golden gate (shape) がカバーしない**値レベル乖離**を検出するハーネスを整備する。

## 主な変更点

- `tests/diff/diff_core.py`: ignore-list 付き再帰 JSON 値 diff。**stdlib のみ**で `python3 tests/diff/test_diff_core.py`
  により単体検証可 (unit test 13 件)。
- `tests/diff/{conftest,test_endpoints}.py`: `mkgo` / `ts` fixture (health 待ち + bootstrap seed) + meta / note packing
  の差分テスト (PoC)。
- `docker-compose.diff.yml` + `tests/diff/{mkgo,ts}.yml` + `Dockerfile.runner`: mk-go (2026.6.0 build) + Misskey TS
  (`misskey/misskey:2026.5.4`) + pytest runner を並列に立てる隔離 stack。
- `Makefile`: `diff-up` / `diff-test` / `diff-down` / `diff-logs`。`docs/diff-e2e.md` に設計。

## 検証

fresh stack で end-to-end 動作確認済: **15 passed** (diff-core 13 + `test_meta_value_parity` + `test_note_packing_parity`)。
- `test_note_packing_parity`: packed note が instance noise を除き値レベルで parity 一致を確認。
- `test_meta_value_parity`: harness が初回に検出した version-gap (2026.6.0 で増えた field) + instance state
  (mediaProxy host / proxyAccountName) を `META_IGNORE` で吸収して pass。

## 隔離 (重要)

compose に `name: mkdiff` を指定し専用 project に固定する。これが無いと default project は directory 名 `mk` に
なり、**本番 UDS stack (`compose.uds.yaml`, 同 project `mk`) の `mkgo` サービスと衝突**する (整備中に実際に踏み、
本番 mkgo を一時 recreate → `compose.uds.yaml` で即復旧、本番 DB は別 volume で無傷)。再発防止として `name:` 固定 +
`docs/diff-e2e.md` に rationale を明記。既存 playwright stack も `name: mk-playwright` で同様に隔離済。

## 関連 / 残タスク (#2089)

- 親: #2078 / 本 issue: #2089
- 本 PR: diff-core + compose/make + PoC (meta/note) を整備。
- 残: endpoint coverage 拡張、検出した値レベル乖離の #2078 sub-issue 化、CI (nightly) 統合。
