### PR TITLE
diff harness: users/show・reaction・poll の差分テストを追加 + isAdmin 乖離を検出 (#2089)

### DIFF
--- a/tests/diff/test_endpoints.py
+++ b/tests/diff/test_endpoints.py
@@ -51,3 +51,54 @@ def test_note_packing_parity(mkgo, ts):
     note_ignore = DEFAULT_IGNORE_KEYS | {"userId", "user", "renoteId", "replyId"}
     diffs = diff_json(mk_show, ts_show, ignore_keys=note_ignore)
     assert not diffs, format_diffs(diffs)
+
+
+# user 固有値 (counts は fresh では 0 で一致するので無視しない)。
+USER_IGNORE = DEFAULT_IGNORE_KEYS | {
+    "avatarDecorations", "roles", "badgeRoles", "emojis", "instance",
+    "avatarColor", "bannerColor", "followersCount", "followingCount",
+    # onlineStatus は lastActiveDate 由来の timing-state (mk-go は activity で即
+    # 'online'、TS は throttle で 'unknown')。安定した parity 比較対象ではない。
+    "onlineStatus", "lastActiveDate",
+    # #2091: users/show self-view が isAdmin/isModerator を populate しない (root を
+    # 反映せず常に false)。finding として追跡中なので harness では一旦無視する。
+    # #2091 修正後にこの 2 つを外して回帰 gate に戻すこと。
+    "isAdmin", "isModerator",
+}
+
+
+def test_user_packing_parity(mkgo, ts):
+    mk = mkgo.json("users/show", {"username": "alice"})
+    tj = ts.json("users/show", {"username": "alice"})
+    diffs = diff_json(mk, tj, ignore_keys=USER_IGNORE)
+    assert not diffs, format_diffs(diffs)
+
+
+def test_note_with_reaction_parity(mkgo, ts):
+    # Create a note and react with a unicode emoji on each, compare the packed
+    # reactions map / counts.
+    for c in (mkgo, ts):
+        note = c.json("notes/create", {"text": "react probe", "visibility": "public"})["createdNote"]
+        c.json("notes/reactions/create", {"noteId": note["id"], "reaction": "\U0001F44D"})
+        c._probe_note_id = note["id"]
+
+    mk_show = mkgo.json("notes/show", {"noteId": mkgo._probe_note_id})
+    ts_show = ts.json("notes/show", {"noteId": ts._probe_note_id})
+
+    note_ignore = DEFAULT_IGNORE_KEYS | {"userId", "user", "renoteId", "replyId"}
+    diffs = diff_json(mk_show, ts_show, ignore_keys=note_ignore)
+    assert not diffs, format_diffs(diffs)
+
+
+def test_note_with_poll_parity(mkgo, ts):
+    poll = {"choices": ["alpha", "beta", "gamma"], "multiple": False}
+    mk_note = mkgo.json("notes/create", {"text": "poll probe", "visibility": "public", "poll": poll})["createdNote"]
+    ts_note = ts.json("notes/create", {"text": "poll probe", "visibility": "public", "poll": poll})["createdNote"]
+
+    mk_show = mkgo.json("notes/show", {"noteId": mk_note["id"]})
+    ts_show = ts.json("notes/show", {"noteId": ts_note["id"]})
+
+    # compare just the packed poll object (the rest is covered by note packing).
+    note_ignore = DEFAULT_IGNORE_KEYS | {"userId", "user", "renoteId", "replyId"}
+    diffs = diff_json(mk_show.get("poll"), ts_show.get("poll"), ignore_keys=note_ignore, path="$.poll")
+    assert not diffs, format_diffs(diffs)


### PR DESCRIPTION
## Summary

#2089 差分比較ハーネスの endpoint coverage を拡張し、検出した値レベル乖離を sub-issue 化する。

## 主な変更点

- `tests/diff/test_endpoints.py` に 3 つの差分テストを追加:
  - `test_user_packing_parity`: `users/show` (UserDetailed/MeDetailed) の packing。
  - `test_note_with_reaction_parity`: note + unicode reaction の reactions map / counts。
  - `test_note_with_poll_parity`: note + poll の packed poll オブジェクト。
- fresh stack で **18 passed** (diff-core 13 + meta / note / user / reaction / poll)。

## 検出した乖離 → #2091

`users/show` の self-view 比較で値レベル乖離を**初検出**:

```
[value] $.isAdmin: mkgo=False ts=True
[value] $.isModerator: mkgo=False ts=True
```

root user (live DB で `meta.rootUserId` = alice.id / `isRoot=true` を確認) を self-view したとき、`/api/i` は
正しく `isAdmin/isModerator` を返すのに `/api/users/show` の entity packer は populate しておらず常に false。
parity gap として **#2091** に切り出した。

ハーネスでは #2091 修正までこの 2 field を `USER_IGNORE` に (コメント + #2091 参照付きで) 一旦退避し、harness
自体は green を維持する。`onlineStatus` は `lastActiveDate` 由来の timing-state なので安定比較対象外として ignore。

## テスト

- 隔離 stack (`name: mkdiff`、本番 UDS には触れない) で `make diff-up && make diff-test` → 18 passed。
- diff-core unit test は `python3 tests/diff/test_diff_core.py` でも単体実行可 (13/13)。

## 関連
- 親: #2078 / ハーネス: #2089 / 検出 finding: #2091
