### PR TITLE
users/show の self-view で isAdmin/isModerator を populate する (#2091)

### DIFF
--- a/internal/api/users/fix_2091_test.go
+++ b/internal/api/users/fix_2091_test.go
@@ -1,0 +1,35 @@
+package users
+
+import (
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// #2091: users/show の self-view (MeDetailed) は isAdmin / isModerator を
+// roleService (moderatorChecker、root fallback 込み) から populate しなければ
+// ならない。upstream / /api/i と同値にする。修正前は entity packer が field を
+// 宣言するだけで常に false だった。
+func TestShow_SelfView_PopulatesIsAdminIsModerator(t *testing.T) {
+	h, repo := newTestHandler(t)
+	alice := newTargetWithProfile(repo, "alice", &model.UserProfile{})
+	// alice を admin/moderator (= root 相当) として扱う stub。
+	h.SetModeratorChecker(modByID{id: "alice"})
+
+	resp := showWithViewer(t, h, "alice", alice)
+	assert.Equal(t, true, resp["isAdmin"], "self-view は root/admin を isAdmin=true で返す")
+	assert.Equal(t, true, resp["isModerator"], "self-view は moderator を isModerator=true で返す")
+}
+
+// 非 admin の self-view は false (zero value ではなく明示的に false を populate)。
+func TestShow_SelfView_NonAdminIsFalse(t *testing.T) {
+	h, repo := newTestHandler(t)
+	bob := newTargetWithProfile(repo, "bob", &model.UserProfile{})
+	// bob 以外を admin にする = bob は非 admin。
+	h.SetModeratorChecker(modByID{id: "someone-else"})
+
+	resp := showWithViewer(t, h, "bob", bob)
+	assert.Equal(t, false, resp["isAdmin"])
+	assert.Equal(t, false, resp["isModerator"])
+}

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -622,6 +622,14 @@ func (h *Handler) Show(c echo.Context) error {
 		// 入れる (misskey_dart の MeDetailed.fromJson は policies を非null Map と
 		// して要求する、#1240)。権威値は /api/i 経由で取得される。
 		me.Policies = corerole.DefaultPolicies()
+		// isAdmin / isModerator も role 依存で entity 層では出せない。upstream は
+		// MeDetailedOnly でこれらを埋める (RoleService.isAdministrator/isModerator、
+		// root fallback 込み) ので、self-view では /api/i と同値になるよう
+		// moderatorChecker (= roleService) から populate する (#2091)。
+		if h.moderatorChecker != nil {
+			me.IsAdmin = h.moderatorChecker.IsAdministrator(bundle.User.ID)
+			me.IsModerator = h.moderatorChecker.IsModerator(bundle.User.ID)
+		}
 		return c.JSON(http.StatusOK, me)
 	}
 	// followers/following count を visibility で gate する (#1558)。ここに来るのは

--- a/tests/diff/test_endpoints.py
+++ b/tests/diff/test_endpoints.py
@@ -60,10 +60,8 @@ USER_IGNORE = DEFAULT_IGNORE_KEYS | {
     # onlineStatus は lastActiveDate 由来の timing-state (mk-go は activity で即
     # 'online'、TS は throttle で 'unknown')。安定した parity 比較対象ではない。
     "onlineStatus", "lastActiveDate",
-    # #2091: users/show self-view が isAdmin/isModerator を populate しない (root を
-    # 反映せず常に false)。finding として追跡中なので harness では一旦無視する。
-    # #2091 修正後にこの 2 つを外して回帰 gate に戻すこと。
-    "isAdmin", "isModerator",
+    # (#2091 修正済: isAdmin/isModerator は self-view で populate されるように
+    # なったため回帰 gate に戻した。ここで ignore しない。)
 }
 
 


### PR DESCRIPTION
## Summary

差分比較ハーネス (#2089) の `users/show` 値レベル比較で検出した乖離 (#2091) を修正する。

root user を self-view したとき、`/api/i` は `isAdmin`/`isModerator` を正しく返すのに `/api/users/show` の
entity packer は populate せず**常に false** だった (data は正しく `meta.rootUserId` / `user.isRoot` で root)。

```
検出 (ハーネス): $.isAdmin: mkgo=False ts=True / $.isModerator: mkgo=False ts=True
```

## 主な変更点

- `internal/api/users/handler.go`: self-view (`viewer==target`) block で `me.IsAdmin` / `me.IsModerator` を
  `moderatorChecker` (= `roleService`、root fallback 込み) から populate。upstream の MeDetailedOnly
  (`roleService.isAdministrator/isModerator`) と `/api/i` に揃える。`isAdmin`/`isModerator` は MeDetailedOnly
  なので non-self には付かない (従来通り)。
- regression test 2 件 (admin self-view → true、非 admin → false)。
- `tests/diff/test_endpoints.py`: 検出元のハーネスで `isAdmin`/`isModerator` を `USER_IGNORE` から外し回帰 gate に
  戻した。

## テスト

- `internal/api/users`: 新規 2 test + 既存 self-view test green、`go vet ./...` / coverage 90.4%。
- **end-to-end**: 修正版 mk-go を rebuild した隔離ハーネス (`make diff-up && make diff-test`) で `isAdmin`/
  `isModerator` を un-ignore した状態でも **18 passed** = parity 回復を実証 (本番 UDS には触れない)。

## Closes

Closes #2091
