### PR TITLE
diff harness: reply/renote/hashtag/state/i の差分テストを追加 + /api/i 乖離検出 (#2089)

### DIFF
--- a/tests/diff/test_endpoints.py
+++ b/tests/diff/test_endpoints.py
@@ -57,6 +57,9 @@ def test_note_packing_parity(mkgo, ts):
 USER_IGNORE = DEFAULT_IGNORE_KEYS | {
     "avatarDecorations", "roles", "badgeRoles", "emojis", "instance",
     "avatarColor", "bannerColor", "followersCount", "followingCount",
+    # notesCount は eventual-consistency (mk-go は note 作成で即時、TS は chart/job
+    # で遅延更新) のため瞬間値が割れる timing-state。安定比較対象外。
+    "notesCount",
     # onlineStatus は lastActiveDate 由来の timing-state (mk-go は activity で即
     # 'online'、TS は throttle で 'unknown')。安定した parity 比較対象ではない。
     "onlineStatus", "lastActiveDate",
@@ -85,6 +88,77 @@ def test_note_with_reaction_parity(mkgo, ts):
 
     note_ignore = DEFAULT_IGNORE_KEYS | {"userId", "user", "renoteId", "replyId"}
     diffs = diff_json(mk_show, ts_show, ignore_keys=note_ignore)
+    assert not diffs, format_diffs(diffs)
+
+
+NOTE_IGNORE = DEFAULT_IGNORE_KEYS | {"userId", "user", "renoteId", "replyId"}
+
+
+def test_note_with_reply_parity(mkgo, ts):
+    # parent note -> reply -> show the reply, compare the packed reply (incl. the
+    # embedded parent under `reply`).
+    for c in (mkgo, ts):
+        parent = c.json("notes/create", {"text": "parent", "visibility": "public"})["createdNote"]
+        reply = c.json("notes/create", {"text": "child reply", "replyId": parent["id"], "visibility": "public"})["createdNote"]
+        c._probe_note_id = reply["id"]
+    mk_show = mkgo.json("notes/show", {"noteId": mkgo._probe_note_id})
+    ts_show = ts.json("notes/show", {"noteId": ts._probe_note_id})
+    # the embedded `reply` object is itself a note (instance-specific ids/user).
+    diffs = diff_json(mk_show, ts_show, ignore_keys=NOTE_IGNORE, ignore_paths={"$.reply"})
+    assert not diffs, format_diffs(diffs)
+
+
+def test_note_with_renote_parity(mkgo, ts):
+    # pure renote (no text) of a parent; compare the packed renote object.
+    for c in (mkgo, ts):
+        parent = c.json("notes/create", {"text": "renote target", "visibility": "public"})["createdNote"]
+        renote = c.json("notes/create", {"renoteId": parent["id"], "visibility": "public"})["createdNote"]
+        c._probe_note_id = renote["id"]
+    mk_show = mkgo.json("notes/show", {"noteId": mkgo._probe_note_id})
+    ts_show = ts.json("notes/show", {"noteId": ts._probe_note_id})
+    diffs = diff_json(mk_show, ts_show, ignore_keys=NOTE_IGNORE, ignore_paths={"$.renote"})
+    assert not diffs, format_diffs(diffs)
+
+
+def test_note_hashtags_parity(mkgo, ts):
+    # text -> tags extraction (hashtags). mentions carry user ids (instance-
+    # specific) so we ignore `mentions` and compare `tags`.
+    text = "hello #harness #ParityCheck world"
+    mk_note = mkgo.json("notes/create", {"text": text, "visibility": "public"})["createdNote"]
+    ts_note = ts.json("notes/create", {"text": text, "visibility": "public"})["createdNote"]
+    mk_show = mkgo.json("notes/show", {"noteId": mk_note["id"]})
+    ts_show = ts.json("notes/show", {"noteId": ts_note["id"]})
+    diffs = diff_json(mk_show, ts_show, ignore_keys=NOTE_IGNORE | {"mentions"})
+    assert not diffs, format_diffs(diffs)
+
+
+def test_note_state_parity(mkgo, ts):
+    for c in (mkgo, ts):
+        note = c.json("notes/create", {"text": "state probe", "visibility": "public"})["createdNote"]
+        c._probe_note_id = note["id"]
+    mk = mkgo.json("notes/state", {"noteId": mkgo._probe_note_id})
+    tj = ts.json("notes/state", {"noteId": ts._probe_note_id})
+    diffs = diff_json(mk, tj)
+    assert not diffs, format_diffs(diffs)
+
+
+# /api/i (authoritative MeDetailed). 自己固有 / role 依存 / version-gap を吸収する。
+I_IGNORE = META_IGNORE | {
+    "policies",  # role policy 依存 (instance role 設定で変わる)
+    "avatarId", "bannerId", "achievements", "loggedInDays", "signupReason",
+    "twoFactorEnabled", "usePasswordLessLogin", "securityKeys",
+    "notesCount", "twoFactorBackupCodesStock", "lastActiveDate", "onlineStatus",
+    "isAdmin", "isModerator",  # role 依存 (root fallback) は users/show 側で gate 済
+    # #2094: presence 乖離 (moderationNote 未 emit / room・clientData の vestigial
+    # extra)。finding として追跡中なので harness では一旦無視する。
+    "moderationNote", "room", "clientData",
+}
+
+
+def test_i_meDetailed_parity(mkgo, ts):
+    mk = mkgo.json("i", {})
+    tj = ts.json("i", {})
+    diffs = diff_json(mk, tj, ignore_keys=I_IGNORE)
     assert not diffs, format_diffs(diffs)
 
 


### PR DESCRIPTION
## Summary

#2089 差分比較ハーネスの endpoint coverage を第2弾として拡張し、検出した乖離を sub-issue 化する。

## 主な変更点 (tests/diff/test_endpoints.py、計 11 比較・23 passed)

新規 5 比較を追加:
- `test_note_with_reply_parity`: reply 付き note の packing (embedded reply 含む)。
- `test_note_with_renote_parity`: 純 renote の packing (embedded renote 含む)。
- `test_note_hashtags_parity`: text → tags (hashtag) 抽出。
- `test_note_state_parity`: notes/state。
- `test_i_meDetailed_parity`: /api/i (authoritative MeDetailed)。

reply / renote / hashtag / state はいずれも **parity 一致** を確認。

## 検出した乖離 → #2094

`/api/i` 比較で presence-level 乖離 3 件を検出:
```
[missing_in_mkgo] $.moderationNote: mkgo=absent ts=''   # upstream は moderator viewer に emit、mk-go は未 emit
[missing_in_ts]   $.room:           mkgo={}      absent  # upstream 削除済、mk-go は vestigial extra
[missing_in_ts]   $.clientData:     mkgo={}      absent  # 同上
```
upstream 2026.6.0 と照合済 (`UserEntityService.ts:574` の `moderationNote: iAmModerator ? ... : undefined`、room/
clientData は schema から削除)。**#2094** に切り出し、harness では修正まで `I_IGNORE` に退避。

## 安定性

- `notesCount` は eventual-consistency (mk-go 即時 / TS chart 遅延) で瞬間値が割れる timing-state のため
  `USER_IGNORE` に追加 (flaky 防止)。fresh stack で 23 passed を 2 回確認。
- 全工程 隔離 `mkdiff` stack、本番 UDS には触れない。

## 関連
- 親: #2078 / ハーネス: #2089 / 検出 finding: #2094
