### PR TITLE
/api/i: moderationNote を moderator viewer に emit する (#2094)

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -939,6 +939,17 @@ func (h *Handler) Me(c echo.Context) error {
 	}
 	resp["isAdmin"] = isAdmin
 	resp["isModerator"] = isMod
+	// upstream UserEntityService.ts:574: moderationNote は moderator viewer のみに
+	// emit する (空なら '')。/api/i は self-view なので viewer==self、self が moderator
+	// のとき自身の profile.moderationNote を返す。非 moderator では field 自体を出さない
+	// (upstream の undefined 相当、#2094)。
+	if isMod && profile != nil {
+		mn := ""
+		if profile.ModerationNote != nil {
+			mn = *profile.ModerationNote
+		}
+		resp["moderationNote"] = mn
+	}
 	// isDeleted / isExplorable は PackMeDetailed 由来で base 展開済 (#971)。
 	// 未読系フィールドを依存する repo / service から実際に引く
 	// (hasUnreadAntenna / hasUnreadChannel は antennaUnreadRepo /

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -2757,3 +2757,43 @@ func TestVerifyURL(t *testing.T) {
 	h2 := &Handler{serverURL: "https://example.com"}
 	assert.Equal(t, "https://example.com/verify-email/abc", h2.verifyURL("abc"))
 }
+
+// #2094: /api/i は moderator viewer (= self が moderator) のとき moderationNote を
+// emit する (空なら "")。非 moderator では field を出さない (upstream の undefined 相当)。
+func TestMe_ModerationNote_ModeratorGated(t *testing.T) {
+	mn := "keep an eye on this account"
+	callMe := func(t *testing.T, h *Handler, user *model.User) map[string]any {
+		t.Helper()
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodPost, "/api/i", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.Set(string(middleware.UserContextKey), user)
+		require.NoError(t, h.Me(c))
+		require.Equal(t, http.StatusOK, rec.Code)
+		var resp map[string]any
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		return resp
+	}
+
+	t.Run("moderator sees moderationNote", func(t *testing.T) {
+		h, userRepo, _, _ := newTestHandler(t)
+		h.SetRoleProvider(&stubRoleProvider{moderator: true})
+		user := &model.User{ID: "u1", Username: "u1", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+		userRepo.Users["u1"] = user
+		userRepo.Profiles["u1"] = &model.UserProfile{UserID: "u1", ModerationNote: &mn, Fields: datatypes.JSON([]byte("[]"))}
+		resp := callMe(t, h, user)
+		assert.Equal(t, mn, resp["moderationNote"])
+	})
+
+	t.Run("non-moderator omits moderationNote", func(t *testing.T) {
+		h, userRepo, _, _ := newTestHandler(t)
+		h.SetRoleProvider(&stubRoleProvider{moderator: false})
+		user := &model.User{ID: "u2", Username: "u2", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+		userRepo.Users["u2"] = user
+		userRepo.Profiles["u2"] = &model.UserProfile{UserID: "u2", ModerationNote: &mn, Fields: datatypes.JSON([]byte("[]"))}
+		resp := callMe(t, h, user)
+		_, present := resp["moderationNote"]
+		assert.False(t, present, "non-moderator must not receive moderationNote")
+	})
+}

--- a/tests/diff/test_endpoints.py
+++ b/tests/diff/test_endpoints.py
@@ -149,9 +149,12 @@ I_IGNORE = META_IGNORE | {
     "twoFactorEnabled", "usePasswordLessLogin", "securityKeys",
     "notesCount", "twoFactorBackupCodesStock", "lastActiveDate", "onlineStatus",
     "isAdmin", "isModerator",  # role 依存 (root fallback) は users/show 側で gate 済
-    # #2094: presence 乖離 (moderationNote 未 emit / room・clientData の vestigial
-    # extra)。finding として追跡中なので harness では一旦無視する。
-    "moderationNote", "room", "clientData",
+    # room / clientData は mk-go の **意図的な** pass-through extra (upstream は削除済
+    # だが mk-go は client 固有 JSON 保存機能として read/write/test 付きで保持、#2094 で
+    # intentional と判断)。upstream に無い field なので harness では永続無視する。
+    "room", "clientData",
+    # (#2094 修正済: moderationNote は moderator viewer に emit するようになったため
+    # ここで ignore しない = 回帰 gate に戻した。)
 }
 
 


### PR DESCRIPTION
## Summary

差分比較ハーネス (#2089) の `/api/i` 比較で検出した presence 乖離 (#2094) を修正する。

## 主な変更点

### moderationNote を emit (real gap の修正)

upstream `UserEntityService.ts:574` は `moderationNote: iAmModerator ? (profile.moderationNote ?? '') : undefined`
で **moderator viewer のとき** `moderationNote` を emit するが、mk-go の `/api/i` は未 emit だった。

`internal/api/i/handler.go`: self-view の self が moderator のとき `profile.moderationNote` (空なら `""`) を返すよう
修正。非 moderator では field を出さない (upstream の `undefined` 相当)。regression test 2 件追加。

### room / clientData は intentional として保持

`room` / `clientData` は upstream 2026.6.0 では削除済だが、mk-go は **client 固有 JSON の pass-through 保存機能**
として read (`/api/i`) / write (`i/update`) / test (`TestMe_ClientDataAndRoom*`) 付きで意図的に保持している
(model コメント「クライアント固有の任意 JSON を pass-through 保存」)。`feedback_verify_misskey_ts_before_drift_fix`
の罠 (意図的 deviation を消さない) に従い**除去せず intentional extra と判断**。harness では upstream に無い field
として永続無視に re-comment。

## テスト

- `internal/api/i`: 新規 2 test (moderator → emit / 非 moderator → 省略)、`go vet` / coverage 90.6%。
- **end-to-end**: 修正版 mk-go を rebuild した隔離ハーネスで `moderationNote` を un-ignore した状態でも **23 passed**
  = parity 回復を実証 (本番 UDS には触れない)。

## Closes

Closes #2094
