### PR TITLE
users/show: follower に followedMessage=null を emit する (#2097)

### DIFF
--- a/internal/api/userrelation/resolver.go
+++ b/internal/api/userrelation/resolver.go
@@ -104,10 +104,11 @@ func (r Repos) Apply(detailed *entity.UserDetailed, viewerID string, target *mod
 			detailed.Notify = &none
 		}
 		detailed.WithReplies = &withReplies
-		// followedMessage は follower にだけ見せる (upstream relation ブロックの
-		// `relation.isFollowing ? profile.followedMessage : undefined`、#1558)。
+		// followedMessage は follower にだけ見せる。upstream は未設定でも null を
+		// emit する (`relation.isFollowing ? (profile.followedMessage ?? null) :
+		// undefined`、#1558 / #2097)。
 		if isFollowing && profile != nil {
-			detailed.FollowedMessage = profile.FollowedMessage
+			entity.SetFollowedMessageForFollower(detailed, profile.FollowedMessage)
 		}
 	}
 	if r.Blocking != nil {

--- a/internal/api/userrelation/resolver_test.go
+++ b/internal/api/userrelation/resolver_test.go
@@ -1,6 +1,7 @@
 package userrelation
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/shiroha-a/mk/internal/entity"
@@ -76,7 +77,7 @@ func TestApply_FullRelationBlock(t *testing.T) {
 	require.NotNil(t, d.WithReplies)
 	assert.True(t, *d.WithReplies)
 	require.NotNil(t, d.FollowedMessage)
-	assert.Equal(t, "thanks for following", *d.FollowedMessage)
+	assert.JSONEq(t, `"thanks for following"`, string(d.FollowedMessage))
 	require.NotNil(t, d.IsBlocked)
 	assert.True(t, *d.IsBlocked, "target blocks viewer")
 	require.NotNil(t, d.IsBlocking)
@@ -125,8 +126,9 @@ func TestApply_FollowWithoutNotify(t *testing.T) {
 	r.Apply(&d, "viewer", target, profile)
 	require.NotNil(t, d.Notify)
 	assert.Equal(t, "none", *d.Notify)
-	// follower なので followedMessage は出すが、profile に無いので nil のまま。
-	assert.Nil(t, d.FollowedMessage)
+	// follower なので followedMessage を出す。profile に無くても upstream 互換で
+	// null を emit する (#2097)。
+	assert.Equal(t, json.RawMessage("null"), d.FollowedMessage)
 }
 
 // nil repo は対応する flag を skip する (= omit)。

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -1131,7 +1131,7 @@ func (h *Handler) packRelationItems(
 				d.EnsureRelationFlags()
 				// follower にだけ followedMessage を見せる (#1558)。
 				if isFollowing && b.Profile != nil {
-					d.FollowedMessage = b.Profile.FollowedMessage
+					entity.SetFollowedMessageForFollower(&d, b.Profile.FollowedMessage)
 				}
 			}
 			if stats := remoteStatsMap[b.User.ID]; stats != nil {

--- a/internal/core/user/user_service.go
+++ b/internal/core/user/user_service.go
@@ -760,7 +760,8 @@ func (s *Service) publishMeUpdated(bundle *UserWithProfile) {
 	// profile から補填する。これを欠くと i/update で followedMessage を変更しても
 	// frontend の $i.followedMessage が即時反映されない。
 	if bundle.Profile != nil {
-		body.FollowedMessage = bundle.Profile.FollowedMessage
+		// self event は本人なので follower 扱いで emit (未設定でも null、#2097)。
+		entity.SetFollowedMessageForFollower(&body, bundle.Profile.FollowedMessage)
 	}
 	// PackUserDetailed は pinnedNoteIDs を空で返すため、piningRepo が
 	// あれば pin ID だけ埋める (full note pack は不要で frontend 側で

--- a/internal/entity/user.go
+++ b/internal/entity/user.go
@@ -94,19 +94,20 @@ type UserDetailed struct {
 	Location       *string `json:"location"`
 	Birthday       *string `json:"birthday"`
 	Lang           *string `json:"lang"`
-	// FollowedMessage は follower / self だけに見せる private 文字列なので
-	// omitempty で「非 follower には省略」を表現する。packer はこの field を
-	// set せず、self は AsMeDetailed、follower は users/show handler が set する
-	// (upstream UserEntityService の relation/isMe ブロックでのみ emit、#1558)。
-	FollowedMessage     *string        `json:"followedMessage,omitempty"`
-	PublicReactions     bool           `json:"publicReactions"`
-	Fields              datatypes.JSON `json:"fields"`
-	VerifiedLinks       []string       `json:"verifiedLinks"`
-	FollowersCount      int            `json:"followersCount"`
-	FollowingCount      int            `json:"followingCount"`
-	NotesCount          int            `json:"notesCount"`
-	FollowersVisibility string         `json:"followersVisibility"`
-	FollowingVisibility string         `json:"followingVisibility"`
+	// FollowedMessage は follower / self だけに見せる (#1558)。upstream は follower
+	// には未設定でも null を emit する (#2097) ため、単純な *string + omitempty では
+	// 「null を出す」と「省略する」を区別できない。RawMessage にして、follower path は
+	// SetFollowedMessageForFollower で null/値をセットし、非 follower path は未設定
+	// (nil → omitempty で省略) で表現する。
+	FollowedMessage     json.RawMessage `json:"followedMessage,omitempty"`
+	PublicReactions     bool            `json:"publicReactions"`
+	Fields              datatypes.JSON  `json:"fields"`
+	VerifiedLinks       []string        `json:"verifiedLinks"`
+	FollowersCount      int             `json:"followersCount"`
+	FollowingCount      int             `json:"followingCount"`
+	NotesCount          int             `json:"notesCount"`
+	FollowersVisibility string          `json:"followersVisibility"`
+	FollowingVisibility string          `json:"followingVisibility"`
 	// ChatScope は 1-on-1 チャットの受信許可レベル (#692)。FE の
 	// /settings/privacy が `i/update` レスポンスから直接 `$i.chatScope` に
 	// 反映するため、この field を expose しないと UI が保存後に古い値で
@@ -630,6 +631,25 @@ func GateCountVisibility(d *UserDetailed, isMe, isModerator, isFollowing bool) {
 	if !countVisible(d.FollowingVisibility, isMe, isModerator, isFollowing) {
 		d.FollowingCount = 0
 	}
+}
+
+// SetFollowedMessageForFollower marks followedMessage as visible to a
+// follower/self on d, emitting `null` when msg is nil. upstream は follower には
+// 未設定でも null を返す (UserEntityService の `relation.isFollowing ?
+// (profile.followedMessage ?? null) : undefined`) ので、follower path は必ずこの
+// helper を通すこと。非 follower path はこの helper を呼ばず field を未設定のままに
+// して omitempty で省略させる (#2097)。
+func SetFollowedMessageForFollower(d *UserDetailed, msg *string) {
+	if msg == nil {
+		d.FollowedMessage = json.RawMessage("null")
+		return
+	}
+	b, err := json.Marshal(*msg)
+	if err != nil {
+		d.FollowedMessage = json.RawMessage("null")
+		return
+	}
+	d.FollowedMessage = b
 }
 
 // ApplyModeratorSecurityFields sets twoFactorEnabled / usePasswordLessLogin /

--- a/tests/diff/test_endpoints.py
+++ b/tests/diff/test_endpoints.py
@@ -230,9 +230,9 @@ def test_user_relation_parity(mkgo, ts):
         c._probe = bob["id"]
     mk = mkgo.json("users/show", {"userId": mkgo._probe})
     tj = ts.json("users/show", {"userId": ts._probe})
-    # #2097: follower viewer に followedMessage=null を emit せず省略する乖離を
-    # 検出。finding として追跡中なので relation 比較では一旦無視する。
-    diffs = diff_json(mk, tj, ignore_keys=USER_IGNORE | {"followedMessage"})
+    # (#2097 修正済: follower には followedMessage=null を emit するようになったため
+    # 回帰 gate に戻した = ここで ignore しない。)
+    diffs = diff_json(mk, tj, ignore_keys=USER_IGNORE)
     assert not diffs, format_diffs(diffs)
 
 


### PR DESCRIPTION
## Summary

差分比較ハーネス (#2089) の user relation 比較で検出した乖離 (#2097) を修正する。

mk-go の `UserDetailed.followedMessage` は `omitempty` 付き `*string` で、follower が見るときも値が null (相手が
未設定) なら nil pointer として**省略**していた。upstream は follower には未設定でも `null` を emit する
(`relation.isFollowing ? (profile.followedMessage ?? null) : undefined`) ため shape が割れていた。

## 主な変更点

`omitempty` は「null を出す」と「省略する」を区別できないので、`UserDetailed.FollowedMessage` を
**`json.RawMessage`** に変更:
- follower path は `entity.SetFollowedMessageForFollower(d, msg)` で `null` (未設定時) または値をセット。
- 非 follower path は未設定のまま (nil → omitempty で省略)。
- self event (`user_service`) も self は follower 扱いで emit。

`internal/entity/user.go` (型 + helper) / `resolver.go` (単体 users/show) / `handler.go` (follow list) /
`user_service.go` (self event) の 4 setter を helper 経由に統一。

## テスト

- `resolver_test.go`: follower-with-null → `null` emit、非 follower → 省略 を検証 (回帰 gate)。既存 #1558 test
  (follower→値 emit / 非 follower→省略 / self→emit) も green。
- `go vet ./...` / 影響 package (entity / userrelation / users / core/user / i) green。
- **end-to-end**: 修正版 mk-go を rebuild した隔離ハーネスで `followedMessage` を un-ignore した状態でも **29 passed**
  = parity 回復を実証 (本番 UDS には触れない)。

## Closes

Closes #2097
