### PR TITLE
user-facing /api/announcements から admin field (forExistingUsers/isActive) を除去する (#2101)

### DIFF
--- a/internal/api/announcements/handler.go
+++ b/internal/api/announcements/handler.go
@@ -503,14 +503,11 @@ func (h *Handler) AdminList(c echo.Context) error {
 	return c.JSON(http.StatusOK, out)
 }
 
-// packAnnouncement wraps entity.PackAnnouncement for handler use. isRead
-// defaults to false at this layer; the caller overrides after viewer check.
-// Retains `forExistingUsers` / `isActive` which List pre-existing API
-// clients may rely on (entity packer targets the event body which TS
-// doesn't include these two).
+// packAnnouncement wraps entity.PackAnnouncement for the user-facing List/Show.
+// isRead defaults to false at this layer; the caller overrides after the viewer
+// check. admin 管理用 field (forExistingUsers / isActive) は user-facing には
+// 出さない: upstream の user-facing pack (AnnouncementEntityService.pack) はこれらを
+// 返さず、admin は AdminList が別途返す (#2101)。
 func packAnnouncement(a *model.Announcement, idGen id.Generator) map[string]any {
-	out := entity.PackAnnouncement(a, idGen, false)
-	out["forExistingUsers"] = a.ForExistingUsers
-	out["isActive"] = a.IsActive
-	return out
+	return entity.PackAnnouncement(a, idGen, false)
 }

--- a/internal/api/announcements/handler_test.go
+++ b/internal/api/announcements/handler_test.go
@@ -785,3 +785,23 @@ func TestAdminCreate_GlobalBroadcasts(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, []string{"announcementCreated"}, bc.events, "global は broadcast へ (#2056)")
 }
+
+// #2101: user-facing List は admin 管理用 field (forExistingUsers / isActive) を
+// 露出しない (upstream user-facing pack に揃える)。admin は AdminList が返す。
+func TestList_OmitsAdminFields(t *testing.T) {
+	h, repo := newTestHandler(t)
+	idGen, _ := id.NewGenerator("aidx")
+	validID := idGen.Generate(java_time())
+	repo.Items[validID] = &model.Announcement{ID: validID, Title: "Hi", Text: "Hello", IsActive: true, ForExistingUsers: true}
+	rec := doPost(h.List, `{}`, &model.User{ID: "u1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	item := resp[0].(map[string]any)
+	_, hasForExisting := item["forExistingUsers"]
+	_, hasIsActive := item["isActive"]
+	assert.False(t, hasForExisting, "user-facing List は forExistingUsers を出さない")
+	assert.False(t, hasIsActive, "user-facing List は isActive を出さない")
+	assert.Equal(t, "Hi", item["title"], "user-facing field は維持")
+}

--- a/tests/diff/test_endpoints.py
+++ b/tests/diff/test_endpoints.py
@@ -337,10 +337,9 @@ def test_announcement_packing_parity(mkgo, ts):
         c.json("admin/announcements/create", {"title": "harness ann", "text": "body", "imageUrl": None})
     mk = mkgo.json("announcements", {})
     tj = ts.json("announcements", {})
-    # #2101: user-facing /api/announcements が admin field forExistingUsers/isActive を
-    # 露出する乖離を検出。finding として追跡中なので一旦無視する。
-    ann_ignore = DEFAULT_IGNORE_KEYS | {"forExistingUsers", "isActive"}
-    diffs = diff_json(mk, tj, ignore_keys=ann_ignore)
+    # (#2101 修正済: user-facing から admin field forExistingUsers/isActive を除去した
+    # ため回帰 gate に戻した = ここで ignore しない。)
+    diffs = diff_json(mk, tj, ignore_keys=DEFAULT_IGNORE_KEYS)
     assert not diffs, format_diffs(diffs)
 
 


### PR DESCRIPTION
## Summary

差分比較ハーネス (#2089) が検出した、user-facing `/api/announcements` の admin field 露出 (#2101) を修正する。

mk-go の user-facing List/Show 用 local `packAnnouncement` が `entity.PackAnnouncement` に admin 管理用 field の
`forExistingUsers` / `isActive` を足して露出していた。upstream の user-facing pack
(`AnnouncementEntityService.pack`) はこれらを返さない (admin/announcements 管理用)。

## 主な変更点

- `internal/api/announcements/handler.go`: `packAnnouncement` から `forExistingUsers` / `isActive` を除去し
  upstream の user-facing pack に揃える。
- **admin 影響なし**: `admin/announcements/list` (`AdminList`) は独自の inline packing でこれらを引き続き返す。
- regression test: user-facing `List` が admin field を出さず、user-facing field (title 等) は維持することを検証。

## 判断について

handler.go に「pre-existing API clients may rely on」という意図的 retain コメントがあったが、(1) これらは admin
管理用 field、(2) 具体的な依存クライアント不明、(3) drop-in 先は upstream Misskey client でこれらを期待しない、
(4) admin は AdminList が別途提供、という理由で **upstream parity を優先して除去** (ユーザー承認済)。

## テスト

- `internal/api/announcements`: 新規 regression test、coverage 96.4%、`go vet` green。
- **end-to-end**: 修正版 mk-go を rebuild した隔離ハーネスで announcement field を un-ignore した状態でも
  **36 passed** = parity 回復を実証 (本番 UDS には触れない)。

## Closes

Closes #2101
