### PR TITLE
diff harness: flash/favorites/mute を追加 (#2089)

### DIFF
--- a/tests/diff/test_endpoints.py
+++ b/tests/diff/test_endpoints.py
@@ -353,6 +353,37 @@ def test_emoji_packing_parity(mkgo, ts):
     assert not diffs, format_diffs(diffs)
 
 
+def test_flash_parity(mkgo, ts):
+    params = {"title": "harness flash", "summary": "s", "script": "<: 'hi'", "permissions": []}
+    for c in (mkgo, ts):
+        f = c.json("flash/create", params)
+        c._probe = f["id"]
+    mk = mkgo.json("flash/show", {"flashId": mkgo._probe})
+    tj = ts.json("flash/show", {"flashId": ts._probe})
+    diffs = diff_json(mk, tj, ignore_keys=DEFAULT_IGNORE_KEYS | {"userId", "user"})
+    assert not diffs, format_diffs(diffs)
+
+
+def test_favorites_parity(mkgo, ts):
+    for c in (mkgo, ts):
+        note = c.json("notes/create", {"text": "fav me", "visibility": "public"})["createdNote"]
+        c.json("notes/favorites/create", {"noteId": note["id"]})
+    mk = mkgo.json("i/favorites", {})
+    tj = ts.json("i/favorites", {})
+    diffs = diff_json(mk, tj, ignore_keys=DEFAULT_IGNORE_KEYS | {"noteId", "note"})
+    assert not diffs, format_diffs(diffs)
+
+
+def test_mute_list_parity(mkgo, ts):
+    for c in (mkgo, ts):
+        bob = _create_second_user(c, "bobmute")
+        c.json("mute/create", {"userId": bob["id"]})
+    mk = mkgo.json("mute/list", {})
+    tj = ts.json("mute/list", {})
+    diffs = diff_json(mk, tj, ignore_keys=DEFAULT_IGNORE_KEYS | {"muteeId", "mutee"})
+    assert not diffs, format_diffs(diffs)
+
+
 def test_note_with_poll_parity(mkgo, ts):
     poll = {"choices": ["alpha", "beta", "gamma"], "multiple": False}
     mk_note = mkgo.json("notes/create", {"text": "poll probe", "visibility": "public", "poll": poll})["createdNote"]


### PR DESCRIPTION
## Summary

#2089 差分比較ハーネスの coverage を別の entity packer (flash / favorites / mute) へ拡張 (計 26 比較・39 passed)。

## 主な変更点 (tests/diff/test_endpoints.py)

新規 3 比較を追加 (いずれも parity 一致・乖離なし):
- `test_flash_parity`: `flash/create` → `flash/show` の Play (flash) packer。
- `test_favorites_parity`: `notes/favorites/create` → `i/favorites` の favorite packer。
- `test_mute_list_parity`: `mute/create` → `mute/list` の muting packer。

flash / favorite / muting の各 packer はいずれも parity 一致。追加の乖離は検出されなかった。

## テスト

- 隔離 `mkdiff` stack で 39 passed。本番 UDS には触れない。

## 関連
- 親: #2078 / ハーネス: #2089
