### PR TITLE
レガシー /api/signin の 2FA バイパスを修正 (CRITICAL, #2106 H2)

### DIFF
--- a/internal/api/signin/handler.go
+++ b/internal/api/signin/handler.go
@@ -153,7 +153,25 @@ func (h *Handler) Signin(c echo.Context) error {
 		return h.fail(c, user, http.StatusForbidden, "932c904e-9460-45b7-9ce6-7ed33be7eb2c")
 	}
 
-	// 認証成功
+	// #2106 H2 (CRITICAL): 2FA 有効ユーザーには password のみで token を発行しない。
+	// レガシー /api/signin は 2 要素を完遂できない (req に token/credential が無い)
+	// ため challenge を返して /signin-flow へ誘導する。これを欠くと 2FA が完全に
+	// バイパスされ password 漏洩だけでアカウントが乗っ取られる (SigninFlow は正しく
+	// 2FA を扱う、本 endpoint のみが穴だった)。
+	if profile.TwoFactorEnabled {
+		next := "totp"
+		if h.webauthnSvc != nil && h.securityKeyRepo != nil {
+			if ks, kerr := h.securityKeyRepo.ListByUser(user.ID); kerr == nil && len(ks) > 0 {
+				next = "passkey"
+			}
+		}
+		return c.JSON(http.StatusOK, map[string]any{
+			"finished": false,
+			"next":     next,
+		})
+	}
+
+	// 認証成功 (2FA 無し)
 	return h.ok(c, user)
 }
 

--- a/internal/api/signin/handler_test.go
+++ b/internal/api/signin/handler_test.go
@@ -578,3 +578,20 @@ func TestSigninFlow_Step1_CaptchaNext_WhenNoCaptchaConfigured(t *testing.T) {
 	assert.Equal(t, false, resp["finished"])
 	assert.Equal(t, "captcha", resp["next"])
 }
+
+// #2106 H2 (CRITICAL): レガシー /api/signin は 2FA 有効ユーザーに password だけで
+// token を発行してはならない。challenge を返し /signin-flow へ誘導する。
+func TestSignin_LegacyTwoFactorNotBypassed(t *testing.T) {
+	h, repo := newTestHandler(t)
+	createTestUser(repo, "admin", "pass123")
+	repo.Profiles["u1"].TwoFactorEnabled = true
+
+	rec := doPost(h.Signin, `{"username":"admin","password":"pass123"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["finished"])
+	assert.Equal(t, "totp", resp["next"])
+	_, hasToken := resp["i"]
+	assert.False(t, hasToken, "2FA user must NOT receive a session token via legacy /signin")
+}


### PR DESCRIPTION
## Summary

全コードベース再監査 (#2106) の HIGH/CRITICAL finding H2 (個別敵対的再検証で REAL 確定)。

mk-go 独自のレガシー `/api/signin` (upstream 2026.6.0 には無く `/signin-flow` のみ) が password 検証後に
`TwoFactorEnabled` を見ず無条件で native session token を発行していた。**2FA を設定したアカウントが password 漏洩
のみで乗っ取られる**重大な認証バイパス。`SigninFlow()` (/signin-flow) は正しく 2FA を扱っており、本 endpoint のみが穴。

## 修正

`Signin()` Step 2 で password 検証後に 2FA gate を追加。`profile.TwoFactorEnabled` なら token を発行せず
`{finished:false, next:"totp"|"passkey"}` を返し `/signin-flow` へ誘導する (legacy endpoint は req に token/credential
が無く 2 要素を完遂できない)。非 2FA 経路は不変。

## テスト

- `TestSignin_LegacyTwoFactorNotBypassed`: 2FA user が password のみで token を得られず challenge を返すことを検証。
- 既存 signin テスト green、coverage 93.9%、`go vet`。

Closes #2107