### PR TITLE
stream の sr message が note 購読の度に全通知既読化するバグを修正 (#2106 H6)

### DIFF
--- a/internal/stream/dispatcher.go
+++ b/internal/stream/dispatcher.go
@@ -115,11 +115,13 @@ func (d *Dispatcher) HandleClientMessage(msgType string, body json.RawMessage) {
 		d.handleChannelMessage(body)
 	case "readNotification":
 		d.handleReadNotification()
-	case "subNote", "s":
+	case "subNote", "s", "sr":
+		// upstream Connection.ts:152 では 'sr' は 'onSubscribeNote' (= subNote/s)
+		// の単純な alias。全通知既読 (readAllNotification) は別 type 'readNotification'
+		// のみが行う。'sr' で handleReadNotification を呼ぶと、frontend が note を
+		// capture する度 (use-note-capture が 'sr' を送る) に未読通知が全消去される
+		// バグになる (#2106 H6)。
 		d.handleSubNote(body)
-	case "sr":
-		d.handleSubNote(body)
-		d.handleReadNotification()
 	case "unsubNote", "un":
 		d.handleUnsubNote(body)
 	}

--- a/internal/stream/dispatcher_test.go
+++ b/internal/stream/dispatcher_test.go
@@ -1200,3 +1200,23 @@ func TestChannelContext_UserPolicies_NilConn(t *testing.T) {
 		t.Fatalf("expected nil, got %v", got)
 	}
 }
+
+// #2106 H6: stream の 'sr' message は note 購読のみ行い、全通知既読 (readAllNotification)
+// を起こしてはならない。frontend は note capture の度に 'sr' を送るため。
+type fakeNotifReader struct{ called int }
+
+func (f *fakeNotifReader) ReadAll(string) error { f.called++; return nil }
+
+func TestDispatcher_SrDoesNotReadAllNotifications(t *testing.T) {
+	conn := NewConnection("c1", &model.User{ID: "alice"}, newFakeConn())
+	d := NewDispatcher(conn, NewRegistry(), newStubBus())
+	nr := &fakeNotifReader{}
+	d.SetNotificationReader(nr)
+
+	d.HandleClientMessage("sr", json.RawMessage(`{"id":"note1"}`))
+	assert.Equal(t, 0, nr.called, "'sr' (subNote alias) must NOT trigger readAllNotifications")
+
+	// 正規の readNotification は引き続き全通知既読を行う。
+	d.HandleClientMessage("readNotification", json.RawMessage(`{}`))
+	assert.Equal(t, 1, nr.called, "'readNotification' must mark all notifications read")
+}


### PR DESCRIPTION
## Summary

全コードベース再監査 (#2106) の HIGH finding H6 (個別敵対的再検証で REAL 確定)。

WebSocket dispatcher が client message type `sr` を受けると `handleSubNote` に加えて `handleReadNotification`
(全通知既読 `MarkAllAsRead`) を呼んでいた。frontend は note を capture する度に `connection.send('sr', {id})` を
送る (`use-note-capture.ts`) ため、**タイムラインで note を見るだけで未読通知が毎回全消去**されていた。

upstream `Connection.ts:152` の `sr` は `onSubscribeNote` (= `subNote`/`s`) の単純 alias で notification には
一切触れない (全通知既読は別 type `readNotification`)。

## 修正

`case "sr"` を `case "subNote", "s", "sr": handleSubNote(body)` に統合し `handleReadNotification()` 呼び出しを除去。
`readNotification` type の正規経路は不変。

## テスト

- `TestDispatcher_SrDoesNotReadAllNotifications`: `sr` が ReadAll を呼ばず、`readNotification` は呼ぶことを検証。
- `go vet` / stream coverage 90.9%。

Closes #2109