### PR TITLE
notes/show が非可視 viewer に followers/specified 本文を leak する問題を修正 (#2106 H1)

### DIFF
--- a/internal/api/notes/fix_h1_test.go
+++ b/internal/api/notes/fix_h1_test.go
@@ -1,0 +1,41 @@
+package notes
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #2106 H1: notes/show は ID-known doctrine (#799) で followers/specified note を
+// 200 で返すが、非可視 viewer には本文を blank しなければならない (content leak 防止)。
+func TestShow_FollowersNoteBlankedForNonViewer(t *testing.T) {
+	h, noteRepo := newShowHandler(t)
+	noteRepo.Notes["n1"] = &model.Note{
+		ID: "n1", UserID: "author", Visibility: "followers",
+		Text: strPtr("secret followers body"),
+		User: &model.User{ID: "author", Username: "author"},
+	}
+
+	// anonymous (非フォロワー): 200 だが本文は blank。
+	c, rec := newJSONRequest(t, "/api/notes/show", `{"noteId":"n1"}`)
+	require.NoError(t, h.Show(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["isHidden"])
+	assert.Nil(t, resp["text"], "followers note body must not leak to a non-viewer")
+
+	// author 本人: full content。
+	c2, rec2 := newJSONRequest(t, "/api/notes/show", `{"noteId":"n1"}`)
+	setAuthUser(c2, &model.User{ID: "author"})
+	require.NoError(t, h.Show(c2))
+	require.Equal(t, http.StatusOK, rec2.Code)
+	var resp2 map[string]any
+	require.NoError(t, json.Unmarshal(rec2.Body.Bytes(), &resp2))
+	assert.Equal(t, "secret followers body", resp2["text"])
+	assert.NotEqual(t, true, resp2["isHidden"])
+}

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -576,6 +576,14 @@ func (h *Handler) Show(c echo.Context) error {
 	s := []entity.NoteEntity{packed}
 	h.fieldResolver().Apply(s, viewer)
 	notehide.HideEmbeds(viewer, s)
+	// #2106 H1: ID-known doctrine (#799) で note は 200 で返すが、follower/specified を
+	// 見られない viewer (非フォロワー/匿名/非対象) には upstream NoteEntityService.hideNote
+	// 同様に本文 (text/cw/files/poll/visibleUserIds) を blank する。これを欠くと ID を
+	// 知るだけで非公開ノートの本文が full leak する。upstream は shouldHideNote=true の
+	// とき 200 + blanked content を返す挙動と一致 (status は #799 で 200 を維持)。
+	if h.queryService != nil && !h.queryService.CanSee(viewer, n) {
+		entity.HideNoteEntity(&s[0])
+	}
 	return c.JSON(http.StatusOK, s[0])
 }
 


### PR DESCRIPTION
## Summary

全コードベース再監査 (#2106) の HIGH finding H1 (個別敵対的再検証で REAL 確定、content confidentiality breach)。

`notes/show` は #799 の「ID を知る viewer には 200 で返す」doctrine で followers-only / specified note を 200 で
返すが、**本文を一切 blank しない**ため、非フォロワー/匿名/非対象の viewer が note ID を知るだけで
`text` / `cw` / `files` / `poll` / `visibleUserIds` を full leak していた。upstream は同条件で 200 を返すが
`NoteEntityService.hideNote` で本文を blank する。

## 修正

`Show` で pack 後に `if !queryService.CanSee(viewer, n) { entity.HideNoteEntity(&s[0]) }` を適用。
`HideNoteEntity` は upstream `hideNote` と同じ 7 field を blank し `isHidden=true` を立てる。HTTP status は #799 通り
200 を維持 (= upstream の shouldHideNote=true 時の挙動と一致)。author / follower / specified 対象は full content。

## テスト

- `TestShow_FollowersNoteBlankedForNonViewer`: 匿名 viewer → 200 + `isHidden=true` + `text=null`、author → full content。
- 既存 notes テスト green、`go vet`。

Closes #2111