### PR TITLE
/files の MIME 生配信による stored XSS を修正 (#2106 H3)

### DIFF
--- a/internal/core/drive/browsersafe.go
+++ b/internal/core/drive/browsersafe.go
@@ -1,0 +1,57 @@
+package drive
+
+import "strings"
+
+// fileTypeBrowserSafe mirrors upstream const.ts FILE_TYPE_BROWSERSAFE: the MIME
+// types Misskey considers safe to serve inline to a browser (image / audio /
+// video only — never text/html, image/svg+xml, text/xml, application/xml, etc.).
+// Anything else must be served as application/octet-stream so a browser will not
+// render attacker-controlled markup/script from the file origin (stored XSS).
+var fileTypeBrowserSafe = map[string]struct{}{
+	"image/png":       {},
+	"image/gif":       {},
+	"image/jpeg":      {},
+	"image/webp":      {},
+	"image/avif":      {},
+	"image/apng":      {},
+	"image/bmp":       {},
+	"image/tiff":      {},
+	"image/x-icon":    {},
+	"audio/opus":      {},
+	"video/ogg":       {},
+	"audio/ogg":       {},
+	"application/ogg": {},
+	"video/quicktime": {},
+	"video/mp4":       {},
+	"audio/mp4":       {},
+	"video/x-m4v":     {},
+	"audio/x-m4a":     {},
+	"video/3gpp":      {},
+	"video/3gpp2":     {},
+	"video/mpeg":      {},
+	"audio/mpeg":      {},
+	"video/webm":      {},
+	"audio/webm":      {},
+	"audio/aac":       {},
+	"audio/flac":      {},
+	"audio/wav":       {},
+	"audio/x-flac":    {},
+	"audio/vnd.wave":  {},
+}
+
+// BrowserSafeContentType returns contentType unchanged when its MIME (charset
+// parameter stripped) is in the browser-safe allowlist, otherwise
+// "application/octet-stream". Mirrors upstream FileServerUtils.getSafeContentType
+// so non-browsersafe uploads (HTML / SVG / XML / plain text, etc.) cannot be
+// rendered as active content from the file origin (#2106 H3/H4).
+func BrowserSafeContentType(contentType string) string {
+	mime := contentType
+	if i := strings.IndexByte(mime, ';'); i >= 0 {
+		mime = mime[:i]
+	}
+	mime = strings.ToLower(strings.TrimSpace(mime))
+	if _, ok := fileTypeBrowserSafe[mime]; ok {
+		return contentType
+	}
+	return "application/octet-stream"
+}

--- a/internal/core/drive/browsersafe_test.go
+++ b/internal/core/drive/browsersafe_test.go
@@ -1,0 +1,24 @@
+package drive
+
+import "testing"
+
+func TestBrowserSafeContentType(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"image/png", "image/png"},
+		{"image/jpeg", "image/jpeg"},
+		{"video/mp4", "video/mp4"},
+		{"audio/mpeg", "audio/mpeg"},
+		// non-browsersafe → octet-stream (XSS 防御)
+		{"text/html; charset=utf-8", "application/octet-stream"},
+		{"image/svg+xml", "application/octet-stream"},
+		{"text/xml; charset=utf-8", "application/octet-stream"},
+		{"application/xml", "application/octet-stream"},
+		{"text/plain; charset=utf-8", "application/octet-stream"},
+		{"application/javascript", "application/octet-stream"},
+	}
+	for _, tc := range cases {
+		if got := BrowserSafeContentType(tc.in); got != tc.want {
+			t.Errorf("BrowserSafeContentType(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/server/files.go
+++ b/internal/server/files.go
@@ -82,6 +82,11 @@ func filesHandler(lookup filesDriveLookup, primary, local coredrive.Storage) ech
 		buf := make([]byte, 512)
 		n, _ := seeker.Read(buf)
 		contentType := http.DetectContentType(buf[:n])
+		// #2106 H3: sniff した MIME を browser-safe allowlist に通し、非該当
+		// (text/html, image/svg+xml, text/xml 等) は application/octet-stream に
+		// 矯正する。これを欠くと任意アップロードが file origin から active content
+		// として実行され stored XSS になる (upstream FileServerUtils.getSafeContentType)。
+		contentType = coredrive.BrowserSafeContentType(contentType)
 		if _, err := seeker.Seek(0, io.SeekStart); err != nil {
 			return c.NoContent(http.StatusInternalServerError)
 		}
@@ -92,6 +97,12 @@ func filesHandler(lookup filesDriveLookup, primary, local coredrive.Storage) ech
 		// する + サイズが切れる」現象を起こす。`immutable` で長期 cache 化、
 		// `no-transform` で binary 1:1 配信を契約する。
 		c.Response().Header().Set("Cache-Control", "max-age=31536000, immutable, no-transform")
+		// #2106 H3: upstream FileServerService と同じ防御 header。CSP で file origin
+		// からの script/object 実行を封じ、nosniff で MIME sniffing を止め、
+		// Content-Disposition: inline で download 名を制御する (octet-stream と多層防御)。
+		c.Response().Header().Set("Content-Security-Policy", "default-src 'none'; img-src 'self'; media-src 'self'; style-src 'unsafe-inline'")
+		c.Response().Header().Set("X-Content-Type-Options", "nosniff")
+		c.Response().Header().Set("Content-Disposition", "inline")
 		c.Response().Header().Set(echo.HeaderContentType, contentType)
 		http.ServeContent(c.Response(), c.Request(), key, modtime, seeker)
 		return nil

--- a/internal/server/files_test.go
+++ b/internal/server/files_test.go
@@ -204,3 +204,20 @@ func TestFilesHandler_SetsDetectedContentType(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "image/png", rec.Header().Get(echo.HeaderContentType))
 }
+
+// #2106 H3: 非 browser-safe MIME (HTML/SVG 等) は application/octet-stream に矯正し、
+// CSP / nosniff 防御 header を付けて stored XSS を防ぐ。
+func TestFilesHandler_NonBrowserSafeIsOctetStreamWithCSP(t *testing.T) {
+	key := "html-key"
+	htmlBody := "<html><body><script>alert(1)</script></body></html>"
+	primary := &memStorage{byKey: map[string]string{key: htmlBody}}
+	c, rec := newFilesTestContext(t, key)
+	h := filesHandler(nil, primary, nil)
+	require.NoError(t, h(c))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/octet-stream", rec.Header().Get(echo.HeaderContentType),
+		"HTML must be served as octet-stream, not text/html (XSS)")
+	assert.Contains(t, rec.Header().Get("Content-Security-Policy"), "default-src 'none'")
+	assert.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
+}


### PR DESCRIPTION
## Summary

全コードベース再監査 (#2106) の HIGH finding H3 (個別敵対的再検証で REAL 確定、stored XSS)。

`/files/:accessKey` が `http.DetectContentType` の sniff 結果をそのまま Content-Type に設定し、CSP /
X-Content-Type-Options / Content-Disposition を一切付けないため、HTML/SVG/XML をアップロードして配信させると
**file origin から active content として実行され stored XSS** になっていた。upload gate は既定 `text/*` 許可で
HTML を通すため防御にならず、配信時に再 sniff するため stored type 矯正も無効。

## 修正

- `core/drive` に upstream `FILE_TYPE_BROWSERSAFE` allowlist + `BrowserSafeContentType` helper を追加 (H4 でも再利用)。
- `files.go` で sniff 結果を `application/octet-stream` 矯正 + CSP `default-src 'none'` + `X-Content-Type-Options:
  nosniff` + `Content-Disposition: inline` を付与 (upstream FileServerService 相当の多層防御)。image/audio/video は不変。

## テスト

- `TestBrowserSafeContentType` (allowlist 判定)、`TestFilesHandler_NonBrowserSafeIsOctetStreamWithCSP`
  (HTML→octet-stream + CSP + nosniff)。既存 PNG test (image→image/png) も green。`go vet`。

Closes #2113