### PR TITLE
S3Storage.Put の MIME 生保存による CDN 直配信 XSS を修正 (#2106 H4)

### DIFF
--- a/internal/core/drive/s3_storage.go
+++ b/internal/core/drive/s3_storage.go
@@ -101,14 +101,21 @@ func (s *S3Storage) Put(accessKey string, body io.Reader) (string, error) {
 	if len(sniff) > 512 {
 		sniff = sniff[:512]
 	}
-	contentType := http.DetectContentType(sniff)
+	// #2106 H4: sniff した MIME を browser-safe allowlist に通す。public-read S3/CDN
+	// 直配信では /files ハンドラ・media proxy を両方バイパスして object の Content-Type が
+	// 描画を支配するため、非 browser-safe (HTML/SVG/XML 等) を octet-stream に矯正
+	// しないと CDN ドメイン上で stored XSS になる (upstream DriveService と同等)。
+	contentType := BrowserSafeContentType(http.DetectContentType(sniff))
 
 	input := &s3.PutObjectInput{
-		Bucket:       aws.String(s.bucket),
-		Key:          aws.String(key),
-		Body:         bytes.NewReader(data),
-		ContentType:  aws.String(contentType),
-		CacheControl: aws.String("max-age=31536000, immutable"),
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+		Body:   bytes.NewReader(data),
+		// octet-stream 矯正と併せ Content-Disposition: inline を付け、active content の
+		// インライン実行をさらに抑止する (upstream FileServerUtils.setFileResponseHeaders 相当)。
+		ContentType:        aws.String(contentType),
+		ContentDisposition: aws.String("inline"),
+		CacheControl:       aws.String("max-age=31536000, immutable"),
 	}
 	if s.setPublicRead {
 		input.ACL = types.ObjectCannedACLPublicRead

--- a/internal/core/drive/s3_storage_test.go
+++ b/internal/core/drive/s3_storage_test.go
@@ -266,3 +266,25 @@ func TestS3Storage_PublicURL_PrefixWithoutTrailingSlash(t *testing.T) {
 	assert.Equal(t, "files/abc123", *mock.putInput.Key,
 		"S3 PutObject Key must be 'files/abc123' even when operator omits the trailing slash")
 }
+
+// #2106 H4: 非 browser-safe MIME (HTML/SVG 等) は S3 object でも octet-stream に
+// 矯正し Content-Disposition: inline を付ける (public-read CDN 直配信での stored XSS 防止)。
+func TestS3Storage_Put_NonBrowserSafeOctetStream(t *testing.T) {
+	mock := &mockS3API{}
+	st := NewS3Storage(S3StorageConfig{Client: mock, Bucket: "b", BaseURL: "https://cdn.example.com"})
+	_, err := st.Put("htmlkey", bytes.NewReader([]byte("<html><body><script>alert(1)</script></body></html>")))
+	require.NoError(t, err)
+	require.NotNil(t, mock.putInput)
+	assert.Equal(t, "application/octet-stream", *mock.putInput.ContentType, "HTML must be stored as octet-stream")
+	require.NotNil(t, mock.putInput.ContentDisposition)
+	assert.Equal(t, "inline", *mock.putInput.ContentDisposition)
+}
+
+func TestS3Storage_Put_ImageKeepsContentType(t *testing.T) {
+	mock := &mockS3API{}
+	st := NewS3Storage(S3StorageConfig{Client: mock, Bucket: "b", BaseURL: "https://cdn.example.com"})
+	png := append([]byte("\x89PNG\r\n\x1a\n"), make([]byte, 16)...)
+	_, err := st.Put("pngkey", bytes.NewReader(png))
+	require.NoError(t, err)
+	assert.Equal(t, "image/png", *mock.putInput.ContentType, "browser-safe image keeps its MIME")
+}


### PR DESCRIPTION
## Summary

全コードベース再監査 (#2106) の HIGH finding H4 (個別敵対的再検証で REAL 確定)。

`S3Storage.Put` が sniff した生 MIME を `ContentType` にそのまま設定し `Content-Disposition` も付けないため、
`useObjectStorage=true` + `objectStorageSetPublicRead=true` 構成で HTML/SVG が **CDN ドメイン上から active content
として配信され stored XSS** になる (packer は local-origin file を proxy せず raw S3/CDN URL を emit するため
/files ハンドラ・media proxy を両方バイパス)。

## 修正

H3 (#2114) で `core/drive` に追加した `BrowserSafeContentType` を `S3Storage.Put` でも適用し、非 browser-safe を
`application/octet-stream` 矯正 + `ContentDisposition: inline` を付与 (upstream DriveService 相当)。image/audio/video
は不変。

## テスト

- `TestS3Storage_Put_NonBrowserSafeOctetStream` (HTML→octet-stream + inline)、`TestS3Storage_Put_ImageKeepsContentType`。
  既存 Put テスト green、`go vet`。

Closes #2115