### PR TITLE
specified(DM) の to を remote 受信者の実 URI に解決する (#2106 H5)

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -1565,7 +1565,18 @@ func (r *Renderer) addressing(n *model.Note) (to []string, cc []string) {
 	case model.NoteVisibilitySpecified:
 		to = make([]string, 0, len(n.VisibleUserIDs))
 		for _, uid := range n.VisibleUserIDs {
-			to = append(to, r.urls.UserURI(uid))
+			// #2106 H5: visibleUser の AP URI を解決する。remote 受信者には remote
+			// actor の実 URI (例 https://remote/users/xxx) を入れないと、受信側 Misskey が
+			// resolvePerson に失敗して visibleUsers が空になり DM が silent-drop する
+			// (自ドメイン /users/<remoteId> は送信元で 404、内部 ID 漏洩にもなる)。
+			// mentionResolver は local→UserURI / remote→user.URI を返す (mention と同経路)。
+			uri := r.urls.UserURI(uid)
+			if r.mentionResolver != nil {
+				if _, resolved, err := r.mentionResolver.ResolveMention(uid); err == nil && resolved != "" {
+					uri = resolved
+				}
+			}
+			to = append(to, uri)
 		}
 	}
 	return to, cc

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -1400,3 +1400,24 @@ func TestRenderer_RenderAddRemoveFeatured(t *testing.T) {
 	assert.Equal(t, "https://example.com/users/u1/collections/featured", rm["target"])
 	assert.Equal(t, "https://example.com/notes/n1", rm["object"])
 }
+
+// #2106 H5: specified(DM) の to は remote 受信者に remote actor の実 URI を入れる
+// (自ドメイン /users/<id> ではない)。これを欠くと連合先で DM が silent-drop する。
+func TestRenderer_RenderNote_SpecifiedRemoteRecipient(t *testing.T) {
+	r := newRenderer()
+	r.SetMentionResolver(&stubMentionResolver{entries: map[string]struct{ name, uri string }{
+		"u2":      {name: "@local", uri: "https://example.com/users/u2"},
+		"uRemote": {name: "@bob@remote.example", uri: "https://remote.example/users/bob"},
+	}})
+	idGen := newIDGen(t)
+	n := &model.Note{
+		ID:             idGen.Generate(time.Now()),
+		UserID:         "author",
+		Visibility:     model.NoteVisibilitySpecified,
+		VisibleUserIDs: pq.StringArray{"u2", "uRemote"},
+	}
+	out := r.RenderNote(n, idGen)
+	assert.Contains(t, out.To, "https://remote.example/users/bob", "remote recipient must get its real remote URI")
+	assert.NotContains(t, out.To, "https://example.com/users/uRemote", "remote recipient must NOT get an own-domain URI")
+	assert.Contains(t, out.To, "https://example.com/users/u2", "local recipient keeps local URI")
+}


### PR DESCRIPTION
## Summary

全コードベース再監査 (#2106) の HIGH finding H5 (個別敵対的再検証で REAL 確定、連合 DM 機能破壊 + 内部 ID 漏洩)。

AP note renderer の `addressing()` が specified(DM) visibility で `VisibleUserIDs` を無条件に自ドメイン
`UserURI(uid)` で `to` に入れていたため、**remote 受信者の id も `https://<self>/users/<remoteId>` になり**、受信側
Misskey が `resolvePerson` に失敗 (送信元では remote user の `/users/<id>` は 404) → `visibleUsers` が空 →
**DM が届くが見えない silent-drop**。送信元の内部 remote-user-id 漏洩にもなっていた。

## 修正

`addressing()` specified 分岐で `UserURI` 直書きをやめ、`mentionResolver.ResolveMention(uid)`
(local→`UserURI` / remote→`user.URI`、mention 解決と同経路) で解決した URI を `to` に入れる。解決失敗時のみ従来の
`UserURI` に fallback。upstream の `to = mentionedRemoteUsers.map(uri)` と挙動を揃える。

## テスト

- `TestRenderer_RenderNote_SpecifiedRemoteRecipient`: remote 受信者 → remote 実 URI、自ドメイン URI を入れない、
  local 受信者 → local URI。既存 specified test (resolver 無し → UserURI fallback) も green。`go vet`。

Closes #2117