### PR TITLE
admin/update-meta から identity column (rootUserId 等) を carve-out (#2106 S1)

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -1222,6 +1222,14 @@ func (h *Handler) UpdateMeta(c echo.Context) error {
 	}
 	// "i" フィールドを除外 (auth token)
 	delete(fields, "i")
+	// #2106 S1: identity / 専用 endpoint 管轄の column を generic map 経路から除外する。
+	// update-meta は admin が任意 meta column を書ける generic passthrough 設計 (model
+	// コメント参照) だが、rootUserId を書けると root 権限を別 user に付け替えられ
+	// (admin→root 昇格)、id は singleton PK を壊す。proxyAccountId は
+	// admin/update-proxy-account が管轄。upstream の paramDef もこれらを accept しない。
+	for _, protected := range []string{"id", "rootUserId", "proxyAccountId"} {
+		delete(fields, protected)
+	}
 	// upstream update-meta.ts の enum 制約を持つ field を pre-validate (#1108
 	// sweep)。silent fallback で不正値が DB に書かれる drift を防ぐ:
 	// sensitiveMediaDetection が "purple" のような不正値で保存されると

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -3495,3 +3495,18 @@ func TestShowUsers_DoesNotLeakAdminOnlyFields(t *testing.T) {
 	// UserDetailed の基本 field は出る。
 	assert.Equal(t, "leaky", resp[0]["username"])
 }
+
+// #2106 S1: update-meta は identity / 専用 endpoint 管轄の column (rootUserId / id /
+// proxyAccountId) を書き込めない (admin→root 昇格防止)。他 meta field は従来通り更新可。
+func TestUpdateMeta_IdentityColumnsCarvedOut(t *testing.T) {
+	h, _, metaRepo, _ := newTestHandler(t)
+	orig := "root-original"
+	metaRepo.Meta.RootUserID = &orig
+	rec := doPost(h.UpdateMeta, `{"rootUserId":"attacker","id":"evil","tosUrl":"https://example.test/tos"}`, nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.NotNil(t, metaRepo.Meta.RootUserID)
+	assert.Equal(t, "root-original", *metaRepo.Meta.RootUserID, "rootUserId must NOT be writable via update-meta")
+	// 他 field (tosUrl→termsOfServiceUrl) は従来通り更新される。
+	require.NotNil(t, metaRepo.Meta.TermsOfServiceURL)
+	assert.Equal(t, "https://example.test/tos", *metaRepo.Meta.TermsOfServiceURL)
+}


### PR DESCRIPTION
## Summary

全コードベース再監査 (#2106) の security MEDIUM finding S1 (個別敵対的再検証で REAL 確定、admin→root 昇格 primitive)。

`admin/update-meta` は request body を `map[string]any` で受け allowlist filter せず `metaRepo.Update` に渡すため、
GORM の map Updates で `{"rootUserId":"<uid>"}` を送ると `meta.rootUserId` が書き換わり、role service の root 判定
(`meta.rootUserId == userID` → IsAdministrator) により **admin が root 権限を任意 user に付け替えられた**。`{"id":...}`
で singleton PK 破壊も可能。`write:admin:meta` scope の OAuth token も到達する。

## 修正

update-meta は admin が任意 meta column を編集できる generic passthrough 設計 (model コメントが意図を明記) なので
passthrough 自体は維持し、**identity / 専用 endpoint 管轄の column (id / rootUserId / proxyAccountId) を map から
carve-out** する。upstream の update-meta.ts も paramDef でこれらを accept しない。

## テスト

- `TestUpdateMeta_IdentityColumnsCarvedOut`: rootUserId/id を送っても meta.rootUserId 不変、他 field (tosUrl) は更新可。
- 既存 update-meta テスト green、`go vet`。

Closes #2119