### PR TITLE
admin/accounts/create が app/OAuth token を拒否するよう修正 (#2106 S2)

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -582,6 +582,13 @@ func (h *Handler) AccountsCreate(c echo.Context) error {
 		if meta.RootUserID == nil || *meta.RootUserID != user.ID {
 			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 		}
+		// #2106 S2: upstream create.ts の inline `token !== null` gate を再現する。
+		// この endpoint は route middleware を持たず paramDef に kind も無いため、
+		// app/OAuth access token (read:account 等の狭い scope) でも root に到達して
+		// アカウント作成できる scope 越境になる。native login token のみ許可する。
+		if sc := middleware.GetAuthScope(c); sc != nil && sc.IsApp {
+			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
+		}
 	}
 
 	result, err := h.signupService.Signup(req.Username, req.Password, isInitialSetup)

--- a/internal/api/admin/handler_test.go
+++ b/internal/api/admin/handler_test.go
@@ -3510,3 +3510,23 @@ func TestUpdateMeta_IdentityColumnsCarvedOut(t *testing.T) {
 	require.NotNil(t, metaRepo.Meta.TermsOfServiceURL)
 	assert.Equal(t, "https://example.test/tos", *metaRepo.Meta.TermsOfServiceURL)
 }
+
+// #2106 S2: admin/accounts/create は app/OAuth access token (IsApp) を root でも拒否する
+// (upstream の inline `token !== null` gate)。native login token のみ許可。
+func TestAccountsCreate_AppTokenDenied(t *testing.T) {
+	h, _, metaRepo, _ := newTestHandler(t)
+	rootID := "root1"
+	metaRepo.Meta.RootUserID = &rootID
+	rootUser := &model.User{ID: "root1", Username: "root"}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"username":"user2","password":"pass"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set(string(middleware.UserContextKey), rootUser)
+	c.Set(string(middleware.AuthScopeContextKey), &middleware.AuthScope{IsApp: true})
+
+	_ = h.AccountsCreate(c)
+	assert.Equal(t, http.StatusForbidden, rec.Code, "app/OAuth token must be denied even for root")
+}


### PR DESCRIPTION
## Summary

全コードベース再監査 (#2106) の security MEDIUM finding S2 (個別敵対的再検証で REAL 確定、OAuth scope 越境)。

`admin/accounts/create` の非初回セットアップ分岐が request の token 種別 (native vs app/OAuth) を区別せず admin 判定し、
route middleware も無いため、`read:account` 等の狭い scope の OAuth app token でも root 到達してアカウント作成できた。
upstream create.ts は inline `token !== null` で app token を accessDenied する。

## 修正

非初回分岐に `GetAuthScope(c).IsApp` による app token 拒否を追加 (native login token のみ許可)。初回セットアップ分岐は
`user==nil` 条件で token 解決済 request を既に除外しているため変更不要。

## テスト

- `TestAccountsCreate_AppTokenDenied`: IsApp=true の root でも ACCESS_DENIED。`TestAccountsCreate_AsRootUser`
  (native, scope 無し) は従来通り成功。`go vet`。

Closes #2121