### PR TITLE
users/show に ugcVisibilityForVisitor gate を実装 (#2106 S3)

### DIFF
--- a/internal/api/users/fix_s3_test.go
+++ b/internal/api/users/fix_s3_test.go
@@ -1,0 +1,55 @@
+package users
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/server/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+)
+
+func showStatus(t *testing.T, h *Handler, body string, viewer *model.User) int {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/users/show", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if viewer != nil {
+		c.Set(string(middleware.UserContextKey), viewer)
+	}
+	require.NoError(t, h.Show(c))
+	return rec.Code
+}
+
+// #2106 S3: ugcVisibilityForVisitor='local' のとき匿名 visitor に remote user を出さない。
+func TestShow_UgcVisibilityLocalHidesRemoteFromAnonymous(t *testing.T) {
+	h, repo := newTestHandler(t)
+	h.SetUGCVisibility("local")
+	host := "remote.example"
+	repo.Users["remote1"] = &model.User{ID: "remote1", Username: "bob", UsernameLower: "bob", Host: &host, AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Profiles["remote1"] = &model.UserProfile{UserID: "remote1", Fields: datatypes.JSON([]byte("[]"))}
+
+	assert.Equal(t, http.StatusNotFound, showStatus(t, h, `{"userId":"remote1"}`, nil),
+		"anonymous must not see remote user under ugcVisibility=local")
+	assert.Equal(t, http.StatusOK, showStatus(t, h, `{"userId":"remote1"}`, &model.User{ID: "viewer1"}),
+		"authenticated viewer can see remote user")
+}
+
+// ugcVisibility='all' では匿名でも remote user が見える (gate しない)。
+func TestShow_UgcVisibilityAllShowsRemoteToAnonymous(t *testing.T) {
+	h, repo := newTestHandler(t)
+	h.SetUGCVisibility("all")
+	host := "remote.example"
+	repo.Users["remote2"] = &model.User{ID: "remote2", Username: "carol", UsernameLower: "carol", Host: &host, AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Profiles["remote2"] = &model.UserProfile{UserID: "remote2", Fields: datatypes.JSON([]byte("[]"))}
+
+	assert.Equal(t, http.StatusOK, showStatus(t, h, `{"userId":"remote2"}`, nil),
+		"ugcVisibility=all does not gate anonymous remote view")
+}

--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -80,6 +80,9 @@ type Handler struct {
 	// 判定し、remote user / 非 public reactions の閲覧制限を bypass するため
 	// に使う (upstream の iAmModerator 経路)。
 	moderatorChecker ModeratorChecker
+	// ugcVisibility は meta.ugcVisibilityForVisitor。'local' (既定) のとき匿名
+	// visitor に remote user プロフィールを出さない (upstream users/show、#2106 S3)。
+	ugcVisibility string
 	// driveFileRepo は users/pages で page の attachedFiles / eyeCatchingImage を
 	// drive file から解決するのに使う (#1662)。未配線なら両 field は default。
 	driveFileRepo repository.DriveFileRepository
@@ -159,6 +162,12 @@ type ModeratorChecker interface {
 // nil keeps the gate strict (= test fixture / unwired)。
 func (h *Handler) SetModeratorChecker(m ModeratorChecker) {
 	h.moderatorChecker = m
+}
+
+// SetUGCVisibility sets the meta.ugcVisibilityForVisitor policy used to hide
+// remote user profiles from anonymous visitors when set to "local" (#2106 S3).
+func (h *Handler) SetUGCVisibility(v string) {
+	h.ugcVisibility = v
 }
 
 // ModeratorLister lists moderator/administrator users for abuse-report fanout
@@ -524,6 +533,12 @@ func (h *Handler) Show(c echo.Context) error {
 	if req.UserID != nil {
 		bundle, err = h.userService.ShowByID(*req.UserID)
 	} else {
+		// #2106 S3: ugcVisibilityForVisitor='local' のとき、匿名 visitor が host 指定で
+		// remote user を解決させること自体を resolve 前に弾く (upstream show.ts:157-159、
+		// 未知 remote host への外向き resolve 誘発 = SSRF amplification も防ぐ)。
+		if req.Host != nil && *req.Host != "" && viewer == nil && h.ugcVisibility == "local" {
+			return apierr.JSONNoSuchUser(c)
+		}
 		bundle, err = h.userService.ShowByUsername(*req.Username, req.Host)
 	}
 
@@ -538,6 +553,12 @@ func (h *Handler) Show(c echo.Context) error {
 	// 存在しないものとして扱い NO_SUCH_USER(4362f8dc...) を返す。moderator は
 	// 従来どおり閲覧できる。匿名/未配線は iAmModerator=false で fail-closed。
 	if !iAmModerator && bundle.User.IsSuspended {
+		return apierr.JSONNoSuchUser(c)
+	}
+
+	// #2106 S3: ugcVisibilityForVisitor='local' のとき匿名 visitor に remote user を
+	// 出さない (upstream show.ts:177-179)。userId 指定経路もここでカバーする。
+	if viewer == nil && bundle.User.Host != nil && h.ugcVisibility == "local" {
 		return apierr.JSONNoSuchUser(c)
 	}
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1432,6 +1432,10 @@ func (s *Server) setupRoutes() {
 	// Users endpoints
 	usersHandler := users.NewHandler(userService, followingService, noteRepo, idGen)
 	usersHandler.SetChartHook(chartHooks)
+	// #2106 S3: 匿名 visitor への remote profile 露出を ugcVisibilityForVisitor で gate。
+	if ugcMeta, err := metaRepo.Fetch(); err == nil {
+		usersHandler.SetUGCVisibility(ugcMeta.UgcVisibilityForVisitor)
+	}
 	usersHandler.SetFeaturedRanking(featuredService) // #1687: users/featured-notes ランキング
 	usersHandler.SetPiningRepo(piningRepo)
 	usersHandler.SetFollowingRepo(followingRepo)


### PR DESCRIPTION
## Summary

全コードベース再監査 (#2106) の security MEDIUM finding S3 (個別敵対的再検証で REAL 確定、info-leak + 軽度 SSRF amplification)。

`users/show` の単体経路が `meta.ugcVisibilityForVisitor` (既定 `'local'`) を未実装で、匿名 visitor が remote user の
プロフィールを取得でき、`username`+`host` 指定で未知 remote host への外向き resolve も誘発できた。upstream show.ts は
resolve 前 (157-159) と lookup 後 (177-179) の 2 段で gate する。notes handler には既に ugcVisibility gate があったが
users handler に欠けていた。

## 修正

`users.Handler` に `ugcVisibility` field + `SetUGCVisibility` を追加し router で wire。`Show` 単体経路に 2 段 gate:
**resolve 前** (host 指定 + 匿名 + `'local'` → NoSuchUser、外向き resolve 誘発防止) と **lookup 後** (匿名 +
remote user + `'local'` → NoSuchUser、userId 経路カバー)。bulk (userIds) 経路は upstream も gate しないため不変。
`'none'` は upstream で comment-out のため `'local'` のみ実装。

## テスト

- `TestShow_UgcVisibilityLocalHidesRemoteFromAnonymous` (匿名→404 / authed→200)、
  `TestShow_UgcVisibilityAllShowsRemoteToAnonymous` (all→gate しない)。既存 users テスト green、`go vet`。

Closes #2123