### PR TITLE
drive/files/create で enableIpLogging を尊重する (#2106 S4)

### DIFF
--- a/internal/api/drive/fix_s4_test.go
+++ b/internal/api/drive/fix_s4_test.go
@@ -1,0 +1,45 @@
+package drive
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func onlyDriveFile(t *testing.T, repo *testutil.MockDriveFileRepository) *model.DriveFile {
+	t.Helper()
+	require.Len(t, repo.Files, 1)
+	for _, f := range repo.Files {
+		return f
+	}
+	return nil
+}
+
+// #2106 S4: drive/files/create は meta.enableIpLogging が有効なときだけ requestIp を保存する。
+func TestFilesCreate_IPLoggingGate(t *testing.T) {
+	run := func(enabled bool) *model.DriveFile {
+		h, fileRepo, _ := newHandler(t)
+		mr := testutil.NewMockMetaRepository()
+		mr.Meta = &model.Meta{ID: "x", EnableIPLogging: enabled}
+		h.SetMetaRepo(mr)
+		c, rec := newMultipartReq(t, "raw.txt", "hello", nil)
+		c.Request().RemoteAddr = "203.0.113.5:9999"
+		setUser(c, "u1")
+		require.NoError(t, h.FilesCreate(c))
+		require.Equal(t, http.StatusOK, rec.Code)
+		return onlyDriveFile(t, fileRepo)
+	}
+
+	t.Run("disabled: requestIp not stored", func(t *testing.T) {
+		assert.Nil(t, run(false).RequestIP, "enableIpLogging=false must not store requestIp")
+	})
+	t.Run("enabled: requestIp stored", func(t *testing.T) {
+		f := run(true)
+		require.NotNil(t, f.RequestIP, "enableIpLogging=true stores requestIp")
+		assert.Equal(t, "203.0.113.5", *f.RequestIP)
+	})
+}

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -40,6 +40,15 @@ type Handler struct {
 	bufReader    entity.BufferedReactionsReader
 	fieldRes     *entity.NoteFieldResolver
 	urlUploader  URLUploadProcessor
+	// metaRepo は drive/files/create で meta.enableIpLogging を確認し、無効時に
+	// requestIp / requestHeaders を保存しないために使う (#2106 S4)。nil なら保存しない
+	// (= 安全側)。
+	metaRepo repository.MetaRepository
+}
+
+// SetMetaRepo wires the meta repository used to honor enableIpLogging on upload.
+func (h *Handler) SetMetaRepo(m repository.MetaRepository) {
+	h.metaRepo = m
 }
 
 // SetURLUploader wires the processor used by /drive/files/upload-from-url to
@@ -189,10 +198,17 @@ func (h *Handler) FilesCreate(c echo.Context) error {
 	}
 
 	in := coredrive.UploadInput{
-		User:           user,
-		Body:           body,
-		RequestIP:      requestIPFromContext(c),
-		RequestHeaders: requestHeadersForDrive(c),
+		User: user,
+		Body: body,
+	}
+	// #2106 S4: requestIp / requestHeaders は meta.enableIpLogging が有効なときのみ
+	// 保存する (upstream create.ts:120-121 の `enableIpLogging ? x : null`)。プライバシー
+	// 設定を尊重し PII の過剰保存を防ぐ。upload-from-url は upstream 同様 gate しない (別 handler)。
+	if h.metaRepo != nil {
+		if m, ferr := h.metaRepo.Fetch(); ferr == nil && m != nil && m.EnableIPLogging {
+			in.RequestIP = requestIPFromContext(c)
+			in.RequestHeaders = requestHeadersForDrive(c)
+		}
 	}
 	// upstream create.ts:98-108 の name 決定: ps.name ?? file.name を trim し、
 	// 空 / 'blob' は null 化、それ以外は validateFileName 失敗で

--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -119,6 +119,10 @@ func TestFilesCreate_AllFormFields(t *testing.T) {
 // 含まれていないことも assert (DB dump 流出時の token 漏洩防止)。
 func TestFilesCreate_RecordsRequestIPAndHeaders(t *testing.T) {
 	h, fileRepo, _ := newHandler(t)
+	// #2106 S4: requestIp/headers は enableIpLogging=true のときのみ記録される。
+	mr := testutil.NewMockMetaRepository()
+	mr.Meta = &model.Meta{ID: "x", EnableIPLogging: true}
+	h.SetMetaRepo(mr)
 	c, rec := newMultipartReq(t, "ip.txt", "hello", nil)
 	// echo.Context の RealIP() は X-Forwarded-For / X-Real-IP / RemoteAddr
 	// の順で resolve される。test では RemoteAddr が "192.0.2.1:1234" 形式

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1793,6 +1793,7 @@ func (s *Server) setupRoutes() {
 	driveHandler.SetEmojiRepo(emojiRepo)
 	driveHandler.SetReactionReader(reactionCountWriter)
 	driveHandler.SetNoteFieldResolver(noteFieldResolver)
+	driveHandler.SetMetaRepo(metaRepo) // #2106 S4: enableIpLogging を尊重して requestIp/headers 保存を gate
 	api.POST("/drive", driveHandler.Usage, middleware.RequireAuth(), middleware.RequireScope("read:drive"))
 	api.POST("/drive/files", driveHandler.FilesList, middleware.RequireAuth(), middleware.RequireScope("read:drive"))
 	api.POST("/drive/files/create", driveHandler.FilesCreate, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:drive"))


### PR DESCRIPTION
## Summary

全コードベース再監査 (#2106) の security MEDIUM finding S4 (個別敵対的再検証で REAL 確定、PII 過剰保存)。

`drive/files/create` が `requestIp` / `requestHeaders` を `meta.enableIpLogging` に関わらず常時 drive_file に保存して
いた。upstream create.ts:120-121 は `enableIpLogging ? ip : null` で gate する。mk-go は signin IP logging では
enableIpLogging を尊重しているのに drive create では無視していた (sensitive header は既に deny-list 除外済なので
credential leak ではなく uploader IP + 良性 header の over-retention)。

## 修正

drive `Handler` に `metaRepo` + `SetMetaRepo` を追加し router で wire。`FilesCreate` で `enableIpLogging` が true の
ときだけ requestIp/requestHeaders を `UploadInput` に set する。`upload-from-url` は upstream 同様 ungated のまま。

## テスト

- `TestFilesCreate_IPLoggingGate`: disabled→requestIp 非保存 / enabled→保存。`go vet`。

Closes #2125