### PR TITLE
role cache が期限切れ assignment を最大5分延命する問題を修正 (#2106 S5)

### DIFF
--- a/internal/core/role/role_s5_internal_test.go
+++ b/internal/core/role/role_s5_internal_test.go
@@ -1,0 +1,46 @@
+package role
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #2106 S5: time-limited assignment を持つ user の role cache entry は固定 TTL (5分)
+// ではなく assignment の expiresAt で失効する (期限切れ role の延命防止)。
+func TestGetUserRoles_CacheExpiryCappedAtAssignmentExpiry(t *testing.T) {
+	roleRepo := testutil.NewMockRoleRepository()
+	assignRepo := testutil.NewMockRoleAssignmentRepository(roleRepo)
+	metaRepo := testutil.NewMockMetaRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	svc := NewService(roleRepo, assignRepo, metaRepo, idGen)
+	roleRepo.Roles["r1"] = &model.Role{ID: "r1", Name: "Temp"}
+
+	// time-limited (90s < 5min TTL) → entry は soon で失効する。
+	soon := time.Now().Add(90 * time.Second)
+	assignRepo.Assignments["user1:r1"] = &model.RoleAssignment{
+		ID: "a1", UserID: "user1", RoleID: "r1", ExpiresAt: &soon, Role: roleRepo.Roles["r1"],
+	}
+	_, err := svc.GetUserRoles("user1")
+	require.NoError(t, err)
+	v, ok := svc.userRoleCache.Load("user1")
+	require.True(t, ok)
+	assert.False(t, v.(*roleCacheEntry).expiresAt.After(soon),
+		"cache entry must expire by the assignment expiresAt, not the 5min TTL")
+
+	// 期限なし assignment は従来通り full TTL (~5min)。
+	assignRepo.Assignments["user2:r1"] = &model.RoleAssignment{
+		ID: "a2", UserID: "user2", RoleID: "r1", Role: roleRepo.Roles["r1"],
+	}
+	_, err = svc.GetUserRoles("user2")
+	require.NoError(t, err)
+	v2, ok := svc.userRoleCache.Load("user2")
+	require.True(t, ok)
+	assert.True(t, v2.(*roleCacheEntry).expiresAt.After(time.Now().Add(4*time.Minute)),
+		"non-expiring assignment keeps the full TTL")
+}

--- a/internal/core/role/role_service.go
+++ b/internal/core/role/role_service.go
@@ -288,9 +288,21 @@ func (s *Service) GetUserRoles(userID string) ([]*model.Role, error) {
 	// 配慮した soft-fail。
 	condRoles := s.evaluateConditionalRoles(userID, assignedRoles)
 	roles := append(assignedRoles, condRoles...)
+	// #2106 S5: cache 失効を「TTL」と「最も早い assignment expiresAt」の min にする。
+	// ListByUser は fetch 時点で有効な assignment しか返さないが、TTL 中に期限切れに
+	// なる time-limited assignment はそのまま cache に残り、最大 roleCacheTTL の間
+	// role/policy として効き続けてしまう (upstream は getUserAssigns で read 毎に
+	// expiresAt を再 filter)。entry を soonest expiry で drop すれば、次 read が
+	// 再 fetch して DB filter が期限切れ assignment を除外する。
+	cacheExpiry := time.Now().Add(roleCacheTTL)
+	for _, a := range assignments {
+		if a.ExpiresAt != nil && a.ExpiresAt.Before(cacheExpiry) {
+			cacheExpiry = *a.ExpiresAt
+		}
+	}
 	s.userRoleCache.Store(userID, &roleCacheEntry{
 		roles:     roles,
-		expiresAt: time.Now().Add(roleCacheTTL),
+		expiresAt: cacheExpiry,
 	})
 	return roles, nil
 }


### PR DESCRIPTION
## Summary

全コードベース再監査 (#2106) の security MEDIUM finding S5 (個別敵対的再検証で REAL 確定、authz staleness)。

`GetUserRoles` の per-user cache が resolved roles を固定 `roleCacheTTL` (5分) で保持し、cache hit 時に各 assignment の
`expiresAt` を再評価しないため、TTL 中に期限切れになる time-limited assignment が**期限切れ後も最大 5 分 role/policy
として効き続けて**いた (IsModerator/IsAdministrator/HasRolePolicy)。upstream RoleService は read 毎に `expiresAt > now`
を再 filter するため window=0。

## 修正

cache entry の失効時刻を `min(now+roleCacheTTL, 最も早い assignment expiresAt)` にする。soonest expiry で entry を
drop すれば次 read が再 fetch し、DB filter (`expiresAt > now`) が期限切れ assignment を除外する。期限なし assignment
のみの user は従来通り full TTL。

## テスト

- `TestGetUserRoles_CacheExpiryCappedAtAssignmentExpiry` (internal test): time-limited → entry が assignment
  expiresAt で失効 / 期限なし → full TTL。`go vet`。

Closes #2127