### PR TITLE
i/update のレスポンスで isAdmin/isModerator を実値で返す (#2106 N1)

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -1657,6 +1657,13 @@ func (h *Handler) Update(c echo.Context) error {
 	// unread 系は meDetailedWithUnread で実値を埋める。生 PackMeDetailed だと
 	// unreadNotificationsCount:0 等の default が `$i` を clobber する (#1258 fu)。
 	resp := h.meDetailedWithUnread(c.Request().Context(), bundle.User, bundle.Profile)
+	// #2106 N1: isAdmin/isModerator は role 依存で PackMeDetailed が埋めない (MeDetailed の
+	// 両 field は omitempty 無し bool なので default false が乗る)。Me handler 同様
+	// roleProvider から override し upstream の MeDetailed isMe ブロック (実値を返す) に揃える。
+	if h.roleProvider != nil {
+		resp["isAdmin"] = h.roleProvider.IsAdministrator(bundle.User.ID)
+		resp["isModerator"] = h.roleProvider.IsModerator(bundle.User.ID)
+	}
 	// upstream i/update は pack(..., {includeSecrets: isSecure}) を返すため native
 	// session では email / emailVerified / securityKeysList を含める (#1919)。Token
 	// 判定は middleware が確実に load する me を使い、email は更新後の最新 profile を

--- a/internal/api/i/handler_test.go
+++ b/internal/api/i/handler_test.go
@@ -2797,3 +2797,20 @@ func TestMe_ModerationNote_ModeratorGated(t *testing.T) {
 		assert.False(t, present, "non-moderator must not receive moderationNote")
 	})
 }
+
+// #2106 N1: i/update のレスポンス (MeDetailed) は moderator/admin に対し isAdmin/isModerator
+// を実値で返す (Me handler と同様 roleProvider から override)。
+func TestUpdate_ReturnsRoleFlags(t *testing.T) {
+	h, repo, _, _ := newTestHandler(t)
+	user := &model.User{ID: "u1", Username: "alice", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["u1"] = user
+	repo.Profiles["u1"] = &model.UserProfile{UserID: "u1", Fields: datatypes.JSON([]byte("[]"))}
+	h.SetRoleProvider(&stubRoleProvider{admin: true, moderator: true})
+
+	rec := post(h.Update, `{"name":"updated"}`, user)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, true, resp["isAdmin"], "admin の i/update は isAdmin=true を返す")
+	assert.Equal(t, true, resp["isModerator"])
+}


### PR DESCRIPTION
## Summary

全コードベース再監査 (#2106) の parity MEDIUM finding N1。

i/update のレスポンス (MeDetailed) が moderator/admin に対しても `isAdmin`/`isModerator` を常に false で返していた。
`meDetailedWithUnread` (PackMeDetailed) は role 依存 field を埋めず、MeDetailed の両 field は omitempty 無し bool なので
default false が乗る。Me handler (/api/i) は roleProvider から override するが Update は参照していなかった。upstream は
MeDetailed の isMe ブロックで実値を返す (#2091/#2094 と同系統の条件付き field 出し分けミス)。

## 修正

Update のレスポンス組み立て後に roleProvider が wire されていれば `resp["isAdmin"]`/`resp["isModerator"]` を override
(Me handler と同パターン)。

## テスト
- `TestUpdate_ReturnsRoleFlags`: admin の i/update が isAdmin/isModerator=true を返す。full i package green、`go vet`。

Closes #2129