### PR TITLE
/api/announcements の isActive:false が inactive のみ返すよう修正 (#2106 N7)

### DIFF
--- a/internal/repository/announcement.go
+++ b/internal/repository/announcement.go
@@ -62,9 +62,10 @@ func (r *announcementRepository) FindByID(id string) (*model.Announcement, error
 
 func (r *announcementRepository) List(activeOnly bool, limit, offset int, sinceID, untilID string) ([]*model.Announcement, error) {
 	q := r.db.Order(paginationOrder(sinceID, untilID, "id"))
-	if activeOnly {
-		q = q.Where("\"isActive\" = true")
-	}
+	// #2106 N7: activeOnly は upstream announcements.ts の ps.isActive (default true)
+	// に相当する「フィルタ値」。常に等値比較を当てる (true=active のみ / false=inactive
+	// のみ)。false を「フィルタ無し」と解釈して active+inactive 両方返す regression を修正。
+	q = q.Where("\"isActive\" = ?", activeOnly)
 	if limit <= 0 {
 		limit = 10
 	}
@@ -91,9 +92,10 @@ func (r *announcementRepository) List(activeOnly bool, limit, offset int, sinceI
 
 func (r *announcementRepository) ListGlobal(activeOnly bool, limit, offset int, sinceID, untilID string) ([]*model.Announcement, error) {
 	q := r.db.Where(`"userId" IS NULL`).Order(paginationOrder(sinceID, untilID, "id"))
-	if activeOnly {
-		q = q.Where("\"isActive\" = true")
-	}
+	// #2106 N7: activeOnly は upstream announcements.ts の ps.isActive (default true)
+	// に相当する「フィルタ値」。常に等値比較を当てる (true=active のみ / false=inactive
+	// のみ)。false を「フィルタ無し」と解釈して active+inactive 両方返す regression を修正。
+	q = q.Where("\"isActive\" = ?", activeOnly)
 	if limit <= 0 {
 		limit = 10
 	}
@@ -122,9 +124,10 @@ func (r *announcementRepository) ListForUser(userID string, activeOnly bool, lim
 	// 囲まれないので、明示的に囲まないとAND側の他フィルタ(isActive等)を
 	// バイパスしてしまう(SQL優先順位: AND > OR)。note.go:423と同じ gotcha。
 	q := r.db.Where(`("userId" IS NULL OR "userId" = ?)`, userID).Order(paginationOrder(sinceID, untilID, "id"))
-	if activeOnly {
-		q = q.Where("\"isActive\" = true")
-	}
+	// #2106 N7: activeOnly は upstream announcements.ts の ps.isActive (default true)
+	// に相当する「フィルタ値」。常に等値比較を当てる (true=active のみ / false=inactive
+	// のみ)。false を「フィルタ無し」と解釈して active+inactive 両方返す regression を修正。
+	q = q.Where("\"isActive\" = ?", activeOnly)
 	if limit <= 0 {
 		limit = 10
 	}

--- a/internal/repository/announcement_test.go
+++ b/internal/repository/announcement_test.go
@@ -26,15 +26,18 @@ func TestAnnouncementRepository_CRUD(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "Test", found.Title)
 
-	// List (active)
+	// List (active) — 作成した active な ann_1 が返る
 	items, err := repo.List(true, 10, 0, "", "")
 	require.NoError(t, err)
 	assert.NotEmpty(t, items)
 
-	// List (all)
+	// #2106 N7: List は isActive を等値フィルタで扱う。List(false)=inactive のみなので
+	// active な ann_1 は含まれない (旧実装は false を「フィルタ無し」と誤解釈していた)。
 	items, err = repo.List(false, 10, 0, "", "")
 	require.NoError(t, err)
-	assert.NotEmpty(t, items)
+	for _, it := range items {
+		assert.NotEqual(t, "ann_1", it.ID, "List(false) は active announcement を含めない")
+	}
 
 	// UpdateFields
 	require.NoError(t, repo.UpdateFields(a.ID, map[string]any{"title": "Updated"}))
@@ -523,4 +526,37 @@ func TestAnnouncementRepository_CountReadsByAnnouncementIDs(t *testing.T) {
 	out, err = repo.CountReadsByAnnouncementIDs(nil)
 	require.NoError(t, err)
 	assert.Empty(t, out)
+}
+
+// #2106 N7: ListGlobal は isActive を等値フィルタで扱う (false=inactive のみ、active を混ぜない)。
+func TestAnnouncementRepository_ListGlobal_IsActiveFilter(t *testing.T) {
+	repo := NewAnnouncementRepository(testDB)
+	active := &model.Announcement{ID: "ann_n7_act", Title: "A", Text: "t", Icon: "info", Display: "normal", IsActive: true}
+	inactive := &model.Announcement{ID: "ann_n7_inact", Title: "B", Text: "t", Icon: "info", Display: "normal", IsActive: false}
+	require.NoError(t, repo.Create(active))
+	require.NoError(t, repo.Create(inactive))
+	// GORM は bool zero-value (false) を Create で省略し column default:true を当てるため、
+	// inactive を確実に isActive=false にするには明示 UpdateFields する。
+	require.NoError(t, repo.UpdateFields(inactive.ID, map[string]any{"isActive": false}))
+	defer cleanupAnnouncement(t, active.ID)
+	defer cleanupAnnouncement(t, inactive.ID)
+
+	contains := func(items []*model.Announcement, id string) bool {
+		for _, a := range items {
+			if a.ID == id {
+				return true
+			}
+		}
+		return false
+	}
+
+	got, err := repo.ListGlobal(true, 100, 0, "", "")
+	require.NoError(t, err)
+	assert.True(t, contains(got, "ann_n7_act"), "isActive=true returns active")
+	assert.False(t, contains(got, "ann_n7_inact"), "isActive=true excludes inactive")
+
+	got, err = repo.ListGlobal(false, 100, 0, "", "")
+	require.NoError(t, err)
+	assert.True(t, contains(got, "ann_n7_inact"), "isActive=false returns inactive")
+	assert.False(t, contains(got, "ann_n7_act"), "isActive=false must NOT mix in active announcements")
 }


### PR DESCRIPTION
全コードベース再監査 (#2106) の parity MEDIUM finding N7。user-facing /api/announcements で `isActive:false` を渡すと active+inactive 両方が返っていた (frontend の『過去のお知らせ』タブに active が混入)。repository の List/ListGlobal/ListForUser が `activeOnly=false` を「フィルタ無し」と誤解釈。

upstream announcements.ts は `isActive = ps.isActive` (default true) の等値比較を常に当てる。repo 3 メソッドを常に等値比較に変更 (true=active のみ / false=inactive のみ)。List は test 専用。回帰テスト追加。

Closes #2131