### PR TITLE
GET /federation/instances で query param を束縛する (#2106 N9)

### DIFF
--- a/internal/api/federation/handler.go
+++ b/internal/api/federation/handler.go
@@ -103,22 +103,27 @@ func (h *Handler) requesterIsModerator(c echo.Context) bool {
 }
 
 // InstancesRequest is the request body for federation/instances.
+//
+// query タグは upstream instances.ts の allowGet:true 経路用 (#2106 N9)。echo の
+// DefaultBinder は GET で BindQueryParams を呼ぶが、explicit query タグの無い field は
+// 束縛しない。frontend welcome.entrance.classic.vue は misskeyApiGet で sort/limit/blocked
+// 等を渡すため、これらが無いと表示順・件数・block 除外が全て効かなくなる。
 type InstancesRequest struct {
-	Host          string `json:"host"`
-	Suspended     *bool  `json:"suspended"`
-	NotResponding *bool  `json:"notResponding"`
-	Blocked       *bool  `json:"blocked"`
-	Silenced      *bool  `json:"silenced"`
-	Federating    *bool  `json:"federating"`
-	Subscribing   *bool  `json:"subscribing"`
-	Publishing    *bool  `json:"publishing"`
-	Sort          string `json:"sort"`
-	Limit         int    `json:"limit"`
-	Offset        int    `json:"offset"`
-	SinceID       string `json:"sinceId"`
-	UntilID       string `json:"untilId"`
-	SinceDate     *int64 `json:"sinceDate"`
-	UntilDate     *int64 `json:"untilDate"`
+	Host          string `json:"host" query:"host"`
+	Suspended     *bool  `json:"suspended" query:"suspended"`
+	NotResponding *bool  `json:"notResponding" query:"notResponding"`
+	Blocked       *bool  `json:"blocked" query:"blocked"`
+	Silenced      *bool  `json:"silenced" query:"silenced"`
+	Federating    *bool  `json:"federating" query:"federating"`
+	Subscribing   *bool  `json:"subscribing" query:"subscribing"`
+	Publishing    *bool  `json:"publishing" query:"publishing"`
+	Sort          string `json:"sort" query:"sort"`
+	Limit         int    `json:"limit" query:"limit"`
+	Offset        int    `json:"offset" query:"offset"`
+	SinceID       string `json:"sinceId" query:"sinceId"`
+	UntilID       string `json:"untilId" query:"untilId"`
+	SinceDate     *int64 `json:"sinceDate" query:"sinceDate"`
+	UntilDate     *int64 `json:"untilDate" query:"untilDate"`
 }
 
 // Instances handles POST /api/federation/instances.

--- a/internal/api/federation/handler_test.go
+++ b/internal/api/federation/handler_test.go
@@ -475,3 +475,23 @@ func TestShowInstance_OmitsNonUpstreamFields(t *testing.T) {
 	_, hasIsNotResponding := got["isNotResponding"]
 	assert.True(t, hasIsNotResponding, "isNotResponding は upstream response field")
 }
+
+// #2106 N9: GET /federation/instances は query param を束縛する (json タグだけだと
+// echo の GET binder が無視し、limit/sort/blocked 等が全て効かなくなる)。
+func TestInstances_GETBindsQueryParams(t *testing.T) {
+	h, repo := newHandler(t)
+	seedInstance(t, repo, "alpha.example")
+	seedInstance(t, repo, "beta.example")
+	seedInstance(t, repo, "gamma.example")
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/federation/instances?limit=1", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.Instances(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Len(t, resp, 1, "GET ?limit=1 must bind the query param (else default 30 returns all 3)")
+}


### PR DESCRIPTION
全コードベース再監査 (#2106) の bug MEDIUM finding N9。GET /federation/instances で sort/host/limit/blocked 等が束縛されず (query タグ欠落 → echo GET binder が無視)、sort=id DESC / limit=30 / blocked 無視で固定。frontend classic federation 一覧の表示が狂う。upstream は allowGet:true。InstancesRequest 全 field に query タグ追加 + 回帰テスト。Closes #2133