### PR TITLE
signup で used_username に記録する (#2106 N23)

### DIFF
--- a/internal/core/signup/signup_service.go
+++ b/internal/core/signup/signup_service.go
@@ -137,6 +137,19 @@ func (s *Service) SetUsedUsernameRepo(r repository.UsedUsernameRepository) {
 	s.usedUsernameRepo = r
 }
 
+// recordUsedUsername best-effort records lower in used_username so the username
+// cannot be reclaimed after account deletion (#2106 N23). Failures are logged but
+// never fail the signup; the non-transactional callers have already created the
+// user/profile, so aborting here would leave an inconsistent state.
+func (s *Service) recordUsedUsername(lower string) {
+	if s.usedUsernameRepo == nil {
+		return
+	}
+	if err := s.usedUsernameRepo.Create(lower); err != nil {
+		slog.Warn("failed to record used username", "username", lower, "error", err)
+	}
+}
+
 // isUsedUsername reports whether lower (already lowercased) is recorded in
 // used_usernames (削除済 account)。repo 未配線 / 照合失敗時は false (fail-open、
 // オンライン性優先で既存 preserved/duplicate ガードに委ねる)。
@@ -322,6 +335,10 @@ func (s *Service) Signup(username, password string, isInitialSetup bool) (*Signu
 	if err := s.userRepo.CreateProfile(profile); err != nil {
 		return nil, err
 	}
+
+	// #2106 N23: upstream SignupService は全 signup で used_username に記録し、account
+	// 削除後も同名 username の再取得を恒久的に防ぐ (SignupService.ts:151-154)。
+	s.recordUsedUsername(lower)
 
 	// RSA keypair (federation 用)。keypairRepo が未設定の場合はスキップする
 	// (従来の単体テストのため)。
@@ -537,6 +554,13 @@ func (s *Service) promotePendingTx(pending *model.UserPending) (*SignupResult, e
 			return err
 		}
 
+		// #2106 N23: used_username に同 tx 内で記録する (upstream SignupService:151-154、
+		// 削除後の username 再取得を恒久的に防ぐ)。fresh username のみ到達するため
+		// (Exists guard が既使用を事前に弾く) conflict は起きない想定。
+		if err := tx.Create(&model.UsedUsername{Username: lower}).Error; err != nil {
+			return err
+		}
+
 		// keypair (federation 用) — keypairRepo が wire されているときのみ
 		if s.keypairRepo != nil {
 			privPEM, pubPEM, err := activitypub.GenerateRSAKeypair()
@@ -631,6 +655,8 @@ func (s *Service) promotePendingNoTx(pending *model.UserPending) (*SignupResult,
 	if err := s.userRepo.CreateProfile(profile); err != nil {
 		return nil, err
 	}
+	// #2106 N23: used_username に記録 (non-tx 経路。Signup と mirror)。
+	s.recordUsedUsername(lower)
 	if s.keypairRepo != nil {
 		privPEM, pubPEM, err := activitypub.GenerateRSAKeypair()
 		if err != nil {

--- a/internal/core/signup/signup_service_integration_test.go
+++ b/internal/core/signup/signup_service_integration_test.go
@@ -40,6 +40,9 @@ func cleanupSignupRows(t *testing.T, db *gorm.DB, prefix string) {
 	db.Exec(`DELETE FROM "user_keypair_extra" WHERE "userId" LIKE ?`, prefix+"%")
 	db.Exec(`DELETE FROM "user" WHERE id LIKE ? OR "usernameLower" LIKE ?`, prefix+"%", prefix+"%")
 	db.Exec(`DELETE FROM "registration_ticket" WHERE id LIKE ? OR code LIKE ?`, prefix+"%", prefix+"%")
+	// #2106 N23: promotePendingTx は used_username に必ず insert するため、idempotent な
+	// 再実行のために prefix 付き行を掃除する (used_username は account 削除後も残る設計)。
+	db.Exec(`DELETE FROM "used_username" WHERE "username" LIKE ?`, prefix+"%")
 }
 
 func newTxService(t *testing.T, db *gorm.DB) *signup.Service {

--- a/internal/core/signup/signup_service_test.go
+++ b/internal/core/signup/signup_service_test.go
@@ -1,6 +1,7 @@
 package signup_test
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -561,4 +562,52 @@ func TestSignup_UsedUsername(t *testing.T) {
 	svc2, _, _ := newTestService(t)
 	_, err = svc2.Signup("taken", "password123", false)
 	assert.NoError(t, err, "repo 未配線時は used_usernames を見ない")
+}
+
+// #2106 N23: Signup は used_username に lowercase username を記録する
+// (account 削除後の同名 username 再取得を恒久的に防ぐ guard のため)。
+func TestSignup_RecordsUsedUsername(t *testing.T) {
+	svc, _, _ := newTestService(t)
+	usedRepo := testutil.NewMockUsedUsernameRepository()
+	svc.SetUsedUsernameRepo(usedRepo)
+
+	_, err := svc.Signup("NewUser", "password123", false)
+	require.NoError(t, err)
+
+	exists, err := usedRepo.Exists("newuser")
+	require.NoError(t, err)
+	assert.True(t, exists, "signup は used_username に lowercase username を記録する")
+}
+
+// errUsedUsernameRepo always fails Create to exercise the best-effort error path.
+type errUsedUsernameRepo struct{}
+
+func (errUsedUsernameRepo) Create(string) error         { return errors.New("used_username create failed") }
+func (errUsedUsernameRepo) Exists(string) (bool, error) { return false, nil }
+
+// #2106 N23: used_username 記録失敗は best-effort で握り (signup は成功)。
+func TestSignup_UsedUsernameCreateErrorIsBestEffort(t *testing.T) {
+	svc, _, _ := newTestService(t)
+	svc.SetUsedUsernameRepo(errUsedUsernameRepo{})
+	result, err := svc.Signup("besteffort", "password123", false)
+	require.NoError(t, err, "used_username 記録失敗でも signup は成功する")
+	require.NotNil(t, result)
+}
+
+// #2106 N23: non-tx (mock) promote 経路でも used_username に記録する。
+func TestPromotePending_NoTxRecordsUsedUsername(t *testing.T) {
+	svc, _, _ := newTestService(t)
+	pendingRepo := testutil.NewMockUserPendingRepository()
+	svc.SetUserPendingRepo(pendingRepo)
+	usedRepo := testutil.NewMockUsedUsernameRepository()
+	svc.SetUsedUsernameRepo(usedRepo)
+
+	row, err := svc.CreatePending("PendUser", "pend@example.com", "password123", nil)
+	require.NoError(t, err)
+	_, err = svc.PromotePending(row.Code)
+	require.NoError(t, err)
+
+	exists, err := usedRepo.Exists("penduser")
+	require.NoError(t, err)
+	assert.True(t, exists, "non-tx promote も used_username に記録する")
 }


### PR DESCRIPTION
全コードベース再監査 (#2106) の bug MEDIUM finding N23。upstream SignupService は全 signup で used_username に insert し account 削除後の同名 username 再取得を恒久的に防ぐ (SignupService.ts:151-154)。mk-go では Create がどの production 経路からも呼ばれず、#2080 の Exists ガードは TS から drop-in 継承した used_username にしか効かなかった。

Signup / promotePendingTx / promotePendingNoTx の user 作成時に used_username へ記録 (tx 経路は atomic、non-tx は best-effort)。回帰テスト追加。Closes #2135