### PR TITLE
reaction の Unicode 検証を追加する (#2106 N15)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
 	github.com/bbrks/go-blurhash v1.2.0
 	github.com/blezek/tga v0.0.0-20150626111426-80720cbc1017
+	github.com/forPelevin/gomoji v1.4.1
 	github.com/gen2brain/avif v0.4.4
 	github.com/gen2brain/heic v0.4.9
 	github.com/gen2brain/jpegxl v0.4.5
@@ -143,6 +144,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
+	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/forPelevin/gomoji v1.4.1 h1:7U+Bl8o6RV/dOQz7coQFWj/jX6Ram6/cWFOuFDEPEUo=
+github.com/forPelevin/gomoji v1.4.1/go.mod h1:mM6GtmCgpoQP2usDArc6GjbXrti5+FffolyQfGgPboQ=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
@@ -285,6 +287,8 @@ github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzM
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/internal/core/reaction/reaction_service.go
+++ b/internal/core/reaction/reaction_service.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/forPelevin/gomoji"
 	"github.com/shiroha-a/mk/internal/core/note"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/misc/reactionlegacy"
@@ -500,6 +501,15 @@ func (s *Service) resolveReaction(raw string, actorHost *string) (string, *model
 			return ":" + name + "@" + host + ":", emoji
 		}
 		// 見つからなければFallbackにする
+		return FallbackReaction, nil
+	}
+	// #2106 N15: upstream ReactionService.normalize は emojiRegex に一致しない
+	// (= 非絵文字・非legacy・非custom の) 入力を ❤ (FallbackReaction) に矯正する。
+	// mk-go は未検証で任意文字列をそのまま reaction として保存していたため、gomoji で
+	// raw が全て絵文字かを判定し、非絵文字を含むなら fallback する。resolveReaction は
+	// Create / AP inbound (Like の _misskey_reaction) 双方が通る chokepoint なので、
+	// ここに置けば local/連合とも任意文字列 reaction の蓄積を防げる。
+	if gomoji.RemoveEmojis(raw) != "" {
 		return FallbackReaction, nil
 	}
 	// Unicode emoji は variation selector (U+FE0F) を strip して upstream

--- a/internal/core/reaction/reaction_unicode_test.go
+++ b/internal/core/reaction/reaction_unicode_test.go
@@ -1,0 +1,31 @@
+package reaction
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// #2106 N15: resolveReaction の unicode 分岐は非絵文字を ❤ (FallbackReaction) に矯正する
+// (upstream ReactionService.normalize 相当)。custom/legacy でない任意文字列は保存しない。
+func TestResolveReaction_UnicodeValidation(t *testing.T) {
+	s := &Service{} // unicode/非custom 入力は emojiRepo を参照しない
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"grinning", "\U0001F600", "\U0001F600"},
+		{"heart_with_vs", "❤️", "❤"}, // VS strip 後の canonical (= U+2764)
+		{"thumbsup_skin", "\U0001F44D\U0001F3FD", "\U0001F44D\U0001F3FD"},
+		{"flag_jp", "\U0001F1EF\U0001F1F5", "\U0001F1EF\U0001F1F5"},
+		{"plain_text", "abc", FallbackReaction},
+		{"hiragana", "あ", FallbackReaction},
+		{"script_tag", "<script>", FallbackReaction},
+		{"emoji_plus_text", "\U0001F600x", FallbackReaction},
+	}
+	for _, c := range cases {
+		got, _ := s.resolveReaction(c.in, nil)
+		assert.Equal(t, c.want, got, "input=%q (%s)", c.in, c.name)
+	}
+}


### PR DESCRIPTION
全コードベース再監査 (#2106) の parity MEDIUM finding N15。resolveReaction の unicode 分岐が raw を検証せず、非絵文字の任意文字列 (例: `abc`) をそのまま reaction として保存していた。upstream ReactionService.normalize は emojiRegex 非一致を ❤ に矯正する。AP inbound (Like の _misskey_reaction) も同経路なので、悪意ある remote が garbage キーを蓄積できた。

go.mod に `github.com/forPelevin/gomoji` を追加し、unicode 分岐で非絵文字を含むなら FallbackReaction を返す。keycap/flag/skin-tone/ZWJ も正しく絵文字判定 (heuristic では不可)。回帰テスト追加。Closes #2137