### PR TITLE
antennas/notes に blockedHosts/suspended フィルタを適用する (#2106 N5)

### DIFF
--- a/internal/api/antennas/handler.go
+++ b/internal/api/antennas/handler.go
@@ -45,6 +45,30 @@ type Handler struct {
 	mutingRepo        repository.MutingRepository
 	blockingRepo      repository.BlockingRepository
 	channelMutingRepo repository.ChannelMutingRepository
+	// metaRepo は antennas/notes の blocked-host filter (#2106 N5、upstream
+	// generateBlockedHostQueryForNote) のために meta.blockedHosts を引く。clips/notes と
+	// 同じ設計。未配線時は blocked-host filter skip。
+	metaRepo repository.MetaRepository
+}
+
+// SetMetaRepo wires a MetaRepository used by the antennas/notes blocked-host filter.
+func (h *Handler) SetMetaRepo(r repository.MetaRepository) {
+	h.metaRepo = r
+}
+
+// blockedHosts returns meta.blockedHosts, or nil when the meta repo is unwired.
+func (h *Handler) blockedHosts() ([]string, error) {
+	if h.metaRepo == nil {
+		return nil, nil
+	}
+	meta, err := h.metaRepo.Fetch()
+	if err != nil {
+		return nil, err
+	}
+	if meta == nil {
+		return nil, nil
+	}
+	return meta.BlockedHosts, nil
 }
 
 // SetMuteBlockRepos wires the muting / blocking / channel-muting repositories so
@@ -398,6 +422,16 @@ func (h *Handler) Notes(c echo.Context) error {
 		return apierr.JSONInternalError(c)
 	}
 	notes = notesfilter.ApplyHardMute(h.userRepo, user, notes)
+	// #2106 N5: admin の blockedHosts でブロックした remote host の note と、suspended な
+	// author の note を除外する (upstream notes.ts:132-133 の generateBaseNoteFilteringQuery
+	// = generateBlockedHostQueryForNote + generateSuspendedUserQueryForNote)。clips/notes が
+	// blocked-host を適用済なのに antennas は未適用で非対称だった。truncate 前に適用する。
+	blockedHosts, err := h.blockedHosts()
+	if err != nil {
+		return apierr.JSONInternalError(c)
+	}
+	notes = notesfilter.ApplyBlockedHosts(notes, blockedHosts)
+	notes = notesfilter.ApplySuspended(notes)
 	// over-fetch 分を要求 limit に揃える。FindManyByIDsWithUser が ids の順序を
 	// 保つので newest-first の先頭 req.Limit 件を返せばよい (#1467 review)。
 	if len(notes) > req.Limit {

--- a/internal/api/antennas/handler_test.go
+++ b/internal/api/antennas/handler_test.go
@@ -845,3 +845,35 @@ func TestRemoveNote_BadParam(t *testing.T) {
 	require.NoError(t, h.RemoveNote(c))
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
+
+// #2106 N5: antennas/notes は admin の blockedHosts でブロックした remote host の note と
+// suspended author の note を除外する (upstream generateBaseNoteFilteringQuery 相当)。
+func TestNotes_FiltersBlockedHostAndSuspended(t *testing.T) {
+	h, repo, noteRepo := newHandler(t)
+	repo.Antennas["a-n5"] = &model.Antenna{ID: "a-n5", UserID: "alice"}
+
+	meta := testutil.NewMockMetaRepository()
+	meta.Meta = &model.Meta{ID: "x", BlockedHosts: []string{"blocked.example"}}
+	h.SetMetaRepo(meta)
+
+	host := "blocked.example"
+	noteRepo.Notes["n-blocked"] = &model.Note{ID: "n-blocked", UserID: "remote1", UserHost: &host}
+	noteRepo.Notes["n-suspended"] = &model.Note{ID: "n-suspended", UserID: "susp", User: &model.User{ID: "susp", IsSuspended: true}}
+	noteRepo.Notes["n-ok"] = &model.Note{ID: "n-ok", UserID: "alice"}
+
+	ctx := context.Background()
+	for _, e := range []struct{ id, sid string }{{"n-blocked", "1-0"}, {"n-suspended", "2-0"}, {"n-ok", "3-0"}} {
+		require.NoError(t, testRedis.Client.XAdd(ctx, &redis.XAddArgs{
+			Stream: "antennaTimeline:a-n5", ID: e.sid, Values: map[string]any{"noteId": e.id},
+		}).Err())
+	}
+
+	c, rec := newReq(t, `{"antennaId":"a-n5"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Notes(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	body := rec.Body.String()
+	assert.NotContains(t, body, "n-blocked", "blockedHosts の note を除外")
+	assert.NotContains(t, body, "n-suspended", "suspended author の note を除外")
+	assert.Contains(t, body, "n-ok", "通常 note は残る")
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -2005,6 +2005,7 @@ func (s *Server) setupRoutes() {
 	antennasHandler.SetUserRepo(userRepo)
 	antennasHandler.SetQueryService(noteQueryService)                              // #1464: Notes の visibility filter (defense-in-depth)
 	antennasHandler.SetMuteBlockRepos(mutingRepo, blockingRepo, channelMutingRepo) // #1544: Notes の mute/block/channel-mute filter
+	antennasHandler.SetMetaRepo(metaRepo)                                          // #2106 N5: Notes の blocked-host filter
 	api.POST("/antennas/create", antennasHandler.Create, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:account"))
 	api.POST("/antennas/show", antennasHandler.Show, middleware.RequireAuth(), middleware.RequireScope("read:account"))
 	api.POST("/antennas/update", antennasHandler.Update, middleware.RequireAuth(), middleware.RequireNotMoved(), middleware.RequireScope("write:account"))


### PR DESCRIPTION
全コードベース再監査 (#2106) の parity MEDIUM finding N5。antennas/notes が admin の meta.blockedHosts ブロック host の note と suspended author の note を除外していなかった (upstream generateBaseNoteFilteringQuery 相当)。clips/notes は ApplyBlockedHosts 適用済で非対称だった。

antennas Handler に metaRepo + blockedHosts() を追加 (clips と同設計)、Notes() で ApplyBlockedHosts + ApplySuspended を適用、router で配線。回帰テスト追加。Closes #2141