### PR TITLE
flash/search を word-AND + LIKE escape に揃える (#2106 N8)

### DIFF
--- a/internal/repository/flash.go
+++ b/internal/repository/flash.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"github.com/shiroha-a/mk/internal/model"
 	"gorm.io/gorm"
+	"strings"
 )
 
 // FlashRepository provides data access for the `flash` table.
@@ -156,9 +157,16 @@ func (r *flashRepository) Search(query, sinceID, untilID string, limit, offset i
 	if limit > 100 {
 		limit = 100
 	}
-	q := r.db.Where("title ILIKE ? OR summary ILIKE ?", "%"+query+"%", "%"+query+"%")
 	// upstream FlashService.search: 公開 flash のみを検索対象にする。
-	q = q.Where("visibility = ?", "public")
+	q := r.db.Where("visibility = ?", "public")
+	// #2106 N8: upstream は query を空白区切りで各語を AND し sqlLikeEscape する
+	// (= 全語を含む検索 + wildcard 無効化)。単一 substring + escape 漏れだった旧実装を
+	// flash_like.go の search と同じ word-split + escapeLike に揃える。空 query は語が
+	// 無いので visibility=public 全件 (= upstream の ILIKE '%%' と同じ)。
+	for _, word := range strings.Fields(query) {
+		like := "%" + escapeLike(word) + "%"
+		q = q.Where("title ILIKE ? OR summary ILIKE ?", like, like)
+	}
 	if sinceID != "" {
 		q = q.Where("id > ?", sinceID)
 	}

--- a/internal/repository/flash_test.go
+++ b/internal/repository/flash_test.go
@@ -294,3 +294,44 @@ func TestFlashRepository_Search_QueryError(t *testing.T) {
 	_, err := repo.Search("any", "", "", 10, 0)
 	assert.Error(t, err)
 }
+
+// #2106 N8: flash/search は query を空白区切りで各語を AND し (全語を含む検索)、
+// LIKE メタ文字 (% _) を escape する (wildcard 無効化)。
+func TestFlashRepository_Search_WordAndAndLikeEscape(t *testing.T) {
+	repo := NewFlashRepository(testDB)
+	user := insertTestUser(t, "u_fla_n8", "flashusern8")
+	defer cleanupUser(t, user.ID)
+
+	flashes := map[string]string{
+		"fl_n8_both": "foo bar baz", // foo と baz 両方含む
+		"fl_n8_foo":  "foo only",    // baz を含まない
+		"fl_n8_pct":  "100%done",    // literal %
+		"fl_n8_oth":  "100Xdone",    // % を wildcard 扱いするとヒットしてしまう対象
+	}
+	for id, title := range flashes {
+		f := newTestFlash(id, user.ID, title)
+		require.NoError(t, repo.Create(f))
+		defer cleanupFlash(t, f.ID)
+	}
+
+	contains := func(rows []*model.Flash, id string) bool {
+		for _, f := range rows {
+			if f.ID == id {
+				return true
+			}
+		}
+		return false
+	}
+
+	// word-AND: 'foo baz' は両語を含む flash のみ
+	rows, err := repo.Search("foo baz", "", "", 100, 0)
+	require.NoError(t, err)
+	assert.True(t, contains(rows, "fl_n8_both"), "全語を含む flash はヒット")
+	assert.False(t, contains(rows, "fl_n8_foo"), "baz を含まない flash は除外 (word-AND)")
+
+	// LIKE escape: '100%done' の % は literal として扱う (100Xdone を拾わない)
+	rows, err = repo.Search("100%done", "", "", 100, 0)
+	require.NoError(t, err)
+	assert.True(t, contains(rows, "fl_n8_pct"), "literal % にマッチ")
+	assert.False(t, contains(rows, "fl_n8_oth"), "% は wildcard でなく literal (100Xdone は除外)")
+}


### PR DESCRIPTION
全コードベース再監査 (#2106) の bug MEDIUM finding N8。flash/search が query を単一 substring 扱いし word-split も LIKE escape もしなかった。upstream FlashService.search は空白区切りで各語 AND + sqlLikeEscape する。flash_like.go (my-likes) は正しく実装済で非対称だった。

flash.go Search を flash_like.go と同じ strings.Fields word-AND + escapeLike に揃える。回帰テスト追加 (word-AND + % escape)。Closes #2145