### PR TITLE
deliver/webhook で 429 を retryable 扱いにする (#2106 N30)

### DIFF
--- a/internal/queue/processors/deliver.go
+++ b/internal/queue/processors/deliver.go
@@ -333,7 +333,9 @@ func (p *DeliverProcessor) Handle(_ context.Context, t driver.Task) error {
 	// Ed25519 sign で 4xx が返った場合は host を degrade して RSA で 1 回 retry
 	// する safety net。"assertionMethod を expose しているが Ed25519 verify が
 	// 壊れている" broken impl 対策。retry も失敗したら通常 4xx 経路で扱う。
-	if useEd25519 && resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != http.StatusGone && resp.StatusCode != http.StatusNotFound {
+	// #2106 N30: 429 (rate limited) は Ed25519 verify の問題ではなく単なる送信過多なので、
+	// Ed25519→RSA degrade 経路には乗せず通常の retryable 扱い (下の switch) に落とす。
+	if useEd25519 && resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != http.StatusGone && resp.StatusCode != http.StatusNotFound && resp.StatusCode != http.StatusTooManyRequests {
 		slog.Warn("ap deliver: ed25519 4xx, recording failure + retry with RSA",
 			"host", host, "status", resp.StatusCode)
 		p.recordEd25519Failure(host)
@@ -367,6 +369,15 @@ func (p *DeliverProcessor) Handle(_ context.Context, t driver.Task) error {
 			p.recordGoneSuspended(payload.Inbox)
 		}
 		return fmt.Errorf("target gone (%d): %w", resp.StatusCode, driver.SkipRetry)
+	case resp.StatusCode == http.StatusTooManyRequests:
+		// #2106 N30: 429 は 4xx だが upstream status-error.ts では retryable
+		// (isRetryable = !isClientError || statusCode === 429)。rate-limited な配送先には
+		// backoff 付きで再試行する。「応答した」事実があるので isNotResponding は解除する
+		// (instance は健在で rate-limit しているだけ)。SkipRetry を付けず queue に retry させる。
+		slog.Warn("ap deliver: rate limited (429), will retry",
+			"inbox", payload.Inbox)
+		p.recordSuccess(payload.Inbox)
+		return fmt.Errorf("rate limited (429): %s", resp.Status)
 	case resp.StatusCode >= 400 && resp.StatusCode < 500:
 		// その他の4xxは受信側の不正リクエスト扱い。HTTP として応答が返って
 		// きているので isNotResponding 状態は解除する。

--- a/internal/queue/processors/deliver_test.go
+++ b/internal/queue/processors/deliver_test.go
@@ -575,3 +575,12 @@ func TestDeliverProcessor_Ed25519KeyCacheReuse(t *testing.T) {
 	require.Len(t, signer.keys, 2)
 	assert.Same(t, signer.keys[0], signer.keys[1], "同一 Ed25519 PEM は cache hit で再利用する")
 }
+
+// #2106 N30: 429 (rate limited) は 4xx だが upstream 同様 retryable (SkipRetry を付けない)。
+func TestDeliverProcessor_RateLimited_Retries(t *testing.T) {
+	signer := &stubSigner{resp: okResponse(http.StatusTooManyRequests)}
+	p := processors.NewDeliverProcessor(signer)
+	err := p.Handle(context.Background(), makeTask(t, makePayload(t)))
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, driver.SkipRetry)
+}

--- a/internal/queue/processors/webhook.go
+++ b/internal/queue/processors/webhook.go
@@ -133,6 +133,10 @@ func (p *WebhookProcessor) handle(ctx context.Context, t driver.Task, user bool)
 	switch {
 	case resp.StatusCode >= 200 && resp.StatusCode < 300:
 		return nil
+	case resp.StatusCode == http.StatusTooManyRequests:
+		// #2106 N30: 429 は 4xx だが upstream status-error.ts では retryable。
+		// rate-limited な webhook 先には backoff 付きで再試行する (SkipRetry を付けない)。
+		return errors.New("webhook rate limited: " + resp.Status)
 	case resp.StatusCode >= 400 && resp.StatusCode < 500:
 		// 4xx は受信側の不正リクエスト扱いでリトライしない。
 		return fmt.Errorf("webhook client error (%d): %w", resp.StatusCode, driver.SkipRetry)

--- a/internal/queue/processors/webhook_test.go
+++ b/internal/queue/processors/webhook_test.go
@@ -295,3 +295,16 @@ func TestWebhookProcessor_BodyForwardedUnchanged(t *testing.T) {
 	require.NoError(t, p.HandleUser(context.Background(), task))
 	assert.Equal(t, body, client.body)
 }
+
+// #2106 N30: webhook 先が 429 を返したら retryable (SkipRetry を付けない)。
+func TestWebhookProcessor_User_429Retries(t *testing.T) {
+	client := &stubHTTPClient{status: http.StatusTooManyRequests}
+	p, repo, _ := newTestWebhookProcessor(t, client, map[string]*model.Webhook{
+		"h1": {ID: "h1", URL: "https://hook.example/u1"},
+	}, nil)
+	task := queue.NewUserWebhookTask(queue.WebhookPayload{WebhookID: "h1", EventType: "note", Body: []byte(`{}`)})
+	err := p.HandleUser(context.Background(), task)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, driver.SkipRetry)
+	assert.Equal(t, http.StatusTooManyRequests, repo.statusCalled["h1"])
+}


### PR DESCRIPTION
全コードベース再監査 (#2106) の parity MEDIUM finding N30。deliver/webhook の 4xx 分岐が 429 も SkipRetry で即 drop していた。upstream status-error.ts は 429 だけ 4xx でも retryable。rate-limited な配送先のアクティビティを mk-go は落としていた。

deliver/webhook の switch で 429 を special-case し retryable error を返す。deliver の Ed25519→RSA degrade 経路からも 429 を除外。回帰テスト追加。Closes #2147