### PR TITLE
notes/reactions の type filter で remote custom emoji を verbatim 扱いにする (#2106 N17)

### DIFF
--- a/internal/core/reaction/reaction_service.go
+++ b/internal/core/reaction/reaction_service.go
@@ -437,9 +437,9 @@ func (s *Service) List(user *model.User, noteID, untilID, sinceID string, limit 
 	}
 	var reactions []string
 	if reaction != "" {
-		// List はローカルクエリ context (filter 用) なので actor host
-		// 補完は不要。nil で従来挙動を維持する。
-		reactions = reactionVariants(s.normalizeReaction(reaction, nil))
+		// #2106 N17: type filter は emoji 存在検証なしで正規化する。normalizeReaction だと
+		// 未キャッシュの remote custom emoji が ❤ に化けて誤った reaction を返していた。
+		reactions = reactionVariants(s.normalizeReactionForFilter(reaction))
 	}
 	return s.reactionRepo.ListByNoteID(target.ID, untilID, sinceID, limit, reactions)
 }
@@ -459,6 +459,34 @@ func (s *Service) List(user *model.User, noteID, untilID, sinceID string, limit 
 func (s *Service) normalizeReaction(raw string, actorHost *string) string {
 	n, _ := s.resolveReaction(raw, actorHost)
 	return n
+}
+
+// normalizeReactionForFilter normalizes a reaction string for use as the
+// notes/reactions type filter. Unlike normalizeReaction it does NOT verify custom
+// emoji existence (#2106 N17: an uncached remote custom emoji like
+// ":foo@remote.example:" was rewritten to ❤ and the filter returned hearts instead
+// of the requested reaction) and does NOT fall back non-emoji unicode to ❤ (a
+// garbage filter simply matches nothing). Local custom emoji are normalized to the
+// "@." canonical so reactionVariants also queries the bare ":name:" form; remote
+// custom emoji and unicode are kept verbatim (unicode only loses its variation
+// selector to match the stored canonical). Mirrors upstream notes/reactions which
+// filters by the requested type verbatim.
+func (s *Service) normalizeReactionForFilter(raw string) string {
+	if v, ok := reactionlegacy.Convert(raw); ok {
+		return v
+	}
+	if m := customEmojiPattern.FindStringSubmatch(raw); m != nil {
+		name := m[1]
+		host := ""
+		if len(m) >= 3 {
+			host = m[2]
+		}
+		if host == "" || host == "." {
+			return ":" + name + "@.:"
+		}
+		return ":" + name + "@" + host + ":"
+	}
+	return stripVariationSelector(raw)
 }
 
 // resolveReaction is the shared core of normalizeReaction. In addition to the

--- a/internal/core/reaction/reaction_service_test.go
+++ b/internal/core/reaction/reaction_service_test.go
@@ -824,3 +824,22 @@ func TestService_Create_NoAcceptanceKeepsEmoji(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, ":custom@.:", r)
 }
+
+// #2106 N17: 未キャッシュの remote custom emoji で filter しても (❤ に化けず) その
+// reaction だけを返す。旧実装は emojiRepo に無い remote emoji を ❤ fallback していた。
+func TestService_List_RemoteCustomEmojiFilter(t *testing.T) {
+	svc, noteRepo, reactRepo, _, _ := newService(t)
+	seedNote(noteRepo, "n1", "author", model.NoteVisibilityPublic)
+	// emojiRepo には foo@remote.example を入れない (= 未キャッシュ remote emoji)
+	reactRepo.Reactions["rx_remote"] = &model.NoteReaction{
+		ID: "rx_remote", UserID: "u1", NoteID: "n1", Reaction: ":foo@remote.example:",
+	}
+	reactRepo.Reactions["rx_heart"] = &model.NoteReaction{
+		ID: "rx_heart", UserID: "u2", NoteID: "n1", Reaction: "❤",
+	}
+
+	out, err := svc.List(nil, "n1", "", "", 10, ":foo@remote.example:")
+	require.NoError(t, err)
+	require.Len(t, out, 1, "remote custom emoji filter は該当 reaction のみ返す (❤ に化けない)")
+	assert.Equal(t, ":foo@remote.example:", out[0].Reaction)
+}


### PR DESCRIPTION
全コードベース再監査 (#2106) の bug MEDIUM finding N17。type filter が未キャッシュ remote custom emoji を ❤ に誤変換し、要求した reaction でなくハートを返していた。upstream は verbatim で filter する。

emoji 存在検証なしの normalizeReactionForFilter を追加 (legacy 変換 + local は :name@.: 正規化 + remote/unicode verbatim)。finding の suggestedFix (@.:→:) は reactionVariants と組むと local filter を壊すため不採用。回帰テスト追加。Closes #2149