### PR TITLE
prohibited words を keyword.IsKeyWordIncluded + poll choices に揃える (#2106 N12)

### DIFF
--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -481,8 +481,12 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 		}
 	}
 
-	// プロhibited wordsチェック (meta.prohibitedWordsマッチ)
-	if err := checkProhibitedWords(meta, in.Text, in.CW); err != nil {
+	// プロhibited wordsチェック (meta.prohibitedWordsマッチ)。#2106 N12: poll choices も検査。
+	var prohibitedPollChoices []string
+	if in.Poll != nil {
+		prohibitedPollChoices = in.Poll.Choices
+	}
+	if err := checkProhibitedWords(meta, in.Text, in.CW, prohibitedPollChoices); err != nil {
 		return nil, err
 	}
 
@@ -1182,31 +1186,32 @@ func matchesSensitiveWords(meta *model.Meta, text, cw *string) bool {
 	return false
 }
 
-// checkProhibitedWords scans text + cw for any word listed in
+// checkProhibitedWords scans cw + text + poll choices for any word listed in
 // meta.prohibitedWords. Returns ErrContainsProhibitedWords on match.
 // meta が nil または prohibitedWords が空なら skip する (= caller の
 // fetch error も nil 渡しで fail-open される)。meta は呼び元の Create が
 // 1 度だけ fetch して渡す (perf: matchesSensitiveWords と統合)。
-func checkProhibitedWords(meta *model.Meta, text, cw *string) error {
+//
+// #2106 N12: 旧実装は text+cw のみを strings.ToLower→Contains で素朴に検査し、
+// poll choices を見ず、`/regex/flags` / スペース区切り AND も解釈せず、強制 lowercase で
+// case-sensitive な upstream とも乖離していた。matchesSensitiveWords と同じく
+// keyword.IsKeyWordIncluded (regex / space-AND / case-sensitive) に揃え、upstream
+// checkProhibitedWordsContain と同じく poll choices も検査対象に含める。各 field を
+// 独立に渡すのは sensitiveWords (#1106) と同方針 (concat 案は改行越境 match で挙動が読みにくい)。
+func checkProhibitedWords(meta *model.Meta, text, cw *string, pollChoices []string) error {
 	if meta == nil || len(meta.ProhibitedWords) == 0 {
 		return nil
 	}
-	haystacks := make([]string, 0, 2)
-	if text != nil && *text != "" {
-		haystacks = append(haystacks, strings.ToLower(*text))
+	words := []string(meta.ProhibitedWords)
+	if cw != nil && *cw != "" && keyword.IsKeyWordIncluded(*cw, words) {
+		return ErrContainsProhibitedWords
 	}
-	if cw != nil && *cw != "" {
-		haystacks = append(haystacks, strings.ToLower(*cw))
+	if text != nil && *text != "" && keyword.IsKeyWordIncluded(*text, words) {
+		return ErrContainsProhibitedWords
 	}
-	for _, word := range meta.ProhibitedWords {
-		word = strings.TrimSpace(strings.ToLower(word))
-		if word == "" {
-			continue
-		}
-		for _, h := range haystacks {
-			if strings.Contains(h, word) {
-				return ErrContainsProhibitedWords
-			}
+	for _, choice := range pollChoices {
+		if choice != "" && keyword.IsKeyWordIncluded(choice, words) {
+			return ErrContainsProhibitedWords
 		}
 	}
 	return nil

--- a/internal/core/note/note_create_service_test.go
+++ b/internal/core/note/note_create_service_test.go
@@ -2125,3 +2125,44 @@ func TestCreateService_SpecifiedAddsReplyTargetToVisible(t *testing.T) {
 	assert.Contains(t, []string(created.VisibleUserIDs), "userB",
 		"specified note の reply target は visibleUserIds に自動追加される")
 }
+
+// #2106 N12: prohibited words は poll choices も検査する (upstream checkProhibitedWordsContain)。
+func TestCreateService_ProhibitedWords_PollChoice(t *testing.T) {
+	svc, _, _ := newCreateService(t)
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "m1", ProhibitedWords: []string{"badword"}}
+	svc.SetMetaRepo(metaRepo)
+
+	text := "clean text"
+	_, err := svc.Create(note.CreateInput{
+		User: &model.User{ID: "u1"},
+		Text: &text,
+		Poll: &note.PollInput{Choices: []string{"ok choice", "has badword inside"}},
+	})
+	assert.ErrorIs(t, err, note.ErrContainsProhibitedWords, "poll choice 内の禁止語をブロック")
+}
+
+// #2106 N12: prohibited words は /regex/flags 形式を解釈する (素朴 Contains でない)。
+func TestCreateService_ProhibitedWords_Regex(t *testing.T) {
+	svc, _, _ := newCreateService(t)
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "m1", ProhibitedWords: []string{"/b[a4]dword/i"}}
+	svc.SetMetaRepo(metaRepo)
+
+	text := "this is a b4dword test"
+	_, err := svc.Create(note.CreateInput{User: &model.User{ID: "u1"}, Text: &text})
+	assert.ErrorIs(t, err, note.ErrContainsProhibitedWords, "regex 形式の禁止語をブロック")
+}
+
+// #2106 N12: prohibited words の判定は case-sensitive (upstream isKeyWordIncluded 準拠)。
+// 旧実装は強制 lowercase で upstream とマッチ結果が乖離していた。
+func TestCreateService_ProhibitedWords_CaseSensitive(t *testing.T) {
+	svc, _, _ := newCreateService(t)
+	metaRepo := testutil.NewMockMetaRepository()
+	metaRepo.Meta = &model.Meta{ID: "m1", ProhibitedWords: []string{"badword"}}
+	svc.SetMetaRepo(metaRepo)
+
+	text := "this has BADWORD in caps"
+	_, err := svc.Create(note.CreateInput{User: &model.User{ID: "u1"}, Text: &text})
+	require.NoError(t, err, "大文字の BADWORD は小文字 badword フィルタに (case-sensitive で) マッチしない")
+}


### PR DESCRIPTION
全コードベース再監査 (#2106) の parity MEDIUM finding N12。checkProhibitedWords が text+cw のみを素朴 Contains (lowercase) で検査し、poll choices 未検査・regex/space-AND 未解釈・case 乖離だった。prohibited は 400 hard block なので moderation 設定が silently 無効化されていた。sensitiveWords は正しく IsKeyWordIncluded を使うのに非対称。

checkProhibitedWords を sensitiveWords と同じ keyword.IsKeyWordIncluded (regex/space-AND/case-sensitive) + cw/text/各 poll choice 独立検査に揃える。回帰テスト追加。Closes #2151