### PR TITLE
/proxy の resize mode で非変換 MIME を 404 にする (#2106 N19)

### DIFF
--- a/internal/core/mediaproxy/service.go
+++ b/internal/core/mediaproxy/service.go
@@ -508,6 +508,14 @@ func (s *Service) processAndReturn(ctx context.Context, data []byte, contentType
 			return s.passThrough(data, contentType)
 		}
 	}
+	// #2106 N19: resize 系 mode (emoji/avatar/static/preview/badge) は変換可能な image を
+	// 要求する。video 静止画化 + animated passThrough を経た後でも convertible でない MIME
+	// (text/html, application/pdf 等) は upstream FileServerProxyHandler の "Unexpected mime"
+	// と同じく 404 にする。生 bytes を宣言 content-type で配信すると passThrough 経路の
+	// browsersafe allowlist を回避でき、CSP の無い /proxy 上で XSS 補助面になる。
+	if isResizeMode(mode) && !isConvertibleImage(contentType) {
+		return nil, ErrNotFound
+	}
 	switch mode {
 	case ModeEmoji:
 		return s.processResize(data, contentType, 0, emojiHeight, out)

--- a/internal/core/mediaproxy/video_thumbnail_test.go
+++ b/internal/core/mediaproxy/video_thumbnail_test.go
@@ -319,3 +319,14 @@ func TestIsResizeMode(t *testing.T) {
 	}
 	assert.False(t, isResizeMode(ModeDefault))
 }
+
+// #2106 N19: resize 系 mode は非変換 MIME (text/html 等) を 404 にする (生 bytes を
+// 宣言 content-type で配信しない)。upstream FileServerProxyHandler の "Unexpected mime" 404。
+func TestProcessAndReturn_ResizeMode_NonConvertibleMIME_NotFound(t *testing.T) {
+	s := testService(nil)
+	html := []byte("<html><body><script>alert(1)</script></body></html>")
+	for _, mode := range []ProxyMode{ModeEmoji, ModeAvatar, ModeStatic, ModePreview, ModeBadge} {
+		_, err := s.processAndReturn(context.Background(), html, "text/html", mode, FormatWebP, "https://remote.example/x.html")
+		assert.ErrorIs(t, err, ErrNotFound, "mode=%v: 非変換 MIME は 404", mode)
+	}
+}


### PR DESCRIPTION
全コードベース再監査 (#2106) の parity MEDIUM finding N19。/proxy の resize 系 mode で非変換 MIME (text/html 等) を raw 配信していた。upstream は 404 'Unexpected mime'。passThrough は browsersafe で弾くのに resize 系は非対称で、signed URL 経由の text/html 配信が CSP 無し /proxy で XSS 補助面になっていた。

processAndReturn の resize case 前に isResizeMode && !isConvertibleImage → ErrNotFound (404)。animated gif は convertible なので従来通り。回帰テスト追加。Closes #2153