### PR TITLE
inbound Reject(Follow) で spurious な Undo(Follow) 逆配送を止める (#2106 N11)

### DIFF
--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -1829,7 +1829,10 @@ func (p *Processor) handleReject(act genericActivity) error {
 		return nil
 	}
 	// 既存のフォローがあれば解除する。pending な follow request も同様。
-	if err := p.followingService.Unfollow(follower.ID, followee.ID); err != nil &&
+	// #2106 N11: upstream remoteReject は AP 配送を伴わない内部削除なので、federating な
+	// Unfollow ではなく UnfollowSilent を使い、rejecter へ余計な Undo(Follow) を逆配送
+	// しない (Following 行が残るエッジケースでの連合ノイズ / 相手の重複処理を防ぐ)。
+	if err := p.followingService.UnfollowSilent(follower.ID, followee.ID); err != nil &&
 		!errors.Is(err, corefollowing.ErrNotFollowing) {
 		return err
 	}

--- a/internal/core/following/following_service.go
+++ b/internal/core/following/following_service.go
@@ -352,6 +352,20 @@ func (s *Service) Follow(followerID, followeeID string, opts FollowOptions) (*Fo
 
 // Unfollow removes a following relationship from follower to followee.
 func (s *Service) Unfollow(followerID, followeeID string) error {
+	return s.unfollow(followerID, followeeID, true)
+}
+
+// UnfollowSilent removes the following without delivering an Undo(Follow) to a
+// remote followee, mirroring upstream UserFollowingService.remoteReject which
+// cleans up the local relation (and publishes the main-stream unfollow event)
+// without any AP delivery. Used by inbound Reject(Follow) handling (#2106 N11)
+// so that receiving a Reject does not bounce a spurious Undo(Follow) back to the
+// rejecter. The normal Unfollow path still federates.
+func (s *Service) UnfollowSilent(followerID, followeeID string) error {
+	return s.unfollow(followerID, followeeID, false)
+}
+
+func (s *Service) unfollow(followerID, followeeID string, deliver bool) error {
 	if followerID == followeeID {
 		return ErrSelfFollow
 	}
@@ -377,7 +391,10 @@ func (s *Service) Unfollow(followerID, followeeID string) error {
 		follower, ferr := s.userRepo.FindByID(followerID)
 		followee, eerr := s.userRepo.FindByID(followeeID)
 		if ferr == nil && eerr == nil {
-			if s.federationHook != nil {
+			// #2106 N11: deliver=false (inbound Reject 処理) では Undo(Follow) を
+			// rejecter へ逆配送しない。chart / webhook / main stream は upstream
+			// remoteReject も publishUnfollow するので維持する。
+			if deliver && s.federationHook != nil {
 				s.federationHook.OnLocalUnfollowed(follower, followee)
 			}
 			if s.chartHook != nil {

--- a/internal/core/following/following_service_test.go
+++ b/internal/core/following/following_service_test.go
@@ -1244,3 +1244,39 @@ func TestFollow_NoInstanceRepoStillWorks(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, fRepo.Followings, 1)
 }
+
+// #2106 N11: UnfollowSilent は Undo(Follow) を逆配送しない (federationHook 不発火) が、
+// main stream の unfollow event は upstream remoteReject 同様に publish する。
+func TestUnfollowSilent_DoesNotFederateButPublishes(t *testing.T) {
+	svc, userRepo, _, _ := newSvc(t)
+	addUser(t, userRepo, "alice", false)
+	addUser(t, userRepo, "bob", false)
+	_, err := svc.Follow("alice", "bob", following.FollowOptions{})
+	require.NoError(t, err)
+
+	// Follow 時の hook 呼び出しを無視するため fresh な hook / pub に差し替える。
+	fed := &stubFederationHook{}
+	svc.SetFederationHook(fed)
+	pub := &stubMainStreamPublisher{}
+	svc.SetMainStreamPublisher(pub)
+
+	require.NoError(t, svc.UnfollowSilent("alice", "bob"))
+	assert.Empty(t, fed.unfollowed, "UnfollowSilent は Undo(Follow) を逆配送しない")
+	require.Len(t, pub.calls, 1, "main stream の unfollow event は publish する")
+	assert.Equal(t, "unfollow", pub.calls[0].eventType)
+}
+
+// #2106 N11 regression guard: 通常 Unfollow は従来通り federationHook (Undo 配送) を発火する。
+func TestUnfollow_StillFederates(t *testing.T) {
+	svc, userRepo, _, _ := newSvc(t)
+	addUser(t, userRepo, "alice", false)
+	addUser(t, userRepo, "bob", false)
+	_, err := svc.Follow("alice", "bob", following.FollowOptions{})
+	require.NoError(t, err)
+
+	fed := &stubFederationHook{}
+	svc.SetFederationHook(fed)
+
+	require.NoError(t, svc.Unfollow("alice", "bob"))
+	assert.Equal(t, []string{"alice->bob"}, fed.unfollowed, "通常 Unfollow は Undo を配送する")
+}


### PR DESCRIPTION
全コードベース再監査 (#2106) の parity MEDIUM finding N11。handleReject が federating Unfollow を呼ぶため、Following 行が残るエッジケースで rejecter へ余計な Undo(Follow) を逆配送していた。upstream remoteReject は内部削除 + publishUnfollow のみで AP 配送なし。

followingService に UnfollowSilent (federationHook 不発火、chart/webhook/main stream は維持) を追加し handleReject から使う。handleUndoAccept の Unfollow は upstream も再配送するため対象外。回帰テスト追加。Closes #2155