### PR TITLE
signer==actor 経路で LD-Signature verify 失敗による drop を止める (#2106 N26)

### DIFF
--- a/internal/core/federation/ld_signature_verifier.go
+++ b/internal/core/federation/ld_signature_verifier.go
@@ -116,3 +116,27 @@ func (v *LDSignatureVerifier) VerifyAndCreator(rawBody []byte) (string, bool, er
 	}
 	return creator, true, nil
 }
+
+// CheckForbiddenDirectivesIfPresent runs only the forbidden-directive hardening of
+// the LD-Signature pipeline (no public-key resolution, no RsaSignature2017 verify).
+//
+// Used by the signer==actor inbound path (#2106 N26) where upstream
+// InboxProcessorService skips LD-Signature processing entirely. mk-go keeps the
+// JSON-LD term-redefinition defense (CheckForForbiddenDirectives) but, unlike
+// VerifyIfPresent, does NOT drop an HTTP-signature-authenticated activity merely
+// because its LD-Signature fails to verify (uncached creator key / legacy or
+// mismatched LD-sig / normalize 差異). Returns nil when the body carries no
+// `signature` field (same scope as VerifyIfPresent).
+func (v *LDSignatureVerifier) CheckForbiddenDirectivesIfPresent(rawBody []byte) error {
+	if v == nil {
+		return nil
+	}
+	var act map[string]any
+	if err := json.Unmarshal(rawBody, &act); err != nil {
+		return fmt.Errorf("ld-sig: body unmarshal: %w", err)
+	}
+	if sigRaw, hasSig := act["signature"]; !hasSig || sigRaw == nil {
+		return nil
+	}
+	return ld.NewProcessor().CheckForForbiddenDirectives(act)
+}

--- a/internal/core/federation/ld_signature_verifier_test.go
+++ b/internal/core/federation/ld_signature_verifier_test.go
@@ -147,3 +147,38 @@ func TestLDSignatureVerifier_InterfaceShape(t *testing.T) {
 }
 
 var _ error = errors.New("compile-time anchor for errors import")
+
+// #2106 N26: CheckForbiddenDirectivesIfPresent は signature 無しを素通しする。
+func TestLDSignatureVerifier_CheckForbidden_NoSignature(t *testing.T) {
+	v := corefederation.NewLDSignatureVerifier(testutil.NewMockUserPublickeyRepository())
+	require.NoError(t, v.CheckForbiddenDirectivesIfPresent([]byte(`{"type":"Note","id":"https://example.com/n1"}`)))
+}
+
+// #2106 N26: forbidden directive は CheckForbiddenDirectivesIfPresent でも reject される。
+func TestLDSignatureVerifier_CheckForbidden_ForbiddenDirective(t *testing.T) {
+	v := corefederation.NewLDSignatureVerifier(testutil.NewMockUserPublickeyRepository())
+	err := v.CheckForbiddenDirectivesIfPresent([]byte(`{
+		"type":"Note","@graph":[{"type":"Note"}],
+		"signature":{"type":"RsaSignature2017","creator":"https://example.com/users/alice#main-key","signatureValue":"AAAA"}
+	}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden")
+}
+
+// #2106 N26: forbidden directive が無ければ、creator 鍵が未解決でも (= VerifyIfPresent なら
+// verify 失敗で drop する状況でも) CheckForbiddenDirectivesIfPresent は nil を返す。
+func TestLDSignatureVerifier_CheckForbidden_UnresolvableKeyStillPasses(t *testing.T) {
+	v := corefederation.NewLDSignatureVerifier(testutil.NewMockUserPublickeyRepository())
+	body := []byte(`{
+		"@context":"https://www.w3.org/ns/activitystreams","type":"Note",
+		"signature":{"type":"RsaSignature2017","creator":"https://example.com/users/alice#main-key","signatureValue":"AAAA"}
+	}`)
+	require.Error(t, v.VerifyIfPresent(body), "VerifyIfPresent は creator 鍵未解決で error")
+	require.NoError(t, v.CheckForbiddenDirectivesIfPresent(body), "forbidden 無し + 鍵不要なので nil")
+}
+
+// #2106 N26: 不正 JSON は CheckForbiddenDirectivesIfPresent でも error。
+func TestLDSignatureVerifier_CheckForbidden_BadJSON(t *testing.T) {
+	v := corefederation.NewLDSignatureVerifier(testutil.NewMockUserPublickeyRepository())
+	require.Error(t, v.CheckForbiddenDirectivesIfPresent([]byte(`{not json`)))
+}

--- a/internal/queue/processors/inbox.go
+++ b/internal/queue/processors/inbox.go
@@ -80,6 +80,11 @@ type InboxChartHook interface {
 // 実装は core/federation.LDSignatureVerifier。
 type LDSignatureVerifier interface {
 	VerifyIfPresent(rawBody []byte) error
+	// CheckForbiddenDirectivesIfPresent runs only the forbidden-directive hardening
+	// (no key resolution / RSA verify). Used by the signer==actor path (#2106 N26)
+	// so an HTTP-signature-authenticated activity is not dropped just because its
+	// LD-Signature fails to verify, while keeping the JSON-LD injection defense.
+	CheckForbiddenDirectivesIfPresent(rawBody []byte) error
 	// VerifyAndCreator additionally reports whether the activity carried an
 	// LD-Signature and, on success, the verified signature.creator key URI.
 	// Used to authenticate forwarded activities whose HTTP signer differs
@@ -287,9 +292,13 @@ func (p *InboxProcessor) authorizeActor(body []byte, signer *model.User) error {
 	}
 
 	if signerURI != "" && signerURI == bodyActor {
-		// 署名者 == actor。LD-Signature があれば hardening のため検証する。
+		// #2106 N26: 署名者 == actor かつ HTTP 署名検証済みの通常経路では、upstream
+		// InboxProcessorService は LD-Signature を一切検証しない。mk-go は
+		// forbidden-directive hardening (JSON-LD term 再定義防御) のみ残し、署名 verify
+		// 失敗 (creator 鍵未解決 / legacy LD-sig / normalize 差異) で HTTP 署名済の正規
+		// activity を drop しないようにする。
 		if p.ldVerifier != nil {
-			return p.ldVerifier.VerifyIfPresent(body)
+			return p.ldVerifier.CheckForbiddenDirectivesIfPresent(body)
 		}
 		return nil
 	}

--- a/internal/queue/processors/inbox_test.go
+++ b/internal/queue/processors/inbox_test.go
@@ -439,11 +439,19 @@ type stubLDVerifier struct {
 	creator      string
 	present      bool
 	creatorCount int
+	// CheckForbiddenDirectivesIfPresent outcome (signer==actor path, #2106 N26).
+	forbiddenErr   error
+	forbiddenCount int
 }
 
 func (s *stubLDVerifier) VerifyIfPresent(_ []byte) error {
 	s.callCount++
 	return s.err
+}
+
+func (s *stubLDVerifier) CheckForbiddenDirectivesIfPresent(_ []byte) error {
+	s.forbiddenCount++
+	return s.forbiddenErr
 }
 
 func (s *stubLDVerifier) VerifyAndCreator(_ []byte) (string, bool, error) {
@@ -759,4 +767,66 @@ func TestInboxProcessor_GenericErrorPropagatesForRetry(t *testing.T) {
 	assert.True(t, errors.Is(err, boom), "underlying error must be wrapped, not swallowed")
 	assert.False(t, errors.Is(err, driver.SkipRetry),
 		"transient errors should NOT carry SkipRetry — driver retry handles them")
+}
+
+// #2106 N26: HTTP 署名済 + signer==actor の通常経路では、LD-Signature verify 失敗
+// (creator 鍵未解決 / legacy LD-sig 等) でも正規 activity を drop しない (upstream は
+// LD-Signature を一切検証しない)。forbidden-directive hardening は維持する。
+func TestInboxProcessor_SignerIsActor_LDSigVerifyFailureNotDropped(t *testing.T) {
+	priv, pub, err := activitypub.GenerateRSAKeypair()
+	require.NoError(t, err)
+	key, err := activitypub.NewPrivateKey("https://remote.example/users/alice#main-key", priv)
+	require.NoError(t, err)
+
+	host := "remote.example"
+	verifier := &multiActorVerifier{
+		pubKey: pub,
+		byURI: map[string]*model.User{
+			"https://remote.example/users/alice": {ID: "alice", Host: &host, URI: uptr("https://remote.example/users/alice")},
+		},
+	}
+	stub := &stubFedProcessor{}
+	p := processors.NewInboxProcessor(stub)
+	p.SetSignatureVerifier(verifier)
+	// VerifyIfPresent はエラー (鍵未解決) だが forbidden-directive check は通る。
+	ldv := &stubLDVerifier{present: true, err: errors.New("ld-sig: public key not found"), forbiddenErr: nil}
+	p.SetLDSignatureVerifier(ldv)
+
+	body := []byte(`{"id":"https://remote.example/creates/1","type":"Create","actor":"https://remote.example/users/alice","signature":{"type":"RsaSignature2017","creator":"https://remote.example/users/alice#main-key"}}`)
+	payload := signedInboxPayload(t, key, body)
+	require.NoError(t, p.Handle(context.Background(), driver.RawTask{
+		TypeName: queue.TaskTypeInbox, Body: mustEncode(t, payload),
+	}))
+	require.Len(t, stub.calls, 1, "signer==actor の HTTP 署名済 activity は LD-sig verify 失敗でも処理される")
+	assert.Equal(t, 0, ldv.callCount, "signer==actor 経路では VerifyIfPresent を呼ばない")
+	assert.Equal(t, 1, ldv.forbiddenCount, "forbidden-directive hardening は実行する")
+}
+
+// #2106 N26: signer==actor でも forbidden directive が検出されれば drop する (hardening 維持)。
+func TestInboxProcessor_SignerIsActor_ForbiddenDirectiveDropped(t *testing.T) {
+	priv, pub, err := activitypub.GenerateRSAKeypair()
+	require.NoError(t, err)
+	key, err := activitypub.NewPrivateKey("https://remote.example/users/alice#main-key", priv)
+	require.NoError(t, err)
+
+	host := "remote.example"
+	verifier := &multiActorVerifier{
+		pubKey: pub,
+		byURI: map[string]*model.User{
+			"https://remote.example/users/alice": {ID: "alice", Host: &host, URI: uptr("https://remote.example/users/alice")},
+		},
+	}
+	stub := &stubFedProcessor{}
+	p := processors.NewInboxProcessor(stub)
+	p.SetSignatureVerifier(verifier)
+	ldv := &stubLDVerifier{present: true, forbiddenErr: errors.New("ld-sig: forbidden directive")}
+	p.SetLDSignatureVerifier(ldv)
+
+	body := []byte(`{"id":"https://remote.example/creates/1","type":"Create","actor":"https://remote.example/users/alice","signature":{"type":"RsaSignature2017","creator":"https://remote.example/users/alice#main-key"}}`)
+	payload := signedInboxPayload(t, key, body)
+	require.NoError(t, p.Handle(context.Background(), driver.RawTask{
+		TypeName: queue.TaskTypeInbox, Body: mustEncode(t, payload),
+	}))
+	require.Len(t, stub.calls, 0, "forbidden directive は signer==actor でも drop する")
+	assert.Equal(t, 1, ldv.forbiddenCount)
 }


### PR DESCRIPTION
全コードベース再監査 (#2106) の bug MEDIUM finding N26。authorizeActor が signer==actor (HTTP 署名検証済) でも LD-Signature を毎回 verify し、creator 鍵未解決等の失敗で HTTP 署名済の正規 activity を drop していた。upstream は同経路で LD-sig を検証しない。

signer==actor 経路では forbidden-directive hardening のみ実行する CheckForbiddenDirectivesIfPresent を呼ぶ (JSON-LD 防御は維持、verify-drop は廃止)。legacy 経路 (LD-sig が唯一の認証) と転送経路は full verify 維持。回帰テスト追加。Closes #2157