### PR TITLE
silenced instance の remote public note を home に降格する (#2106 N14)

### DIFF
--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -180,6 +180,10 @@ type Resolver struct {
 	// (全 host 許可) にフォールバック。
 	hostBlocker HostBlockChecker
 
+	// silencedChecker は remote note ingest 時に meta.silencedHosts 該当 host の
+	// public note を home に降格する判定に使う (#2106 N14)。未配線時は降格しない。
+	silencedChecker SilencedHostChecker
+
 	// resolveActorGroup / resolveNoteGroup は同一 URI への並行 ResolveActor /
 	// ResolveNote 呼び出しを 1 度の DB lookup + HTTP fetch に collapse する
 	// (#300 3-7)。inbox 受信時に同じ remote actor / note を参照する activity
@@ -313,6 +317,19 @@ func (r *Resolver) SetDriveFileRepo(repo repository.DriveFileRepository) {
 // gate が無効化されて legacy 挙動 (全 host 許可) に倒れる。
 func (r *Resolver) SetHostBlockChecker(c HostBlockChecker) {
 	r.hostBlocker = c
+}
+
+// SilencedHostChecker reports whether a remote host is in meta.silencedHosts.
+// *instance.Service implements it (IsSilenced).
+type SilencedHostChecker interface {
+	IsSilenced(host string) bool
+}
+
+// SetSilencedHostChecker attaches the meta.silencedHosts checker used to demote
+// a silenced remote instance's public notes to home on ingest (#2106 N14).
+// 未配線時は降格しない。
+func (r *Resolver) SetSilencedHostChecker(c SilencedHostChecker) {
+	r.silencedChecker = c
 }
 
 // hostAllowed reports whether the resolver may talk to / persist content
@@ -1163,6 +1180,14 @@ func (r *Resolver) ingestNoteWithCreated(body []byte, deliveringActorURI string,
 		UserHost:   actor.Host,
 		URI:        &noteURI,
 		Visibility: deriveVisibility(apNote.To, apNote.CC),
+	}
+	// #2106 N14: silenced instance (meta.silencedHosts) の remote public note は home に
+	// 降格する (upstream NoteCreateService.ts:491-495 の inSilencedInstance 降格)。public
+	// timeline / 連合 broadcast から外す admin moderation 機能。silencedChecker 未配線時は
+	// 降格しない (legacy 挙動)。
+	if note.Visibility == model.NoteVisibilityPublic && actor.Host != nil && *actor.Host != "" &&
+		r.silencedChecker != nil && r.silencedChecker.IsSilenced(*actor.Host) {
+		note.Visibility = model.NoteVisibilityHome
 	}
 	// TS本家ApNoteService.tsと同じ3段フォールバックでtext抽出:
 	// 1. source.content (MFM) → 2. _misskey_content → 3. content (HTML→MFM変換)

--- a/internal/core/federation/resolver_allowlist_test.go
+++ b/internal/core/federation/resolver_allowlist_test.go
@@ -186,3 +186,30 @@ func TestProcessCreate_AllowedSenderNonFederatedAttributedToIsDropped(t *testing
 	require.NoError(t, p.Process(body))
 	assert.Empty(t, noteRepo.Notes, "非連合 host (attributedTo) の note は永続化しない")
 }
+
+// stubSilencedChecker implements federation.SilencedHostChecker.
+type stubSilencedChecker struct{ silenced map[string]bool }
+
+func (s *stubSilencedChecker) IsSilenced(host string) bool { return s.silenced[host] }
+
+// #2106 N14: silenced instance (meta.silencedHosts) の remote public note は home に降格される。
+func TestIngestNote_SilencedHostPublicDemotedToHome(t *testing.T) {
+	r, _, _ := newGatedResolver(t, sampleActor, nil)
+	r.SetSilencedHostChecker(&stubSilencedChecker{silenced: map[string]bool{"remote.example": true}})
+
+	note, _, err := r.IngestNoteWithCreated([]byte(sampleRemoteNote), "")
+	require.NoError(t, err)
+	require.NotNil(t, note)
+	assert.Equal(t, model.NoteVisibilityHome, note.Visibility, "silenced host の public note は home に降格")
+}
+
+// #2106 N14: silenced でない host の public note は public のまま (降格しない)。
+func TestIngestNote_NonSilencedHostPublicStaysPublic(t *testing.T) {
+	r, _, _ := newGatedResolver(t, sampleActor, nil)
+	r.SetSilencedHostChecker(&stubSilencedChecker{silenced: map[string]bool{"other.example": true}})
+
+	note, _, err := r.IngestNoteWithCreated([]byte(sampleRemoteNote), "")
+	require.NoError(t, err)
+	require.NotNil(t, note)
+	assert.Equal(t, model.NoteVisibilityPublic, note.Visibility, "silenced でない host は public のまま")
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -619,6 +619,7 @@ func (s *Server) setupRoutes() {
 	// resolver の入口 (fetchActor / resolveNoteOnce / IngestNoteWithCreated) に
 	// 適用する。deliver_service / inboxProcessor と同じ instanceService を共有。
 	federationResolver.SetHostBlockChecker(instanceService)
+	federationResolver.SetSilencedHostChecker(instanceService) // #2106 N14: silenced host の public note を home 降格
 	// 新規 instance row 発見時に nodeinfo を取得して metadata を更新する。
 	// admin/federation/refresh-remote-instance-metadata でも同じ fetcher を
 	// 再利用して on-demand で再取得する (#351 フォロー)。


### PR DESCRIPTION
全コードベース再監査 (#2106) の parity MEDIUM finding N14。meta.silencedHosts の remote instance の public note が mk-go では public のまま LTL/GTL に出続けていた。upstream は inSilencedInstance で public→home に降格する。

Resolver に SilencedHostChecker (instance.Service.IsSilenced backed) を optional 配線し、IngestNoteWithCreated で remote public note の silenced host を home 降格。回帰テスト追加。Closes #2159