### PR TITLE
signup で prohibitedWordsForNameOfUser を検証する (#2106 N20)

### DIFF
--- a/internal/core/signup/signup_service.go
+++ b/internal/core/signup/signup_service.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/shiroha-a/mk/internal/activitypub"
 	"github.com/shiroha-a/mk/internal/misc/id"
+	"github.com/shiroha-a/mk/internal/misc/keyword"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
 	"golang.org/x/crypto/bcrypt"
@@ -284,8 +285,17 @@ func (s *Service) Signup(username, password string, isInitialSetup bool) (*Signu
 	// admin / root が予約ワードに含まれうるので除外する。meta fetch 失敗時は
 	// ベストエフォートで通過させる (オンライン性を優先)。
 	if !isInitialSetup {
-		if meta, err := s.metaRepo.Fetch(); err == nil && isReservedUsername(lower, meta.PreservedUsernames) {
-			return nil, ErrUsernameReserved
+		if meta, err := s.metaRepo.Fetch(); err == nil {
+			if isReservedUsername(lower, meta.PreservedUsernames) {
+				return nil, ErrUsernameReserved
+			}
+			// #2106 N20: meta.prohibitedWordsForNameOfUser に該当する username を弾く
+			// (upstream SignupService:97-100、rootUserId!=null = 非初回セットアップ時)。
+			// upstream は 'USED_USERNAME' を throw するので USED_USERNAME にマップされる
+			// ErrUsernameUsed を返す (preserved の DENIED_USERNAME とは別コード)。
+			if keyword.IsKeyWordIncluded(lower, meta.ProhibitedWordsForNameOfUser) {
+				return nil, ErrUsernameUsed
+			}
 		}
 	}
 
@@ -413,8 +423,14 @@ func (s *Service) CreatePending(username, email, password string, invitationTick
 	if s.isUsedUsername(lower) {
 		return nil, ErrUsernameUsed
 	}
-	if meta, err := s.metaRepo.Fetch(); err == nil && isReservedUsername(lower, meta.PreservedUsernames) {
-		return nil, ErrUsernameReserved
+	if meta, err := s.metaRepo.Fetch(); err == nil {
+		if isReservedUsername(lower, meta.PreservedUsernames) {
+			return nil, ErrUsernameReserved
+		}
+		// #2106 N20: prohibited words for username (Signup と同じ guard、email 確認経路)。
+		if keyword.IsKeyWordIncluded(lower, meta.ProhibitedWordsForNameOfUser) {
+			return nil, ErrUsernameUsed
+		}
 	}
 
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)

--- a/internal/core/signup/signup_service_test.go
+++ b/internal/core/signup/signup_service_test.go
@@ -611,3 +611,31 @@ func TestPromotePending_NoTxRecordsUsedUsername(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, exists, "non-tx promote も used_username に記録する")
 }
+
+// #2106 N20: meta.prohibitedWordsForNameOfUser に該当する username を signup で弾く。
+func TestSignup_ProhibitedUsername(t *testing.T) {
+	svc, _, metaRepo := newTestService(t)
+	metaRepo.Meta.ProhibitedWordsForNameOfUser = []string{"badname"}
+	_, err := svc.Signup("badname123", "pass", false)
+	assert.ErrorIs(t, err, signup.ErrUsernameUsed)
+}
+
+// #2106 N20: 初回セットアップ (isInitialSetup=true / rootUserId==null) では prohibited
+// チェックを skip する (upstream は rootUserId!=null のときのみ評価)。
+func TestSignup_ProhibitedUsernameAllowedOnInitialSetup(t *testing.T) {
+	svc, _, metaRepo := newTestService(t)
+	metaRepo.Meta.ProhibitedWordsForNameOfUser = []string{"badname"}
+	result, err := svc.Signup("badname123", "pass", true)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+// #2106 N20: CreatePending (email 確認経路) でも prohibited username を弾く。
+func TestCreatePending_ProhibitedUsername(t *testing.T) {
+	svc, _, metaRepo := newTestService(t)
+	pendingRepo := testutil.NewMockUserPendingRepository()
+	svc.SetUserPendingRepo(pendingRepo)
+	metaRepo.Meta.ProhibitedWordsForNameOfUser = []string{"badname"}
+	_, err := svc.CreatePending("badname123", "x@example.com", "pass", nil)
+	assert.ErrorIs(t, err, signup.ErrUsernameUsed)
+}


### PR DESCRIPTION
全コードベース再監査 (#2106) の parity MEDIUM finding N20。Signup / CreatePending が meta.prohibitedWordsForNameOfUser を見ず、禁止語を含む username が弾かれなかった。upstream は isKeyWordIncluded で 'USED_USERNAME' を throw する。

Signup (非初回) / CreatePending で keyword.IsKeyWordIncluded(lower, ProhibitedWordsForNameOfUser) を評価し ErrUsernameUsed (→ USED_USERNAME) を返す。回帰テスト追加 (prohibited reject / initial-setup skip / CreatePending)。Closes #2161