### PR TITLE
i/notifications で notifier 解決不能の通知を drop する (#2106 N6)

### DIFF
--- a/internal/api/notifications/grouped_test.go
+++ b/internal/api/notifications/grouped_test.go
@@ -191,18 +191,18 @@ func TestGrouped_RenotesDifferentTargetsStaySeparate(t *testing.T) {
 	assert.Equal(t, "renote", resp[1]["type"])
 }
 
-// renote grouping で notifier user が解決できない場合でも group は成立し、
-// users[] は解決できた分のみになる (renoteUsers の空初期化分岐を覆う)。
-func TestGrouped_RenoteGroupWithUnresolvedFirstUser(t *testing.T) {
+// #2106 N6: renote 通知の notifier user が解決できない (= hard-delete 等) 場合、その通知は
+// 丸ごと drop される (upstream #packInternal の needsUser && !userIfNeed)。bob が解決不能なら
+// bob の renote 通知は落ち、解決できた carol の renote 1 件のみが残る (単独なので grouped で
+// なく単発の "renote")。
+func TestGrouped_RenoteUnresolvedNotifierDropped(t *testing.T) {
 	h, svc, userRepo, noteRepo := groupedHandler(t)
-	// 最初の notifier (bob) は userRepo に登録しない → packed["user"] 不在。
+	// notifier bob は userRepo に登録しない → notifier 解決不能 → 通知ごと drop。
 	userRepo.Users["carol"] = &model.User{ID: "carol", Username: "carol"}
 	noteRepo.Notes["rn1"] = &model.Note{ID: "rn1", UserID: "bob", Visibility: "public", RenoteID: strPtr("target"), User: &model.User{ID: "bob"}}
 	noteRepo.Notes["rn2"] = &model.Note{ID: "rn2", UserID: "carol", Visibility: "public", RenoteID: strPtr("target"), User: &model.User{ID: "carol"}}
 
 	ctx := context.Background()
-	// carol を先に作る → list は newest-first で [bob(rn1), carol(rn2)]。
-	// 先頭 (bob) が未解決なので renoteUsers は空初期化、続く carol だけ users[] に入る。
 	_, err := svc.Create(ctx, notification.CreateInput{NotifieeID: "alice", NotifierID: "carol", Type: notification.TypeRenote, NoteID: "rn2"})
 	require.NoError(t, err)
 	_, err = svc.Create(ctx, notification.CreateInput{NotifieeID: "alice", NotifierID: "bob", Type: notification.TypeRenote, NoteID: "rn1"})
@@ -213,11 +213,8 @@ func TestGrouped_RenoteGroupWithUnresolvedFirstUser(t *testing.T) {
 	require.NoError(t, h.Grouped(c))
 
 	resp := decodeGrouped(t, rec.Body.Bytes())
-	require.Len(t, resp, 1)
-	assert.Equal(t, "renote:grouped", resp[0]["type"])
-	users, _ := resp[0]["users"].([]any)
-	// bob は解決不能なので carol の 1 件のみ。
-	assert.Len(t, users, 1)
+	require.Len(t, resp, 1, "bob (解決不能 notifier) の通知は drop され carol の 1 件のみ")
+	assert.Equal(t, "renote", resp[0]["type"], "残り 1 件は単発の renote")
 }
 
 // reaction group の後ろに非グループ通知 (follow) が並ぶと grouping が途切れる。

--- a/internal/api/notifications/handler.go
+++ b/internal/api/notifications/handler.go
@@ -289,12 +289,17 @@ func (h *Handler) collectNotifications(c echo.Context, user *model.User, req Lis
 	}
 
 	notifierByID := make(map[string]*model.User, len(notifierIDSet))
+	// #2106 N6: notifier fetch が成功したかを記録する。成功時のみ unresolved notifier の
+	// notifier-required 通知を drop する (transient な FindManyByIDs 失敗で全件 mass-drop
+	// しないため)。userRepo 未配線 / notifier 不要のときは false のままで drop しない。
+	notifierFetchOK := false
 	if h.userRepo != nil && len(notifierIDSet) > 0 {
 		ids := make([]string, 0, len(notifierIDSet))
 		for id := range notifierIDSet {
 			ids = append(ids, id)
 		}
 		if users, err := h.userRepo.FindManyByIDs(ids); err == nil {
+			notifierFetchOK = true
 			for _, u := range users {
 				notifierByID[u.ID] = u
 			}
@@ -307,6 +312,25 @@ func (h *Handler) collectNotifications(c echo.Context, user *model.User, req Lis
 	// NotificationEntityService #filterValidNotifier)。noteIDSet は survivor から
 	// 組み立てる (落とした通知の note を無駄に引かない)。
 	filtered = h.filterValidNotifiers(user.ID, filtered, notifierByID)
+
+	// #2106 N6: notifier user が解決できなかった notifier-required 通知を drop する
+	// (upstream NotificationEntityService #packInternal の `needsUser && !userIfNeed →
+	// return null`)。misskey-js / misskey_dart は Notification.user を non-null 必須で
+	// decode するため、hard-delete された notifier の shape 不整合通知を返すと strict
+	// client が当該ページ decode で crash する。transient な fetch 失敗では mass-drop
+	// しないよう、fetch 成功時のみ適用する。
+	if notifierFetchOK {
+		kept := filtered[:0]
+		for _, n := range filtered {
+			if n.NotifierID != "" {
+				if _, ok := notifierByID[n.NotifierID]; !ok {
+					continue
+				}
+			}
+			kept = append(kept, n)
+		}
+		filtered = kept
+	}
 
 	noteIDSet := make(map[string]struct{})
 	for _, n := range filtered {

--- a/internal/api/notifications/handler_test.go
+++ b/internal/api/notifications/handler_test.go
@@ -944,3 +944,26 @@ func TestShow_QueryServiceNil_NoteEmbedDropped(t *testing.T) {
 	assert.False(t, hasNote, "queryService 未配線時は fail-closed で note embed を skip すること")
 	assert.Equal(t, "n1", resp[0]["noteId"], "noteId 自体は echo される")
 }
+
+// #2106 N6: i/notifications は notifier user が解決できない notifier-required 通知を drop
+// する (upstream #packInternal の needsUser && !userIfNeed)。strict client (misskey_dart 等)
+// は Notification.user を non-null 必須で decode するため shape 不整合通知を返さない。
+func TestShow_UnresolvedNotifierDropped(t *testing.T) {
+	h, svc, userRepo, _ := groupedHandler(t)
+	userRepo.Users["carol"] = &model.User{ID: "carol", Username: "carol"}
+	// bob は userRepo に登録しない → 解決不能 → 通知ごと drop。
+	ctx := context.Background()
+	_, err := svc.Create(ctx, notification.CreateInput{NotifieeID: "alice", NotifierID: "carol", Type: notification.TypeFollow})
+	require.NoError(t, err)
+	_, err = svc.Create(ctx, notification.CreateInput{NotifieeID: "alice", NotifierID: "bob", Type: notification.TypeFollow})
+	require.NoError(t, err)
+
+	c, rec := newJSONRequest(t, "/api/i/notifications", `{"limit":50}`)
+	setAuth(c, &model.User{ID: "alice"})
+	require.NoError(t, h.Show(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1, "bob (解決不能 notifier) の follow 通知は drop、carol のみ残る")
+	assert.Equal(t, "carol", resp[0]["userId"])
+}


### PR DESCRIPTION
全コードベース再監査 (#2106) の parity MEDIUM finding N6。notifier user 解決不能 (hard-delete 等) の通知を mk-go は user 欠落のまま返し、misskey-js / misskey_dart の non-null cast で strict client が crash し得た。upstream は当該通知を drop する。

collectNotifications で notifier fetch 成功時のみ notifier-required かつ未解決の通知を drop (transient 失敗では mass-drop しない)。回帰テスト追加 (grouped / 非 grouped)。Closes #2163