### PR TITLE
rateLimitFactor を upstream の除数 semantics に揃える (#2106 N28)

### DIFF
--- a/internal/server/middleware/ratelimit.go
+++ b/internal/server/middleware/ratelimit.go
@@ -172,10 +172,12 @@ func (rl *RateLimiter) Middleware() echo.MiddlewareFunc {
 			for _, a := range actors {
 				effectiveMax := scaledMax(limit.Max, a.factor)
 
-				// minInterval チェック (factor は適用しない — minInterval は連投
-				// 抑止が目的なので user role で緩和する semantics ではない)
+				// minInterval チェック。#2106 N28: upstream RateLimiterService は
+				// `duration: minInterval * factor` で window に factor を乗算する
+				// (旧 mk-go は factor 未適用で乖離していた)。
 				if limit.MinInterval > 0 {
-					info, err := rl.store.Check(ctx, a.key+":"+endpoint+":min", limit.MinInterval, 1)
+					minInterval := scaledMinInterval(limit.MinInterval, a.factor)
+					info, err := rl.store.Check(ctx, a.key+":"+endpoint+":min", minInterval, 1)
 					if err != nil {
 						slog.Warn("rate limit store error (minInterval)", "endpoint", endpoint, "err", err)
 						continue
@@ -271,16 +273,34 @@ func (rl *RateLimiter) userFactor(userID string) float64 {
 	return 1.0
 }
 
-// scaledMax applies factor to the base Max. factor=1.0 では base そのまま、
-// factor が小さすぎても 1 を下回らないようにクランプ (factor=0 等の事故で
-// 全 user が瞬時に 429 を食らうのを防ぐ)。
+// scaledMax divides the base Max by factor, mirroring upstream
+// RateLimiterService.limit() の `max: limitation.max / factor` (#2106 N28)。
+// rateLimitFactor は **除数** で、値が大きいほど実効 max が小さくなる
+// (= role policy で締める) — 例 factor=3(300%) で 1/3 に厳格化、factor=0.3(30%) で
+// 約 3.3x に緩和。factor=1.0 / 不正値 (<=0) は base そのまま。結果は最低 1 に
+// クランプ (factor 過大の事故で全 user が瞬時に 429 を食らうのを防ぐ)。
 func scaledMax(base int, factor float64) int {
 	if factor <= 0 || factor == 1.0 {
 		return base
 	}
-	scaled := int(float64(base) * factor)
+	scaled := int(float64(base) / factor)
 	if scaled < 1 {
 		return 1
+	}
+	return scaled
+}
+
+// scaledMinInterval multiplies the base minInterval window by factor, mirroring
+// upstream RateLimiterService の `duration: limitation.minInterval * factor`
+// (#2106 N28)。max と同じく factor が大きいほど window が長くなり (= 連投間隔が
+// 厳しくなる)、小さいほど緩む。factor=1.0 / 不正値は base そのまま。
+func scaledMinInterval(base time.Duration, factor float64) time.Duration {
+	if factor <= 0 || factor == 1.0 {
+		return base
+	}
+	scaled := time.Duration(float64(base) * factor)
+	if scaled < 0 {
+		return base
 	}
 	return scaled
 }

--- a/internal/server/middleware/ratelimit_test.go
+++ b/internal/server/middleware/ratelimit_test.go
@@ -214,8 +214,8 @@ func TestMiddleware_AuthenticatedActor_IPDisabled(t *testing.T) {
 	assert.Equal(t, "u1:notes/create", store.calls[0].Key)
 }
 
-// PolicyProvider 経由で rateLimitFactor=2.0 が反映されると Max が
-// scale される (#606 item 4)。
+// PolicyProvider 経由で rateLimitFactor=2.0 が反映されると Max が upstream 同様
+// max/factor で scale される (#606 item 4 / #2106 N28: factor=2.0 で 1/2 に厳格化)。
 func TestMiddleware_PolicyProviderScalesMax(t *testing.T) {
 	store := &mockLimitStore{
 		results: []mockResult{
@@ -233,8 +233,8 @@ func TestMiddleware_PolicyProviderScalesMax(t *testing.T) {
 	doRequest(e, rl.Middleware(), h, "/api/notes/create", &model.User{ID: "vip"})
 
 	require.Len(t, store.calls, 2)
-	// userID bucket は factor=2.0 で 600 に scale、IP bucket は factor=1.0
-	assert.Equal(t, 600, store.calls[0].Max, "userID bucket: 300 * 2.0")
+	// userID bucket は factor=2.0 で 150 に scale (300/2.0)、IP bucket は factor=1.0
+	assert.Equal(t, 150, store.calls[0].Max, "userID bucket: 300 / 2.0 (factor は除数)")
 	assert.Equal(t, 300, store.calls[1].Max, "IP bucket は factor 適用外")
 }
 
@@ -276,14 +276,24 @@ func (s stubPolicy) GetUserPolicies(_ string) map[string]any {
 	return map[string]any{"rateLimitFactor": s.factor}
 }
 
-// scaledMax の境界値テスト (factor=0.001 等で 1 を下回らずクランプ)
+// scaledMax は upstream RateLimiterService の max/factor (除数) semantics (#2106 N28)。
+// factor が大きいほど実効 max が小さく (厳格)、小さいほど大きく (緩和) なる。
 func TestScaledMax(t *testing.T) {
 	assert.Equal(t, 300, scaledMax(300, 1.0))
-	assert.Equal(t, 600, scaledMax(300, 2.0))
-	assert.Equal(t, 150, scaledMax(300, 0.5))
-	assert.Equal(t, 1, scaledMax(10, 0.001), "極小 factor でも 1 にクランプ")
+	assert.Equal(t, 150, scaledMax(300, 2.0), "factor=2.0 (200%) で 1/2 に厳格化")
+	assert.Equal(t, 600, scaledMax(300, 0.5), "factor=0.5 (50%) で 2x に緩和")
+	assert.Equal(t, 1, scaledMax(10, 1000.0), "極大 factor でも 1 にクランプ")
 	assert.Equal(t, 300, scaledMax(300, 0), "factor=0 は 1.0 扱い (= base)")
 	assert.Equal(t, 300, scaledMax(300, -1), "負数も 1.0 扱い (防御)")
+}
+
+// scaledMinInterval は upstream の minInterval*factor semantics (#2106 N28)。
+func TestScaledMinInterval(t *testing.T) {
+	base := 1000 * time.Millisecond
+	assert.Equal(t, base, scaledMinInterval(base, 1.0))
+	assert.Equal(t, 2000*time.Millisecond, scaledMinInterval(base, 2.0), "factor=2.0 で window 2x (厳格)")
+	assert.Equal(t, 500*time.Millisecond, scaledMinInterval(base, 0.5), "factor=0.5 で window 半分 (緩和)")
+	assert.Equal(t, base, scaledMinInterval(base, 0), "factor=0 は base")
 }
 
 func TestMiddleware_UnauthenticatedIPActor(t *testing.T) {


### PR DESCRIPTION
全コードベース再監査 (#2106) の parity MEDIUM finding N28。scaledMax が base*factor (乗算) で upstream の max/factor (除算) と符号反転していた。minInterval も upstream の minInterval*factor 未適用。結果 factor が意図と真逆 (緩和目的で下げたら締まる) に作用していた。

scaledMax を base/factor に変更 + scaledMinInterval (minInterval*factor) を追加して check で適用。テスト期待値も upstream 仕様に修正。**注意: rateLimitFactor を mk-go の旧 (誤) 挙動前提で設定した運用は実効値が反転する (= upstream/TS と同じ正しい挙動になる)**。Closes #2165