### PR TITLE
federation/update-remote-user の moderator gate を RequireAuth に緩和する (#2106 N29/N10)

### DIFF
--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1968,7 +1968,13 @@ func (s *Server) setupRoutes() {
 	// admin overview から `misskeyApiGet` で叩かれるため GET も登録 (#421)。
 	api.POST("/federation/stats", federationHandler.Stats)
 	api.GET("/federation/stats", federationHandler.Stats)
-	api.POST("/federation/update-remote-user", federationHandler.UpdateRemoteUser, middleware.RequireModerator(roleService))
+	// #2106 N29/N10: upstream update-remote-user.ts は requireCredential:false の公開
+	// endpoint で、frontend get-user-menu はリモートユーザーメニューの「リモート情報を
+	// 更新」を全ログインユーザーに無条件表示する。RequireModerator だと非モデレーターが
+	// 403 ROLE_PERMISSION_DENIED になり frontend 機能が壊れるため緩和する。匿名トリガー
+	// 可能な AP 再 fetch (amplification) を防ぐため、upstream の anonymous 許可までは
+	// 開けず RequireAuth に留める (frontend は menu 表示にログイン必須なので互換性は保つ)。
+	api.POST("/federation/update-remote-user", federationHandler.UpdateRemoteUser, middleware.RequireAuth())
 
 	// Channels endpoints (Phase 4.2)
 	channelsHandler := apichannels.NewHandler(channelService, idGen)


### PR DESCRIPTION
全コードベース再監査 (#2106) の parity MEDIUM (N29=N10)。federation/update-remote-user を RequireModerator で gate していたが upstream は requireCredential:false の公開 endpoint。frontend は全ログインユーザーに「リモート情報を更新」を表示するため非モデレーターが 403 になり drop-in frontend が壊れていた。

RequireModerator → RequireAuth に緩和 (匿名トリガー AP 再 fetch amplification を防ぐため anonymous までは開けず、frontend 互換は保つ意図的 divergence)。router wire-layer 変更 (handler / middleware は各々単体テスト済、合成は e2e 検証)。Closes #2167