### PR TITLE
visibility push-down の read 経路を upstream に揃える (main-stream は #1472 維持) (#2106 N27)

### DIFF
--- a/internal/api/notes/handler_extra_test.go
+++ b/internal/api/notes/handler_extra_test.go
@@ -489,36 +489,26 @@ func mentionIDs(t *testing.T, rec *httptest.ResponseRecorder) map[string]bool {
 	return ids
 }
 
-// #1441 攻撃 a: 非 follower を mention した followers note は、mention された
-// だけの非 follower viewer には返らない。follower になれば返る。
-func TestMentions_FollowersNonFollowerExcluded(t *testing.T) {
+// #2106 N27: 非 follower でも mention されていれば followers note は read 経路 (notes/mentions)
+// で見える (upstream generateVisibilityQuery の mentions cross-visibility、#1441 の read-side
+// 除外を revert)。main-stream realtime push の #1472 strict gate は別途維持 (本 read 緩和とは独立)。
+func TestMentions_FollowersMentionedNonFollowerIncluded(t *testing.T) {
 	h, noteRepo, _ := newExtraHandler(t)
 	noteRepo.Notes["m_fol"] = &model.Note{ID: "m_fol", UserID: "author", Mentions: []string{"victim"}, Visibility: "followers", User: &model.User{ID: "author"}}
 
-	// victim は author を follow していない -> followers note は出ない。
 	ids := mentionIDs(t, postExtra(h.Mentions, `{}`, &model.User{ID: "victim"}))
-	assert.False(t, ids["m_fol"], "非 follower を mention した followers note は漏らさない")
-
-	// follower になれば出る。
-	noteRepo.Following = map[string][]string{"victim": {"author"}}
-	ids = mentionIDs(t, postExtra(h.Mentions, `{}`, &model.User{ID: "victim"}))
-	assert.True(t, ids["m_fol"], "follower には mention された followers note が出る")
+	assert.True(t, ids["m_fol"], "mention されていれば非 follower でも followers note が read 経路で見える")
 }
 
-// #1441 攻撃 b: visibleUserIds に含まれない viewer を mention した specified
-// note は、その viewer には返らない。visibleUserIds 対象なら返る。
-func TestMentions_SpecifiedNonTargetExcluded(t *testing.T) {
+// #2106 N27: visibleUserIds 非対象でも mention されていれば specified note は read 経路で
+// 見える (mentions cross-visibility、#1441 の read-side 除外を revert)。
+func TestMentions_SpecifiedMentionedIncluded(t *testing.T) {
 	h, noteRepo, _ := newExtraHandler(t)
 	// mentions に victim を含むが visibleUserIds は other のみ。
 	noteRepo.Notes["m_spec"] = &model.Note{ID: "m_spec", UserID: "author", Mentions: []string{"victim"}, Visibility: "specified", VisibleUserIDs: []string{"other"}, User: &model.User{ID: "author"}}
 
 	ids := mentionIDs(t, postExtra(h.Mentions, `{"visibility":"specified"}`, &model.User{ID: "victim"}))
-	assert.False(t, ids["m_spec"], "visibleUserIds 非対象を mention した specified note は漏らさない")
-
-	// victim が visibleUserIds 対象なら出る。
-	noteRepo.Notes["m_spec"].VisibleUserIDs = []string{"victim"}
-	ids = mentionIDs(t, postExtra(h.Mentions, `{"visibility":"specified"}`, &model.User{ID: "victim"}))
-	assert.True(t, ids["m_spec"], "visibleUserIds 対象には specified mention が出る")
+	assert.True(t, ids["m_spec"], "mention されていれば visibleUserIds 非対象でも specified note が見える")
 }
 
 // #1451: 未指定 (default) は upstream TS と同じく全種別を返す。public mention に

--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -937,7 +937,7 @@ func (s *CreateService) publishNoteMainEvents(note *model.Note, author *model.Us
 		viewer := &model.User{ID: replyTarget.UserID}
 		// upstream はスレッドミュート中の reply 先には reply event を出さない
 		// (#1954)。thread は reply 先ノートの threadId (無ければ自身の id)。
-		if CanSeeNote(viewer, note, s.followingRepo) && !s.isThreadMuted(replyTarget.UserID, replyTarget) {
+		if canSeeNoteForStream(viewer, note, s.followingRepo) && !s.isThreadMuted(replyTarget.UserID, replyTarget) {
 			s.mainStreamPublisher.PublishMainEvent(replyTarget.UserID, "reply", packed)
 		}
 	}
@@ -946,7 +946,7 @@ func (s *CreateService) publishNoteMainEvents(note *model.Note, author *model.Us
 	// renote (= Text/CW 持ち) は本文ごと leak する。
 	if renoteTarget != nil && renoteTarget.UserHost == nil && renoteTarget.UserID != author.ID {
 		viewer := &model.User{ID: renoteTarget.UserID}
-		if CanSeeNote(viewer, note, s.followingRepo) {
+		if canSeeNoteForStream(viewer, note, s.followingRepo) {
 			s.mainStreamPublisher.PublishMainEvent(renoteTarget.UserID, "renote", packed)
 		}
 	}
@@ -972,7 +972,7 @@ func (s *CreateService) publishNoteMainEvents(note *model.Note, author *model.Us
 		// 指定は別) ため、CanSeeNote の slices.Contains で visibleUserIDs 外の
 		// mention target を弾く。followers visibility 経路でも non-follower
 		// mention をここで止める。
-		if !CanSeeNote(u, note, s.followingRepo) {
+		if !canSeeNoteForStream(u, note, s.followingRepo) {
 			continue
 		}
 		// mention 先がこのスレッドをミュートしていれば mention event を出さない

--- a/internal/core/note/visibility.go
+++ b/internal/core/note/visibility.go
@@ -17,6 +17,57 @@ func CanSeeNote(viewer *model.User, n *model.Note, followingChecker repository.F
 	if n == nil {
 		return false
 	}
+	if n.Visibility == model.NoteVisibilityPublic || n.Visibility == model.NoteVisibilityHome {
+		return true
+	}
+	// 以降 (followers / specified) は viewer 必須。
+	if viewer == nil {
+		return false
+	}
+	// 投稿者本人は常に閲覧可。
+	if viewer.ID == n.UserID {
+		return true
+	}
+	// #2106 N27: upstream generateVisibilityQuery / isVisibleForMe と同じく、visibility 横断で
+	// mentions / visibleUserIds に含まれる viewer は閲覧可 (followers note の mention/visibleUser
+	// 宛を read 経路で過剰に隠さない)。SQL push-down (repository.applyViewerVisibility) と整合。
+	// 注意: main-stream realtime push の #1472 anti-leak gate はこの緩和を含めない
+	// canSeeNoteForStream を使う (mentioned 非フォロワーへの本文 realtime push を防ぐ)。
+	if slices.Contains(n.Mentions, viewer.ID) || slices.Contains(n.VisibleUserIDs, viewer.ID) {
+		return true
+	}
+	switch n.Visibility {
+	case model.NoteVisibilityFollowers:
+		// #2106 N27: reply 先が viewer の followers note は閲覧可 (upstream followers 分岐の
+		// replyUserId=meId)。
+		if n.ReplyUserID != nil && *n.ReplyUserID == viewer.ID {
+			return true
+		}
+		if followingChecker == nil {
+			return false
+		}
+		ok, err := followingChecker.Exists(viewer.ID, n.UserID)
+		if err != nil {
+			return false
+		}
+		return ok
+	case model.NoteVisibilitySpecified:
+		// visibleUserIds は上で判定済。それ以外の specified は不可視。
+		return false
+	}
+	return false
+}
+
+// canSeeNoteForStream is the strict main-stream realtime-push visibility gate
+// (#1472). Unlike CanSeeNote (#2106 N27 で read 経路を upstream に緩和) it does NOT
+// grant visibility via mentions / replyUserId, so a followers note's body/CW is
+// never pushed in real time to a mentioned / replied-to non-follower (anti-leak /
+// anti-harassment hardening を維持)。visibleUserIds は specified note の正規の宛先
+// なので許可する (N13 で reply target も visibleUserIds に入るため specified reply は届く)。
+func canSeeNoteForStream(viewer *model.User, n *model.Note, followingChecker repository.FollowingRepository) bool {
+	if n == nil {
+		return false
+	}
 	switch n.Visibility {
 	case model.NoteVisibilityPublic, model.NoteVisibilityHome:
 		return true
@@ -24,7 +75,6 @@ func CanSeeNote(viewer *model.User, n *model.Note, followingChecker repository.F
 		if viewer == nil {
 			return false
 		}
-		// 投稿者本人は常に閲覧可
 		if viewer.ID == n.UserID {
 			return true
 		}

--- a/internal/core/note/visibility_test.go
+++ b/internal/core/note/visibility_test.go
@@ -99,3 +99,31 @@ func TestCanSeeNote_UnknownVisibility(t *testing.T) {
 	n := &model.Note{UserID: "author", Visibility: model.NoteVisibility("unknown")}
 	assert.False(t, note.CanSeeNote(&model.User{ID: "viewer"}, n, nil))
 }
+
+// #2106 N27: followers note で viewer が mention されていれば read 可 (upstream)。
+func TestCanSeeNote_FollowersMentioned(t *testing.T) {
+	repo := testutil.NewMockFollowingRepository() // 非フォロワー
+	n := &model.Note{UserID: "author", Visibility: model.NoteVisibilityFollowers, Mentions: pq.StringArray{"viewer"}}
+	assert.True(t, note.CanSeeNote(&model.User{ID: "viewer"}, n, repo))
+}
+
+// #2106 N27: followers note で reply 先が viewer なら read 可 (upstream followers 分岐の replyUserId)。
+func TestCanSeeNote_FollowersReplyToViewer(t *testing.T) {
+	repo := testutil.NewMockFollowingRepository() // 非フォロワー
+	rid := "viewer"
+	n := &model.Note{UserID: "author", Visibility: model.NoteVisibilityFollowers, ReplyUserID: &rid}
+	assert.True(t, note.CanSeeNote(&model.User{ID: "viewer"}, n, repo))
+}
+
+// #2106 N27: specified note で mention されていれば visibleUserIds 外でも read 可 (cross-visibility)。
+func TestCanSeeNote_SpecifiedMentioned(t *testing.T) {
+	n := &model.Note{UserID: "author", Visibility: model.NoteVisibilitySpecified, VisibleUserIDs: pq.StringArray{"other"}, Mentions: pq.StringArray{"viewer"}}
+	assert.True(t, note.CanSeeNote(&model.User{ID: "viewer"}, n, nil))
+}
+
+// #2106 N27 regression guard: followers note で非フォロワー・非mention・非reply は依然 不可視。
+func TestCanSeeNote_FollowersStrangerStillHidden(t *testing.T) {
+	repo := testutil.NewMockFollowingRepository()
+	n := &model.Note{UserID: "author", Visibility: model.NoteVisibilityFollowers, Mentions: pq.StringArray{"someone-else"}}
+	assert.False(t, note.CanSeeNote(&model.User{ID: "stranger"}, n, repo))
+}

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -1234,11 +1234,18 @@ func (r *noteRepository) ListByUserList(listID string, limit int, sinceID, until
 	if viewerID == "" {
 		q = q.Where(`"note"."visibility" IN ('public','home')`)
 	} else {
+		// #2106 N27: followers note でも viewer が visibleUserIds / mentions に含まれる、
+		// もしくは reply 先が viewer のときは閲覧可 (CanSeeNote と整合)。specified (DM) は
+		// list timeline では従来通り drop するため、これらの cross-visibility 条件は
+		// followers 分岐内に限定する。
 		q = q.Where(
 			`("note"."visibility" IN ('public','home') `+
 				`OR ("note"."visibility" = 'followers' AND ("note"."userId" = ? `+
-				`OR "note"."userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?))))`,
-			viewerID, viewerID)
+				`OR "note"."userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?) `+
+				`OR ? = ANY("note"."visibleUserIds") `+
+				`OR ? = ANY("note"."mentions") `+
+				`OR "note"."replyUserId" = ?)))`,
+			viewerID, viewerID, viewerID, viewerID, viewerID)
 	}
 	// reply 内包: user_list_membership.withReplies を尊重して返信を出し分ける
 	// (#1496, upstream user-list-timeline getFromDb と一致)。返信でない / 自己への

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -2154,10 +2154,13 @@ func TestNoteRepository_ListMentions_Following(t *testing.T) {
 	assert.False(t, ids["lmf_ns"], "非フォローの stranger の note は除外される")
 }
 
-// TestNoteRepository_ListMentions_VisibilityPushDown は #1441 を検証する。
-// mention 対象 (= viewer) が CanSeeNote で見られない followers / specified note を
-// mention されただけでは取得できないこと、follow / visibleUserIds 対象なら
-// 取得できることを確認する。
+// TestNoteRepository_ListMentions_VisibilityPushDown は #2106 N27 を検証する。
+// upstream QueryService.generateVisibilityQuery と同じく、mention 対象 (= viewer) は
+// followers / specified note でも mention されていれば read できる (旧 #1441 の
+// 「mention だけでは見えない」挙動を upstream に揃えて revert した)。follow も
+// visibleUserIds も不要で、mention だけで read 経路では可視になる。
+// (main-stream realtime push の #1472 strict gate は core/note.canSeeNoteForStream で
+// 別途維持しており、本 read 緩和とは独立。)
 func TestNoteRepository_ListMentions_VisibilityPushDown(t *testing.T) {
 	repo := NewNoteRepository(testDB)
 	followingRepo := NewFollowingRepository(testDB)
@@ -2190,20 +2193,17 @@ func TestNoteRepository_ListMentions_VisibilityPushDown(t *testing.T) {
 		return out
 	}
 
-	// follow なし / visibleUserIds 非対象 -> public のみ (followers/specified は隠れる)。
+	// #2106 N27: follow なし / visibleUserIds 非対象でも、mention されていれば
+	// followers / specified note を read できる (upstream の mentions cross-visibility)。
 	out, err := repo.ListMentions(victim.ID, "", false, 50, "", "")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"n_lm_pub"}, idsOf(out))
+	assert.Equal(t, []string{"n_lm_fol", "n_lm_pub", "n_lm_spec"}, idsOf(out),
+		"mention されていれば followers/specified も read 経路では可視")
 
-	// victim が author を follow すると followers note も見える。
+	// follow しても visibleUserIds に追加しても結果は不変 (既に mention で可視)。
 	f := &model.Following{ID: "fl_lm_1", FollowerID: victim.ID, FolloweeID: author.ID}
 	require.NoError(t, followingRepo.Create(f))
 	defer testDB.Exec(`DELETE FROM "following" WHERE id = ?`, f.ID)
-	out, err = repo.ListMentions(victim.ID, "", false, 50, "", "")
-	require.NoError(t, err)
-	assert.Equal(t, []string{"n_lm_fol", "n_lm_pub"}, idsOf(out))
-
-	// specified の visibleUserIds に victim を含めると specified も見える。
 	require.NoError(t, repo.UpdateFields("n_lm_spec", map[string]any{"visibleUserIds": pq.StringArray{victim.ID}}))
 	out, err = repo.ListMentions(victim.ID, "", false, 50, "", "")
 	require.NoError(t, err)

--- a/internal/repository/visibility.go
+++ b/internal/repository/visibility.go
@@ -18,12 +18,19 @@ func applyViewerVisibility(q *gorm.DB, viewerID string) *gorm.DB {
 	if viewerID == "" {
 		return q.Where(`"visibility" IN ('public','home')`)
 	}
+	// #2106 N27: upstream QueryService.generateVisibilityQuery 相当の OR を網羅する。
+	// visibleUserIds / mentions は visibility 横断で許可し (specified に限らない)、
+	// followers 分岐には reply 先が viewer のケース (replyUserId=viewer) を足す。これが
+	// 無いと followers note の mention/reply/visibleUser 宛が read 経路で過剰に隠れる。
+	// (main-stream realtime push の #1472 strict gate は core/note.canSeeNoteForStream
+	// 側で別途維持しており、本 helper の read 緩和とは独立。)
 	return q.Where(
 		`("visibility" IN ('public','home') `+
 			`OR "userId" = ? `+
-			`OR ("visibility" = 'followers' AND "userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
-			`OR ("visibility" = 'specified' AND ? = ANY("visibleUserIds")))`,
-		viewerID, viewerID, viewerID)
+			`OR ? = ANY("visibleUserIds") `+
+			`OR ? = ANY("mentions") `+
+			`OR ("visibility" = 'followers' AND ("userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?) OR "replyUserId" = ?)))`,
+		viewerID, viewerID, viewerID, viewerID, viewerID)
 }
 
 // applyViewerVisibilityExists is the correlated-EXISTS variant of
@@ -38,11 +45,13 @@ func applyViewerVisibilityExists(q *gorm.DB, noteIDColumn, viewerID string) *gor
 	if viewerID == "" {
 		return q.Where(`EXISTS (SELECT 1 FROM "note" v WHERE v."id" = ` + noteIDColumn + ` AND v."visibility" IN ('public','home'))`)
 	}
+	// #2106 N27: applyViewerVisibility と同じく generateVisibilityQuery 相当に揃える。
 	return q.Where(
 		`EXISTS (SELECT 1 FROM "note" v WHERE v."id" = `+noteIDColumn+` AND (`+
 			`v."visibility" IN ('public','home') `+
 			`OR v."userId" = ? `+
-			`OR (v."visibility" = 'followers' AND v."userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?)) `+
-			`OR (v."visibility" = 'specified' AND ? = ANY(v."visibleUserIds"))))`,
-		viewerID, viewerID, viewerID)
+			`OR ? = ANY(v."visibleUserIds") `+
+			`OR ? = ANY(v."mentions") `+
+			`OR (v."visibility" = 'followers' AND (v."userId" IN (SELECT f."followeeId" FROM "following" f WHERE f."followerId" = ?) OR v."replyUserId" = ?))))`,
+		viewerID, viewerID, viewerID, viewerID, viewerID)
 }

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1556,14 +1556,35 @@ func (m *MockNoteRepository) ListByUserList(listID string, limit int, sinceID, u
 				continue
 			}
 			if viewerID != n.UserID {
-				followed := false
-				for _, fid := range m.Following[viewerID] {
-					if fid == n.UserID {
-						followed = true
+				// #2106 N27: visibleUserIds / mentions に含まれる、または reply 先が
+				// viewer の followers note は閲覧可 (CanSeeNote / real SQL と整合)。
+				visible := false
+				for _, id := range n.VisibleUserIDs {
+					if id == viewerID {
+						visible = true
 						break
 					}
 				}
-				if !followed {
+				if !visible {
+					for _, id := range n.Mentions {
+						if id == viewerID {
+							visible = true
+							break
+						}
+					}
+				}
+				if !visible && n.ReplyUserID != nil && *n.ReplyUserID == viewerID {
+					visible = true
+				}
+				if !visible {
+					for _, fid := range m.Following[viewerID] {
+						if fid == n.UserID {
+							visible = true
+							break
+						}
+					}
+				}
+				if !visible {
 					continue
 				}
 			}
@@ -1939,8 +1960,24 @@ func noteVisibleToViewer(viewerID string, n *model.Note, following map[string][]
 	if viewerID == n.UserID {
 		return true
 	}
+	// #2106 N27: visibility 横断で mentions / visibleUserIds に含まれる viewer は閲覧可
+	// (CanSeeNote の N27 緩和と整合させる drift detector #1507)。
+	for _, id := range n.Mentions {
+		if id == viewerID {
+			return true
+		}
+	}
+	for _, id := range n.VisibleUserIDs {
+		if id == viewerID {
+			return true
+		}
+	}
 	switch n.Visibility {
 	case model.NoteVisibilityFollowers:
+		// #2106 N27: reply 先が viewer の followers note は閲覧可。
+		if n.ReplyUserID != nil && *n.ReplyUserID == viewerID {
+			return true
+		}
 		for _, followee := range following[viewerID] {
 			if followee == n.UserID {
 				return true
@@ -1948,11 +1985,7 @@ func noteVisibleToViewer(viewerID string, n *model.Note, following map[string][]
 		}
 		return false
 	case model.NoteVisibilitySpecified:
-		for _, id := range n.VisibleUserIDs {
-			if id == viewerID {
-				return true
-			}
-		}
+		// visibleUserIds は上で判定済。
 		return false
 	}
 	return false


### PR DESCRIPTION
全コードベース再監査 (#2106) の parity MEDIUM finding N27。applyViewerVisibility / CanSeeNote が followers note の mention/reply/visibleUser 宛を read 経路で過剰に隠していた (upstream generateVisibilityQuery / isVisibleForMe の mentions/visibleUserIds/replyUserId OR 欠落)。

**ユーザー承認: read のみ upstream 化 + #1472 維持**。applyViewerVisibility(Exists) + CanSeeNote に upstream 相当 OR 追加。main-stream realtime push は #1472 anti-harassment 維持のため strict gate canSeeNoteForStream を新設 (mentioned 非フォロワーへの本文 realtime push を防ぐ)。#1441 test を新挙動に更新、CanSeeNote N27 分岐 test 追加。Closes #2169