### PR TITLE
reaction 置き換え時に古い reaction の unreacted を publish する (#2106 N16)

### DIFF
--- a/internal/core/reaction/reaction_service.go
+++ b/internal/core/reaction/reaction_service.go
@@ -309,6 +309,13 @@ func (s *Service) Create(user *model.User, noteID, rawReaction string) (string, 
 		if s.federationHook != nil {
 			s.federationHook.OnReactionRemoved(user, target, existing.Reaction)
 		}
+		// #2106 N16: noteStream に古いリアクションの unreacted を publish する。upstream
+		// ReactionService.create の置き換えは delete() 経由で unreacted を発火するが、mk-go は
+		// 新 reaction の reacted のみ送っており、subNote 購読クライアントで古い reaction の
+		// カウントが reload まで残存していた。reacted/unreacted を対称にする。
+		if s.noteStreamHook != nil {
+			s.noteStreamHook.OnUnreacted(target.ID, user.ID, decodeReactionForStream(existing.Reaction))
+		}
 	}
 
 	rec := &model.NoteReaction{

--- a/internal/core/reaction/reaction_service_test.go
+++ b/internal/core/reaction/reaction_service_test.go
@@ -667,9 +667,11 @@ func TestService_NoteStreamHook_OnDelete(t *testing.T) {
 	assert.Equal(t, ":smile@.:", hook.unreacted[0].reaction)
 }
 
-// 同じ user が別 reaction に置き換えた場合は upstream 互換で reacted のみ
-// 1 度だけ発火、unreacted は走らない。
-func TestService_NoteStreamHook_OnReplace_NoUnreacted(t *testing.T) {
+// #2106 N16: 同じ user が別 reaction に置き換えた場合、新 reaction の reacted と
+// 古い reaction の unreacted を両方発火する (upstream ReactionService.create は置き換えを
+// delete() 経由で行い unreacted を publish する)。旧テストは「unreacted は走らない」と
+// 誤った upstream 互換を主張していた。
+func TestService_NoteStreamHook_OnReplace_PublishesBoth(t *testing.T) {
 	svc, repo, _, _, _ := newService(t)
 	seedNote(repo, "n1", "author", model.NoteVisibilityPublic)
 	hook := &recordingNoteStreamHook{}
@@ -682,7 +684,8 @@ func TestService_NoteStreamHook_OnReplace_NoUnreacted(t *testing.T) {
 	require.Len(t, hook.reacted, 2)
 	assert.Equal(t, "👍", hook.reacted[0].reaction)
 	assert.Equal(t, "🎉", hook.reacted[1].reaction)
-	assert.Empty(t, hook.unreacted, "置き換え経路では unreacted は呼ばない (upstream 挙動)")
+	require.Len(t, hook.unreacted, 1, "置き換えで古い reaction の unreacted を publish")
+	assert.Equal(t, "👍", hook.unreacted[0].reaction)
 }
 
 // 古い `:name:` 形式 (TS-era DB レコード) で保存された reaction を Delete


### PR DESCRIPTION
全コードベース再監査 (#2106) の frontend MEDIUM finding N16。reaction 付け替え時、置き換え分岐が noteStreamHook.OnUnreacted を呼ばず、subNote 購読クライアントで古い reaction のカウントが reload まで残存していた。upstream は delete() 経由で unreacted を発火する。

置き換え分岐で OnUnreacted を発火し reacted/unreacted を対称にする。回帰テスト追加。Closes #2171