### PR TITLE
chat unreact で emoji を正規化してから array_remove する (#2106 N4)

### DIFF
--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -1169,16 +1169,34 @@ func (s *Service) normalizeChatReaction(raw string) (string, error) {
 	return strings.ReplaceAll(raw, "\ufe0f", ""), nil
 }
 
+// normalizeChatReactionForm canonicalises a chat reaction string WITHOUT validating
+// custom emoji existence: a `:name:` custom-emoji reaction is kept as `:name:`,
+// anything else is treated as a unicode emoji with its variation selector (U+FE0F)
+// stripped. normalizeChatReaction (react、存在検証あり) と Unreact (#2106 N4、検証不要)
+// で同じ canonical form を使い、array_append と array_remove を一致させる。
+func normalizeChatReactionForm(raw string) string {
+	if m := chatCustomEmojiPattern.FindStringSubmatch(raw); m != nil {
+		return ":" + m[1] + ":"
+	}
+	return strings.ReplaceAll(raw, "️", "")
+}
+
 // Unreact removes a reaction and publishes an `unreact` stream event (#1549)。
 func (s *Service) Unreact(ctx context.Context, messageID string, reactor *model.User, emoji string) error {
+	// #2106 N4: React と同じく emoji を canonical form に正規化してから array_remove する。
+	// React は VS strip / custom `:name:` 化して保存するため、raw emoji (VS 付き等) のままだと
+	// 厳密一致 array_remove で取り消せず silent fail する。custom emoji の存在検証は unreact
+	// では不要なので form だけ揃える (upstream ChatService.unreact も同様)。
+	reaction := normalizeChatReactionForm(emoji)
 	msg, err := s.repo.FindMessageByID(messageID)
 	if err != nil {
 		return ErrNotFound
 	}
-	if err := s.repo.RemoveReaction(messageID, reactor.ID+"/"+emoji); err != nil {
+	if err := s.repo.RemoveReaction(messageID, reactor.ID+"/"+reaction); err != nil {
 		return fmt.Errorf("remove reaction: %w", err)
 	}
-	s.publishReaction(ctx, msg, EventUnreact, reactor, emoji)
+	// #2106 N4: stream event も正規化済 reaction で publish し React と対称にする。
+	s.publishReaction(ctx, msg, EventUnreact, reactor, reaction)
 	return nil
 }
 

--- a/internal/core/chat/service_test.go
+++ b/internal/core/chat/service_test.go
@@ -736,3 +736,23 @@ func TestReadRoomChat_NoError(t *testing.T) {
 	svc, _, _ := newSvc(t)
 	assert.NoError(t, svc.ReadRoomChat(context.Background(), "alice", "r1"))
 }
+
+// #2106 N4: Unreact は React と同じく emoji を正規化 (VS strip / custom :name:) してから
+// array_remove する。raw (VS 付き) のままだと厳密一致で取り消せず silent fail していた。
+func TestUnreact_NormalizesVariationSelector(t *testing.T) {
+	svc, repo, pub := newSvc(t)
+	to := "bob"
+	repo.Messages["m1"] = &model.ChatMessage{ID: "m1", FromUserID: "carol", ToUserID: &to}
+
+	// VS 付き ❤️ で react → "bob/❤" (VS strip) で保存。
+	require.NoError(t, svc.React(context.Background(), "m1", &model.User{ID: "bob"}, "❤️"))
+	require.Contains(t, repo.AddedReactions, "bob/❤")
+
+	// VS 付き ❤️ (raw) で unreact → 正規化されて同じ "bob/❤" key で array_remove。
+	require.NoError(t, svc.Unreact(context.Background(), "m1", &model.User{ID: "bob"}, "❤️"))
+	require.Contains(t, repo.RemovedReactions, "bob/❤", "VS strip した key で array_remove する")
+	// stream event も正規化済 reaction で publish。
+	last := pub.userCalls[len(pub.userCalls)-1]
+	body := last.body.(map[string]any)
+	assert.Equal(t, "❤", body["reaction"])
+}

--- a/internal/testutil/mock_chat.go
+++ b/internal/testutil/mock_chat.go
@@ -35,6 +35,10 @@ type MockChatRepository struct {
 	Memberships map[string]*model.ChatRoomMembership
 	// Invitations keyed by invitation ID.
 	Invitations map[string]*model.ChatRoomInvitation
+	// AddedReactions / RemovedReactions record the keys passed to
+	// AddReaction / RemoveReaction so tests can assert canonicalisation (#2106 N4).
+	AddedReactions   []string
+	RemovedReactions []string
 
 	// CreateErr forces Create* to return this error without persisting.
 	CreateErr error
@@ -537,5 +541,12 @@ func (m *MockChatRepository) ListRoomHistory(_ string, _ int) ([]*model.ChatMess
 
 // --- Reactions ---
 
-func (m *MockChatRepository) AddReaction(_, _ string) error    { return nil }
-func (m *MockChatRepository) RemoveReaction(_, _ string) error { return nil }
+func (m *MockChatRepository) AddReaction(_, key string) error {
+	m.AddedReactions = append(m.AddedReactions, key)
+	return nil
+}
+
+func (m *MockChatRepository) RemoveReaction(_, key string) error {
+	m.RemovedReactions = append(m.RemovedReactions, key)
+	return nil
+}


### PR DESCRIPTION
全コードベース再監査 (#2106) の bug MEDIUM finding N4。chat React は emoji を VS strip / custom :name: 化して保存するが Unreact は raw のまま array_remove するため、VS 付き emoji で unreact すると一致せず silent fail していた。upstream は react/unreact で対称に正規化する。

normalizeChatReactionForm (存在検証なし) を切り出し Unreact でも適用。回帰テスト追加 (mock の RemoveReaction key 記録)。Closes #2173