### PR TITLE
import 完了で importCompleted 通知を発火しない (#2106 N25)

### DIFF
--- a/internal/core/transfer/import_test.go
+++ b/internal/core/transfer/import_test.go
@@ -152,9 +152,9 @@ func TestImport_Following_AppliesEachRow(t *testing.T) {
 	require.Len(t, fs.callsOpts, 2)
 	assert.True(t, fs.callsOpts[0].WithReplies, "row 1 (bob,withReplies=true) should propagate WithReplies=true")
 	assert.False(t, fs.callsOpts[1].WithReplies, "row 2 (carol,withReplies=false) should propagate WithReplies=false")
-	require.Len(t, notifier.calls, 1)
-	assert.Equal(t, "importCompleted", string(notifier.calls[0].Type))
-	assert.Equal(t, "following", notifier.calls[0].Extra["importedEntity"])
+	// #2106 N25: import 完了通知は upstream の通知 type enum に存在しない (exportCompleted のみ)
+	// ため発火しない。strict-enum client の notification decode crash を防ぐ。
+	require.Empty(t, notifier.calls, "import 完了通知は発火しない")
 }
 
 // #1058: CSV row の withReplies=true が FollowOptions として Service に threading

--- a/internal/core/transfer/importer.go
+++ b/internal/core/transfer/importer.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/shiroha-a/mk/internal/core/notification"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
 	"github.com/shiroha-a/mk/internal/repository"
@@ -132,18 +131,10 @@ func (i *Importer) Import(ctx context.Context, userID, importType, fileID string
 		return nil, err
 	}
 
-	if i.deps.Notifier != nil {
-		_, _ = i.deps.Notifier.Create(ctx, notification.CreateInput{
-			NotifieeID: user.ID,
-			Type:       notification.TypeImportCompleted,
-			Extra: map[string]any{
-				"importedEntity": importType,
-				"total":          result.Total,
-				"applied":        result.Applied,
-				"skipped":        result.Skipped,
-			},
-		})
-	}
+	// #2106 N25: upstream の通知 type enum には exportCompleted のみが存在し importCompleted
+	// は無い (Import*ProcessorService も完了通知を発火しない)。import 完了通知を出すと
+	// strict-enum decode を行う client (misskey_dart 等) が未知 type で notification 一覧の
+	// decode を巻き込んで crash しうるため、upstream 同様に通知を発火しない。
 	return result, nil
 }
 


### PR DESCRIPTION
全コードベース再監査 (#2106) の parity MEDIUM finding N25。importer が upstream に存在しない importCompleted 通知を発火し、strict-enum client (misskey_dart 等) の notification decode を crash させうる。upstream は exportCompleted のみ。

import 完了通知を発火しないようにする。const / entitycompat packing は旧 DB 通知の decode 互換のため残す。回帰テスト更新。Closes #2175