### PR TITLE
users/show バルクモードで viewer relation を解決する (#2106 N2)

### DIFF
--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -506,17 +506,24 @@ func (h *Handler) Show(c echo.Context) error {
 		// で pack する。旧実装は UserLite を返していた (#1547)。move 解決と remote
 		// stats fetch は list path 同様 N+1 回避のため bulk では行わない。
 		out := make([]entity.UserDetailed, 0, len(visible))
+		viewerID := ""
+		if viewer != nil {
+			viewerID = viewer.ID
+		}
 		for _, b := range visible {
 			detailed := entity.PackUserDetailed(b.User, b.Profile, h.idGen)
 			resolver.FillUserLite(&detailed.UserLite)
 			h.populateUserEmojis(b.User, &detailed.UserLite)
 			h.applyModerationNote(&detailed, iAmModerator, b.Profile)
 			entity.ApplyModeratorSecurityFields(&detailed, iAmModerator, b.Profile)
-			// bulk は per-user の follow 関係を解決しないため isFollowing=false で
-			// gate する (#1558)。self / moderator は count を保持。non-public
-			// visibility の非 follower count は 0 化される (privacy 安全側)。
+			// #2106 N2: バルク show も他のマルチユーザー path (search / recommendation 等) 同様に
+			// viewer relation (isFollowing/isBlocking/isMuted/hasPendingFollowRequest* 等) を解決する。
+			// upstream show.ts:151 の packMany は getRelations を batch で当てる。最大 100 件なので
+			// per-user Apply で許容範囲。viewerIsFollowing は GateCountVisibility に渡し、follower の
+			// non-public count が誤って 0 化されないようにする。
+			viewerIsFollowing := h.viewerRelationRepos().Apply(&detailed, viewerID, b.User, b.Profile)
 			isMe := viewer != nil && viewer.ID == b.User.ID
-			entity.GateCountVisibility(&detailed, isMe, iAmModerator, false)
+			entity.GateCountVisibility(&detailed, isMe, iAmModerator, viewerIsFollowing)
 			out = append(out, detailed)
 		}
 		return c.JSON(http.StatusOK, out)

--- a/internal/api/users/handler_parity1547_test.go
+++ b/internal/api/users/handler_parity1547_test.go
@@ -228,3 +228,28 @@ func TestShow_NonModeratorOmitsModerationNote(t *testing.T) {
 	_, ok := out["moderationNote"]
 	assert.False(t, ok, "非 moderator には moderationNote を omit (#1547)")
 }
+
+// #2106 N2: users/show の userIds バルクモードも viewer relation (isFollowing 等) を emit する。
+func TestShow_BulkUserIDs_EmbedsViewerRelation(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addTestUser(repo) // user1 / testuser
+	fRepo := testutil.NewMockFollowingRepository()
+	require.NoError(t, fRepo.Create(&model.Following{ID: "f1", FollowerID: "viewer1", FolloweeID: "user1"}))
+	h.SetFollowingRepo(fRepo)
+
+	rec := postStub(h.Show, `{"userIds":["user1"]}`, &model.User{ID: "viewer1"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	assert.Equal(t, true, out[0]["isFollowing"], "bulk show の user に viewer relation (isFollowing=true)")
+
+	// 匿名 bulk には relation を出さない。
+	rec = post(h.Show, `{"userIds":["user1"]}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var anon []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &anon))
+	require.Len(t, anon, 1)
+	_, has := anon[0]["isFollowing"]
+	assert.False(t, has, "匿名 bulk show には relation を出さない")
+}


### PR DESCRIPTION
全コードベース再監査 (#2106) の parity MEDIUM finding N2。users/show の userIds バルク path が viewer relation を Apply せず isFollowing=false hardcode で、UserDetailed の relation field 欠落 + follower の non-public count 0 潰れが起きていた。他 4 マルチユーザー path は Apply 済。

bulk path で viewerRelationRepos().Apply() を呼び viewerIsFollowing を GateCountVisibility に渡す。回帰テスト追加。Closes #2177