### PR TITLE
users/followers·following で block/mute relation を batch 解決する (#2106 N3)

### DIFF
--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -1113,6 +1113,8 @@ func (h *Handler) packRelationItems(
 	// `isFollowing` だけだと「pending 中なのに Follow ボタン」が出る regression
 	// になる。upstream UserDetailedNotMe schema と整合させる。
 	pendingFromMap, pendingToMap := h.batchPendingRequestRelations(viewer, bundleByID)
+	// #2106 N3: block/mute relation も batch query で実値を解決する (旧 best-effort false を是正)。
+	blockingMap, blockedMap, mutingMap, renoteMutingMap := h.batchBlockMuteRelations(viewer)
 
 	// remote user の notes/followers/following count を origin instance の
 	// /api/users/show から fetch して上書き (#1146)。Show 経路 (handler.go:329)
@@ -1150,13 +1152,20 @@ func (h *Handler) packRelationItems(
 				pendingTo := pendingToMap[b.User.ID]
 				d.HasPendingFollowRequestFromYou = &pendingFrom
 				d.HasPendingFollowRequestToYou = &pendingTo
-				// misskey_dart の UserDetailed union は isFollowing が present だと
-				// UserDetailedNotMeWithRelations を選び、isBlocking/isBlocked/
-				// isMuted/isRenoteMuted も非null bool として cast する (#1249)。
-				// follow/follower list は block/mute の権威ソースではない (#1144 の
-				// batch を壊さないため per-user lookup は避ける) ので best-effort
-				// false で埋める。正確な値は users/show 単体で取得される。
-				d.EnsureRelationFlags()
+				// #2106 N3: misskey_dart の UserDetailed union は isFollowing が present だと
+				// UserDetailedNotMeWithRelations を選び isBlocking/isBlocked/isMuted/isRenoteMuted も
+				// 非null bool として cast する (#1249)。旧実装は best-effort false に倒していたが、
+				// upstream getRelations 同様 batch query (viewer の outgoing/incoming を 1 query ずつ)
+				// で実値を埋める。
+				isBlocking := blockingMap[b.User.ID]
+				isBlocked := blockedMap[b.User.ID]
+				isMuted := mutingMap[b.User.ID]
+				isRenoteMuted := renoteMutingMap[b.User.ID]
+				d.IsBlocking = &isBlocking
+				d.IsBlocked = &isBlocked
+				d.IsMuted = &isMuted
+				d.IsRenoteMuted = &isRenoteMuted
+				d.EnsureRelationFlags() // 残った nil field を defensive に false で埋める
 				// follower にだけ followedMessage を見せる (#1558)。
 				if isFollowing && b.Profile != nil {
 					entity.SetFollowedMessageForFollower(&d, b.Profile.FollowedMessage)
@@ -1205,6 +1214,44 @@ func (h *Handler) batchFollowRelations(viewer *model.User, bundleByID map[string
 		}
 	}
 	return followingMap, followedMap
+}
+
+// batchBlockMuteRelations resolves viewer's block/mute relations across the whole
+// candidate set in a few batch queries, mirroring upstream getRelations (#2106 N3):
+// blocking = viewer blocks candidate, blocked = candidate blocks viewer, muting /
+// renoteMuting = viewer mutes / renote-mutes candidate. viewer の outgoing/incoming を
+// 1 query ずつ取得して set 化するので per-user N+1 を避けられる (候補との照合は呼び元)。
+// viewer nil / repo 未配線時は nil map (= 各 dimension を解決しない、best-effort)。
+func (h *Handler) batchBlockMuteRelations(viewer *model.User) (blocking, blocked, muting, renoteMuting map[string]bool) {
+	if viewer == nil {
+		return nil, nil, nil, nil
+	}
+	toSet := func(ids []string) map[string]bool {
+		m := make(map[string]bool, len(ids))
+		for _, id := range ids {
+			m[id] = true
+		}
+		return m
+	}
+	if h.blockingRepo != nil {
+		if ids, err := h.blockingRepo.ListBlockeeIDs(viewer.ID); err == nil {
+			blocking = toSet(ids)
+		}
+		if ids, err := h.blockingRepo.ListBlockerIDs(viewer.ID); err == nil {
+			blocked = toSet(ids)
+		}
+	}
+	if h.mutingRepo != nil {
+		if ids, err := h.mutingRepo.ListMuteeIDs(viewer.ID); err == nil {
+			muting = toSet(ids)
+		}
+	}
+	if h.renoteMutingRepo != nil {
+		if ids, err := h.renoteMutingRepo.ListMuteeIDs(viewer.ID); err == nil {
+			renoteMuting = toSet(ids)
+		}
+	}
+	return blocking, blocked, muting, renoteMuting
 }
 
 // batchPendingRequestRelations resolves viewer's pending follow_request

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -2228,3 +2228,33 @@ type stubBufferedReactions struct{}
 func (stubBufferedReactions) GetBufferedMany(_ context.Context, _ []string) (map[string]map[string]int64, error) {
 	return map[string]map[string]int64{}, nil
 }
+
+// #2106 N3: users/followers の embed user に viewer 視点の block/mute 実値を埋める
+// (旧実装は EnsureRelationFlags の best-effort false に倒していた)。
+func TestFollowers_PopulatesBlockMute(t *testing.T) {
+	h, repo := newTestHandler(t)
+	addTestUser(repo) // user1 = target profile
+	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob", UsernameLower: "bob", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	repo.Users["alice"] = &model.User{ID: "alice", Username: "alice", UsernameLower: "alice", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	// alice follows user1 → alice が表示される follower。
+	_, err := h.followingService.Follow("alice", "user1", corefollowing.FollowOptions{})
+	require.NoError(t, err)
+	// viewer(bob) が alice を block + mute。
+	blockRepo := testutil.NewMockBlockingRepository()
+	require.NoError(t, blockRepo.Create(&model.Blocking{ID: "bl1", BlockerID: "bob", BlockeeID: "alice"}))
+	h.SetBlockingRepo(blockRepo)
+	muteRepo := testutil.NewMockMutingRepository()
+	require.NoError(t, muteRepo.Create(&model.Muting{ID: "mu1", MuterID: "bob", MuteeID: "alice"}))
+	h.SetMutingRepo(muteRepo)
+
+	rec := postStub(h.Followers, `{"userId":"user1"}`, repo.Users["bob"])
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Len(t, out, 1)
+	follower := out[0]["follower"].(map[string]any)
+	assert.Equal(t, true, follower["isBlocking"], "viewer が block している follower は isBlocking=true")
+	assert.Equal(t, true, follower["isMuted"], "viewer が mute している follower は isMuted=true")
+	assert.Equal(t, false, follower["isBlocked"])
+	assert.Equal(t, false, follower["isRenoteMuted"])
+}

--- a/internal/repository/blocking.go
+++ b/internal/repository/blocking.go
@@ -18,6 +18,10 @@ type BlockingRepository interface {
 	// roles/notes) to drop notes authored by someone who has blocked the
 	// viewer, matching upstream generateBlockedUserQueryForNotes (#1544).
 	ListBlockerIDs(blockeeID string) ([]string, error)
+	// ListBlockeeIDs returns the blockeeIDs of every block row whose blockerId
+	// equals the given user (= who blockerID blocks). users/followers・following
+	// で viewer の isBlocking を batch 解決するのに使う (#2106 N3)。
+	ListBlockeeIDs(blockerID string) ([]string, error)
 }
 
 type blockingRepository struct {
@@ -82,6 +86,22 @@ func (r *blockingRepository) ListBlockerIDs(blockeeID string) ([]string, error) 
 	if err := r.db.Model(&model.Blocking{}).
 		Where(`"blockeeId" = ?`, blockeeID).
 		Pluck(`"blockerId"`, &ids).Error; err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
+// ListBlockeeIDs returns the blockeeIDs of every block row whose blockerId equals
+// blockerID (= who blockerID blocks). Used by users/followers・following to batch
+// resolve viewer's isBlocking (#2106 N3).
+func (r *blockingRepository) ListBlockeeIDs(blockerID string) ([]string, error) {
+	if blockerID == "" {
+		return nil, nil
+	}
+	var ids []string
+	if err := r.db.Model(&model.Blocking{}).
+		Where(`"blockerId" = ?`, blockerID).
+		Pluck(`"blockeeId"`, &ids).Error; err != nil {
 		return nil, err
 	}
 	return ids, nil

--- a/internal/repository/blocking_test.go
+++ b/internal/repository/blocking_test.go
@@ -54,6 +54,17 @@ func TestBlockingRepository_CRUD(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, empty)
 
+	// #2106 N3: ListBlockeeIDs は blocker 視点で「自分が block している blockee」を返す。
+	blockeeIDs, err := repo.ListBlockeeIDs(u1.ID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{u2.ID}, blockeeIDs)
+	noneBlockee, err := repo.ListBlockeeIDs(u2.ID)
+	require.NoError(t, err)
+	assert.Empty(t, noneBlockee)
+	emptyBlockee, err := repo.ListBlockeeIDs("")
+	require.NoError(t, err)
+	assert.Nil(t, emptyBlockee)
+
 	require.NoError(t, repo.Delete(b))
 	_, err = repo.FindByPair(u1.ID, u2.ID)
 	assert.Error(t, err)

--- a/internal/testutil/mock_block_mute.go
+++ b/internal/testutil/mock_block_mute.go
@@ -81,6 +81,24 @@ func (m *MockBlockingRepository) ListBlockerIDs(blockeeID string) ([]string, err
 	return ids, nil
 }
 
+// ListBlockeeIDs returns blockeeIDs of every block row whose blockerId equals
+// blockerID (#2106 N3).
+func (m *MockBlockingRepository) ListBlockeeIDs(blockerID string) ([]string, error) {
+	if blockerID == "" {
+		return nil, nil
+	}
+	if m.ExistsErr != nil {
+		return nil, m.ExistsErr
+	}
+	var ids []string
+	for _, b := range m.Blockings {
+		if b.BlockerID == blockerID {
+			ids = append(ids, b.BlockeeID)
+		}
+	}
+	return ids, nil
+}
+
 // MockMutingRepository is a test double for repository.MutingRepository.
 type MockMutingRepository struct {
 	Mutings map[string]*model.Muting


### PR DESCRIPTION
全コードベース再監査 (#2106) の parity MEDIUM finding N3。followers/following の embed user が isBlocking/isBlocked/isMuted/isRenoteMuted を false 固定で返し、frontend のブロック/ミュートインジケータが欠落していた。upstream は getRelations で実値を返す。

BlockingRepository に ListBlockeeIDs を追加 (他 3 flag は既存 ListBlockerIDs/ListMuteeIDs を再利用)、batchBlockMuteRelations で viewer の outgoing/incoming を 1 query ずつ set 化して 4 flag を埋める (N+1 回避)。回帰テスト追加。Closes #2179