### PR TITLE
antenna export/import を userListAccts/excludeNotesInSensitiveChannel に揃える (#2106 N24)

### DIFF
--- a/internal/core/transfer/export_edge_test.go
+++ b/internal/core/transfer/export_edge_test.go
@@ -265,3 +265,36 @@ func TestExport_UserLists_FallsBackToUserRepo(t *testing.T) {
 	lines := strings.Split(strings.TrimSpace(body), "\n")
 	assert.Len(t, lines, 1)
 }
+
+// #2106 N24: list source antenna は member を acct 解決して userListAccts に出力し、
+// excludeNotesInSensitiveChannel も含める (cross-instance import 互換)。
+func TestExport_Antennas_UserListAccts(t *testing.T) {
+	saver, _, deps, user := newExportDeps(t)
+	aRepo := deps.AntennaRepo.(*testutil.MockAntennaRepository)
+	listRepo := deps.UserListRepo.(*testutil.MockUserListRepository)
+	userRepo := deps.UserRepo.(*testutil.MockUserRepository)
+	listID := "list1"
+	aRepo.Antennas["a1"] = &model.Antenna{
+		ID: "a1", UserID: user.ID, Name: "news", Src: "list", UserListID: &listID,
+		Keywords: []byte(`[]`), ExcludeKeywords: []byte(`[]`), Users: pq.StringArray{},
+		ExcludeNotesInSensitiveChannel: true,
+	}
+	listRepo.Lists[listID] = &model.UserList{ID: listID, UserID: user.ID, Name: "src"}
+	host := "remote.example"
+	userRepo.Users["bob"] = &model.User{ID: "bob", Username: "bob"}                    // local → "bob"
+	userRepo.Users["carol"] = &model.User{ID: "carol", Username: "carol", Host: &host} // remote → "carol@remote.example"
+	require.NoError(t, listRepo.AddMember(&model.UserListMembership{ID: "m1", UserListID: listID, UserID: "bob"}))
+	require.NoError(t, listRepo.AddMember(&model.UserListMembership{ID: "m2", UserListID: listID, UserID: "carol"}))
+
+	exporter := transfer.NewExporter(deps)
+	_, err := exporter.Export(context.Background(), user.ID, transfer.ExportAntennas)
+	require.NoError(t, err)
+
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(saver.uploads[0].Body, &out))
+	require.Len(t, out, 1)
+	accts, ok := out[0]["userListAccts"].([]any)
+	require.True(t, ok, "list source は userListAccts を配列で出す")
+	assert.ElementsMatch(t, []any{"bob", "carol@remote.example"}, accts)
+	assert.Equal(t, true, out[0]["excludeNotesInSensitiveChannel"])
+}

--- a/internal/core/transfer/export_json.go
+++ b/internal/core/transfer/export_json.go
@@ -67,24 +67,60 @@ func (e *Exporter) exportAntennas(userID string) ([]byte, error) {
 	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, a := range rows {
+		// #2106 N24: users は nil でも [] を出す (upstream Ajv の required array を満たす)。
+		users := []string(a.Users)
+		if users == nil {
+			users = []string{}
+		}
 		entry := map[string]any{
 			"name":            a.Name,
 			"src":             string(a.Src),
 			"keywords":        json.RawMessage(a.Keywords),
 			"excludeKeywords": json.RawMessage(a.ExcludeKeywords),
-			"users":           []string(a.Users),
+			"users":           users,
 			"caseSensitive":   a.CaseSensitive,
 			"localOnly":       a.LocalOnly,
 			"excludeBots":     a.ExcludeBots,
 			"withReplies":     a.WithReplies,
 			"withFile":        a.WithFile,
+			// #2106 N24: upstream ExportedAntenna 互換のため excludeNotesInSensitiveChannel と
+			// userListAccts も出力する。list source は member を acct 解決して配列に、それ以外は null
+			// (ImportAntennasProcessorService が userListAccts で list→users 変換する)。
+			"excludeNotesInSensitiveChannel": a.ExcludeNotesInSensitiveChannel,
+			"userListAccts":                  nil,
 		}
 		if a.UserListID != nil {
 			entry["userListId"] = *a.UserListID
+			if accts, err := e.listAccts(*a.UserListID); err == nil {
+				entry["userListAccts"] = accts
+			}
 		}
 		out = append(out, entry)
 	}
 	return json.Marshal(out)
+}
+
+// listAccts resolves a userList's members to acct strings (username / username@host)
+// for the antenna export userListAccts field (#2106 N24)。CSV user-list export と同じ
+// member 解決を再利用する。
+func (e *Exporter) listAccts(listID string) ([]string, error) {
+	members, err := e.deps.UserListRepo.ListMembers(listID)
+	if err != nil {
+		return nil, err
+	}
+	accts := make([]string, 0, len(members))
+	for _, m := range members {
+		u := m.User
+		if u == nil {
+			u2, err := e.deps.UserRepo.FindByID(m.UserID)
+			if err != nil || u2 == nil {
+				continue
+			}
+			u = u2
+		}
+		accts = append(accts, acct(u))
+	}
+	return accts, nil
 }
 
 // exportClips emits a JSON array of the user's clips, each with the packed

--- a/internal/core/transfer/import_antennas.go
+++ b/internal/core/transfer/import_antennas.go
@@ -21,11 +21,15 @@ type antennaImportEntry struct {
 	ExcludeKeywords json.RawMessage `json:"excludeKeywords"`
 	Users           []string        `json:"users"`
 	UserListID      *string         `json:"userListId"`
-	CaseSensitive   bool            `json:"caseSensitive"`
-	LocalOnly       bool            `json:"localOnly"`
-	ExcludeBots     bool            `json:"excludeBots"`
-	WithReplies     bool            `json:"withReplies"`
-	WithFile        bool            `json:"withFile"`
+	// UserListAccts は upstream ExportedAntenna の list source 用 acct 配列。import 側で
+	// list→users 変換に使う (#2106 N24)。
+	UserListAccts                  []string `json:"userListAccts"`
+	CaseSensitive                  bool     `json:"caseSensitive"`
+	LocalOnly                      bool     `json:"localOnly"`
+	ExcludeBots                    bool     `json:"excludeBots"`
+	WithReplies                    bool     `json:"withReplies"`
+	WithFile                       bool     `json:"withFile"`
+	ExcludeNotesInSensitiveChannel bool     `json:"excludeNotesInSensitiveChannel"`
 }
 
 // importAntennas decodes a JSON array of antenna entries and creates one
@@ -44,22 +48,38 @@ func (i *Importer) importAntennas(user *model.User, body []byte) (*ImportResult,
 		keywords := normalizeJSON(ent.Keywords, "[]")
 		excludeKeywords := normalizeJSON(ent.ExcludeKeywords, "[]")
 
+		// #2106 N24: upstream ImportAntennasProcessorService 互換 — list source antenna は
+		// userListAccts を users source へ倒して取り込む (cross-instance では userListId が
+		// 無意味なため)。userListAccts が無ければ src は維持する。
+		src := model.AntennaSource(ent.Src)
+		users := pq.StringArray(ent.Users)
+		userListID := ent.UserListID
+		if src == model.AntennaSourceList && len(ent.UserListAccts) > 0 {
+			src = model.AntennaSourceUsers
+			users = pq.StringArray(ent.UserListAccts)
+			userListID = nil
+		}
+		if users == nil {
+			users = pq.StringArray{}
+		}
+
 		antenna := &model.Antenna{
-			ID:              i.deps.IDGen.Generate(time.Now()),
-			UserID:          user.ID,
-			Name:            ent.Name,
-			Src:             model.AntennaSource(ent.Src),
-			UserListID:      ent.UserListID,
-			Users:           pq.StringArray(ent.Users),
-			Keywords:        datatypes.JSON(keywords),
-			ExcludeKeywords: datatypes.JSON(excludeKeywords),
-			CaseSensitive:   ent.CaseSensitive,
-			LocalOnly:       ent.LocalOnly,
-			ExcludeBots:     ent.ExcludeBots,
-			WithReplies:     ent.WithReplies,
-			WithFile:        ent.WithFile,
-			IsActive:        true,
-			LastUsedAt:      time.Now(),
+			ID:                             i.deps.IDGen.Generate(time.Now()),
+			UserID:                         user.ID,
+			Name:                           ent.Name,
+			Src:                            src,
+			UserListID:                     userListID,
+			Users:                          users,
+			Keywords:                       datatypes.JSON(keywords),
+			ExcludeKeywords:                datatypes.JSON(excludeKeywords),
+			CaseSensitive:                  ent.CaseSensitive,
+			LocalOnly:                      ent.LocalOnly,
+			ExcludeBots:                    ent.ExcludeBots,
+			WithReplies:                    ent.WithReplies,
+			WithFile:                       ent.WithFile,
+			ExcludeNotesInSensitiveChannel: ent.ExcludeNotesInSensitiveChannel,
+			IsActive:                       true,
+			LastUsedAt:                     time.Now(),
 		}
 		if err := i.deps.AntennaRepo.Create(antenna); err != nil {
 			res.Skipped++

--- a/internal/core/transfer/import_test.go
+++ b/internal/core/transfer/import_test.go
@@ -402,3 +402,24 @@ func TestFollowingServiceAdapter(t *testing.T) {
 	_, err := a.Follow("f", "g", transfer.FollowOptions{})
 	assert.NoError(t, err)
 }
+
+// #2106 N24: import は list source antenna の userListAccts を users source へ変換する。
+func TestImport_Antennas_UserListAcctsConvertsToUsers(t *testing.T) {
+	body := []byte(`[{"name":"news","src":"list","keywords":[[]],"userListId":"oldlist","userListAccts":["bob","carol@remote.example"]}]`)
+	deps, user, _, _, _, _ := newImporterDeps(t, body)
+	imp := transfer.NewImporter(deps)
+	res, err := imp.Import(context.Background(), user.ID, transfer.ImportAntennas, "fid")
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Applied)
+
+	aRepo := deps.AntennaRepo.(*testutil.MockAntennaRepository)
+	require.Len(t, aRepo.Antennas, 1)
+	var got *model.Antenna
+	for _, a := range aRepo.Antennas {
+		got = a
+	}
+	require.NotNil(t, got)
+	assert.Equal(t, model.AntennaSourceUsers, got.Src, "list+userListAccts は users source に変換")
+	assert.Nil(t, got.UserListID, "変換後は cross-instance で無意味な userListId を捨てる")
+	assert.ElementsMatch(t, []string{"bob", "carol@remote.example"}, []string(got.Users))
+}


### PR DESCRIPTION
全コードベース再監査 (#2106) の parity MEDIUM finding N24 (account 移行互換は最優先)。antenna export が userListAccts/excludeNotesInSensitiveChannel を出さず import も読まないため cross-instance 移行が壊れていた。

export で list source の member を acct 解決して userListAccts 出力 + excludeNotesInSensitiveChannel + users:[]。import で userListAccts→users source 変換。回帰テスト追加 (export/import 双方)。Closes #2181