### PR TITLE
locked followee の autoAcceptFollowed を実装する (#2106 N21)

### DIFF
--- a/internal/core/following/following_service.go
+++ b/internal/core/following/following_service.go
@@ -217,6 +217,24 @@ func (s *Service) adjustInstanceCountsForFollowing(f *model.Following, delta int
 // Phase 2 Step B implementation only handles local follows. Federation
 // (HTTP signatures, AP delivery), block checks, and notifications are
 // added in later phases.
+// shouldAutoAcceptFollow reports whether a follow toward a locked followee should be
+// auto-accepted (create Following directly) instead of a follow request, mirroring
+// upstream UserFollowingService.follow の autoAccept 分岐 (#2106 N21): followee が
+// local user で profile.autoAcceptFollowed=true、かつ followee→follower の follow が既に
+// 存在する (相互フォロー) とき。既に follow 済のケースは呼び元の ErrAlreadyFollowing guard で
+// 別途処理される。
+func (s *Service) shouldAutoAcceptFollow(followee *model.User, followerID string) bool {
+	if followee.Host != nil { // remote followee は相手側のサーバーで承認処理される
+		return false
+	}
+	profile, err := s.userRepo.FindProfileByUserID(followee.ID)
+	if err != nil || profile == nil || !profile.AutoAcceptFollowed {
+		return false
+	}
+	mutual, err := s.followingRepo.Exists(followee.ID, followerID)
+	return err == nil && mutual
+}
+
 func (s *Service) Follow(followerID, followeeID string, opts FollowOptions) (*FollowResult, error) {
 	if followerID == followeeID {
 		return nil, ErrSelfFollow
@@ -256,8 +274,12 @@ func (s *Service) Follow(followerID, followeeID string, opts FollowOptions) (*Fo
 		}
 	}
 
-	// Lockedアカウントへのフォローはリクエスト扱い
-	if followee.IsLocked {
+	// Lockedアカウントへのフォローはリクエスト扱い。ただし #2106 N21: followee が
+	// local + profile.autoAcceptFollowed=true + 相互フォロー (followee→follower) のときは
+	// upstream UserFollowingService 同様に follow request を作らず即 Following を成立させる
+	// (下の通常 Following 作成経路に fall through する)。remote follower の場合は handleFollow が
+	// result.Following を見て AP Accept を返送する。
+	if followee.IsLocked && !s.shouldAutoAcceptFollow(followee, followerID) {
 		// 既存リクエストがあればエラー
 		if exists, err := s.followRequestRepo.Exists(followerID, followeeID); err != nil {
 			return nil, err

--- a/internal/core/following/following_service_test.go
+++ b/internal/core/following/following_service_test.go
@@ -1280,3 +1280,39 @@ func TestUnfollow_StillFederates(t *testing.T) {
 	require.NoError(t, svc.Unfollow("alice", "bob"))
 	assert.Equal(t, []string{"alice->bob"}, fed.unfollowed, "通常 Unfollow は Undo を配送する")
 }
+
+// #2106 N21: locked + autoAcceptFollowed の followee に相互フォロー相手から follow すると
+// follow request でなく即 Following が成立する (upstream UserFollowingService の autoAccept)。
+func TestFollow_LockedAutoAcceptFollowed_AutoAccepts(t *testing.T) {
+	svc, userRepo, fRepo, frRepo := newSvc(t)
+	addUser(t, userRepo, "alice", false)
+	addUser(t, userRepo, "bob", true) // bob is locked
+	userRepo.Profiles["bob"] = &model.UserProfile{UserID: "bob", AutoAcceptFollowed: true}
+	// bob → alice (相互フォローの片側)。alice は非 locked なので即 Following。
+	_, err := svc.Follow("bob", "alice", following.FollowOptions{})
+	require.NoError(t, err)
+
+	// alice → bob (locked + autoAcceptFollowed + 相互) → 即 Following。
+	res, err := svc.Follow("alice", "bob", following.FollowOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, res.Following, "autoAcceptFollowed + 相互で即 Following")
+	assert.Nil(t, res.Request)
+	assert.Empty(t, frRepo.Requests, "follow request は作られない")
+	// alice→bob の Following が存在する。
+	ex, _ := fRepo.Exists("alice", "bob")
+	assert.True(t, ex)
+}
+
+// #2106 N21: autoAcceptFollowed でも相互フォローでなければ通常通り follow request 止まり。
+func TestFollow_LockedAutoAcceptFollowed_NoMutual_CreatesRequest(t *testing.T) {
+	svc, userRepo, _, frRepo := newSvc(t)
+	addUser(t, userRepo, "alice", false)
+	addUser(t, userRepo, "bob", true)
+	userRepo.Profiles["bob"] = &model.UserProfile{UserID: "bob", AutoAcceptFollowed: true}
+	// bob は alice を follow していない (非相互)。
+	res, err := svc.Follow("alice", "bob", following.FollowOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, res.Request, "相互でなければ request 止まり")
+	assert.Nil(t, res.Following)
+	assert.Len(t, frRepo.Requests, 1)
+}


### PR DESCRIPTION
全コードベース再監査 (#2106) の parity MEDIUM finding N21。Follow が locked followee に無条件で follow request を作り、autoAcceptFollowed (相互フォロー時の自動承認) が未実装だった。

Follow の locked 分岐で shouldAutoAcceptFollow (followee local + profile.autoAcceptFollowed + 相互) を確認し、満たすなら即 Following 作成経路へ fall through。remote follower の AP Accept は handleFollow の result.Following 既存ロジックでカバー。回帰テスト追加。Closes #2183