### PR TITLE
carefulBot (bot フォロワーの follow-request 化) を実装する (#2106 N22)

### DIFF
--- a/internal/core/following/following_service.go
+++ b/internal/core/following/following_service.go
@@ -274,12 +274,20 @@ func (s *Service) Follow(followerID, followeeID string, opts FollowOptions) (*Fo
 		}
 	}
 
-	// Lockedアカウントへのフォローはリクエスト扱い。ただし #2106 N21: followee が
-	// local + profile.autoAcceptFollowed=true + 相互フォロー (followee→follower) のときは
-	// upstream UserFollowingService 同様に follow request を作らず即 Following を成立させる
-	// (下の通常 Following 作成経路に fall through する)。remote follower の場合は handleFollow が
+	// follow request 化の判定 (upstream UserFollowingService.follow の OR 条件)。
+	// #2106 N22: locked に加え、bot follower かつ local followee の profile.carefulBot=true でも
+	// follow request 化する (「Bot からのフォローに慎重」設定)。
+	needsApproval := followee.IsLocked
+	if !needsApproval && follower.IsBot && followee.Host == nil {
+		if profile, perr := s.userRepo.FindProfileByUserID(followeeID); perr == nil && profile != nil && profile.CarefulBot {
+			needsApproval = true
+		}
+	}
+	// #2106 N21: followee が local + profile.autoAcceptFollowed=true + 相互フォロー
+	// (followee→follower) のときは follow request を作らず即 Following を成立させる
+	// (下の通常 Following 作成経路に fall through)。remote follower の場合は handleFollow が
 	// result.Following を見て AP Accept を返送する。
-	if followee.IsLocked && !s.shouldAutoAcceptFollow(followee, followerID) {
+	if needsApproval && !s.shouldAutoAcceptFollow(followee, followerID) {
 		// 既存リクエストがあればエラー
 		if exists, err := s.followRequestRepo.Exists(followerID, followeeID); err != nil {
 			return nil, err

--- a/internal/core/following/following_service_test.go
+++ b/internal/core/following/following_service_test.go
@@ -1316,3 +1316,35 @@ func TestFollow_LockedAutoAcceptFollowed_NoMutual_CreatesRequest(t *testing.T) {
 	assert.Nil(t, res.Following)
 	assert.Len(t, frRepo.Requests, 1)
 }
+
+// #2106 N22: carefulBot=true の非 locked followee を bot が follow すると follow request になる。
+func TestFollow_CarefulBot_BotFollowerCreatesRequest(t *testing.T) {
+	svc, userRepo, fRepo, frRepo := newSvc(t)
+	addUser(t, userRepo, "alice", false) // alice は非 locked
+	userRepo.Profiles["alice"] = &model.UserProfile{UserID: "alice", CarefulBot: true}
+	// bob は bot。
+	addUser(t, userRepo, "bob", false)
+	userRepo.Users["bob"].IsBot = true
+
+	res, err := svc.Follow("bob", "alice", following.FollowOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, res.Request, "carefulBot + bot follower は follow request 化")
+	assert.Nil(t, res.Following)
+	assert.Empty(t, fRepo.Followings)
+	assert.Len(t, frRepo.Requests, 1)
+}
+
+// #2106 N22: carefulBot でも非 bot follower は通常通り即フォロー成立。
+func TestFollow_CarefulBot_NonBotFollowerFollowsDirectly(t *testing.T) {
+	svc, userRepo, fRepo, _ := newSvc(t)
+	addUser(t, userRepo, "alice", false)
+	userRepo.Profiles["alice"] = &model.UserProfile{UserID: "alice", CarefulBot: true}
+	addUser(t, userRepo, "carol", false) // 非 bot
+
+	res, err := svc.Follow("carol", "alice", following.FollowOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, res.Following, "非 bot follower は carefulBot の影響を受けない")
+	assert.Nil(t, res.Request)
+	ex, _ := fRepo.Exists("carol", "alice")
+	assert.True(t, ex)
+}


### PR DESCRIPTION
全コードベース再監査 (#2106) の parity MEDIUM finding N22。Follow が follow-request 化を followee.IsLocked のみで判定し、carefulBot (bot からのフォローに慎重) が未実装だった。

Follow の request 化判定を bot follower かつ local followee の profile.CarefulBot でも request 化するよう拡張。回帰テスト追加。Closes #2185