### PR TITLE
admin/reset-password の error code/UUID を upstream に揃える (#2106 L1/L2)

### DIFF
--- a/internal/api/admin/password_reset.go
+++ b/internal/api/admin/password_reset.go
@@ -39,10 +39,12 @@ func (h *Handler) ResetPassword(c echo.Context) error {
 	if h.userRepo != nil {
 		user, err := h.userRepo.FindByID(req.UserID)
 		if err != nil || user == nil {
-			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "2b730f78-1179-461b-88ad-d24c9af1a5ce"))
+			// #2106 L2: upstream reset-password.ts:26 固有の UUID に揃える。
+			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "ccafc7fe-5074-4edd-9dc0-8ef9ef6a701d"))
 		}
 		if user.IsRoot {
-			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Cannot reset the password of a root account.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
+			// #2106 L1: upstream は専用エラー cannotResetPasswordOfRootUser (kind 未指定 = 400) を投げる。
+			return c.JSON(http.StatusBadRequest, apierr.Error("CANNOT_RESET_PASSWORD_OF_ROOT_USER", "Cannot reset password of the root user.", "f28fc207-42ca-44c7-a577-44b4f0ec5999"))
 		}
 		target = user
 	}

--- a/internal/api/admin/password_reset_test.go
+++ b/internal/api/admin/password_reset_test.go
@@ -79,8 +79,10 @@ func TestResetPasswordAdmin_RootRejected(t *testing.T) {
 	h, userRepo, _, _ := newTestHandler(t)
 	userRepo.Users["root1"] = &model.User{ID: "root1", Username: "admin", IsRoot: true}
 	rec := doPost(h.ResetPassword, `{"userId":"root1"}`, adminUser)
-	require.Equal(t, http.StatusForbidden, rec.Code)
-	assert.Contains(t, rec.Body.String(), "ACCESS_DENIED")
+	// #2106 L1: upstream は専用エラー CANNOT_RESET_PASSWORD_OF_ROOT_USER (400)。
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "CANNOT_RESET_PASSWORD_OF_ROOT_USER")
+	assert.Contains(t, rec.Body.String(), "f28fc207-42ca-44c7-a577-44b4f0ec5999")
 }
 
 func TestResetPasswordAdmin_WritesModerationLog(t *testing.T) {


### PR DESCRIPTION
#2106 LOW parity batch (api-admin)。L1: root ガードを ACCESS_DENIED(403) → CANNOT_RESET_PASSWORD_OF_ROOT_USER(400, id f28fc207)。L2: NO_SUCH_USER の UUID を ccafc7fe (reset-password 固有) に修正。テスト更新。Closes #2187