### PR TITLE
notesummary / hashtag.Extract / config doc の upstream 乖離を修正 (#2106 L63-L66)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -196,9 +196,9 @@ type Source struct {
 	AutoScaleCooldownSeconds *int `mapstructure:"autoScaleCooldownSeconds"`
 
 	// JobQueueDriver selects the worker / inspector implementation
-	// behind internal/queue. "asynq" (default) uses
-	// hibiken/asynq; "mkq" uses the BullMQ-compatible
-	// shiroha-a/mkq library. Empty / unset = "asynq".
+	// behind internal/queue. "mkq" (default, recommended) uses the
+	// BullMQ-compatible shiroha-a/mkq library; "asynq" is the legacy
+	// hibiken/asynq driver. Empty / unset = "mkq".
 	JobQueueDriver string `mapstructure:"jobQueueDriver"`
 
 	MediaProxy              string `mapstructure:"mediaProxy"`

--- a/internal/misc/hashtag/extract.go
+++ b/internal/misc/hashtag/extract.go
@@ -46,8 +46,11 @@ func Extract(parts ...string) []string {
 	seen := make(map[string]struct{}, len(tags))
 	out := make([]string, 0, len(tags))
 	for _, tag := range tags {
-		if len(tag) > MaxTagLength {
-			tag = tag[:MaxTagLength]
+		// #2106 L65: byte 単位の truncate は multibyte rune を途中で分割し不正な UTF-8 を
+		// 生成する。NormalizeNoteTags と同じく code point 数で判定し、>128 の tag は drop する
+		// (upstream の user-tag 経路も truncate せず DB varchar 制約に委ねる)。
+		if utf8.RuneCountInString(tag) > MaxTagLength {
+			continue
 		}
 		key := strings.ToLower(tag)
 		if _, ok := seen[key]; ok {

--- a/internal/misc/hashtag/extract_test.go
+++ b/internal/misc/hashtag/extract_test.go
@@ -84,9 +84,11 @@ func TestExtract(t *testing.T) {
 			want: []string{"foo", "bar"},
 		},
 		{
-			name: "long tag truncated",
-			in:   []string{"#" + strings.Repeat("a", MaxTagLength+50)},
-			want: []string{strings.Repeat("a", MaxTagLength)},
+			// #2106 L65: >128 code point の tag は byte truncate でなく drop する
+			// (NormalizeNoteTags と揃える)。同行の有効な tag は残る。
+			name: "long tag dropped",
+			in:   []string{"#" + strings.Repeat("a", MaxTagLength+50) + " #ok"},
+			want: []string{"ok"},
 		},
 		{
 			name: "fenced code block excluded",

--- a/internal/misc/notesummary/summary.go
+++ b/internal/misc/notesummary/summary.go
@@ -27,8 +27,12 @@ func Get(note map[string]any) string {
 	}
 
 	var summary string
-	if cw, ok := note["cw"].(string); ok && cw != "" {
-		summary = cw
+	// #2106 L64: upstream は note.cw != null で判定する (空文字 CW でも採用し text に
+	// フォールバックしない)。cw キーが存在し非 nil なら CW (空文字含む) を使う。
+	if cwVal, exists := note["cw"]; exists && cwVal != nil {
+		if cw, ok := cwVal.(string); ok {
+			summary = cw
+		}
 	} else if text, ok := note["text"].(string); ok {
 		summary = text
 	}
@@ -39,14 +43,20 @@ func Get(note map[string]any) string {
 	if poll, ok := note["poll"]; ok && poll != nil {
 		summary += " (\U0001F4CA)"
 	}
+	// #2106 L63: replyId/renoteId が立っているのに reply/renote が未 hydrate の場合でも
+	// upstream は "RE: ..." / "RN: ..." を付与する (push 通知本文の reply/renote 示唆を保つ)。
 	if replyID, ok := note["replyId"].(string); ok && replyID != "" {
 		if reply, ok := note["reply"].(map[string]any); ok {
 			summary += "\n\nRE: " + Get(reply)
+		} else {
+			summary += "\n\nRE: ..."
 		}
 	}
 	if renoteID, ok := note["renoteId"].(string); ok && renoteID != "" {
 		if renote, ok := note["renote"].(map[string]any); ok {
 			summary += "\n\nRN: " + Get(renote)
+		} else {
+			summary += "\n\nRN: ..."
 		}
 	}
 	return strings.TrimSpace(summary)

--- a/internal/misc/notesummary/summary_test.go
+++ b/internal/misc/notesummary/summary_test.go
@@ -60,7 +60,26 @@ func TestGet_ReplyIDWithoutReplyObject(t *testing.T) {
 		"text":    "x",
 		"replyId": "n1",
 	}
-	assert.Equal(t, "x", notesummary.Get(note))
+	// #2106 L63: replyId が立っているのに reply が未 hydrate でも upstream は "RE: ..." を付与する。
+	assert.Equal(t, "x\n\nRE: ...", notesummary.Get(note))
+}
+
+// #2106 L63: renoteId が立っているのに renote が未 hydrate でも "RN: ..." を付与する。
+func TestGet_RenoteIDWithoutRenoteObject(t *testing.T) {
+	note := map[string]any{
+		"text":     "y",
+		"renoteId": "n2",
+	}
+	assert.Equal(t, "y\n\nRN: ...", notesummary.Get(note))
+}
+
+// #2106 L64: 空文字 CW は (null ではないので) text にフォールバックせず空 CW を採用する。
+func TestGet_EmptyStringCW(t *testing.T) {
+	note := map[string]any{
+		"cw":   "",
+		"text": "body",
+	}
+	assert.Equal(t, "", notesummary.Get(note))
 }
 
 func TestGet_Nil(t *testing.T) {


### PR DESCRIPTION
#2106 LOW batch (model-config-misc)。L63: notesummary の reply/renote 未 hydrate 時 "RE/RN: ..." 追加。L64: CW 判定を null 基準に。L65 (bug): hashtag.Extract の byte truncate を rune drop に (UTF-8 破損回避)。L66: config doc を mkq default に修正。回帰テスト追加。Closes #2189