### PR TITLE
fetch-rss / update-remote-user の意図的 divergence を明記 (#2106 L27-L29)

### DIFF
--- a/internal/api/federation/update_remote_user.go
+++ b/internal/api/federation/update_remote_user.go
@@ -22,10 +22,16 @@ func (h *Handler) UpdateRemoteUser(c echo.Context) error {
 	}
 	user, err := h.userRepo.FindByID(req.UserID)
 	if err != nil {
+		// #2106 L29: upstream は GetterService の IdentifiableError(15348ddd) を
+		// ApiCallService が INTERNAL_ERROR(500) に包む。mk-go は意図的に明快な
+		// 404 NO_SUCH_USER を返す (worse な 500 拡散を避ける)。
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "ae1bd95a-1a3b-4d4e-9c47-7e76a2020f8e"))
 	}
 	if user.URI == nil || *user.URI == "" {
 		// ローカルユーザーは対象外。
+		// #2106 L29: upstream は local user 指定を Error('user is not a remote user') で
+		// 500 にするが、mk-go は remote 更新エンドポイントで local 指定が実質 no-op のため
+		// 204 を返す。
 		return c.NoContent(http.StatusNoContent)
 	}
 	if h.resolver == nil {

--- a/internal/api/fetchrss/handler.go
+++ b/internal/api/fetchrss/handler.go
@@ -36,6 +36,11 @@ const CacheSeconds = 60 * 3
 // MaxBodyBytes caps the response read from the upstream feed server. Real-world
 // feeds rarely exceed a few hundred KB; capping at 1 MiB blocks pathological
 // hosts that try to drown the parser in arbitrary bytes.
+//
+// #2106 L27: upstream HttpRequestService の default size は 10 MiB (fetch-rss は size
+// 未指定)。requireCredential:false の公開エンドポイントなので mk-go は意図的に 1 MiB へ
+// 硬化している (DoS 表面の縮小)。1〜10 MiB の巨大フィードのみ upstream では取得できて
+// mk-go では 502 になる稀な乖離。
 const MaxBodyBytes int64 = 1 << 20
 
 // FetchTimeout matches the upstream `timeout: 5000` ms used by Misskey TS.
@@ -151,6 +156,9 @@ func (h *Handler) Fetch(c echo.Context) error {
 	}
 
 	if rawURL == "" {
+		// #2106 L28: upstream は url 欠落を ajv schema validation で INVALID_PARAM(400) に、
+		// 不正 scheme を send 内 throw → INTERNAL_ERROR(500) に包む。mk-go は両方を意図的に
+		// 明快な INVALID_URL(400) で返す (worse な 500 拡散を避ける)。
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_URL", "url is required.", "9c5ad7d3-6e15-4f3a-87b8-39ec2e91d5a3"))
 	}
 
@@ -158,6 +166,7 @@ func (h *Handler) Fetch(c echo.Context) error {
 	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
 		// 不正 scheme / host 欠落と「URL 未指定」を frontend 側で別扱いに
 		// したい運用に備え、Misskey の慣行どおり別 ID を割り当てる。
+		// #2106 L28: upstream は scheme 不正を 500 INTERNAL_ERROR にするが mk-go は 400 を保つ。
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_URL", "url must be http(s).", "f5b2bd41-7c0a-4d49-b8c8-3d3a4d9b8e21"))
 	}
 


### PR DESCRIPTION
#2106 LOW parity batch (api-federation-misc)。L27/L28/L29 はいずれも mk-go の挙動の方が明快/安全 (1MiB DoS 硬化、INVALID_URL(400)、404 NO_SUCH_USER) なため、#2106 方針に従い挙動維持 + divergence コメントで明記。機能変更なし。Closes #2191