### PR TITLE
signin-flow passkey / OAuth decision・redirect の upstream 乖離を修正 (#2106 L20-L22)

### DIFF
--- a/internal/api/oauth/provider.go
+++ b/internal/api/oauth/provider.go
@@ -183,6 +183,12 @@ func (h *Handler) Decision(c echo.Context) error {
 		return h.redirectError(c, txn.RedirectURI, txn.State, "access_denied", "the user denied the request")
 	}
 
+	// #2106 L21: upstream OAuth2ProviderService は lookup 前に空 login_token を弾く
+	// (InvalidRequestError 'No user')。空文字で FindByToken("") を実行しないようガードする
+	// (token='' 行が万一存在しても consent 完了を防ぐ defense-in-depth)。
+	if loginToken == "" {
+		return h.redirectError(c, txn.RedirectURI, txn.State, "access_denied", "no such user")
+	}
 	// login_token は native session token のみ一致する (app token は別テーブル)。
 	user, err := h.userRepo.FindByToken(loginToken)
 	if err != nil || user == nil {
@@ -406,11 +412,13 @@ func applyOAuthNoStore(c echo.Context) {
 // redirectError redirects to the (validated) client redirect_uri with the OAuth
 // error parameters, including the RFC9207 iss.
 func (h *Handler) redirectError(c echo.Context, redirectURI, state, code, desc string) error {
+	// #2106 L22: upstream は redirect error に error / state / iss のみ載せ、error_description は
+	// 付与しない (RFC 上 optional、token endpoint の JSON error にのみ含める)。desc は log に残す。
+	slog.Debug("oauth: redirect error", "code", code, "desc", desc)
 	redirect := appendQuery(redirectURI, map[string]string{
-		"error":             code,
-		"error_description": desc,
-		"state":             state,
-		"iss":               h.issuer,
+		"error": code,
+		"state": state,
+		"iss":   h.issuer,
 	})
 	return c.Redirect(http.StatusFound, redirect)
 }

--- a/internal/api/oauth/provider_test.go
+++ b/internal/api/oauth/provider_test.go
@@ -618,3 +618,14 @@ func TestAuthorize_UnsupportedResponseType(t *testing.T) {
 	rec := hn.authorize(t, validAuthorizeQuery(hn, challengeFor("verifier-abc")))
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
+
+// #2106 L21/L22: 空 login_token は lookup 前に弾く。redirect error に error_description を載せない。
+func TestDecision_EmptyLoginToken(t *testing.T) {
+	hn := newHarness(t)
+	hn.store.txns["txn1"] = &transaction{ClientID: hn.clientID, RedirectURI: hn.redirect}
+	rec := hn.post(t, hn.h.Decision, url.Values{"transaction_id": {"txn1"}, "login_token": {""}})
+	require.Equal(t, http.StatusFound, rec.Code)
+	loc := rec.Header().Get("Location")
+	assert.Contains(t, loc, "error=access_denied")
+	assert.NotContains(t, loc, "error_description", "#2106 L22: redirect に error_description を載せない")
+}

--- a/internal/api/signin/handler.go
+++ b/internal/api/signin/handler.go
@@ -329,8 +329,10 @@ func (h *Handler) SigninFlow(c echo.Context) error {
 	}
 
 	// 2FA が必要だが token / credential いずれも来ていない。
-	// password が違う場合はここで弾く (challenge を発行しない)。
-	if !passwordOK {
+	// password が違う場合はここで弾く (challenge を発行しない)。ただし #2106 L20:
+	// usePasswordLessLogin=true なら upstream 同様 password 不一致でも passkey challenge を
+	// 発行する (credential 提供済み branch (line 305) と判定を揃える)。
+	if !passwordOK && !profile.UsePasswordLessLogin {
 		return h.fail(c, user, http.StatusForbidden, "932c904e-9460-45b7-9ce6-7ed33be7eb2c")
 	}
 	// security key 保有なら assertion challenge を発行する (`next: 'passkey'`)。

--- a/internal/api/signin/handler_2fa_test.go
+++ b/internal/api/signin/handler_2fa_test.go
@@ -426,3 +426,31 @@ func TestSigninWithPasskey_BeginFails(t *testing.T) {
 	rec := doPost(h.SigninWithPasskey, `{}`)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
+
+// #2106 L20: usePasswordLessLogin=true なら signin-flow で誤パスワードでも passkey
+// challenge を発行する (upstream SigninApiService と同じく same || usePasswordLessLogin)。
+func Test2FA_WebAuthnPasswordless_WrongPassword_StillChallenges(t *testing.T) {
+	h, repo := newTestHandler(t)
+	if signinTestRedis == nil {
+		t.Skip("redis testcontainer unavailable")
+	}
+	signinTestRedis.FlushAll(context.Background())
+	svc, err := twofactor.NewWebAuthnService("https://example.com", "Misskey", signinTestRedis.Client)
+	require.NoError(t, err)
+	skRepo := &inMemorySK{
+		keys: map[string][]*model.UserSecurityKey{
+			"u1": {{ID: "AAEC", PublicKey: "AwQF", UserID: "u1"}},
+		},
+	}
+	h.SetWebAuthn(svc, skRepo)
+
+	newTestUserWithTOTP(repo, "alice", "pass", "JBSWY3DPEHPK3PXP", nil)
+	repo.Profiles["u1"].UsePasswordLessLogin = true
+
+	// 誤パスワードでも passkey challenge (next:passkey) が返る。
+	rec := doPost(h.SigninFlow, `{"username":"alice","password":"wrong"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "passkey", resp["next"], "usePasswordLessLogin なら誤パスワードでも challenge を発行")
+}


### PR DESCRIPTION
#2106 LOW parity batch (api-auth)。L20: passkey challenge branch に usePasswordLessLogin 判定を追加。L21: OAuth /decision に login_token 空チェック追加。L22: error redirect から error_description 除去。回帰テスト追加。Closes #2193