### PR TITLE
webhook retry/status/secret + scheduled note retry の upstream 乖離を修正 (#2106 L59-L62)

### DIFF
--- a/internal/queue/processors/post_scheduled_note.go
+++ b/internal/queue/processors/post_scheduled_note.go
@@ -210,10 +210,10 @@ func (p *PostScheduledNoteProcessor) Handle(ctx context.Context, task driver.Tas
 	}
 	publishedNote, err := p.publisher.Create(in)
 	if err != nil {
-		// publish 失敗時は asynq retry に任せ、draft 行はそのまま残す
-		// (= 次回 retry で再試行可能)。同時に user に postFailed 通知を
-		// 1 度だけ発火する (= upstream \`scheduledNotePostFailed\` と同 shape、
-		// extra に noteDraftId)。
+		// #2106 L61: upstream PostScheduledNoteProcessorService は publish 失敗時に
+		// scheduledNotePostFailed 通知のみ行い rethrow せず正常終了する (retry しない)。
+		// mk-go も error を返さず job を完了扱いにする。これにより lock TTL 内の silent
+		// skip / TTL 超過後の二重 publish (二重通知) という潜在 retry バグを回避する。
 		slog.Warn("scheduled note publish failed",
 			"noteDraftId", payload.NoteDraftID, "userId", draft.UserID, "err", err)
 		if p.notifier != nil {
@@ -222,12 +222,10 @@ func (p *PostScheduledNoteProcessor) Handle(ctx context.Context, task driver.Tas
 				Type:       notification.TypeScheduledNotePostFailed,
 				Extra:      map[string]any{"noteDraftId": draft.ID},
 			}); nerr != nil {
-				// notification 失敗は publish error 経路に影響させない (= retry
-				// 中に多重通知を避ける best-effort)。
 				logNotificationErr("postFailed", payload.NoteDraftID, nerr)
 			}
 		}
-		return fmt.Errorf("publish scheduled note: %w", err)
+		return nil
 	}
 	// publish 成功通知 (#1045 Phase 2-B)。upstream は `noteId` を引数で渡し、
 	// frontend が note を embed して表示する。

--- a/internal/queue/processors/post_scheduled_note_test.go
+++ b/internal/queue/processors/post_scheduled_note_test.go
@@ -133,8 +133,9 @@ func TestPostScheduledNote_Unscheduled(t *testing.T) {
 	assert.Contains(t, draftRepo.drafts, "d1", "unscheduled draft は残す")
 }
 
-// publish 失敗時は error を返して asynq retry に任せる。draft は残る。
-func TestPostScheduledNote_PublishErrorRetries(t *testing.T) {
+// #2106 L61: publish 失敗時も upstream 同様 error を返さず job を完了扱いにする
+// (retry しない)。draft は残る。
+func TestPostScheduledNote_PublishErrorNoRetry(t *testing.T) {
 	scheduledAt := timeFromMs(1234)
 	drafts := map[string]*model.NoteDraft{
 		"d1": {
@@ -146,7 +147,7 @@ func TestPostScheduledNote_PublishErrorRetries(t *testing.T) {
 	p, draftRepo, pub := newProcessor(drafts, users)
 	pub.err = errors.New("publish boom")
 	err := p.Handle(context.Background(), taskFor("d1"))
-	require.Error(t, err)
+	require.NoError(t, err, "publish 失敗でも retry せず job 完了 (upstream 互換)")
 	assert.Contains(t, draftRepo.drafts, "d1", "publish 失敗時は draft 残す")
 }
 
@@ -347,7 +348,7 @@ func TestPostScheduledNote_NotifiesOnFailed(t *testing.T) {
 	p.SetNotifier(notif)
 
 	err := p.Handle(context.Background(), taskFor("d1"))
-	require.Error(t, err, "publish 失敗は handler error で伝播")
+	require.NoError(t, err, "#2106 L61: publish 失敗でも error を返さない (retry しない)")
 	require.Len(t, notif.calls, 1, "postFailed 通知が 1 度発火")
 	assert.Equal(t, "u1", notif.calls[0].NotifieeID)
 	assert.Equal(t, notification.TypeScheduledNotePostFailed, notif.calls[0].Type)

--- a/internal/queue/processors/webhook.go
+++ b/internal/queue/processors/webhook.go
@@ -105,17 +105,18 @@ func (p *WebhookProcessor) handle(ctx context.Context, t driver.Task, user bool)
 	req.Header.Set("User-Agent", p.userAgent)
 	req.Header.Set("X-Misskey-Host", p.host)
 	req.Header.Set("X-Misskey-Hook-Id", payload.WebhookID)
-	if secret != "" {
-		req.Header.Set("X-Misskey-Hook-Secret", secret)
-	}
+	// #2106 L62: upstream は secret 空でも X-Misskey-Hook-Secret ヘッダーを無条件に送る
+	// (受信側が header の有無で分岐する場合の wire 互換)。
+	req.Header.Set("X-Misskey-Hook-Secret", secret)
 
 	resp, err := p.client.Do(req)
 	sentAt := time.Now()
 	if err != nil {
-		// ネットワーク障害はリトライ対象 (asynq が再試行する)。
-		// ステータスコード 0 を記録しておく (override test 送信時は記録しない)。
+		// ネットワーク障害はリトライ対象。
+		// #2106 L60: upstream は非 StatusError (ネットワーク障害) のとき latestStatus=1 を
+		// 記録する (StatusError なら statusCode)。0 は「未送信」を示すので 1 に揃える。
 		if !isOverride {
-			p.recordStatus(payload.WebhookID, user, sentAt, 0)
+			p.recordStatus(payload.WebhookID, user, sentAt, 1)
 		}
 		slog.Warn("webhook deliver: http error",
 			"hookId", payload.WebhookID, "url", url, "err", err)

--- a/internal/queue/processors/webhook_test.go
+++ b/internal/queue/processors/webhook_test.go
@@ -177,7 +177,8 @@ func TestWebhookProcessor_User_Override(t *testing.T) {
 	assert.False(t, recorded, "override test send must not record status on the saved webhook")
 }
 
-func TestWebhookProcessor_User_NoSecretOmitsHeader(t *testing.T) {
+// #2106 L62: secret 空でも upstream は X-Misskey-Hook-Secret ヘッダーを (空値で) 送る。
+func TestWebhookProcessor_User_EmptySecretSendsEmptyHeader(t *testing.T) {
 	client := &stubHTTPClient{}
 	p, _, _ := newTestWebhookProcessor(t, client, map[string]*model.Webhook{
 		"h1": {ID: "h1", URL: "https://hook.example/u1"},
@@ -185,6 +186,9 @@ func TestWebhookProcessor_User_NoSecretOmitsHeader(t *testing.T) {
 	task := queue.NewUserWebhookTask(queue.WebhookPayload{WebhookID: "h1", EventType: "note", Body: []byte(`{}`)})
 	require.NoError(t, p.HandleUser(context.Background(), task))
 	require.Len(t, client.reqs, 1)
+	// ヘッダー自体は存在し (omit しない)、値は空。
+	_, present := client.reqs[0].Header["X-Misskey-Hook-Secret"]
+	assert.True(t, present, "secret 空でも header は送出される")
 	assert.Empty(t, client.reqs[0].Header.Get("X-Misskey-Hook-Secret"))
 }
 
@@ -221,8 +225,8 @@ func TestWebhookProcessor_User_NetworkError(t *testing.T) {
 	err := p.HandleUser(context.Background(), task)
 	require.Error(t, err)
 	assert.NotErrorIs(t, err, driver.SkipRetry)
-	// ネットワークエラーは status=0 で記録
-	assert.Equal(t, 0, repo.statusCalled["h1"])
+	// #2106 L60: ネットワーク障害 (非 StatusError) は upstream 同様 status=1 で記録する。
+	assert.Equal(t, 1, repo.statusCalled["h1"])
 }
 
 func TestWebhookProcessor_User_NotFoundSkipsRetry(t *testing.T) {

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -368,7 +368,10 @@ func (c *Client) EnqueueUserWebhook(ctx context.Context, payload WebhookPayload)
 	body := mustMarshal(payload)
 	base := []driver.EnqueueOption{
 		driver.WithQueue(WebhookQueueName),
-		driver.WithMaxRetry(4),
+		// #2106 L59: upstream QueueService は BullMQ attempts:4 (= 総試行 4 回)。
+		// mkqdriver は WithMaxRetry(N)→WithAttempts(N+1) 変換なので総試行 4 には
+		// WithMaxRetry(3) が正しい (deliver/inbox と同じ total→MaxRetry 規約)。
+		driver.WithMaxRetry(3),
 		// deliver/inbox と同じ custom backoff を webhook 配送にも付与する。
 		// worker 側 strategy は全 queue に登録済みなので enqueue 側で付けるだけで
 		// 段階的なリトライ間隔が効く (#1408)。
@@ -383,7 +386,8 @@ func (c *Client) EnqueueSystemWebhook(ctx context.Context, payload WebhookPayloa
 	body := mustMarshal(payload)
 	base := []driver.EnqueueOption{
 		driver.WithQueue(WebhookQueueName),
-		driver.WithMaxRetry(4),
+		// #2106 L59: upstream 総試行 4 回に揃える (WithMaxRetry(3)+1=4)。
+		driver.WithMaxRetry(3),
 		// user webhook と同様に custom backoff を付与する (#1408)。
 		driver.WithFederationBackoff(),
 	}

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -728,6 +728,10 @@ func TestClient_EnqueueUserWebhook(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, tasks, 1)
 	assert.Equal(t, queue.TaskTypeUserWebhook, tasks[0].Type)
+	// #2106 L59: upstream の総試行 4 回 (= WithMaxRetry(3) → asynq MaxRetry=3 = 3 retries + 1)。
+	info, err := insp.GetTaskInfo(queue.WebhookQueueName, tasks[0].ID)
+	require.NoError(t, err)
+	assert.Equal(t, 3, info.MaxRetry, "webhook は総試行 4 回 (asynq MaxRetry=3)")
 }
 
 func TestClient_EnqueueUserWebhook_ClosedClientFails(t *testing.T) {


### PR DESCRIPTION
#2106 LOW batch (queue)。L59: webhook 総試行 5→4 (WithMaxRetry 4→3)。L60: ネットワーク障害 latestStatus 0→1。L61 (bug): scheduled note publish 失敗を return nil に (upstream は retry しない)。L62: X-Misskey-Hook-Secret を空でも送出。回帰テスト追加/更新。Closes #2195