### PR TITLE
media proxy recursive guard / url preview の upstream 乖離を修正 (#2106 L43-L45)

### DIFF
--- a/internal/api/proxy/handler.go
+++ b/internal/api/proxy/handler.go
@@ -56,7 +56,11 @@ func (h *Handler) Handle(c echo.Context) error {
 	if ua == "" {
 		return c.String(http.StatusBadRequest, "User-Agent is required")
 	}
-	if strings.Contains(strings.ToLower(ua), "misskey/") {
+	// #2106 L43: mk-go の outbound UA は "mk-go/" 始まり (#774 で Misskey/ から rename)。
+	// upstream の "misskey/" 判定だけだと自身の proxy 経由リクエストを recursive 検出できず
+	// loop/増幅防御が効かないため両方を見る。
+	lowerUA := strings.ToLower(ua)
+	if strings.Contains(lowerUA, "misskey/") || strings.Contains(lowerUA, "mk-go/") {
 		return c.String(http.StatusForbidden, "Proxy is recursive")
 	}
 

--- a/internal/api/proxy/handler_test.go
+++ b/internal/api/proxy/handler_test.go
@@ -628,3 +628,15 @@ func TestHandle_TooLarge(t *testing.T) {
 
 	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
 }
+
+// #2106 L43: mk-go 自身の UA (mk-go/) も recursive proxy として弾く。
+func TestHandle_RecursiveProxy_MkGoUA(t *testing.T) {
+	h, e, imgServer := setupHandler(t, map[string]bool{})
+	defer imgServer.Close()
+
+	rec := doRequest(e, h, http.MethodGet,
+		"/proxy/image.webp?url="+imgServer.URL+"/avatar.png",
+		map[string]string{"User-Agent": "mk-go/0.9.1 (https://other.example)"})
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}

--- a/internal/api/url/handler.go
+++ b/internal/api/url/handler.go
@@ -24,6 +24,9 @@ func NewHandler(fetcher *urlpreview.Fetcher) *Handler {
 // Preview handles GET /url (matches Misskey's endpoint path).
 // フロントエンドがリンクプレビューカード表示のために呼ぶ。
 func (h *Handler) Preview(c echo.Context) error {
+	// #2106 L44: upstream は lang query を summaly に渡し OGP の言語別 alternate を選ぶが、
+	// mk-go は HTML を直接 parse する設計のため lang を honor できず無視する (preview の
+	// 言語選択のみ乖離、実害は軽微)。
 	rawURL := c.QueryParam("url")
 	if rawURL == "" {
 		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_PARAM", "url is required.", apierr.UUIDInvalidParam))

--- a/internal/core/urlpreview/oembed.go
+++ b/internal/core/urlpreview/oembed.go
@@ -212,6 +212,13 @@ func isHTTPSURL(u string) bool {
 	return strings.HasPrefix(strings.ToLower(u), "https://")
 }
 
+// isHTTPOrHTTPSURL は http:// または https:// scheme を string match で判定する
+// (#2106 L45: canonical url の scheme 検証用)。
+func isHTTPOrHTTPSURL(u string) bool {
+	lu := strings.ToLower(u)
+	return strings.HasPrefix(lu, "http://") || strings.HasPrefix(lu, "https://")
+}
+
 // numAttr coerces an oEmbed width/height field (which can be number or
 // string in the wild — providers are inconsistent) to int. 0 on failure.
 func numAttr(v any) int {

--- a/internal/core/urlpreview/parser.go
+++ b/internal/core/urlpreview/parser.go
@@ -32,7 +32,10 @@ func ParseHTML(r io.Reader, pageURL string) *Result {
 	apID := resolveURL(base, firstNonEmpty(meta["ap:id"]))
 
 	canonical := resolveURL(base, meta["og:url"])
-	if canonical == "" {
+	// #2106 L45: upstream は summary.url が http(s) でなければ throw する。canonical (og:url) が
+	// javascript:/data: 等の危険な scheme の場合、API レスポンスの url field に素通ししないよう
+	// 安全な pageURL にフォールバックする (defense-in-depth)。
+	if canonical == "" || !isHTTPOrHTTPSURL(canonical) {
 		canonical = pageURL
 	}
 	result := &Result{

--- a/internal/core/urlpreview/parser_test.go
+++ b/internal/core/urlpreview/parser_test.go
@@ -68,3 +68,16 @@ func TestParseHTML_InvalidHTML(t *testing.T) {
 	r := ParseHTML(strings.NewReader("<not valid <<< html"), "https://example.com")
 	assert.Equal(t, "https://example.com", r.URL)
 }
+
+// #2106 L45: og:url が javascript:/data: 等の危険な scheme の場合、url field は安全な
+// pageURL にフォールバックする (素通ししない)。
+func TestParseHTML_DangerousCanonicalURL(t *testing.T) {
+	html := `<html><head>
+		<meta property="og:title" content="x">
+		<meta property="og:url" content="javascript:alert(1)">
+	</head></html>`
+	r := ParseHTML(strings.NewReader(html), "https://example.com/original")
+	if r.URL != "https://example.com/original" {
+		t.Fatalf("dangerous og:url should fall back to pageURL, got %q", r.URL)
+	}
+}


### PR DESCRIPTION
#2106 LOW batch (core-drive-media)。L43: recursive guard に "mk-go/" UA 検出追加。L44: url preview の lang 無視を意図的 divergence として明記。L45 (security): canonical url が非 http(s) のとき pageURL にフォールバック。回帰テスト追加。Closes #2197