### PR TITLE
announcement forYou / drive webpublicUrl / badgeRoles の upstream 乖離 (#2106 L11/L24/L51/L52/L53)

### DIFF
--- a/internal/api/announcements/handler.go
+++ b/internal/api/announcements/handler.go
@@ -147,9 +147,14 @@ func (h *Handler) List(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, apierr.Error("INTERNAL_ERROR", "Internal error.", "5d37dbcb-891e-41ca-a3d6-e690c97775ac"))
 	}
 
+	// #2106 L52: forYou は viewer 自身宛て announcement で true。匿名は viewerID="" (forYou=false)。
+	viewerID := ""
+	if user != nil {
+		viewerID = user.ID
+	}
 	result := make([]map[string]any, 0, len(items))
 	for _, a := range items {
-		item := packAnnouncement(a, h.idGen)
+		item := packAnnouncement(a, h.idGen, viewerID)
 		if user != nil {
 			read, _ := h.repo.IsRead(user.ID, a.ID)
 			item["isRead"] = read
@@ -273,7 +278,8 @@ func (h *Handler) AdminCreate(c echo.Context) error {
 	}
 	// upstream AnnouncementService.create: per-user (userId 指定) は main へ、
 	// global (userId 無し) は broadcast stream へ announcementCreated を流す (#2056)。
-	body := map[string]any{"announcement": entity.PackAnnouncement(a, h.idGen, false)}
+	// #2106 L24/L52: create event は upstream 同様 me-less で pack する (viewerID="" → forYou=false)。
+	body := map[string]any{"announcement": entity.PackAnnouncement(a, h.idGen, false, "")}
 	if a.UserID != nil {
 		if h.mainStreamPublisher != nil {
 			h.mainStreamPublisher.PublishMainEvent(*a.UserID, "announcementCreated", body)
@@ -291,7 +297,8 @@ func (h *Handler) AdminCreate(c echo.Context) error {
 	// forYou/isRead/icon 等を含む full shape。唯一 imageUrl だけ upstream は raw を返す
 	// (admin/list #1967 と同じく proxy しない)。public 用 PackAnnouncement は #1529 で
 	// imageUrl を proxy 化するため、その field だけ raw に上書きする (#1977)。
-	resp := entity.PackAnnouncement(a, h.idGen, false)
+	// #2106 L24: upstream create は me-less pack なので forYou=false (viewerID="")。
+	resp := entity.PackAnnouncement(a, h.idGen, false, "")
 	resp["imageUrl"] = a.ImageURL // upstream wire は raw imageUrl
 	return c.JSON(http.StatusOK, resp)
 }
@@ -508,6 +515,6 @@ func (h *Handler) AdminList(c echo.Context) error {
 // check. admin 管理用 field (forExistingUsers / isActive) は user-facing には
 // 出さない: upstream の user-facing pack (AnnouncementEntityService.pack) はこれらを
 // 返さず、admin は AdminList が別途返す (#2101)。
-func packAnnouncement(a *model.Announcement, idGen id.Generator) map[string]any {
-	return entity.PackAnnouncement(a, idGen, false)
+func packAnnouncement(a *model.Announcement, idGen id.Generator, viewerID string) map[string]any {
+	return entity.PackAnnouncement(a, idGen, false, viewerID)
 }

--- a/internal/api/announcements/handler_show.go
+++ b/internal/api/announcements/handler_show.go
@@ -40,7 +40,12 @@ func (h *Handler) Show(c echo.Context) error {
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_ANNOUNCEMENT", "No such announcement.", "b57b5e1d-4f49-404a-9edb-46b00268f121"))
 		}
 	}
-	item := packAnnouncement(a, h.idGen)
+	// #2106 L52: forYou は viewer 自身宛てで true。匿名は viewerID="" (forYou=false)。
+	viewerID := ""
+	if me != nil {
+		viewerID = me.ID
+	}
+	item := packAnnouncement(a, h.idGen, viewerID)
 	// upstream getAnnouncement は announcement_reads を引いて isRead=(read!==null)
 	// を pack する。匿名では isRead を undefined にし key を省略する。mk-go は read
 	// 状態を見ずに常に false を返していた (#1955)。

--- a/internal/api/announcements/handler_test.go
+++ b/internal/api/announcements/handler_test.go
@@ -312,7 +312,8 @@ func TestAdminCreate_PerUserPublishesAnnouncementCreated(t *testing.T) {
 	packed, ok := body["announcement"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "You", packed["title"])
-	assert.Equal(t, true, packed["forYou"])
+	// #2106 L24/L52: create event は me-less pack なので forYou=false。
+	assert.Equal(t, false, packed["forYou"])
 	assert.Equal(t, false, packed["isRead"])
 }
 

--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -1911,7 +1911,8 @@ func (h *Handler) fillUnreadFields(ctx context.Context, u *model.User, resp map[
 				// 含む upstream 互換の shape に揃える。独自 map だと createdAt が
 				// 欠落し、misskey_dart の AnnouncementsResponse.fromJson が
 				// createdAt を非null String として cast して落ちる (#1224)。
-				packed := entity.PackAnnouncement(a, h.idGen, false)
+				// #2106 L52: UnreadForUser は viewer u 宛て/global の announcement。viewerID=u.ID。
+				packed := entity.PackAnnouncement(a, h.idGen, false, u.ID)
 				if packed == nil {
 					// nil entry を配列に入れると [null] になり、misskey_dart が
 					// 各要素を fromJson する際 null で落ちるため除外する。

--- a/internal/core/announcement/creator.go
+++ b/internal/core/announcement/creator.go
@@ -58,7 +58,8 @@ func (c *Creator) Create(a *model.Announcement) error {
 	if err := c.repo.Create(a); err != nil {
 		return err
 	}
-	body := map[string]any{"announcement": entity.PackAnnouncement(a, c.idGen, false)}
+	// #2106 L52: broadcast event は me-less なので viewerID="" (forYou=false)。
+	body := map[string]any{"announcement": entity.PackAnnouncement(a, c.idGen, false, "")}
 	if a.UserID != nil {
 		if c.publisher != nil {
 			c.publisher.PublishMainEvent(*a.UserID, "announcementCreated", body)

--- a/internal/core/announcement/creator_test.go
+++ b/internal/core/announcement/creator_test.go
@@ -87,7 +87,8 @@ func TestCreate_PerUserPublishesAnnouncementCreated(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, a.ID, packed["id"])
 	assert.Equal(t, "Change to Invitation-Only", packed["title"])
-	assert.Equal(t, true, packed["forYou"])
+	// #2106 L24/L52: create event は upstream 同様 me-less pack なので forYou=false。
+	assert.Equal(t, false, packed["forYou"])
 	assert.Equal(t, false, packed["isRead"])
 	assert.Equal(t, "2026-06-01T12:00:00.000Z", packed["createdAt"])
 }

--- a/internal/entity/announcement.go
+++ b/internal/entity/announcement.go
@@ -10,7 +10,10 @@ import (
 // isRead is a viewer-dependent flag controlled by the caller; for events
 // emitted at creation time it should be false. forYou is set to true when
 // the announcement targets a specific user (UserID != nil).
-func PackAnnouncement(a *model.Announcement, idGen id.Generator, isRead bool) map[string]any {
+// PackAnnouncement serialises an announcement into the upstream-compatible shape.
+// viewerID is the requesting user's ID ("" for me-less paths such as admin create
+// and broadcast events); it drives forYou (#2106 L52: upstream は userId === me.id 判定)。
+func PackAnnouncement(a *model.Announcement, idGen id.Generator, isRead bool, viewerID string) map[string]any {
 	if a == nil {
 		return nil
 	}
@@ -40,7 +43,10 @@ func PackAnnouncement(a *model.Announcement, idGen id.Generator, isRead bool) ma
 		"display":                a.Display,
 		"needConfirmationToRead": a.NeedConfirmationToRead,
 		"silence":                a.Silence,
-		"forYou":                 a.UserID != nil,
-		"isRead":                 isRead,
+		// #2106 L52: upstream は forYou = (announcement.userId === me?.id)。me-less (viewerID="")
+		// では false。通常は List クエリで user-targeted 行が viewer にしか返らないため一致するが、
+		// create レスポンス (me-less) や匿名閲覧で厳密一致させる。
+		"forYou": a.UserID != nil && *a.UserID == viewerID,
+		"isRead": isRead,
 	}
 }

--- a/internal/entity/announcement_test.go
+++ b/internal/entity/announcement_test.go
@@ -25,7 +25,7 @@ func TestPackAnnouncement_Basic(t *testing.T) {
 		Silence:                false,
 		UserID:                 &userID,
 	}
-	out := PackAnnouncement(a, idGen, true)
+	out := PackAnnouncement(a, idGen, true, userID)
 	assert.Equal(t, aid, out["id"])
 	assert.Equal(t, "Hello", out["title"])
 	assert.Equal(t, "World", out["text"])
@@ -44,13 +44,22 @@ func TestPackAnnouncement_Basic(t *testing.T) {
 }
 
 func TestPackAnnouncement_NilInput(t *testing.T) {
-	assert.Nil(t, PackAnnouncement(nil, nil, false))
+	assert.Nil(t, PackAnnouncement(nil, nil, false, ""))
 }
 
 func TestPackAnnouncement_NoUserID_ForYouFalse(t *testing.T) {
 	a := &model.Announcement{ID: "x", Title: "G", Text: "global"}
-	out := PackAnnouncement(a, nil, false)
+	out := PackAnnouncement(a, nil, false, "")
 	assert.Equal(t, false, out["forYou"])
 	assert.Nil(t, out["updatedAt"])
 	assert.Equal(t, "", out["createdAt"])
+}
+
+// #2106 L52: user-targeted announcement は viewerID が一致するときのみ forYou=true。
+func TestPackAnnouncement_ForYouViewerMatch(t *testing.T) {
+	uid := "u1"
+	a := &model.Announcement{ID: "x", Title: "T", Text: "t", UserID: &uid}
+	assert.Equal(t, true, PackAnnouncement(a, nil, false, "u1")["forYou"], "viewer 自身宛て")
+	assert.Equal(t, false, PackAnnouncement(a, nil, false, "u2")["forYou"], "別 viewer")
+	assert.Equal(t, false, PackAnnouncement(a, nil, false, "")["forYou"], "me-less (create/event)")
 }

--- a/internal/entity/drive.go
+++ b/internal/entity/drive.go
@@ -33,9 +33,13 @@ type DriveFileEntity struct {
 	Comment      *string             `json:"comment"`
 	URL          string              `json:"url"`
 	ThumbnailURL *string             `json:"thumbnailUrl"`
-	WebpublicURL *string             `json:"webpublicUrl"`
-	FolderID     *string             `json:"folderId"`
-	UserID       *string             `json:"userId"`
+	// WebpublicURL は upstream の packedDriveFileSchema / misskey-js autogen に存在しない
+	// mk-go 拡張 field (#460 / #1529 由来、proxy 化済み)。misskey-js は structural typing で
+	// 未知 field を無視するため drop-in client は壊れず、値も proxy 化済で IP leak は無い。
+	// 厳密 parity では余剰だが既存 client 依存の可能性を考慮し保持する (#2106 L51)。
+	WebpublicURL *string `json:"webpublicUrl"`
+	FolderID     *string `json:"folderId"`
+	UserID       *string `json:"userId"`
 	// Folder は upstream が detail packing で常に出す (= null or DriveFolder)。
 	// 旧実装は omitempty で省略していたが drop-in shape drift だったため #812
 	// で外した。caller (detail 経路) で pre-fetch してセットし、未設定なら

--- a/internal/entity/user_roles.go
+++ b/internal/entity/user_roles.go
@@ -132,10 +132,13 @@ func resolveUserRolesSorted(userID string) []*model.Role {
 
 // packBadgeRoles returns the user's badge roles ready for JSON serialisation
 // as the `badgeRoles` field of a UserLite. Filter mirrors upstream
-// `r.asBadge && r.isPublic` (the iAmModerator branch — "moderators can see
-// private badges" — is not yet implemented because PackUserLite has no
-// viewer context; that is a follow-up to thread viewer through the entity
-// pack path).
+// `r.asBadge && r.isPublic`.
+//
+// #2106 L11/L53 (documented limitation): upstream は `r.isPublic || iAmModerator` で
+// filter し moderator は非公開 badge も見られるが、mk-go は PackUserLite に viewer context
+// が無いため常に public のみで filter する。viewer/iAmModerator を全 pack 経路に thread する
+// 大改修が必要なため現状は documented limitation として維持する (一般ユーザー視点の出力は
+// upstream と一致、moderator が他者の非公開 badge を見る軽微なケースのみ乖離)。
 //
 // upstream の `(meta.showRoleBadgesOfRemoteUsers || user.host == null)` 条件を
 // 再現する (#1653)。local user (host==nil) は常に pack し、remote user は

--- a/internal/entitycompat/runtime_test.go
+++ b/internal/entitycompat/runtime_test.go
@@ -337,7 +337,7 @@ func TestAnnouncementShapeL2(t *testing.T) {
 		},
 	}
 	for name, a := range cases {
-		assertNoGatedDrift(t, "Announcement["+name+"]", entity.PackAnnouncement(a, idGen, true), schema)
+		assertNoGatedDrift(t, "Announcement["+name+"]", entity.PackAnnouncement(a, idGen, true, ""), schema)
 	}
 }
 


### PR DESCRIPTION
#2106 LOW batch (entity)。L52/L24 (fix): announcement.forYou を upstream の userId===me.id 判定に揃える (PackAnnouncement に viewerID thread、create は me-less で forYou=false)。L51 (doc): drive webpublicUrl を mk-go 拡張として明記。L11/L53 (doc): badgeRoles moderator 例外を documented limitation として明確化。回帰テスト追加/更新。Closes #2199