### PR TITLE
channels create/update の長さ検証 / drive folderId 空文字正規化 (#2106 L12/L13/L14)

### DIFF
--- a/internal/api/channels/handler.go
+++ b/internal/api/channels/handler.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"unicode/utf8"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shiroha-a/mk/internal/api/apierr"
@@ -159,9 +160,11 @@ func NewHandler(svc *corechannel.Service, idGen id.Generator) *Handler {
 
 // CreateRequest is the request body for channels/create.
 type CreateRequest struct {
-	Name                  string  `json:"name"`
-	Description           *string `json:"description"`
-	Color                 string  `json:"color"`
+	Name        string  `json:"name"`
+	Description *string `json:"description"`
+	// #2106 L13: Color は *string で absent (nil → core が default 適用) と explicit ""
+	// (minLength:1 違反で reject) を区別する。
+	Color                 *string `json:"color"`
 	IsSensitive           bool    `json:"isSensitive"`
 	BannerID              *string `json:"bannerId"`
 	AllowRenoteToExternal *bool   `json:"allowRenoteToExternal"`
@@ -177,6 +180,18 @@ func (h *Handler) Create(c echo.Context) error {
 	if err := c.Bind(&req); err != nil || req.Name == "" {
 		return apierr.JSONInvalidParam(c)
 	}
+	// #2106 L12/L13: upstream paramDef の長さ制約を検証する (超過時 DB の varchar 制約で
+	// 500 になるのを防ぎ 400 INVALID_PARAM を返す)。name 1-128 / description <=2048 /
+	// color 指定時 1-16 (空文字 color は minLength:1 違反で reject)。
+	if utf8.RuneCountInString(req.Name) > 128 ||
+		(req.Description != nil && utf8.RuneCountInString(*req.Description) > 2048) {
+		return apierr.JSONInvalidParam(c)
+	}
+	if req.Color != nil {
+		if n := utf8.RuneCountInString(*req.Color); n < 1 || n > 16 {
+			return apierr.JSONInvalidParam(c)
+		}
+	}
 	// bannerId="" は「banner 無し」に正規化する (TS は misskey:id format で空文字を
 	// 400 にするため空文字が DB に入ることはない。mk-go では空文字 column を作らない)。
 	if req.BannerID != nil && *req.BannerID == "" {
@@ -189,11 +204,15 @@ func (h *Handler) Create(c echo.Context) error {
 			return c.JSON(http.StatusBadRequest, apierr.Error("NO_SUCH_FILE", "No such file.", "cd1e9f3e-5a12-4ab4-96f6-5d0a2cc32050"))
 		}
 	}
+	colorVal := ""
+	if req.Color != nil {
+		colorVal = *req.Color
+	}
 	ch, err := h.svc.Create(corechannel.CreateInput{
 		OwnerID:               user.ID,
 		Name:                  req.Name,
 		Description:           req.Description,
-		Color:                 req.Color,
+		Color:                 colorVal,
 		IsSensitive:           req.IsSensitive,
 		BannerID:              req.BannerID,
 		AllowRenoteToExternal: req.AllowRenoteToExternal,
@@ -275,6 +294,22 @@ func (h *Handler) Update(c echo.Context) error {
 	var req UpdateRequest
 	if err := c.Bind(&req); err != nil || req.ChannelID == "" {
 		return apierr.JSONInvalidParam(c)
+	}
+	// #2106 L12: upstream update.ts paramDef の長さ制約を検証する (超過時 DB 制約 500 でなく
+	// 400)。name 指定時 1-128 / description 非 null 時 <=2048 / color 指定時 1-16。
+	if req.Name != nil {
+		if n := utf8.RuneCountInString(*req.Name); n < 1 || n > 128 {
+			return apierr.JSONInvalidParam(c)
+		}
+	}
+	if req.Description.Present && req.Description.Value != nil &&
+		utf8.RuneCountInString(*req.Description.Value) > 2048 {
+		return apierr.JSONInvalidParam(c)
+	}
+	if req.Color != nil {
+		if n := utf8.RuneCountInString(*req.Color); n < 1 || n > 16 {
+			return apierr.JSONInvalidParam(c)
+		}
 	}
 	in := corechannel.UpdateInput{
 		Name:                  req.Name,

--- a/internal/api/channels/handler_test.go
+++ b/internal/api/channels/handler_test.go
@@ -1195,3 +1195,22 @@ func TestResolveBannerURLs_Batch(t *testing.T) {
 	// 全 channel banner なし -> FindByIDs を呼ばず empty。
 	assert.Empty(t, h.resolveBannerURLs([]*model.Channel{{ID: "c3"}}))
 }
+
+// #2106 L12: name が 128 文字超だと DB 500 でなく 400 INVALID_PARAM を返す。
+func TestCreate_NameTooLong(t *testing.T) {
+	h, _, _, _ := newHandler(t)
+	long := strings.Repeat("a", 129)
+	c, rec := newReq(t, `{"name":"`+long+`"}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// #2106 L13: explicit に color:"" を送ると minLength:1 違反で 400 (absent は default 適用)。
+func TestCreate_EmptyColorRejected(t *testing.T) {
+	h, _, _, _ := newHandler(t)
+	c, rec := newReq(t, `{"name":"x","color":""}`)
+	setUser(c, "alice")
+	require.NoError(t, h.Create(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/internal/api/drive/handler.go
+++ b/internal/api/drive/handler.go
@@ -730,6 +730,17 @@ func (h *Handler) Usage(c echo.Context) error {
 }
 
 // FilesList handles POST /api/drive/files — lists user's files.
+// emptyFolderIDToNil normalizes an empty-string folderId pointer to nil so the
+// repository treats it as "root" (folderId IS NULL) instead of filtering on the
+// literal empty string. #2106 L14: upstream は falsy folderId を root 扱いし、
+// 空文字 "" は misskey:id format 違反として扱う。mk-go は "" を root に正規化する。
+func emptyFolderIDToNil(s *string) *string {
+	if s != nil && *s == "" {
+		return nil
+	}
+	return s
+}
+
 func (h *Handler) FilesList(c echo.Context) error {
 	user := middleware.GetUser(c)
 	var req struct {
@@ -759,7 +770,7 @@ func (h *Handler) FilesList(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1173)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
-	files, err := h.fileRepo.ListByUser(user.ID, req.FolderID, false, req.Type, req.Sort, untilID, sinceID, req.Limit)
+	files, err := h.fileRepo.ListByUser(user.ID, emptyFolderIDToNil(req.FolderID), false, req.Type, req.Sort, untilID, sinceID, req.Limit)
 	if err != nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
@@ -797,7 +808,7 @@ func (h *Handler) FilesFind(c echo.Context) error {
 	if h.fileRepo == nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
-	files, err := h.fileRepo.FindByName(user.ID, req.Name, req.FolderID)
+	files, err := h.fileRepo.FindByName(user.ID, req.Name, emptyFolderIDToNil(req.FolderID))
 	if err != nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
@@ -1047,7 +1058,7 @@ func (h *Handler) FoldersList(c echo.Context) error {
 	}
 	// sinceDate / untilDate を aidx prefix に正規化 (#1173)。
 	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
-	folders, err := h.folderRepo.ListByUser(user.ID, req.FolderID, untilID, sinceID, req.Limit)
+	folders, err := h.folderRepo.ListByUser(user.ID, emptyFolderIDToNil(req.FolderID), untilID, sinceID, req.Limit)
 	if err != nil {
 		return c.JSON(http.StatusOK, []any{})
 	}

--- a/internal/api/drive/handler_test.go
+++ b/internal/api/drive/handler_test.go
@@ -1254,3 +1254,17 @@ func TestFoldersFind_NilRepo(t *testing.T) {
 	require.NoError(t, h.FoldersFind(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
+
+// #2106 L14: folderId:"" は root (folderId IS NULL) として扱う (0 件返却にしない)。
+func TestFilesList_EmptyFolderIDTreatedAsRoot(t *testing.T) {
+	h, fileRepo, _ := newHandlerWithRepos(t)
+	uid := "u1"
+	// root (FolderID=nil) の file。
+	fileRepo.Files["f1"] = &model.DriveFile{ID: "f1", UserID: &uid, Name: "root.png"}
+	c, rec := newJSONReq(t, `{"folderId":""}`)
+	setUser(c, "u1")
+	require.NoError(t, h.FilesList(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	// "" → nil 正規化により root の file が返る。
+	assert.Contains(t, rec.Body.String(), "root.png")
+}


### PR DESCRIPTION
#2106 LOW batch (api-drive-channels)。L12: channels の name/description/color 長さ検証 (500→400)。L13: 空文字 color を minLength:1 違反で 400 (Color を *string 化)。L14: drive list/find の folderId:"" を root に正規化。回帰テスト追加。Closes #2201