### PR TITLE
users/reactions block 順 / users/notes 404 / users/show trim (#2106 L8/L9/L10)

### DIFF
--- a/internal/api/users/handler.go
+++ b/internal/api/users/handler.go
@@ -546,7 +546,9 @@ func (h *Handler) Show(c echo.Context) error {
 		if req.Host != nil && *req.Host != "" && viewer == nil && h.ugcVisibility == "local" {
 			return apierr.JSONNoSuchUser(c)
 		}
-		bundle, err = h.userService.ShowByUsername(*req.Username, req.Host)
+		// #2106 L10: upstream show.ts は lookup 前に username を trim する。前後空白を含む
+		// リクエストでも usernameLower 一致するよう揃える。
+		bundle, err = h.userService.ShowByUsername(strings.TrimSpace(*req.Username), req.Host)
 	}
 
 	if err != nil {
@@ -788,8 +790,10 @@ func (h *Handler) Notes(c echo.Context) error {
 	}
 	req.Limit = pagination.ClampLimit(req.Limit, 10, 100)
 
+	// #2106 L9: upstream notes.ts は user 存在確認をせず単に note を query するため、存在しない
+	// userId では [] を返す (noSuchUser は meta の vestigial error)。404 でなく空配列に揃える。
 	if _, err := h.userService.ShowByID(req.UserID); err != nil {
-		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_USER", "No such user.", "27e494ba-2ac2-48e8-893b-10d4d8c2387b"))
+		return c.JSON(http.StatusOK, []any{})
 	}
 
 	// upstream paramDef のデフォルトに合わせる (= withFiles=false /
@@ -902,7 +906,8 @@ func (h *Handler) listRelations(c echo.Context, followers bool) error {
 		if req.Username == "" {
 			return apierr.JSONInvalidParam(c)
 		}
-		bundle, err := h.userService.ShowByUsername(strings.ToLower(req.Username), req.Host)
+		// #2106 L10: Followers/Following も Show と同じく lookup 前に trim する。
+		bundle, err := h.userService.ShowByUsername(strings.ToLower(strings.TrimSpace(req.Username)), req.Host)
 		if err != nil || bundle == nil {
 			nsuID := "63e4aba4-4156-4e53-be25-c9559e42d71b" // users/following
 			if followers {

--- a/internal/api/users/handler_extra.go
+++ b/internal/api/users/handler_extra.go
@@ -352,12 +352,6 @@ func (h *Handler) Reactions(c echo.Context) error {
 	// 丸ごと bypass して reaction list を返す。
 	iAmModerator := viewer != nil && h.moderatorChecker != nil && h.moderatorChecker.IsModerator(viewer.ID)
 
-	// viewer が target にブロックされていれば空配列 (upstream reactions.ts:91-94 の
-	// 非 moderator path 早期 return、#1547)。moderator は bypass。
-	if !iAmModerator && h.isBlockedByTarget(viewer, req.UserID) {
-		return c.JSON(http.StatusOK, []any{})
-	}
-
 	// target user lookup + remote / publicReactions check (non-moderator のみ)。
 	// production では userRepo が必ず wire されるが、既存の handler test
 	// (TestReactions_Success 等) は userRepo を wire しないので nil guard で
@@ -382,6 +376,13 @@ func (h *Handler) Reactions(c echo.Context) error {
 				return c.JSON(http.StatusForbidden, apierr.Error("REACTIONS_NOT_PUBLIC", "Reactions of the user is not public.", "673a7dd2-6924-1093-e0c0-e68456ceae5c"))
 			}
 		}
+	}
+
+	// #2106 L8: block 早期 return は upstream reactions.ts 同様 remote/public check の後に置く。
+	// block されていても remote/非公開 target には IS_REMOTE_USER/REACTIONS_NOT_PUBLIC を先に返す。
+	// moderator は bypass。
+	if !iAmModerator && h.isBlockedByTarget(viewer, req.UserID) {
+		return c.JSON(http.StatusOK, []any{})
 	}
 
 	// reactor の reaction list を取得 (User / Note を Preload 済み)。

--- a/internal/api/users/handler_extra_test.go
+++ b/internal/api/users/handler_extra_test.go
@@ -1023,3 +1023,17 @@ func TestValidListState(t *testing.T) {
 		assert.False(t, users.ValidListState(bad), "state=%q は範囲外で reject (#1996)", bad)
 	}
 }
+
+// #2106 L8: viewer が block されていても remote target には block 早期 return より先に
+// IS_REMOTE_USER を返す (upstream reactions.ts の評価順)。
+func TestReactions_BlockedAndRemote_ReturnsRemoteError(t *testing.T) {
+	h, userRepo, _ := newReactionsHandler(t)
+	host := "remote.example"
+	userRepo.Users["u_remote"] = &model.User{ID: "u_remote", Host: &host}
+	blockRepo := testutil.NewMockBlockingRepository()
+	_ = blockRepo.Create(&model.Blocking{ID: "b1", BlockerID: "u_remote", BlockeeID: "u_viewer"})
+	h.SetBlockingRepo(blockRepo)
+	rec := postExtra(h.Reactions, `{"userId":"u_remote"}`, &model.User{ID: "u_viewer"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "IS_REMOTE_USER")
+}

--- a/internal/api/users/handler_test.go
+++ b/internal/api/users/handler_test.go
@@ -1096,10 +1096,12 @@ func TestNotes_LimitClamp(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// #2106 L9: 存在しない userId は upstream notes.ts 同様 200 [] を返す (404 でない)。
 func TestNotes_UserNotFound(t *testing.T) {
 	h, _ := newTestHandler(t)
 	rec := post(h.Notes, `{"userId": "ghost"}`)
-	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.JSONEq(t, `[]`, rec.Body.String())
 }
 
 func TestNotes_InvalidParam(t *testing.T) {
@@ -2257,4 +2259,15 @@ func TestFollowers_PopulatesBlockMute(t *testing.T) {
 	assert.Equal(t, true, follower["isMuted"], "viewer が mute している follower は isMuted=true")
 	assert.Equal(t, false, follower["isBlocked"])
 	assert.Equal(t, false, follower["isRenoteMuted"])
+}
+
+// #2106 L10: username の前後空白を trim して lookup する (upstream show.ts と同じ)。
+func TestShow_ByUsernameTrimmed(t *testing.T) {
+	h, userRepo := newTestHandler(t)
+	addTestUser(userRepo)
+	rec := post(h.Show, `{"username": "  testuser  "}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "user1", resp["id"], "前後空白を trim して testuser に解決")
 }


### PR DESCRIPTION
#2106 LOW batch (api-users)。L8: reactions の block check を remote/public check の後に移動。L9: users/notes の存在しない userId を 404→200 []。L10: users/show・followers・following の username を lookup 前に TrimSpace。回帰テスト追加。Closes #2203