### PR TITLE
reaction param 必須 / ZWJ selector / 並行 delete / renote message (#2106 L36/L39/L40/L41)

### DIFF
--- a/internal/api/notes/reactions_handler.go
+++ b/internal/api/notes/reactions_handler.go
@@ -25,7 +25,9 @@ func (h *Handler) ReactionsCreate(c echo.Context) error {
 	user := middleware.GetUser(c)
 
 	var req ReactionCreateRequest
-	if err := c.Bind(&req); err != nil || req.NoteID == "" {
+	// #2106 L36: upstream create.ts の paramDef は required:['noteId','reaction']。reaction
+	// 欠落を endpoint 層で 400 にする (欠落時に FallbackReaction(❤) で reaction しない)。
+	if err := c.Bind(&req); err != nil || req.NoteID == "" || req.Reaction == "" {
 		return apierr.JSONInvalidParam(c)
 	}
 
@@ -39,7 +41,7 @@ func (h *Handler) ReactionsCreate(c echo.Context) error {
 		case errors.Is(err, reaction.ErrAlreadyReacted):
 			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_REACTED", "You are already reacting to that note.", "71efcf98-86d6-4e2b-b2ad-9d032369366b"))
 		case errors.Is(err, reaction.ErrCannotReactToPureRenote):
-			return c.JSON(http.StatusBadRequest, apierr.Error("CANNOT_REACT_TO_RENOTE", "You can not react to a pure Renote.", "eaccdc08-ddef-43fe-908f-d108faad57f5"))
+			return c.JSON(http.StatusBadRequest, apierr.Error("CANNOT_REACT_TO_RENOTE", "You cannot react to Renote.", "eaccdc08-ddef-43fe-908f-d108faad57f5"))
 		case errors.Is(err, reaction.ErrBlocked):
 			// upstream notes/reactions/create.ts は ReactionService の内部 id
 			// (e70412a4…) を catch し、endpoint error youHaveBeenBlocked

--- a/internal/api/notes/reactions_handler_test.go
+++ b/internal/api/notes/reactions_handler_test.go
@@ -75,7 +75,7 @@ func TestReactionsCreate_InvalidJSON(t *testing.T) {
 
 func TestReactionsCreate_NoteNotFound(t *testing.T) {
 	h, _, _ := newReactionHandler(t)
-	c, rec := newJSONRequest(t, "/api/notes/reactions/create", `{"noteId":"ghost"}`)
+	c, rec := newJSONRequest(t, "/api/notes/reactions/create", `{"noteId":"ghost","reaction":"👍"}`)
 	setAuthUser(c, &model.User{ID: "viewer"})
 	require.NoError(t, h.ReactionsCreate(c))
 	assert.Equal(t, http.StatusNotFound, rec.Code)
@@ -84,7 +84,7 @@ func TestReactionsCreate_NoteNotFound(t *testing.T) {
 func TestReactionsCreate_NotVisible(t *testing.T) {
 	h, repo, _ := newReactionHandler(t)
 	seedReactionNote(repo, "n1", "followers")
-	c, rec := newJSONRequest(t, "/api/notes/reactions/create", `{"noteId":"n1"}`)
+	c, rec := newJSONRequest(t, "/api/notes/reactions/create", `{"noteId":"n1","reaction":"👍"}`)
 	setAuthUser(c, &model.User{ID: "viewer"})
 	require.NoError(t, h.ReactionsCreate(c))
 	assert.Equal(t, http.StatusForbidden, rec.Code)
@@ -126,7 +126,7 @@ func TestReactionsCreate_Blocked(t *testing.T) {
 	reactSvc.SetBlockingChecker(&stubBlockingCheckerReact{})
 	h := NewHandler(noteRepo, createSvc, deleteSvc, querySvc, nil, reactSvc, nil, nil, idGen)
 
-	c, rec := newJSONRequest(t, "/api/notes/reactions/create", `{"noteId":"n1"}`)
+	c, rec := newJSONRequest(t, "/api/notes/reactions/create", `{"noteId":"n1","reaction":"👍"}`)
 	setAuthUser(c, &model.User{ID: "viewer"})
 	require.NoError(t, h.ReactionsCreate(c))
 	assert.Equal(t, http.StatusForbidden, rec.Code)
@@ -146,7 +146,7 @@ func TestReactionsCreate_PureRenote(t *testing.T) {
 		Visibility: model.NoteVisibilityPublic,
 		RenoteID:   &target,
 	}
-	c, rec := newJSONRequest(t, "/api/notes/reactions/create", `{"noteId":"n1"}`)
+	c, rec := newJSONRequest(t, "/api/notes/reactions/create", `{"noteId":"n1","reaction":"👍"}`)
 	setAuthUser(c, &model.User{ID: "viewer"})
 	require.NoError(t, h.ReactionsCreate(c))
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
@@ -174,7 +174,7 @@ func TestReactionsCreate_RepoError(t *testing.T) {
 	reactSvc := corereaction.NewService(noteRepo, reactRepo, emojiRepo, nil, idGen)
 	h := NewHandler(noteRepo, createSvc, deleteSvc, querySvc, nil, reactSvc, nil, nil, idGen)
 
-	c, rec := newJSONRequest(t, "/api/notes/reactions/create", `{"noteId":"n1"}`)
+	c, rec := newJSONRequest(t, "/api/notes/reactions/create", `{"noteId":"n1","reaction":"👍"}`)
 	setAuthUser(c, &model.User{ID: "viewer"})
 	require.NoError(t, h.ReactionsCreate(c))
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
@@ -185,7 +185,7 @@ func TestReactionsDelete_Success(t *testing.T) {
 	seedReactionNote(repo, "n1", "public")
 
 	// First add a reaction
-	c1, _ := newJSONRequest(t, "/api/notes/reactions/create", `{"noteId":"n1"}`)
+	c1, _ := newJSONRequest(t, "/api/notes/reactions/create", `{"noteId":"n1","reaction":"👍"}`)
 	setAuthUser(c1, &model.User{ID: "viewer"})
 	require.NoError(t, h.ReactionsCreate(c1))
 
@@ -225,8 +225,8 @@ type failingDeleteReactionRepo struct {
 	*testutil.MockNoteReactionRepository
 }
 
-func (f *failingDeleteReactionRepo) Delete(_ *model.NoteReaction) error {
-	return errors.New("delete boom")
+func (f *failingDeleteReactionRepo) Delete(_ *model.NoteReaction) (int64, error) {
+	return 0, errors.New("delete boom")
 }
 
 func TestReactionsDelete_RepoError(t *testing.T) {
@@ -375,4 +375,14 @@ func TestReactions_List_RepoError(t *testing.T) {
 	c, rec := newJSONRequest(t, "/api/notes/reactions", `{"noteId":"n1"}`)
 	require.NoError(t, h.Reactions(c))
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// #2106 L36: reaction param 欠落は 400 INVALID_PARAM (❤ で reaction しない)。
+func TestReactionsCreate_MissingReaction(t *testing.T) {
+	h, repo, _ := newReactionHandler(t)
+	seedReactionNote(repo, "n1", "public")
+	c, rec := newJSONRequest(t, "/api/notes/reactions/create", `{"noteId":"n1"}`)
+	setAuthUser(c, &model.User{ID: "viewer"})
+	require.NoError(t, h.ReactionsCreate(c))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }

--- a/internal/core/federation/processor_step_f_test.go
+++ b/internal/core/federation/processor_step_f_test.go
@@ -1378,8 +1378,8 @@ type deleteFailReactionRepo struct {
 	*testutil.MockNoteReactionRepository
 }
 
-func (r *deleteFailReactionRepo) Delete(_ *model.NoteReaction) error {
-	return errors.New("react delete failed")
+func (r *deleteFailReactionRepo) Delete(_ *model.NoteReaction) (int64, error) {
+	return 0, errors.New("react delete failed")
 }
 
 // deleteFailFollowingRepo causes Delete on followingRepo to fail (for handleReject Unfollow).

--- a/internal/core/reaction/reaction_service.go
+++ b/internal/core/reaction/reaction_service.go
@@ -300,7 +300,7 @@ func (s *Service) Create(user *model.User, noteID, rawReaction string) (string, 
 			return "", ErrAlreadyReacted
 		}
 		// 別のリアクションがすでにあるので置き換える
-		if err := s.reactionRepo.Delete(existing); err != nil {
+		if _, err := s.reactionRepo.Delete(existing); err != nil {
 			return "", err
 		}
 		// 集計列も古いリアクションを-1
@@ -415,8 +415,14 @@ func (s *Service) Delete(user *model.User, noteID string) error {
 	if err != nil {
 		return ErrReactionNotFound
 	}
-	if err := s.reactionRepo.Delete(existing); err != nil {
+	affected, err := s.reactionRepo.Delete(existing)
+	if err != nil {
 		return err
+	}
+	// #2106 L40: 並行 unreact で既に削除済 (affected==0) の場合はカウント減算・Undo・stream
+	// 発火を全てスキップする (upstream の `if (result.affected !== 1) throw` 相当、二重デクリ防止)。
+	if affected == 0 {
+		return ErrReactionNotFound
 	}
 	_ = s.countWriter.Increment(target.ID, existing.Reaction, -1)
 	if s.federationHook != nil {
@@ -617,6 +623,12 @@ func (s *Service) reactorHasAllowedRole(userID string, allowed []string) bool {
 // upstream Misskey TS は同様の正規化を行うため、両 backend の reaction
 // 文字列を揃えるのに必要 (#864)。
 func stripVariationSelector(s string) string {
+	// #2106 L39: upstream normalize \u306f ZWJ (U+200D) \u3092\u542b\u3080\u5408\u5b57\u7d75\u6587\u5b57 (\u4e00\u90e8\u306e\u8077\u696d/\u5bb6\u65cf\u7d75\u6587\u5b57)
+	// \u3067\u306f U+FE0F \u3092\u6b8b\u3059 (`unicode.match('\u200d') ? unicode : unicode.replace(/\ufe0f/g, '')`)\u3002
+	// ZWJ \u3092\u542b\u3080\u5834\u5408\u306f variation selector \u3092 strip \u305b\u305a\u539f\u6587\u3092\u8fd4\u3057 reaction key \u3092 upstream \u306b\u63c3\u3048\u308b\u3002
+	if strings.Contains(s, "\u200d") {
+		return s
+	}
 	return strings.ReplaceAll(s, "\ufe0f", "")
 }
 

--- a/internal/core/reaction/reaction_service_test.go
+++ b/internal/core/reaction/reaction_service_test.go
@@ -219,8 +219,8 @@ type failingReactionRepoOnDelete struct {
 	*testutil.MockNoteReactionRepository
 }
 
-func (f *failingReactionRepoOnDelete) Delete(_ *model.NoteReaction) error {
-	return errors.New("delete boom")
+func (f *failingReactionRepoOnDelete) Delete(_ *model.NoteReaction) (int64, error) {
+	return 0, errors.New("delete boom")
 }
 
 func TestService_Create_ReplaceDeleteError(t *testing.T) {
@@ -276,8 +276,8 @@ type failingDeleteRepo struct {
 	*testutil.MockNoteReactionRepository
 }
 
-func (f *failingDeleteRepo) Delete(_ *model.NoteReaction) error {
-	return errors.New("delete fail")
+func (f *failingDeleteRepo) Delete(_ *model.NoteReaction) (int64, error) {
+	return 0, errors.New("delete fail")
 }
 
 func TestService_Delete_RepoError(t *testing.T) {
@@ -845,4 +845,35 @@ func TestService_List_RemoteCustomEmojiFilter(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, out, 1, "remote custom emoji filter は該当 reaction のみ返す (❤ に化けない)")
 	assert.Equal(t, ":foo@remote.example:", out[0].Reaction)
+}
+
+// zeroAffectedDeleteRepo simulates a concurrent delete: FindByPair finds the row
+// (embedded mock) but Delete reports 0 affected rows (already removed by a racer).
+type zeroAffectedDeleteRepo struct {
+	*testutil.MockNoteReactionRepository
+}
+
+func (z *zeroAffectedDeleteRepo) Delete(_ *model.NoteReaction) (int64, error) {
+	return 0, nil
+}
+
+// #2106 L40: 並行 delete で affected==0 のときは ErrReactionNotFound を返し、カウントを
+// 二重デクリメントしない (upstream の affected!==1 ガード相当)。
+func TestService_Delete_ConcurrentZeroAffected(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	seedNote(noteRepo, "n1", "author", model.NoteVisibilityPublic)
+	mock := testutil.NewMockNoteReactionRepository()
+	mock.Reactions["existing"] = &model.NoteReaction{
+		ID: "existing", UserID: "viewer", NoteID: "n1", Reaction: "👍",
+	}
+	idGen, _ := id.NewGenerator("aidx")
+	svc := reaction.NewService(
+		noteRepo,
+		&zeroAffectedDeleteRepo{MockNoteReactionRepository: mock},
+		testutil.NewMockEmojiRepository(),
+		testutil.NewMockFollowingRepository(),
+		idGen,
+	)
+	err := svc.Delete(&model.User{ID: "viewer"}, "n1")
+	assert.ErrorIs(t, err, reaction.ErrReactionNotFound)
 }

--- a/internal/repository/note_reaction.go
+++ b/internal/repository/note_reaction.go
@@ -15,7 +15,9 @@ var ErrDuplicateReaction = errors.New("user has already reacted to this note")
 // NoteReactionRepository provides data access for note_reaction rows.
 type NoteReactionRepository interface {
 	Create(r *model.NoteReaction) error
-	Delete(r *model.NoteReaction) error
+	// Delete removes the reaction row and returns the number of affected rows so
+	// callers can detect concurrent deletes (#2106 L40: avoid double count-decrement).
+	Delete(r *model.NoteReaction) (int64, error)
 	FindByPair(userID, noteID string) (*model.NoteReaction, error)
 	// FindByUserAndNoteIDs returns reactions for a user across multiple notes.
 	// noteIDをキーとしたmapを返す。
@@ -57,8 +59,9 @@ func (r *noteReactionRepository) Create(rec *model.NoteReaction) error {
 	return nil
 }
 
-func (r *noteReactionRepository) Delete(rec *model.NoteReaction) error {
-	return r.db.Delete(rec).Error
+func (r *noteReactionRepository) Delete(rec *model.NoteReaction) (int64, error) {
+	result := r.db.Delete(rec)
+	return result.RowsAffected, result.Error
 }
 
 func (r *noteReactionRepository) FindByPair(userID, noteID string) (*model.NoteReaction, error) {

--- a/internal/repository/note_reaction_test.go
+++ b/internal/repository/note_reaction_test.go
@@ -84,7 +84,9 @@ func TestNoteReactionRepository_Delete(t *testing.T) {
 
 	rec := &model.NoteReaction{ID: "rx_del_1", UserID: user.ID, NoteID: note.ID, Reaction: "👍"}
 	require.NoError(t, repo.Create(rec))
-	require.NoError(t, repo.Delete(rec))
+	affected, derr := repo.Delete(rec)
+	require.NoError(t, derr)
+	assert.Equal(t, int64(1), affected) // #2106 L40: 削除した行数を返す
 
 	_, err := repo.FindByPair(user.ID, note.ID)
 	assert.Error(t, err)

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1791,9 +1791,12 @@ func (m *MockNoteReactionRepository) Create(r *model.NoteReaction) error {
 	return nil
 }
 
-func (m *MockNoteReactionRepository) Delete(r *model.NoteReaction) error {
+func (m *MockNoteReactionRepository) Delete(r *model.NoteReaction) (int64, error) {
+	if _, ok := m.Reactions[r.ID]; !ok {
+		return 0, nil
+	}
 	delete(m.Reactions, r.ID)
-	return nil
+	return 1, nil
 }
 
 func (m *MockNoteReactionRepository) FindByPair(userID, noteID string) (*model.NoteReaction, error) {


### PR DESCRIPTION
#2106 LOW batch (reaction)。L36: reaction param 欠落を 400 に。L39 (bug): ZWJ 合字で variation selector を strip しない。L40 (bug): Repository.Delete を (int64,error) 化し affected==0 で二重デクリメント防止。L41: renote reaction message を upstream に統一。回帰テスト追加。Closes #2205