### PR TITLE
TOTP doc 修正 / email banned 順 / antenna userListId 制限を明記 (#2106 L46/L47/L48)

### DIFF
--- a/internal/core/antenna/antenna_service.go
+++ b/internal/core/antenna/antenna_service.go
@@ -307,6 +307,11 @@ func (s *Service) Update(ownerID, antennaID string, in UpdateInput) (*model.Ante
 	}
 	if in.UserListID != nil {
 		// 空文字列での nullify を許すため ポインタ非 nil なら上書き対象扱い。
+		// #2106 L48 (documented limitation): upstream update.ts は userListId の明示 null で clear、
+		// 非 list src で null 化するが、Go の *string は JSON の null と absent を区別できないため
+		// mk-go は「空文字列で clear」の convention を採る (JSON null clear / 非 list src 自動 null 化は
+		// 未対応)。validateUserList 連携の都合で edge を残す。通常 UI 経路 (src=list 時のみ
+		// userListId を送る) では乖離しない。
 		fields["userListId"] = in.UserListID
 	}
 	if in.Users != nil {

--- a/internal/core/email/email.go
+++ b/internal/core/email/email.go
@@ -68,6 +68,10 @@ func (s *Service) Validate(ctx context.Context, email string) error {
 	}
 
 	domain := domainOf(email)
+	// #2106 L47: upstream は banned 判定を external validation (disposable/mx/smtp) の後段に
+	// 置くが、mk-go は意図的に banned を先に短絡する (既知 banned ドメインに対し外部
+	// verifymail/truemail/MX への問い合わせを発生させない = 外部漏洩・コスト回避)。caller は
+	// reason を一律 UNAVAILABLE に潰すため client から観測できる差は無い。
 	if IsBannedDomain(domain, s.bannedDomains) {
 		return ErrBanned
 	}

--- a/internal/core/twofactor/totp_service.go
+++ b/internal/core/twofactor/totp_service.go
@@ -63,7 +63,8 @@ func QRDataURL(uri string) (string, error) {
 }
 
 // Validate checks if a TOTP code is valid for the given secret. The acceptance
-// window matches upstream Misskey (window:5 = ±5 steps ≈ ±150s)。
+// window is ±totpSkew steps (= ±30s for Skew=1), matching upstream UserAuthService
+// の validationWindow:1 (#2106 L46: 旧 window:5 / ±150s の記述を実値に修正)。
 func Validate(code, secret string) bool {
 	ok, err := totp.ValidateCustom(code, secret, time.Now().UTC(), totp.ValidateOpts{
 		Period:    30,


### PR DESCRIPTION
#2106 LOW batch (core-misc/role)。L46: TOTP Validate doc を実値に修正。L47: email banned-first を外部問い合わせ回避の意図的 divergence として明記。L48: antenna userListId の null clear 未対応を documented limitation として明記。機能変更なし。Closes #2207