### PR TITLE
/api Cache-Control / chatRoom moderator 購読 / shareable connect ack (#2106 L56/L57/L58)

### DIFF
--- a/internal/core/chat/service.go
+++ b/internal/core/chat/service.go
@@ -1245,6 +1245,23 @@ func (s *Service) IsRoomMember(userID, roomID string) (bool, error) {
 	return false, nil
 }
 
+// CanViewRoomTimeline reports whether userID may subscribe to the room's timeline
+// stream: a room member (owner/member) or a moderator (#2106 L57, mirrors upstream
+// hasPermissionToViewRoomTimeline = isRoomMember || isModerator)。
+func (s *Service) CanViewRoomTimeline(userID, roomID string) (bool, error) {
+	member, err := s.IsRoomMember(userID, roomID)
+	if err != nil {
+		return false, err
+	}
+	if member {
+		return true, nil
+	}
+	if s.moderatorChecker != nil && s.moderatorChecker.IsModerator(userID) {
+		return true, nil
+	}
+	return false, nil
+}
+
 // packMessage produces a JSON-serializable projection of a ChatMessage for
 // outbound WebSocket events. フロント互換のため本家 ChatMessageLite と同じ
 // 主要フィールドを含める。createdAt は idGen の初期化未完了時 (テスト等)

--- a/internal/core/chat/service_test.go
+++ b/internal/core/chat/service_test.go
@@ -756,3 +756,22 @@ func TestUnreact_NormalizesVariationSelector(t *testing.T) {
 	body := last.body.(map[string]any)
 	assert.Equal(t, "❤", body["reaction"])
 }
+
+// #2106 L57: moderator は non-member room の timeline を購読できる (CanViewRoomTimeline)。
+func TestCanViewRoomTimeline_ModeratorBypass(t *testing.T) {
+	svc, repo, _ := newSvc(t)
+	repo.Rooms["r1"] = &model.ChatRoom{ID: "r1", Name: "test-room", OwnerID: "alice"}
+	svc.SetModeratorChecker(&stubModeratorChecker{moderators: map[string]bool{"mod1": true}})
+
+	ok, err := svc.CanViewRoomTimeline("mod1", "r1")
+	require.NoError(t, err)
+	assert.True(t, ok, "moderator は non-member room を購読できる")
+
+	ok2, err := svc.CanViewRoomTimeline("bob", "r1")
+	require.NoError(t, err)
+	assert.False(t, ok2, "非 moderator non-member は購読不可")
+
+	ok3, err := svc.CanViewRoomTimeline("alice", "r1")
+	require.NoError(t, err)
+	assert.True(t, ok3, "owner は moderator でなくても購読可")
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -958,6 +958,17 @@ func (s *Server) setupRoutes() {
 	// この writer を通る。
 	api.Use(middleware.WWWAuthenticate())
 
+	// #2106 L56: upstream ApiServerService は /api scope の全応答に既定の
+	// Cache-Control: private, max-age=0, must-revalidate を付与する。cacheSec endpoint は
+	// handler 内で public, max-age=... に上書きする (handler の Set が後勝ち)。非 cacheSec の
+	// allowGet GET を中間 proxy が誤キャッシュするのを防ぐ。
+	api.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			c.Response().Header().Set("Cache-Control", "private, max-age=0, must-revalidate")
+			return next(c)
+		}
+	})
+
 	// Fastify互換のJSON body事前パース (#1609)。本家はbody parseが
 	// endpoint handler (rate limit / 認証を含む) より先に走るため、
 	// rate limiterより前に登録して malformed JSON を FST_ERR_CTP_* envelope

--- a/internal/stream/channels/chat_room.go
+++ b/internal/stream/channels/chat_room.go
@@ -51,8 +51,10 @@ func (c *ChatRoomChannel) Init(params json.RawMessage) error {
 		return stream.ErrInvalidParams
 	}
 	if c.svc != nil {
-		member, err := c.svc.IsRoomMember(user.ID, p.RoomID)
-		if err != nil || !member {
+		// #2106 L57: room メンバーに加え moderator も購読を許可する
+		// (upstream hasPermissionToViewRoomTimeline)。
+		ok, err := c.svc.CanViewRoomTimeline(user.ID, p.RoomID)
+		if err != nil || !ok {
 			return stream.ErrInvalidParams
 		}
 	}

--- a/internal/stream/dispatcher.go
+++ b/internal/stream/dispatcher.go
@@ -159,7 +159,8 @@ func (d *Dispatcher) handleConnect(body json.RawMessage) {
 	// shouldShare付きチャンネルで既に同名が接続済みなら新規作成しない
 	if d.hasShareableChannelLocked(req.Channel) {
 		d.mu.Unlock()
-		d.sendConnectedIfRequested(req.ID, req.Pong)
+		// #2106 L58: upstream Connection.ts は既接続 shareable channel への重複 connect を
+		// pong 有無に関わらず silent に return する (connected ack を送らない)。
 		return
 	}
 	// 1 接続あたりの channel 数上限 (upstream MAX_CHANNELS_PER_CONNECTION=32、#1943)。

--- a/internal/stream/dispatcher_test.go
+++ b/internal/stream/dispatcher_test.go
@@ -696,7 +696,9 @@ func TestDispatcher_NonPermittedChannel_AlwaysAllowed(t *testing.T) {
 	assert.Len(t, d.channels, 1)
 }
 
-func TestDispatcher_ShareablePongAck(t *testing.T) {
+// #2106 L58: 既接続 shareable channel への重複 connect は pong=true でも connected ack を
+// 返さない (upstream Connection.ts は silent return)。
+func TestDispatcher_ShareableNoPongAck(t *testing.T) {
 	bus := newStubBus()
 	registry := NewRegistry()
 	registry.Register("shared", func(ctx ChannelContext) Channel {
@@ -710,12 +712,14 @@ func TestDispatcher_ShareablePongAck(t *testing.T) {
 	go conn.Start()
 	defer conn.Close()
 
-	// 1回目: 作成される
+	// 1回目: 作成され connected ack が返る。
 	d.HandleClientMessage("connect", json.RawMessage(`{"id":"a","channel":"shared","pong":true}`))
-	// 2回目: 既存共有なのでエントリは作られないが、pongはACKされる
-	d.HandleClientMessage("connect", json.RawMessage(`{"id":"b","channel":"shared","pong":true}`))
+	require.Eventually(t, func() bool { return fc.writeCount() >= 1 }, time.Second, 10*time.Millisecond)
 
-	require.Eventually(t, func() bool { return fc.writeCount() >= 2 }, time.Second, 10*time.Millisecond)
+	// 2回目: 既存共有なので ack しない (write が増えない)。
+	d.HandleClientMessage("connect", json.RawMessage(`{"id":"b","channel":"shared","pong":true}`))
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 1, fc.writeCount(), "既接続 shareable への重複 connect は ack しない")
 }
 
 // --- Init error path ---


### PR DESCRIPTION
#2106 LOW batch (server-middleware/stream)。L56: /api 既定 Cache-Control middleware 追加。L57: chatRoom で moderator の non-member 購読を許可 (CanViewRoomTimeline)。L58: 既接続 shareable connect の ack 削除。回帰テスト追加/更新。Closes #2209