### PR TITLE
poll vote error 順 / note text trim / home fanout 絞り込み (#2106 L32/L33/L34)

### DIFF
--- a/internal/core/note/note_create_service.go
+++ b/internal/core/note/note_create_service.go
@@ -379,6 +379,18 @@ func (s *CreateService) Create(in CreateInput) (*model.Note, error) {
 		return nil, errors.New("user is required")
 	}
 
+	// #2106 L33: upstream NoteCreateService は text を trim し、trim 後が空なら null に正規化
+	// してから content-less 判定・保存を行う。先頭/末尾空白を upstream と同じく除去して
+	// 保存値・AP 配送値を揃える。
+	if in.Text != nil {
+		trimmed := strings.TrimSpace(*in.Text)
+		if trimmed == "" {
+			in.Text = nil
+		} else {
+			in.Text = &trimmed
+		}
+	}
+
 	// notes/createのバリデーション: text/fileIds/renoteIdのいずれかが必須
 	if (in.Text == nil || *in.Text == "") && in.RenoteID == nil && len(in.FileIDs) == 0 {
 		return nil, ErrNoteContentRequired

--- a/internal/core/note/note_create_service_test.go
+++ b/internal/core/note/note_create_service_test.go
@@ -2166,3 +2166,21 @@ func TestCreateService_ProhibitedWords_CaseSensitive(t *testing.T) {
 	_, err := svc.Create(note.CreateInput{User: &model.User{ID: "u1"}, Text: &text})
 	require.NoError(t, err, "大文字の BADWORD は小文字 badword フィルタに (case-sensitive で) マッチしない")
 }
+
+// #2106 L33: 先頭/末尾空白を含む text は trim して保存する。
+func TestCreate_TrimsText(t *testing.T) {
+	svc, _, _ := newCreateService(t)
+	text := "  hello  "
+	n, err := svc.Create(note.CreateInput{User: &model.User{ID: "u1"}, Text: &text, Visibility: model.NoteVisibilityPublic})
+	require.NoError(t, err)
+	require.NotNil(t, n.Text)
+	assert.Equal(t, "hello", *n.Text)
+}
+
+// #2106 L33: 空白のみ text + ファイル/renote 無しは trim 後 nil で content-less 扱い。
+func TestCreate_WhitespaceOnlyTextRejected(t *testing.T) {
+	svc, _, _ := newCreateService(t)
+	text := "   "
+	_, err := svc.Create(note.CreateInput{User: &model.User{ID: "u1"}, Text: &text, Visibility: model.NoteVisibilityPublic})
+	require.ErrorIs(t, err, note.ErrNoteContentRequired)
+}

--- a/internal/core/poll/poll_service.go
+++ b/internal/core/poll/poll_service.go
@@ -155,11 +155,13 @@ func (s *Service) Vote(user *model.User, noteID string, choice int) error {
 		return ErrNoPoll
 	}
 
-	if choice < 0 || choice >= len(p.Choices) {
-		return ErrInvalidChoice
-	}
+	// #2106 L32: upstream notes/polls/vote.ts は alreadyExpired を invalidChoice より先に
+	// 判定する。期限切れ poll への範囲外 choice は ALREADY_EXPIRED を返す。
 	if p.ExpiresAt != nil && !s.nowFn().Before(*p.ExpiresAt) {
 		return ErrPollExpired
+	}
+	if choice < 0 || choice >= len(p.Choices) {
+		return ErrInvalidChoice
 	}
 
 	// 既に同じ choice に投票していたら重複エラー

--- a/internal/core/poll/poll_service_test.go
+++ b/internal/core/poll/poll_service_test.go
@@ -334,3 +334,12 @@ func TestVote_HappyPathIncrementsVotes(t *testing.T) {
 	require.NoError(t, svc.Vote(&model.User{ID: "viewer"}, "n1", 1))
 	assert.Equal(t, int64(1), pollRepo.Polls["n1"].Votes[1])
 }
+
+// #2106 L32: 期限切れ poll への範囲外 choice は invalidChoice より先に ALREADY_EXPIRED を返す。
+func TestVote_ExpiredBeforeInvalidChoice(t *testing.T) {
+	svc, noteRepo, pollRepo, _ := newSvc(t)
+	past := time.Now().Add(-time.Hour)
+	seedPollNote(noteRepo, pollRepo, "n1", "author", false, &past)
+	err := svc.Vote(&model.User{ID: "viewer"}, "n1", 99) // choice=99 は範囲外
+	require.ErrorIs(t, err, poll.ErrPollExpired)
+}

--- a/internal/core/timeline/fanout_hook.go
+++ b/internal/core/timeline/fanout_hook.go
@@ -364,6 +364,12 @@ func (h *FanoutHook) fanoutToFollowersAndStream(ctx context.Context, authorID st
 			}
 		}
 		for _, f := range rows {
+			// #2106 L34: upstream pushToTl は local かつ非 hibernated follower のみ home TL へ
+			// push する。remote follower はこのインスタンスの home TL を読まず、hibernated user は
+			// inactive なので、不要な Redis 書き込み・stream publish を避ける。
+			if f.FollowerHost != nil || f.IsFollowerHibernated {
+				continue
+			}
 			isReplyToFollower := isReply && n.ReplyUserID != nil && *n.ReplyUserID == f.FollowerID
 			// follower が note.mentions に含まれているなら withReplies=false の
 			// reply filter を escape する (mk-go 独自仕様 / 上流 TS は持たない

--- a/internal/core/timeline/fanout_hook_test.go
+++ b/internal/core/timeline/fanout_hook_test.go
@@ -1384,3 +1384,28 @@ func TestFanoutHook_OnNoteDeleted_UserListLookupError(t *testing.T) {
 	n := &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityPublic}
 	h.OnNoteDeleted(n, &model.User{ID: "author"})
 }
+
+// #2106 L34: remote / hibernated follower の home TL には push しない (local non-hibernated のみ)。
+func TestFanoutHook_SkipsRemoteAndHibernatedFollowers(t *testing.T) {
+	h, fanout, following := newTestHook(t)
+	ctx := context.Background()
+	remoteHost := "remote.example"
+	following.Followings["f1"] = &model.Following{ID: "f1", FollowerID: "localf", FolloweeID: "author"}
+	following.Followings["f2"] = &model.Following{ID: "f2", FollowerID: "remotef", FolloweeID: "author", FollowerHost: &remoteHost}
+	following.Followings["f3"] = &model.Following{ID: "f3", FollowerID: "hibf", FolloweeID: "author", IsFollowerHibernated: true}
+
+	noteID := idGen.Generate(time.Now())
+	n := &model.Note{ID: noteID, UserID: "author", Visibility: model.NoteVisibilityPublic}
+	author := &model.User{ID: "author"}
+	h.OnNoteCreated(n, author)
+
+	out, err := fanout.Get(ctx, HomeTimelineName("localf"), "", "", 10)
+	require.NoError(t, err)
+	assert.Equal(t, []string{noteID}, out, "local non-hibernated follower receives home push")
+
+	for _, fid := range []string{"remotef", "hibf"} {
+		out, err := fanout.Get(ctx, HomeTimelineName(fid), "", "", 10)
+		require.NoError(t, err)
+		assert.Empty(t, out, "follower %q (remote/hibernated) should not receive home push", fid)
+	}
+}


### PR DESCRIPTION
#2106 LOW batch (core-note-timeline)。L32: poll vote の expiry を invalidChoice より先に判定。L33: note Create で text trim + 空文字 nil 化。L34: home fanout を local 非 hibernated follower のみに gate。回帰テスト追加。Closes #2211