### PR TITLE
poll expiredAfter 優先 / treatVisibility 降格を packed visibility に反映 (#2106 L5/L6)

### DIFF
--- a/internal/api/notehide/notehide.go
+++ b/internal/api/notehide/notehide.go
@@ -98,6 +98,23 @@ func hideEmbedsAt(viewer *model.User, packed []entity.NoteEntity, repo repositor
 		hideTopLevelIfNeeded(viewer, &packed[i], follows, nowMs)
 		hideEmbedIfNeeded(viewer, packed[i].Renote, follows, nowMs)
 		hideEmbedIfNeeded(viewer, packed[i].Reply, follows, nowMs)
+		// #2106 L5: treatVisibility downgrade を packed entity の visibility field にも反映する
+		// (hide 判定が元の visibility を読み終えた後に書き換える、viewer 非依存)。
+		downgradeVisibilityIfNeeded(&packed[i], nowMs)
+		downgradeVisibilityIfNeeded(packed[i].Renote, nowMs)
+		downgradeVisibilityIfNeeded(packed[i].Reply, nowMs)
+	}
+}
+
+// downgradeVisibilityIfNeeded rewrites a public/home note's packed visibility to
+// 'followers' when the author's makeNotesFollowersOnlyBefore window has passed
+// (#2106 L5, upstream treatVisibility). Viewer-independent.
+func downgradeVisibilityIfNeeded(n *entity.NoteEntity, nowMs int64) {
+	if n == nil {
+		return
+	}
+	if corenote.ShouldDowngradeVisibility(embedFactsFromEntity(n), nowMs) {
+		n.Visibility = string(model.NoteVisibilityFollowers)
 	}
 }
 

--- a/internal/api/notehide/notehide_test.go
+++ b/internal/api/notehide/notehide_test.go
@@ -423,3 +423,17 @@ func TestHideNotificationNotes_NilRepoFailClosed(t *testing.T) {
 		t.Error("nil followingRepo must fail closed (blank followers depth-2 embed)")
 	}
 }
+
+// #2106 L5: public note が makeNotesFollowersOnlyBefore window を過ぎたら packed visibility を
+// followers へ降格する (viewer 非依存)。createdAt は heNowMs より十分過去にする。
+func TestHideEmbedsAt_TreatVisibilityDowngrade(t *testing.T) {
+	mk := -3600
+	pub := entity.NoteEntity{ID: "p", UserID: "a", CreatedAt: "2023-01-01T00:00:00.000Z",
+		User: entity.UserLite{ID: "a", MakeNotesFollowersOnlyBefore: &mk}, Visibility: "public",
+		Text: heStr("hi"), FileIDs: []string{}, Files: []any{}, VisibleUserIDs: []string{}, Mentions: []string{}}
+	packed := []entity.NoteEntity{pub}
+	hideEmbedsAt(nil, packed, followsRepo(), heNowMs)
+	if packed[0].Visibility != "followers" {
+		t.Errorf("public note past makeNotesFollowersOnlyBefore window should downgrade to followers, got %q", packed[0].Visibility)
+	}
+}

--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -408,14 +408,15 @@ func (h *Handler) Create(c echo.Context) error {
 		}
 		// Misskey TS API 互換: expiresAt (絶対 unix ms) と expiredAfter (相対 ms)
 		// のどちらか / 両方が送られる。frontend の form は「期限なし / 日時指定 /
-		// X 後」の 3 択で、相対指定時は expiredAfter のみが入る。両方来た時は
-		// expiresAt を優先する (TS PollService と同じ挙動、#690)。
+		// X 後」の 3 択で、相対指定時は expiredAfter のみが入る。
+		// #2106 L6: 両方来た時は upstream create.ts:230 と同じく expiredAfter (相対) を優先する
+		// (旧コメントの『TS PollService』は誤り、endpoint の create.ts が expiry を決定する)。
 		switch {
-		case req.Poll.ExpiresAt != nil:
-			t := time.UnixMilli(*req.Poll.ExpiresAt)
-			in.Poll.ExpiresAt = &t
 		case req.Poll.ExpiredAfter != nil:
 			t := time.Now().Add(time.Duration(*req.Poll.ExpiredAfter) * time.Millisecond)
+			in.Poll.ExpiresAt = &t
+		case req.Poll.ExpiresAt != nil:
+			t := time.UnixMilli(*req.Poll.ExpiresAt)
 			in.Poll.ExpiresAt = &t
 		}
 	}

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -1046,3 +1046,34 @@ func TestValidateCreateInput_PollUniqueAndExpiredAfter(t *testing.T) {
 	badExpire := &CreateRequest{Poll: &PollRequest{Choices: []string{"a", "b"}, ExpiredAfter: &bad}}
 	assert.Error(t, validateCreateInput(badExpire, nil), "expiredAfter<1 は弾く")
 }
+
+// #2106 L6: poll で expiresAt と expiredAfter 両方指定時は expiredAfter (相対) を優先する。
+func TestCreate_PollExpiredAfterTakesPriority(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	pollRepo := testutil.NewMockPollRepository()
+	idGen, _ := id.NewGenerator("aidx")
+	createSvc := corenote.NewCreateService(noteRepo, pollRepo, idGen, nil)
+	deleteSvc := corenote.NewDeleteService(noteRepo)
+	querySvc := corenote.NewQueryService(noteRepo, nil)
+	h := NewHandler(noteRepo, createSvc, deleteSvc, querySvc, nil, nil, nil, nil, idGen)
+	user := &model.User{ID: "user1", Username: "testuser", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+
+	farFutureMs := time.Now().Add(30 * 24 * time.Hour).UnixMilli() // expiresAt: 30 日後
+	expiredAfterMs := int64(3600 * 1000)                           // expiredAfter: 1 時間
+	body := fmt.Sprintf(`{"text": "Vote!", "poll": {"choices": ["A", "B"], "expiresAt": %d, "expiredAfter": %d}}`, farFutureMs, expiredAfterMs)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/notes/create", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	setAuthUser(c, user)
+	require.NoError(t, h.Create(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.Len(t, pollRepo.Polls, 1)
+	for _, poll := range pollRepo.Polls {
+		require.NotNil(t, poll.ExpiresAt)
+		// expiredAfter (now+1h) を採用 → 30 日後の expiresAt よりずっと前になる。
+		assert.True(t, poll.ExpiresAt.Before(time.Now().Add(2*time.Hour)), "expiredAfter を優先すべき、got %v", poll.ExpiresAt)
+	}
+}

--- a/internal/core/note/hide_embed.go
+++ b/internal/core/note/hide_embed.go
@@ -137,6 +137,22 @@ func HideNoteByPrefsDecision(viewer *model.User, f EmbedFacts, follows func(auth
 	return false
 }
 
+// ShouldDowngradeVisibility reports whether a public/home note must have its
+// PACKED visibility field downgraded to 'followers' because the author opted into
+// makeNotesFollowersOnlyBefore and the note is past that window (#2106 L5, upstream
+// treatVisibility). Viewer-INDEPENDENT — even a follower who can still see the note
+// receives visibility:'followers' (drives the frontend lock icon / renote 可否)。
+// content-hide は別 concern (HideNoteByPrefsDecision)。
+func ShouldDowngradeVisibility(f EmbedFacts, nowMs int64) bool {
+	if !f.AuthorPrefsKnown {
+		return false
+	}
+	if f.Visibility != string(model.NoteVisibilityPublic) && f.Visibility != string(model.NoteVisibilityHome) {
+		return false
+	}
+	return shouldHideNoteByTime(f.MakeNotesFollowersOnlyBefore, f.CreatedAtMs, nowMs)
+}
+
 // viewerIsFollowersRecipient reports whether viewer is allowed to see a
 // followers-visibility note: the reply-target author, a mentioned user, or a
 // follower of the author. Anonymous (viewerID == "") is never a recipient.

--- a/internal/core/note/hide_embed_test.go
+++ b/internal/core/note/hide_embed_test.go
@@ -327,3 +327,25 @@ func TestShouldHideNoteByTime(t *testing.T) {
 		})
 	}
 }
+
+// #2106 L5: public/home が makeNotesFollowersOnlyBefore window を過ぎたら visibility を
+// followers へ降格する (viewer 非依存)。
+func TestShouldDowngradeVisibility(t *testing.T) {
+	cases := []struct {
+		name string
+		f    EmbedFacts
+		want bool
+	}{
+		{"public past window", EmbedFacts{Visibility: "public", MakeNotesFollowersOnlyBefore: ptrInt(-3600), CreatedAtMs: hideTestNowMs - 2*3600*1000, AuthorPrefsKnown: true}, true},
+		{"home past window", EmbedFacts{Visibility: "home", MakeNotesFollowersOnlyBefore: ptrInt(-3600), CreatedAtMs: hideTestNowMs - 2*3600*1000, AuthorPrefsKnown: true}, true},
+		{"within window", EmbedFacts{Visibility: "public", MakeNotesFollowersOnlyBefore: ptrInt(-3600), CreatedAtMs: hideTestNowMs - 1000, AuthorPrefsKnown: true}, false},
+		{"already followers", EmbedFacts{Visibility: "followers", MakeNotesFollowersOnlyBefore: ptrInt(-3600), CreatedAtMs: hideTestNowMs - 2*3600*1000, AuthorPrefsKnown: true}, false},
+		{"prefs unknown", EmbedFacts{Visibility: "public", MakeNotesFollowersOnlyBefore: ptrInt(-3600), CreatedAtMs: hideTestNowMs - 2*3600*1000, AuthorPrefsKnown: false}, false},
+		{"no pref set", EmbedFacts{Visibility: "public", MakeNotesFollowersOnlyBefore: nil, CreatedAtMs: hideTestNowMs - 2*3600*1000, AuthorPrefsKnown: true}, false},
+	}
+	for _, tc := range cases {
+		if got := ShouldDowngradeVisibility(tc.f, hideTestNowMs); got != tc.want {
+			t.Errorf("%s: ShouldDowngradeVisibility = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
#2106 LOW batch (api-notes)。L5: notehide resolver で makeNotesFollowersOnlyBefore 過ぎた public/home note の visibility を 'followers' に降格 (upstream treatVisibility)。L6: poll の expiredAfter を優先。L4 (endpoint 再実装) は別 issue #2215 に切り出し。回帰テスト追加。Closes #2216