### PR TITLE
reversi surrender 順 / chat 1on1 reactions user + reversi/chat divergence 明記 (#2106 L15-L19)

### DIFF
--- a/internal/api/chat/handler.go
+++ b/internal/api/chat/handler.go
@@ -430,15 +430,11 @@ func (h *Handler) packMessageDetailed(m *model.ChatMessage, meID string) map[str
 	// base の {reaction} のまま。room 判定は ToRoomID 列で行う (ToRoom の eager
 	// load 有無に依らない)。
 	//
-	// 既知の差分: upstream は messages/show・search・history で full schema
-	// (packedChatMessageSchema) を使い、1on1 message でも reactions[].user を
-	// 含める。mk-go は全 endpoint が単一の packMessageDetailed を通り、room
-	// だけ user を付けるため、これらの endpoint で 1on1 message を返すと user が
-	// 欠ける。1on1 は参加者が 2 人で reactor が自明なため実害は小さく、room
-	// (多人数) の reactor 表示を優先して本 PR では room のみ対応する。
-	if m.ToRoomID != nil {
-		result["reactions"] = h.packRoomReactions(m)
-	}
+	// #2106 L18: upstream は messages/show・search・history で full schema
+	// (packedChatMessageSchema) を使い、1on1 message でも reactions[].user を必須にする
+	// (frontend XMessage.vue が record.user.id を参照する)。packRoomReactions は ToRoomID
+	// 非依存に "userID/reaction" を解決できるので、room/1on1 双方で user を埋める。
+	result["reactions"] = h.packRoomReactions(m)
 	return result
 }
 
@@ -889,7 +885,9 @@ func (h *Handler) MessagesCreate(c echo.Context) error {
 		}
 		// upstream ChatService.createMessageToUser:177-179 は recipient の
 		// chatAvailability(write) が false なら送信を拒否する (#1796)。recipient が
-		// chat 不可なので 403 ACCESS_DENIED を返す (upstream は generic error)。
+		// chat 不可なので 403 ACCESS_DENIED を返す。
+		// #2106 L19 (意図的 divergence): upstream は generic Error で 500 INTERNAL_ERROR に
+		// なるが、mk-go は semantics 上適切な 403 ACCESS_DENIED を維持する (worse な 500 回避)。
 		if h.chatAvail != nil {
 			policy, _ := h.chatAvail.GetUserPolicies(*req.ToUserID)["chatAvailability"].(string)
 			if !middleware.ChatAvailabilityAllows(policy, "write") {

--- a/internal/api/chat/handler_test.go
+++ b/internal/api/chat/handler_test.go
@@ -1831,7 +1831,8 @@ func TestPackMessageDetailed_RoomReactionsIncludeUser(t *testing.T) {
 }
 
 // 1on1 (lite) message の reactions は user を含まない。
-func TestPackMessageDetailed_1on1ReactionsOmitUser(t *testing.T) {
+// #2106 L18: 1on1 message の reactions も room と同じく user を含む (full ChatMessage schema)。
+func TestPackMessageDetailed_1on1ReactionsIncludeUser(t *testing.T) {
 	h, _ := newTestHandler()
 	userRepo := testutil.NewMockUserRepository()
 	userRepo.Users["u1"] = &model.User{ID: "u1", Username: "alice"}
@@ -1846,8 +1847,9 @@ func TestPackMessageDetailed_1on1ReactionsOmitUser(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, reactions, 1)
 	assert.Equal(t, "👍", reactions[0]["reaction"])
-	_, hasUser := reactions[0]["user"]
-	assert.False(t, hasUser, "1on1 lite reactions は user を省略する")
+	user, hasUser := reactions[0]["user"]
+	assert.True(t, hasUser, "1on1 reactions も user を含む (frontend が record.user.id を参照)")
+	require.NotNil(t, user)
 }
 
 // userRepo 未配線の room message は base の {reaction} に degrade する (crash しない)。

--- a/internal/api/reversi/handler.go
+++ b/internal/api/reversi/handler.go
@@ -269,6 +269,11 @@ func (h *Handler) Games(c echo.Context) error {
 	} else {
 		games, _ = h.repo.ListStartedCursor(sinceID, untilID, req.Limit)
 	}
+	// #2106 L15 (cherrypick-lineage divergence): vanilla の reversi/games は ReversiGameLite
+	// (form1/form2/logs/map を含まない) を返すが、mk-go は cherrypick 系統 + 連合対戦拡張
+	// (crc32 等) を持ち全 endpoint で Detailed packGame を共有する。追加 field は加算的で
+	// misskey-js は未知 field を無視するため drop-in client は壊れない。vanilla golden では
+	// なく cherrypick + 連合拡張を権威とする (MEMORY: reversi_cherrypick_lineage)。
 	out := make([]map[string]any, len(games))
 	for i, g := range games {
 		out[i] = packGame(g, h.idGen)
@@ -591,6 +596,11 @@ func (h *Handler) Surrender(c echo.Context) error {
 	game, err := h.repo.FindByID(req.GameID)
 	if err != nil {
 		return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_GAME", "No such game.", "ace0b11f-e0a6-4076-a30d-e8284c81b2df"))
+	}
+	// #2106 L16: upstream surrender.ts は isEnded(ALREADY_ENDED) を player 判定(ACCESS_DENIED)
+	// より先に評価する。終了済 game への非プレイヤー surrender は ALREADY_ENDED(400) を返す。
+	if game.IsEnded {
+		return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_ENDED", "Game has already ended.", "6c2ad4a6-cbf1-4a5b-b187-b772826cfc6d"))
 	}
 	if game.User1ID != user.ID && game.User2ID != user.ID {
 		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Access denied.", "6e04164b-a992-4c93-8489-2123069973e1"))

--- a/internal/api/reversi/handler_test.go
+++ b/internal/api/reversi/handler_test.go
@@ -1094,3 +1094,14 @@ func surrenderErrorRec(t *testing.T, err error) *httptest.ResponseRecorder {
 	require.NoError(t, surrenderErrorResponse(c, err))
 	return rec
 }
+
+// #2106 L16: 終了済 game への非プレイヤー surrender は ACCESS_DENIED より先に ALREADY_ENDED。
+func TestSurrender_EndedBeforeNotPlayer(t *testing.T) {
+	h, repo := newTestHandler()
+	g := sampleGame()
+	g.IsEnded = true
+	repo.games["g1"] = g
+	rec := post(h.Surrender, `{"gameId":"g1"}`, &model.User{ID: "u3"}) // 非プレイヤー
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "ALREADY_ENDED")
+}

--- a/internal/core/reversi/service.go
+++ b/internal/core/reversi/service.go
@@ -682,6 +682,9 @@ func (s *Service) Surrender(ctx context.Context, gameID, userID string) error {
 	}
 	// PutStone 等と同じ順序でガードする。未スタートの対局に対する surrender は
 	// 「勝ち逃げ」と区別が付かなくなるので、開始前は拒否する。
+	// #2106 L17 (intentional divergence): vanilla/cherrypick の surrender は IsStarted を
+	// ガードせず pending game も終局させられるが、mk-go は勝ち逃げ防止のため未開始を
+	// NOT_STARTED で弾く意図的拡張。除去せず明文化する。
 	if !game.IsStarted {
 		return ErrNotStarted
 	}


### PR DESCRIPTION
#2106 LOW batch (api-chat-reversi)。L16 (fix): reversi surrender の IsEnded を player 判定より先に。L18 (fix): chat 1on1 reactions[].user を埋める。L15/L17/L19: reversi games Detailed / surrender NOT_STARTED / chat 403 を cherrypick-lineage・意図的 divergence として明記。回帰テスト追加/更新。Closes #2218