### PR TITLE
i/update regex 検証 / home TL specified DM / hashtag 並行カウント (#2106 L3/L54/L55)

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/shiroha-a/mk/internal/core/role"
 	"github.com/shiroha-a/mk/internal/core/twofactor"
 	"github.com/shiroha-a/mk/internal/core/user"
+	"github.com/shiroha-a/mk/internal/core/wordmute"
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/misc/langmap"
@@ -1426,6 +1427,13 @@ func (h *Handler) Update(c echo.Context) error {
 			}
 		}
 		return wordMuteLimitValue, wordMuteLimitOk
+	}
+	// #2106 L3: upstream i/update.ts は validateMuteWordRegex で /pattern/flags リテラルが
+	// compile 不能なら INVALID_REGEXP(400) を投げる。mk-go も書き込み時に検証する (読み取り側
+	// wordmute は不正 regex を nil rule で握り潰すため、ここで弾かないとユーザーへの
+	// フィードバックが無く黙殺される)。
+	if wordmute.ValidateMutedWords(req.MutedWords) != nil || wordmute.ValidateMutedWords(req.HardMutedWords) != nil {
+		return c.JSON(http.StatusBadRequest, apierr.Error("INVALID_REGEXP", "Invalid Regular Expression.", "0d786918-10df-41cd-8f33-8dec7d9a89a5"))
 	}
 	if mw, ok, err := normalizeMutedWords(req.MutedWords); err != nil {
 		return apierr.JSONInvalidParam(c)

--- a/internal/api/i/update_aka_test.go
+++ b/internal/api/i/update_aka_test.go
@@ -204,3 +204,11 @@ func TestUpdate_AlsoKnownAs_NoUserRepoFailsClosed(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 	assert.Contains(t, rec.Body.String(), "NO_SUCH_USER")
 }
+
+// #2106 L3: 不正な regex リテラルの mutedWords は INVALID_REGEXP(400) で拒否する。
+func TestUpdate_InvalidMutedWordsRegex(t *testing.T) {
+	h, me := akaHandler(t)
+	rec := post(h.Update, `{"mutedWords":["/[/"]}`, me)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INVALID_REGEXP")
+}

--- a/internal/core/wordmute/wordmute.go
+++ b/internal/core/wordmute/wordmute.go
@@ -14,6 +14,7 @@ package wordmute
 
 import (
 	"encoding/json"
+	"errors"
 	"regexp"
 	"strings"
 
@@ -145,30 +146,7 @@ func parseEntry(e json.RawMessage) rule {
 	var s string
 	if err := json.Unmarshal(e, &s); err == nil {
 		// Misskey TS upstream allows /regex/flags literal as a string entry.
-		// Flags は upstream RE2 (TS) 仕様の i/m/s をサポートする。Go の regexp は
-		// inline flag (?ims) が必要なので prefix で組み立てる。g (global) は Go
-		// regexp の default 動作 (= 全 match) と等価なので無視。u/y は近い等価
-		// 機能が無いが、Go regexp は default で UTF-8 解釈するため u は実質的
-		// に常時 ON、y (sticky) は streaming 用途では使われないので no-op。
-		if m := regexLiteral.FindStringSubmatch(s); m != nil {
-			pattern, flags := m[1], m[2]
-			var inline string
-			if strings.ContainsRune(flags, 'i') {
-				inline += "i"
-			}
-			if strings.ContainsRune(flags, 'm') {
-				inline += "m"
-			}
-			if strings.ContainsRune(flags, 's') {
-				inline += "s"
-			}
-			// 二重指定回避: pattern が既に inline flag group `(?ims)` で始まる
-			// 場合のみ skip する。`(?:...)` / `(?P<n>...)` 等の non-flag group
-			// に対しては flag を inject しないと意図した m / s 等が消えてしまう。
-			if inline != "" && !inlineFlagPrefix.MatchString(pattern) {
-				pattern = "(?" + inline + ")" + pattern
-			}
-			re, err := regexp.Compile(pattern)
+		if re, isLiteral, err := goRegexFromLiteral(s); isLiteral {
 			if err != nil {
 				return nil
 			}
@@ -190,6 +168,66 @@ func parseEntry(e json.RawMessage) rule {
 			return nil
 		}
 		return out
+	}
+	return nil
+}
+
+// goRegexFromLiteral compiles a /pattern/flags literal into a Go regexp, applying
+// the i/m/s inline-flag conversion (g/u/y are no-ops, see parseEntry). Returns
+// (nil, false, nil) when s is not a /.../ literal, and (nil, true, err) when it is
+// a literal that fails to compile (#2106 L3 validation reuse).
+func goRegexFromLiteral(s string) (*regexp.Regexp, bool, error) {
+	m := regexLiteral.FindStringSubmatch(s)
+	if m == nil {
+		return nil, false, nil
+	}
+	pattern, flags := m[1], m[2]
+	var inline string
+	if strings.ContainsRune(flags, 'i') {
+		inline += "i"
+	}
+	if strings.ContainsRune(flags, 'm') {
+		inline += "m"
+	}
+	if strings.ContainsRune(flags, 's') {
+		inline += "s"
+	}
+	// 二重指定回避: pattern が既に inline flag group `(?ims)` で始まる場合のみ skip。
+	if inline != "" && !inlineFlagPrefix.MatchString(pattern) {
+		pattern = "(?" + inline + ")" + pattern
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, true, err
+	}
+	return re, true, nil
+}
+
+// ErrInvalidRegexp is returned by ValidateMutedWords when a regex-literal entry
+// fails to compile. Callers map it to the upstream INVALID_REGEXP API error.
+var ErrInvalidRegexp = errors.New("invalid regexp literal in muted words")
+
+// ValidateMutedWords reports whether every /pattern/flags regex-literal entry in
+// the muted-words JSON compiles, returning ErrInvalidRegexp on the first failure
+// (#2106 L3, upstream i/update.ts validateMuteWordRegex). Non-regex entries (plain
+// keywords / AND-group arrays) and shape errors are ignored here (shape is handled
+// by the caller's normalize step).
+func ValidateMutedWords(raw json.RawMessage) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	var entries []json.RawMessage
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil
+	}
+	for _, e := range entries {
+		var s string
+		if err := json.Unmarshal(e, &s); err != nil {
+			continue // array (AND group), not a regex literal
+		}
+		if _, isLiteral, err := goRegexFromLiteral(s); isLiteral && err != nil {
+			return ErrInvalidRegexp
+		}
 	}
 	return nil
 }

--- a/internal/core/wordmute/wordmute_test.go
+++ b/internal/core/wordmute/wordmute_test.go
@@ -200,3 +200,19 @@ func TestMatch_EvictedRuleReParsesCorrectly(t *testing.T) {
 	assert.True(t, wordmute.Match(first, "find original-keyword again"))
 	assert.False(t, wordmute.Match(first, "no match here"))
 }
+
+// #2106 L3: ValidateMutedWords は不正な /regex/ リテラルで ErrInvalidRegexp を返し、
+// 妥当な regex / 通常語 / AND group では nil を返す。
+func TestValidateMutedWords(t *testing.T) {
+	// 不正 regex リテラル。
+	assert.ErrorIs(t, wordmute.ValidateMutedWords([]byte(`["/[/"]`)), wordmute.ErrInvalidRegexp)
+	// 妥当 regex リテラル。
+	assert.NoError(t, wordmute.ValidateMutedWords([]byte(`["/abc/i"]`)))
+	// 通常語 (regex でない)。
+	assert.NoError(t, wordmute.ValidateMutedWords([]byte(`["plain"]`)))
+	// AND group (配列要素) は regex 検証対象外。
+	assert.NoError(t, wordmute.ValidateMutedWords([]byte(`[["a","b"]]`)))
+	// 空 / nil。
+	assert.NoError(t, wordmute.ValidateMutedWords(nil))
+	assert.NoError(t, wordmute.ValidateMutedWords([]byte(`[]`)))
+}

--- a/internal/repository/hashtag.go
+++ b/internal/repository/hashtag.go
@@ -118,6 +118,13 @@ func (r *hashtagRepository) recordImpl(
 		).Error; err != nil {
 			return err
 		}
+		// 段階 1.5: #2106 L55: 同一 (name, userID) への concurrent record (連投 / inbox 同時処理)
+		// で array_append + count++ が二重発行され、attachedUserIds に重複が入り count が膨らむ
+		// race を防ぐため、対象 hashtag 行を FOR UPDATE で直列化する。2 つ目の tx は 1 つ目の
+		// commit を待ってから NOT (...=ANY) を再評価する (append 済の userID を見て skip)。
+		if err := tx.Exec(`SELECT 1 FROM "hashtag" WHERE name = ? FOR UPDATE`, name).Error; err != nil {
+			return err
+		}
 		// 段階 2: 該当 user がまだ list に居なければ append + count++。
 		// total / (local|remote) を 1 度の UPDATE で更新する。
 		// 文字列連結で column 名を組むのは固定 const のみなので injection 安全。

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -1104,15 +1104,20 @@ func (r *noteRepository) ListHomeTimeline(userID string, limit int, sinceID, unt
 	q := preloadNoteRelations(r.db)
 	if len(filter.FollowedChannelIDs) > 0 {
 		q = q.Where(
-			`(("userId" = ? OR "userId" IN (SELECT "followeeId" FROM "following" WHERE "followerId" = ?)) AND "channelId" IS NULL OR "channelId" IN ?) AND "visibility" IN ('public','home','followers')`,
+			`(("userId" = ? OR "userId" IN (SELECT "followeeId" FROM "following" WHERE "followerId" = ?)) AND "channelId" IS NULL OR "channelId" IN ?)`,
 			userID, userID, filter.FollowedChannelIDs,
 		)
 	} else {
 		q = q.Where(
-			`("userId" = ? OR "userId" IN (SELECT "followeeId" FROM "following" WHERE "followerId" = ?)) AND "channelId" IS NULL AND "visibility" IN ('public','home','followers')`,
+			`("userId" = ? OR "userId" IN (SELECT "followeeId" FROM "following" WHERE "followerId" = ?)) AND "channelId" IS NULL`,
 			userID, userID,
 		)
 	}
+	// #2106 L54: 旧 `visibility IN ('public','home','followers')` リテラルを applyViewerVisibility に
+	// 置換し、followee が viewer 宛てに送った specified DM (visibleUserIds に viewer) も home TL の
+	// DB fallback に surface させる (upstream timeline.ts の generateVisibilityQuery 互換)。read 経路は
+	// N27 で upstream 化済で、main-stream realtime push の #1472 strict gate とは独立。
+	q = applyViewerVisibility(q, userID)
 	q = q.Order(paginationOrder(sinceID, untilID, `"id"`)).Limit(limit)
 	if sinceID != "" {
 		q = q.Where(`"id" > ?`, sinceID)


### PR DESCRIPTION
#2106 LOW batch (api-i/repository)。L3: i/update で不正 regex muted word を INVALID_REGEXP(400) に。L54: ListHomeTimeline を applyViewerVisibility に揃え specified DM を surface。L55 (bug): hashtag recordImpl に FOR UPDATE 直列化。回帰テスト追加。Closes #2220