### PR TITLE
Undo remote-target skip / renderPerson misskey field + AP divergence 明記 (#2106 L30/L31/L49/L50)

### DIFF
--- a/internal/activitypub/renderer.go
+++ b/internal/activitypub/renderer.go
@@ -477,12 +477,12 @@ func rewriteFieldURLValue(value string) string {
 
 // enrichPersonFromProfile fills profile-derived fields into Person.
 func (r *Renderer) enrichPersonFromProfile(p *Person, profile *model.UserProfile) {
+	// #2106 L50: _misskey_summary / _misskey_followedMessage は raw 値を常時出力する (null/値)。
+	// pointer をそのまま渡し、空時も null として出す。Summary (AS2 HTML) は非空時のみ MFM 変換。
+	p.MisskeySummary = profile.Description
 	if profile.Description != nil && *profile.Description != "" {
-		desc := *profile.Description
-		// MFM → HTML
-		nodes := mfm.Parse(desc)
+		nodes := mfm.Parse(*profile.Description)
 		p.Summary = mfm.ToHTML(nodes, r.host)
-		p.MisskeySummary = desc
 	}
 	if profile.Birthday != nil && *profile.Birthday != "" {
 		p.VcardBday = *profile.Birthday
@@ -490,9 +490,7 @@ func (r *Renderer) enrichPersonFromProfile(p *Person, profile *model.UserProfile
 	if profile.Location != nil && *profile.Location != "" {
 		p.VcardAddress = *profile.Location
 	}
-	if profile.FollowedMessage != nil && *profile.FollowedMessage != "" {
-		p.MisskeyFollowedMessage = *profile.FollowedMessage
-	}
+	p.MisskeyFollowedMessage = profile.FollowedMessage
 
 	// profile.Fields → PropertyValue attachment
 	if len(profile.Fields) > 0 {

--- a/internal/activitypub/renderer_test.go
+++ b/internal/activitypub/renderer_test.go
@@ -886,10 +886,13 @@ func TestRenderer_RenderPerson_WithProfile(t *testing.T) {
 	}
 	p := r.RenderPerson(u, profile, "PUBKEY", nil)
 	assert.Contains(t, p.Summary, "<b>hello</b>")
-	assert.Equal(t, desc, p.MisskeySummary)
+	// #2106 L50: _misskey_summary / _misskey_followedMessage は *string で常時出力される。
+	require.NotNil(t, p.MisskeySummary)
+	assert.Equal(t, desc, *p.MisskeySummary)
 	assert.Equal(t, "2000-01-01", p.VcardBday)
 	assert.Equal(t, "Tokyo", p.VcardAddress)
-	assert.Equal(t, "Thanks!", p.MisskeyFollowedMessage)
+	require.NotNil(t, p.MisskeyFollowedMessage)
+	assert.Equal(t, "Thanks!", *p.MisskeyFollowedMessage)
 	assert.True(t, p.IsCat)
 	require.Len(t, p.Attachment, 1)
 	pv, ok := p.Attachment[0].(PropertyValue)
@@ -1420,4 +1423,21 @@ func TestRenderer_RenderNote_SpecifiedRemoteRecipient(t *testing.T) {
 	assert.Contains(t, out.To, "https://remote.example/users/bob", "remote recipient must get its real remote URI")
 	assert.NotContains(t, out.To, "https://example.com/users/uRemote", "remote recipient must NOT get an own-domain URI")
 	assert.Contains(t, out.To, "https://example.com/users/u2", "local recipient keeps local URI")
+}
+
+// #2106 L50: description/followedMessage が無い actor でも _misskey_summary /
+// _misskey_followedMessage を null として常時出力する (key 省略しない)。
+func TestRenderer_RenderPerson_MisskeyFieldsAlwaysPresent(t *testing.T) {
+	r := newRenderer()
+	u := &model.User{ID: "u1", Username: "alice"}
+	profile := &model.UserProfile{UserID: "u1"} // description / followedMessage 無し
+	p := r.RenderPerson(u, profile, "PUBKEY", nil)
+	assert.Nil(t, p.MisskeySummary)
+	assert.Nil(t, p.MisskeyFollowedMessage)
+
+	b, err := json.Marshal(p)
+	require.NoError(t, err)
+	s := string(b)
+	assert.Contains(t, s, `"_misskey_summary":null`)
+	assert.Contains(t, s, `"_misskey_followedMessage":null`)
 }

--- a/internal/activitypub/types.go
+++ b/internal/activitypub/types.go
@@ -256,16 +256,19 @@ type Person struct {
 	// _misskey_requireSigninToViewContents を常に boolean で出力する。omitempty だと
 	// false で key 自体が消えて wire-shape が乖離するため omitempty を外す (#1948-11)。
 	// 値は RenderPerson で user 状態から populate 済み。
-	ManuallyApproves                    bool   `json:"manuallyApprovesFollowers"`
-	Discoverable                        bool   `json:"discoverable"`
-	IsCat                               bool   `json:"isCat"`
-	VcardBday                           string `json:"vcard:bday,omitempty"`
-	VcardAddress                        string `json:"vcard:Address,omitempty"`
-	MisskeySummary                      string `json:"_misskey_summary,omitempty"`
-	MisskeyFollowedMessage              string `json:"_misskey_followedMessage,omitempty"`
-	MisskeyRequireSigninToViewContents  bool   `json:"_misskey_requireSigninToViewContents"`
-	MisskeyMakeNotesFollowersOnlyBefore *int   `json:"_misskey_makeNotesFollowersOnlyBefore,omitempty"`
-	MisskeyMakeNotesHiddenBefore        *int   `json:"_misskey_makeNotesHiddenBefore,omitempty"`
+	ManuallyApproves bool   `json:"manuallyApprovesFollowers"`
+	Discoverable     bool   `json:"discoverable"`
+	IsCat            bool   `json:"isCat"`
+	VcardBday        string `json:"vcard:bday,omitempty"`
+	VcardAddress     string `json:"vcard:Address,omitempty"`
+	// #2106 L50: upstream renderPerson は _misskey_summary / _misskey_followedMessage を常時
+	// 出力する (description/followedMessage が null なら JSON null)。*string + omitempty 無しで
+	// nil→null を明示出力し wire-shape を揃える。
+	MisskeySummary                      *string `json:"_misskey_summary"`
+	MisskeyFollowedMessage              *string `json:"_misskey_followedMessage"`
+	MisskeyRequireSigninToViewContents  bool    `json:"_misskey_requireSigninToViewContents"`
+	MisskeyMakeNotesFollowersOnlyBefore *int    `json:"_misskey_makeNotesFollowersOnlyBefore,omitempty"`
+	MisskeyMakeNotesHiddenBefore        *int    `json:"_misskey_makeNotesHiddenBefore,omitempty"`
 	// MisskeyCanChat は CherryPick の chat 連合 capability flag (#692)。
 	// 受信側 instance が DM を受け付けるか (false なら拒絶) を表す boolean。
 	// pointer で持つことで「未指定 (= 旧実装 / 互換) → 許可」を区別する。

--- a/internal/core/federation/ld_signature_verifier.go
+++ b/internal/core/federation/ld_signature_verifier.go
@@ -102,6 +102,14 @@ func (v *LDSignatureVerifier) VerifyAndCreator(rawBody []byte) (string, bool, er
 	// に切り替える必要がある (= remote context が後付け directive を inject
 	// する経路が成立してしまうため)。その場合は本コメントを更新し、
 	// `proc.Compact(act, ...)` を挟んでから check するフローに変更する。
+	//
+	// #2106 L49 (documented limitation): upstream は verify 前に compact して任意の @context を
+	// 標準形へ畳んでから URDNA2015 normalize するが、mk-go は compact を省く。3 つの preload
+	// context (AS2.0 / security v1 / identity v1) 外の custom context を参照する activity は
+	// normalize 段で ErrContextNotPreloaded になり、HTTP 署名の無い forwarded/relay 経路
+	// (LD-Signature が唯一の authenticator) で reject されうる。標準 context のみの一般的な
+	// Misskey/Mastodon activity では問題にならない。compact 導入は LD-Signature 経路の
+	// security-sensitive な変更のため、現状は documented limitation として維持する。
 	proc := ld.NewProcessor()
 	if err := proc.CheckForForbiddenDirectives(act); err != nil {
 		return "", true, err

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -832,6 +832,12 @@ func (p *Processor) handleUndoFollow(act genericActivity, inner genericActivity)
 	if err != nil {
 		return errors.New("unknown followee")
 	}
+	// #2106 L30: upstream undoFollow は followee が remote (host != null) なら skip する
+	// (handleFollow の gate と対称)。remote→remote の Undo を DB 走査 / counter 経路に
+	// 入れない防御線を Undo 側にも揃える。
+	if followee.Host != nil {
+		return nil
+	}
 	if err := p.followingService.Unfollow(follower.ID, followee.ID); err != nil &&
 		!errors.Is(err, corefollowing.ErrNotFollowing) {
 		return err
@@ -1893,6 +1899,11 @@ func (p *Processor) handleUndoBlock(act genericActivity, inner genericActivity) 
 	blockee, err := p.resolveTargetUser(blockeeURI)
 	if err != nil {
 		return errors.New("unknown blockee")
+	}
+	// #2106 L30: upstream undoBlock は blockee が remote (host != null) なら skip する
+	// (handleBlock の gate と対称)。
+	if blockee.Host != nil {
+		return nil
 	}
 	if err := p.blockingService.Unblock(blocker.ID, blockee.ID); err != nil {
 		if errors.Is(err, coreblocking.ErrNotBlocking) {

--- a/internal/core/federation/processor_test.go
+++ b/internal/core/federation/processor_test.go
@@ -2038,3 +2038,41 @@ func TestProcess_CreateNote_ObjectAudienceStillHonored(t *testing.T) {
 	note := findIngestedRemoteNote(t, noteRepo, noteURI)
 	assert.Equal(t, model.NoteVisibilityPublic, note.Visibility)
 }
+
+// #2106 L30: remote followee 宛の Undo(Follow) は skip される (handleFollow gate と対称)。
+func TestProcess_UndoFollow_RemoteFolloweeSkipped(t *testing.T) {
+	p, repo, _, _ := newProcessor(t, aliceActor)
+	bobURI := "https://remote2.example/users/bob"
+	bobHost := "remote2.example"
+	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob", URI: &bobURI, Host: &bobHost}
+
+	undo := []byte(`{
+		"type": "Undo",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"type": "Follow",
+			"actor": "https://remote.example/users/alice",
+			"object": "https://remote2.example/users/bob"
+		}
+	}`)
+	require.NoError(t, p.Process(undo)) // remote followee なので skip (nil)
+}
+
+// #2106 L30: remote blockee 宛の Undo(Block) は skip される (handleBlock gate と対称)。
+func TestProcess_UndoBlock_RemoteBlockeeSkipped(t *testing.T) {
+	p, repo, _ := newProcessorWithBlocking(t)
+	bobURI := "https://remote2.example/users/bob"
+	bobHost := "remote2.example"
+	repo.Users["bob"] = &model.User{ID: "bob", Username: "bob", URI: &bobURI, Host: &bobHost}
+
+	undoBody := []byte(`{
+		"type": "Undo",
+		"actor": "https://remote.example/users/alice",
+		"object": {
+			"type": "Block",
+			"actor": "https://remote.example/users/alice",
+			"object": "https://remote2.example/users/bob"
+		}
+	}`)
+	require.NoError(t, p.Process(undoBody)) // remote blockee なので skip (nil)
+}

--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -565,8 +565,8 @@ func (r *Resolver) resolveActorOnce(uri string, allowCrossHost bool) (*model.Use
 // が良く、mid-tag 切断による壊れ HTML を parser に渡す経路が無い。
 func extractRemoteDescription(actor *activitypub.Person) *string {
 	var raw string
-	if actor.MisskeySummary != "" {
-		raw = actor.MisskeySummary
+	if actor.MisskeySummary != nil && *actor.MisskeySummary != "" {
+		raw = *actor.MisskeySummary
 	} else if actor.Summary != "" {
 		// AP summary は Mastodon / Pleroma 等が HTML で送ってくる仕様
 		// (`<p>...</p>` ラップが典型)。MFM render を期待する frontend に
@@ -2034,6 +2034,12 @@ func (r *Resolver) upsertEmojis(tags []activitypub.EmojiTag, host string) pq.Str
 // 差は出るが、to/cc は note の author (Announce では announcer) が自分の note/boost に
 // 対して設定するものなので、緩めても自分のコンテンツの可視性が変わるだけで第三者の
 // note を露出させることはない。
+//
+// #2106 L31 (documented limitation): mk-go は remote user の followersUri を保持しないため
+// upstream ApAudienceService.isFollowers (`id === actor.followersUri ?? actor.uri+'/followers'`)
+// の厳密一致を行えず suffix heuristic で近似する。exotic audience (他人の followers collection
+// を to/cc に含む note) で upstream が specified に倒すところを followers に倒す微差が残る
+// (#1864 の既知トレードオフ)。将来 followersUri を保持・参照できるようになったら厳密化する。
 func deriveVisibility(to, cc []string) model.NoteVisibility {
 	hasFollowers := func(list []string) bool {
 		for _, v := range list {


### PR DESCRIPTION
#2106 LOW batch (core-federation/activitypub)。L30 (fix): handleUndoFollow/Block に remote-target skip 追加。L50 (fix): renderPerson の _misskey_summary/_misskey_followedMessage を常時 null/値 出力。L31/L49: deriveVisibility suffix heuristic / LD-Signature compact 省略を documented limitation として明記。回帰テスト追加。Closes #2222