### PR TITLE
reaction list legacy 正規化 + reaction 可視性/webhook/push の divergence 明記 (#2106 L7/L35/L37/L38/L42)

### DIFF
--- a/internal/api/notes/reactions_handler.go
+++ b/internal/api/notes/reactions_handler.go
@@ -37,6 +37,9 @@ func (h *Handler) ReactionsCreate(c echo.Context) error {
 		case errors.Is(err, reaction.ErrNoteNotFound):
 			return c.JSON(http.StatusNotFound, apierr.Error("NO_SUCH_NOTE", "No such note.", "033d0620-5bfe-4027-965d-980b0c85a3ea"))
 		case errors.Is(err, reaction.ErrNoteNotVisible):
+			// #2106 L38 (意図的 divergence): upstream は ReactionService の可視性 IdentifiableError を
+			// catch せず ApiCallService が generic INTERNAL_ERROR(500) に包む。mk-go は semantics 上
+			// 適切な 403 ACCESS_DENIED を維持する (worse な 500 拡散を避ける)。
 			return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "You can not see this note.", "fe8d7103-0ea8-4ec3-814d-f8b401dc69e9"))
 		case errors.Is(err, reaction.ErrAlreadyReacted):
 			return c.JSON(http.StatusBadRequest, apierr.Error("ALREADY_REACTED", "You are already reacting to that note.", "71efcf98-86d6-4e2b-b2ad-9d032369366b"))
@@ -136,7 +139,10 @@ func (h *Handler) Reactions(c echo.Context) error {
 			"id":        r.ID,
 			"createdAt": createdAt,
 			"user":      userField,
-			"type":      r.Reaction,
+			// #2106 L7: upstream NoteReactionEntityService.pack は convertLegacyReaction を通す。
+			// TS から移行した legacy 値 (like / :smile: host無) を 👍 / :smile@.: に正規化して揃える
+			// (mk-native は write-time 正規化済だが drop-in 直後の DB 値はここで揃う)。
+			"type": entity.NormalizeReactionWithLegacy(r.Reaction),
 		})
 	}
 	return c.JSON(http.StatusOK, out)

--- a/internal/api/notes/reactions_handler_test.go
+++ b/internal/api/notes/reactions_handler_test.go
@@ -386,3 +386,23 @@ func TestReactionsCreate_MissingReaction(t *testing.T) {
 	require.NoError(t, h.ReactionsCreate(c))
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
+
+// #2106 L7: TS-era legacy reaction (like / host無 :smile:) は convertLegacyReaction 相当の
+// 正規化を type に適用する (👍 / :smile@.:)。
+func TestReactions_List_LegacyReactionNormalized(t *testing.T) {
+	h, repo, reactRepo := newReactionHandler(t)
+	seedReactionNote(repo, "n1", "public")
+	idGen, _ := id.NewGenerator("aidx")
+	rxID := idGen.Generate(timeNow())
+	reactRepo.Reactions[rxID] = &model.NoteReaction{
+		ID: rxID, UserID: "viewer", NoteID: "n1", Reaction: "like", // legacy
+	}
+
+	c, rec := newJSONRequest(t, "/api/notes/reactions", `{"noteId":"n1"}`)
+	require.NoError(t, h.Reactions(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "👍", resp[0]["type"], "legacy like を 👍 に正規化")
+}

--- a/internal/core/notification/hooks.go
+++ b/internal/core/notification/hooks.go
@@ -553,6 +553,13 @@ func (h *Hook) notifyLocalUser(ctx context.Context, notifieeID string, in Create
 	// 通知の永続化に成功したらWeb Push配信キューへ投入する。
 	// packerが未設定でもtype/id/userIdは最低限埋まるので、sw.js側の24h
 	// 破棄チェックとユーザー判定は成立する。
+	//
+	// #2106 L35 (known divergence, follow-up #2224): upstream NotificationService は
+	// push を 2 秒の setTimeout + latestRead guard の後にのみ発火し、作成から 2 秒以内に既読化
+	// (MarkAllAsRead) されると push も抑制する。mk-go は push を即時・無条件で配信するため、
+	// すぐ既読化しても冗長な push が届く (unreadNotification stream event 側は
+	// scheduleUnreadPublish で guard 済)。push を同 guard 経路へ移す改修は notification.Service
+	// への push delivery thread が要るため follow-up issue に切り出す。
 	if h.webpush != nil && n != nil {
 		h.webpush.PushNotification(notifieeID, h.buildPushBody(n, notifieeID))
 	}

--- a/internal/core/reaction/reaction_service.go
+++ b/internal/core/reaction/reaction_service.go
@@ -442,6 +442,11 @@ func (s *Service) List(user *model.User, noteID, untilID, sinceID string, limit 
 	if err != nil {
 		return nil, ErrNoteNotFound
 	}
+	// #2106 L37 (意図的 divergence): upstream notes/reactions は requireCredential:false で
+	// 可視性 filter を一切掛けず、followers/specified note の reaction list も誰にでも 200 で
+	// 返す。mk-go は閲覧不可 viewer に CanSeeNote gate を掛け 404 NO_SUCH_NOTE を返す
+	// (本文だけでなく reaction list も漏らさない privacy 強化)。worse な upstream 露出に
+	// 揃えず mk-go の堅牢な挙動を維持する。
 	if !note.CanSeeNote(user, target, s.followingRepo) {
 		return nil, ErrNoteNotVisible
 	}

--- a/internal/core/webhook/hooks.go
+++ b/internal/core/webhook/hooks.go
@@ -98,6 +98,12 @@ func NewReactionCreateHook(svc *Service, idGen id.Generator) *ReactionCreateHook
 }
 
 // OnReactionCreated fires the `reaction` webhook event on the note author.
+//
+// #2106 L42 (intentional additive extension): upstream は webhookEventTypes に 'reaction' を
+// 定義しているものの (Webhook.ts), enqueueUserWebhook では reaction を一切 fire しない
+// (note/reply/renote/mention/follow 系のみ)。mk-go は valid な購読 enum である 'reaction' を
+// 実際に配信する additive 拡張。'reaction' webhook が来ないことを前提にした client との観測差は
+// あるが破壊ではない (購読していなければ届かない)。upstream が未配信であることを差分として記録。
 func (h *ReactionCreateHook) OnReactionCreated(note *model.Note, reactor *model.User, reaction string) {
 	if h == nil || h.svc == nil || note == nil || reactor == nil {
 		return


### PR DESCRIPTION
#2106 LOW batch (reaction、最終)。L7 (fix): reaction list の type に legacy 正規化を適用。L35 (follow-up #2224): Web Push 2 秒抑制未適用を明記+切り出し。L37/L38/L42: reaction list 可視性 gate / 403 / webhook を意図的 divergence・additive 拡張として明記。回帰テスト追加。Closes #2225