### PR TITLE
Web Push を 2 秒既読抑制 guard 経路へ移す (#2106 L35, Closes #2224)

### DIFF
--- a/internal/core/notification/hooks.go
+++ b/internal/core/notification/hooks.go
@@ -545,23 +545,24 @@ func (h *Hook) notifyLocalUser(ctx context.Context, notifieeID string, in Create
 	if !h.passesReceiveConfig(notifieeID, in) {
 		return
 	}
-	n, err := h.svc.Create(ctx, in)
-	if err != nil {
+	// #2106 L35 / #2224: Web Push を notification.Service の scheduleUnreadPublish guard 内へ
+	// 移す。upstream NotificationService 同様、作成から unreadPublishDelay (既定 2 秒) 以内に
+	// 既読化 (MarkAllAsRead) されると unreadNotification stream event だけでなく Web Push も
+	// 抑制される。pushFn は webpush 配線時のみ渡し、guard の latestRead チェックを越えた後に
+	// 永続化済 Notification から push body を組んで配信する。
+	// packer 未設定でも type/id/userId は最低限埋まるので sw.js 側の 24h 破棄チェックと
+	// ユーザー判定は成立する。
+	var pushFn func(*Notification)
+	if h.webpush != nil {
+		pushFn = func(n *Notification) {
+			if n != nil {
+				h.webpush.PushNotification(notifieeID, h.buildPushBody(n, notifieeID))
+			}
+		}
+	}
+	if _, err := h.svc.CreateWithPush(ctx, in, pushFn); err != nil {
 		slog.Warn("notification create failed", "type", in.Type, "notifiee", notifieeID, "err", err)
 		return
-	}
-	// 通知の永続化に成功したらWeb Push配信キューへ投入する。
-	// packerが未設定でもtype/id/userIdは最低限埋まるので、sw.js側の24h
-	// 破棄チェックとユーザー判定は成立する。
-	//
-	// #2106 L35 (known divergence, follow-up #2224): upstream NotificationService は
-	// push を 2 秒の setTimeout + latestRead guard の後にのみ発火し、作成から 2 秒以内に既読化
-	// (MarkAllAsRead) されると push も抑制する。mk-go は push を即時・無条件で配信するため、
-	// すぐ既読化しても冗長な push が届く (unreadNotification stream event 側は
-	// scheduleUnreadPublish で guard 済)。push を同 guard 経路へ移す改修は notification.Service
-	// への push delivery thread が要るため follow-up issue に切り出す。
-	if h.webpush != nil && n != nil {
-		h.webpush.PushNotification(notifieeID, h.buildPushBody(n, notifieeID))
 	}
 }
 

--- a/internal/core/notification/hooks_test.go
+++ b/internal/core/notification/hooks_test.go
@@ -3,6 +3,7 @@ package notification
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/lib/pq"
 	"github.com/shiroha-a/mk/internal/model"
@@ -16,6 +17,9 @@ func newTestHook(t *testing.T) (*Hook, *Service, *testutil.MockUserRepository) {
 	t.Helper()
 	testRedis.FlushAll(context.Background())
 	svc := NewService(testRedis.Client, idGen, "")
+	// #2106 L35: push が scheduleUnreadPublish guard 経由になったので、Hook test では delay=0 で
+	// 同期発火させて push の同期 assert を維持する。
+	svc.SetUnreadPublishDelay(0)
 	userRepo := testutil.NewMockUserRepository()
 	return NewHook(svc, userRepo), svc, userRepo
 }
@@ -981,4 +985,26 @@ func TestHook_NotifyVisibleToTarget(t *testing.T) {
 			assert.Equal(t, tc.want, h.notifyVisibleToTarget(n, tc.target))
 		})
 	}
+}
+
+// #2106 L35 / #2224: 作成から unreadPublishDelay 以内に MarkAllAsRead されると、
+// unreadNotification だけでなく Web Push も抑制される。
+func TestHook_WebPushSuppressedAfterRead(t *testing.T) {
+	h, svc, repo := newTestHook(t)
+	svc.SetUnreadPublishDelay(50 * time.Millisecond) // deferred 化して read レースを作る
+	addLocalUser(repo, "alice", "alice")
+
+	pub := &stubWebPushPublisher{}
+	h.SetWebPushPublisher(pub)
+	h.SetPackers(
+		stubUserPacker{out: map[string]any{"id": "bob"}},
+		stubNotePacker{out: map[string]any{"id": "n1"}},
+	)
+
+	h.OnReactionCreated("alice", "bob", "n1", "\U0001F44D") // deferred push をスケジュール
+	// delay 前に既読化 (latestRead marker を最新へ前進)。
+	require.NoError(t, svc.MarkAllAsRead(context.Background(), "alice"))
+	// delay 経過を待つ。
+	time.Sleep(120 * time.Millisecond)
+	assert.Empty(t, pub.calls, "delay 内既読化で Web Push が抑制される")
 }

--- a/internal/core/notification/notification_service.go
+++ b/internal/core/notification/notification_service.go
@@ -240,6 +240,20 @@ var (
 // Create writes a notification entry to the user's notification stream.
 // notifier == notifiee の場合は何もしない (Misskey本家の挙動を踏襲)。
 func (s *Service) Create(ctx context.Context, in CreateInput) (*Notification, error) {
+	return s.createWithPush(ctx, in, nil)
+}
+
+// CreateWithPush is Create plus a Web Push delivery callback that is fired inside
+// the same 2-second + latestRead guard as the unreadNotification stream event
+// (#2106 L35 / #2224). pushFn receives the persisted Notification and is invoked
+// only when the recipient has NOT read their notifications within the delay window,
+// so a quick MarkAllAsRead suppresses both the stream badge and the push (upstream
+// NotificationService.ts parity). pushFn nil = no push (the other Create callers).
+func (s *Service) CreateWithPush(ctx context.Context, in CreateInput, pushFn func(*Notification)) (*Notification, error) {
+	return s.createWithPush(ctx, in, pushFn)
+}
+
+func (s *Service) createWithPush(ctx context.Context, in CreateInput, pushFn func(*Notification)) (*Notification, error) {
 	if in.NotifieeID == "" {
 		return nil, errors.New("notifieeId is required")
 	}
@@ -316,7 +330,13 @@ func (s *Service) Create(ctx context.Context, in CreateInput) (*Notification, er
 	// `latestReadNotification` Redis key の値で、これは MarkAllAsRead が
 	// `XRevRangeN(...)[0].ID` (= 実 streamID) を書き込むので、Redis が
 	// 採番した actual な streamID を渡す。
-	s.scheduleUnreadPublish(in.NotifieeID, streamID, packed)
+	// #2106 L35: push を unreadNotification と同じ 2 秒 + latestRead guard 経路に乗せる。
+	// pushFn は createWithPush 呼び元が指定した時のみ非 nil (notifyLocalUser のみ)。
+	var boundPush func()
+	if pushFn != nil {
+		boundPush = func() { pushFn(n) }
+	}
+	s.scheduleUnreadPublish(in.NotifieeID, streamID, packed, boundPush)
 	return n, nil
 }
 
@@ -463,25 +483,32 @@ func (s *Service) DeleteByTypeAndNotifier(ctx context.Context, notifieeID string
 // (#420 follow-up)。streamID は Redis が採番した `<unix-ms>-<seq>` 形式
 // (XAdd の Result) で、`latestReadNotification` Redis key と直接
 // lexicographic 比較できる。delay==0 は同期 publish (テスト用)。
-func (s *Service) scheduleUnreadPublish(notifieeID, streamID string, packed any) {
-	if s.mainStreamPublisher == nil {
+func (s *Service) scheduleUnreadPublish(notifieeID, streamID string, packed any, pushFn func()) {
+	if s.mainStreamPublisher == nil && pushFn == nil {
 		// SetMainStreamPublisher は nil で実行する (= publish 機能を無効化
 		// する) ことを明示的に許容している。テストや mainStream が不要な
 		// 構成でも Create が呼ばれるたびに Warn ログを出すと noise になる
-		// ので silent skip する (#420 Devin review)。
+		// ので silent skip する (#420 Devin review)。push も無いなら何もしない。
 		return
 	}
 	publish := func() {
 		latestRead, err := s.client.Get(context.Background(), s.readKey(notifieeID)).Result()
 		if err == nil && latestRead != "" && latestRead >= streamID {
-			// 待機中に既読化された → publish skip。badge を burn しない。
-			slog.Debug("notification: unreadNotification suppressed (already read)",
+			// 待機中に既読化された → unreadNotification も Web Push も skip。
+			// badge を burn せず、冗長な push も送らない (#2106 L35)。
+			slog.Debug("notification: unreadNotification/push suppressed (already read)",
 				"userId", notifieeID, "streamId", streamID, "latestRead", latestRead)
 			return
 		}
-		s.mainStreamPublisher.PublishMainEvent(notifieeID, "unreadNotification", packed)
-		slog.Debug("notification: published unreadNotification",
-			"userId", notifieeID, "streamId", streamID)
+		if s.mainStreamPublisher != nil {
+			s.mainStreamPublisher.PublishMainEvent(notifieeID, "unreadNotification", packed)
+			slog.Debug("notification: published unreadNotification",
+				"userId", notifieeID, "streamId", streamID)
+		}
+		// #2106 L35: Web Push も latestRead guard を越えた後にのみ発火する。
+		if pushFn != nil {
+			pushFn()
+		}
 	}
 	if s.unreadPublishDelay <= 0 {
 		publish()


### PR DESCRIPTION
#2106 L35 の follow-up (#2224)。Web Push を notification.Service の scheduleUnreadPublish guard 内へ移し、作成から unreadPublishDelay (既定 2 秒) 以内に MarkAllAsRead されると unreadNotification stream event だけでなく Web Push も抑制する (upstream NotificationService 互換)。CreateWithPush(ctx, in, pushFn) を追加し notifyLocalUser のみ push を渡す (他の Create 呼び元は不変)。回帰テスト追加。Closes #2224