### PR TITLE
POST /api/notes を upstream の public note 一覧 endpoint として実装する (#2106 L4, Closes #2215)

### DIFF
--- a/internal/api/notes/handler.go
+++ b/internal/api/notes/handler.go
@@ -932,34 +932,63 @@ func (h *Handler) Conversation(c echo.Context) error {
 	return c.JSON(http.StatusOK, packed)
 }
 
-// BulkShow handles POST /api/notes — bulk note lookup by noteIds.
-// visibility チェックを通して非公開ノートの漏洩を防ぐ。
+// BulkShow handles POST /api/notes.
+//
+// #2106 L4 / #2215: hybrid endpoint。upstream notes.ts は {local,reply,renote,withFiles,
+// poll,limit,sinceId/untilId/sinceDate/untilDate} で public(visibility=public,
+// localOnly=FALSE) note の一覧を時系列ページングする公開タイムライン的 endpoint。mk-go は
+// 加えて独自拡張の noteIds bulk lookup も同 endpoint で受ける: noteIds 指定時は bulk
+// (visibility filter 付き)、不在時は upstream 互換の public note 一覧を返す。これで
+// misskey-js SDK の {local:true,limit:30} 呼び出しも、既存の {noteIds:[...]} 呼び出しも
+// 両立する。
 func (h *Handler) BulkShow(c echo.Context) error {
 	var req struct {
 		NoteIDs []string `json:"noteIds"`
+		// upstream notes.ts public-note timeline params (noteIds 不在時に使用)。
+		Local     bool   `json:"local"`
+		Reply     *bool  `json:"reply"`
+		Renote    *bool  `json:"renote"`
+		WithFiles *bool  `json:"withFiles"`
+		Poll      *bool  `json:"poll"`
+		Limit     int    `json:"limit"`
+		SinceID   string `json:"sinceId"`
+		UntilID   string `json:"untilId"`
+		SinceDate *int64 `json:"sinceDate"`
+		UntilDate *int64 `json:"untilDate"`
 	}
 	if err := c.Bind(&req); err != nil {
 		return apierr.JSONInvalidParam(c)
 	}
-	if len(req.NoteIDs) == 0 {
-		return c.JSON(http.StatusOK, []any{})
+	viewer := middleware.GetUser(c)
+
+	// noteIds 指定時は mk-go 拡張の bulk lookup。visibility チェックを通して非公開ノートの
+	// 漏洩を防ぐ。queryService 未配線時は fail-closed で空配列 (#509 / #505)。
+	if len(req.NoteIDs) > 0 {
+		if len(req.NoteIDs) > 100 {
+			req.NoteIDs = req.NoteIDs[:100]
+		}
+		notes, err := h.noteRepo.FindManyByIDsWithUser(req.NoteIDs)
+		if err != nil || h.queryService == nil {
+			return c.JSON(http.StatusOK, []any{})
+		}
+		notes = h.queryService.FilterVisible(viewer, notes)
+		return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))
 	}
-	if len(req.NoteIDs) > 100 {
-		req.NoteIDs = req.NoteIDs[:100]
-	}
-	notes, err := h.noteRepo.FindManyByIDsWithUser(req.NoteIDs)
+
+	// noteIds 不在時は upstream notes.ts の public note 一覧。public note のみなので追加の
+	// visibility filter は不要 (upstream も requireCredential:false で filter 無し)。
+	limit := pagination.ClampLimit(req.Limit, 10, 100)
+	sinceID, untilID := id.NormalizeCursor(req.SinceID, req.UntilID, req.SinceDate, req.UntilDate)
+	notes, err := h.noteRepo.ListPublicNotes(model.PublicNotesFilter{
+		Local:     req.Local,
+		Reply:     req.Reply,
+		Renote:    req.Renote,
+		WithFiles: req.WithFiles,
+		Poll:      req.Poll,
+	}, limit, sinceID, untilID)
 	if err != nil {
 		return c.JSON(http.StatusOK, []any{})
 	}
-	viewer := middleware.GetUser(c)
-	// queryService 未配線時は visibility filter を経ずに全 note を返してしまう
-	// と、followers / specified visibility のノートが任意の閲覧者に漏洩する。
-	// production の router.go では常に wire されるが、wiring が壊れた場合の
-	// fail-closed として空配列で返す (#509、#445 / PR #505 と同じ defensive)。
-	if h.queryService == nil {
-		return c.JSON(http.StatusOK, []any{})
-	}
-	notes = h.queryService.FilterVisible(viewer, notes)
 	return c.JSON(http.StatusOK, h.packMany(c.Request().Context(), notes, viewer))
 }
 

--- a/internal/api/notes/handler_test.go
+++ b/internal/api/notes/handler_test.go
@@ -918,6 +918,9 @@ func (f *failingNoteRepo) ListLocalTimeline(_ int, _, _ string, _ model.Timeline
 func (f *failingNoteRepo) ListGlobalTimeline(_ int, _, _ string, _ model.TimelineDBFilter) ([]*model.Note, error) {
 	return nil, nil
 }
+func (f *failingNoteRepo) ListPublicNotes(_ model.PublicNotesFilter, _ int, _, _ string) ([]*model.Note, error) {
+	return nil, errors.New("boom")
+}
 func (f *failingNoteRepo) DeleteExpiredRemoteNotes(_, _ int) (int64, error) { return 0, nil }
 func (f *failingNoteRepo) DeleteByUserBatch(_ string, _ int) (int64, error) { return 0, nil }
 func (f *failingNoteRepo) CountReplyTargets(_, _ string, _ int) ([]model.ReplyTargetCount, error) {
@@ -1076,4 +1079,25 @@ func TestCreate_PollExpiredAfterTakesPriority(t *testing.T) {
 		// expiredAfter (now+1h) を採用 → 30 日後の expiresAt よりずっと前になる。
 		assert.True(t, poll.ExpiresAt.Before(time.Now().Add(2*time.Hour)), "expiredAfter を優先すべき、got %v", poll.ExpiresAt)
 	}
+}
+
+// #2106 L4 / #2215: noteIds 不在の POST /notes は upstream notes.ts の public note 一覧を返す
+// (localOnly note は除外)。
+func TestBulkShow_PublicTimeline(t *testing.T) {
+	h, noteRepo := newTestHandler(t)
+	noteRepo.Notes["np1"] = &model.Note{ID: "np1", UserID: "u1", Visibility: "public", User: &model.User{ID: "u1"}}
+	noteRepo.Notes["np2"] = &model.Note{ID: "np2", UserID: "u1", Visibility: "public", LocalOnly: true, User: &model.User{ID: "u1"}}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/notes", strings.NewReader(`{"limit":30}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	require.NoError(t, h.BulkShow(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var out []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	// localOnly (np2) は除外され、public な np1 のみ返る。
+	require.Len(t, out, 1)
+	assert.Equal(t, "np1", out[0]["id"])
 }

--- a/internal/model/timeline_filter.go
+++ b/internal/model/timeline_filter.go
@@ -51,3 +51,14 @@ type TimelineDBFilter struct {
 	// の note のみ (= followed user の channel note は home から除外される)。
 	FollowedChannelIDs []string
 }
+
+// PublicNotesFilter carries the optional filters of the upstream notes.ts
+// public-note timeline (#2106 L4 / #2215). Pointer bools distinguish "unset"
+// (no filter) from an explicit true/false, matching upstream's `!== undefined`.
+type PublicNotesFilter struct {
+	Local     bool  // userHost IS NULL (local-only notes)
+	Reply     *bool // replyId IS [NOT] NULL
+	Renote    *bool // renoteId IS [NOT] NULL
+	WithFiles *bool // fileIds != / = '{}'
+	Poll      *bool // hasPoll = TRUE / FALSE
+}

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -169,6 +169,10 @@ type NoteRepository interface {
 	ListHomeTimeline(userID string, limit int, sinceID, untilID string, filter model.TimelineDBFilter) ([]*model.Note, error)
 	ListLocalTimeline(limit int, sinceID, untilID string, filter model.TimelineDBFilter) ([]*model.Note, error)
 	ListGlobalTimeline(limit int, sinceID, untilID string, filter model.TimelineDBFilter) ([]*model.Note, error)
+	// ListPublicNotes returns public, non-localOnly notes for the upstream
+	// notes.ts public-note timeline (#2106 L4 / #2215), with optional
+	// local/reply/renote/withFiles/poll filters and keyset pagination.
+	ListPublicNotes(filter model.PublicNotesFilter, limit int, sinceID, untilID string) ([]*model.Note, error)
 	// DeleteExpiredRemoteNotes deletes up to batchSize remote notes older
 	// than expiryDays in a single DELETE statement. Returns the count
 	// actually removed in this batch. Callers drive the loop themselves so
@@ -1145,6 +1149,58 @@ func (r *noteRepository) ListLocalTimeline(limit int, sinceID, untilID string, f
 		q = q.Where(`"id" < ?`, untilID)
 	}
 	q = applyTimelineFilter(q, filter)
+	var notes []*model.Note
+	if err := q.Find(&notes).Error; err != nil {
+		return nil, err
+	}
+	return notes, nil
+}
+
+// ListPublicNotes implements the upstream notes.ts query: public, non-localOnly
+// notes time-ordered with optional local/reply/renote/withFiles/poll filters.
+// Unlike ListGlobalTimeline this does NOT exclude channel notes (upstream notes.ts
+// has no channelId filter) (#2106 L4 / #2215).
+func (r *noteRepository) ListPublicNotes(filter model.PublicNotesFilter, limit int, sinceID, untilID string) ([]*model.Note, error) {
+	q := preloadNoteRelations(r.db).
+		Where(`"visibility" = 'public' AND "localOnly" = FALSE`).
+		Order(paginationOrder(sinceID, untilID, `"id"`)).Limit(limit)
+	if sinceID != "" {
+		q = q.Where(`"id" > ?`, sinceID)
+	}
+	if untilID != "" {
+		q = q.Where(`"id" < ?`, untilID)
+	}
+	if filter.Local {
+		q = q.Where(`"userHost" IS NULL`)
+	}
+	if filter.Reply != nil {
+		if *filter.Reply {
+			q = q.Where(`"replyId" IS NOT NULL`)
+		} else {
+			q = q.Where(`"replyId" IS NULL`)
+		}
+	}
+	if filter.Renote != nil {
+		if *filter.Renote {
+			q = q.Where(`"renoteId" IS NOT NULL`)
+		} else {
+			q = q.Where(`"renoteId" IS NULL`)
+		}
+	}
+	if filter.WithFiles != nil {
+		if *filter.WithFiles {
+			q = q.Where(`"fileIds" != '{}'`)
+		} else {
+			q = q.Where(`"fileIds" = '{}'`)
+		}
+	}
+	if filter.Poll != nil {
+		if *filter.Poll {
+			q = q.Where(`"hasPoll" = TRUE`)
+		} else {
+			q = q.Where(`"hasPoll" = FALSE`)
+		}
+	}
 	var notes []*model.Note
 	if err := q.Find(&notes).Error; err != nil {
 		return nil, err

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -3416,3 +3416,75 @@ func TestNoteRepository_SearchByFilter_DateRange(t *testing.T) {
 	assert.NotContains(t, got, id2021, "2021 は範囲外")
 	assert.NotContains(t, got, id2023, "2023 は範囲外")
 }
+
+// #2106 L4 / #2215: ListPublicNotes は public/非 localOnly note を返し、
+// local/reply/renote/withFiles/poll の各 filter を適用する。
+func TestNoteRepository_ListPublicNotes(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+	user := insertTestUser(t, "u_lpn_1", "lpnuser")
+	defer cleanupUser(t, user.ID)
+
+	text := "x"
+	host := "remote.example"
+	mk := func(id string, mut func(*model.Note)) *model.Note {
+		n := &model.Note{ID: id, UserID: user.ID, Text: &text, Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}"))}
+		mut(n)
+		require.NoError(t, repo.Create(n))
+		return n
+	}
+	// reply/renote の FK 制約を満たすため参照先 note を先に作る。
+	refNote := mk("n_lpn_ref", func(n *model.Note) {})
+	ref := refNote.ID
+	plain := mk("n_lpn_plain", func(n *model.Note) {})
+	remote := mk("n_lpn_remote", func(n *model.Note) { n.UserHost = &host })
+	reply := mk("n_lpn_reply", func(n *model.Note) { n.ReplyID = &ref })
+	renote := mk("n_lpn_renote", func(n *model.Note) { n.RenoteID = &ref })
+	files := mk("n_lpn_files", func(n *model.Note) { n.FileIDs = pq.StringArray{"f1"} })
+	poll := mk("n_lpn_poll", func(n *model.Note) { n.HasPoll = true })
+	localonly := mk("n_lpn_localonly", func(n *model.Note) { n.LocalOnly = true })
+	followers := mk("n_lpn_followers", func(n *model.Note) { n.Visibility = model.NoteVisibilityFollowers })
+	for _, n := range []*model.Note{refNote, plain, remote, reply, renote, files, poll, localonly, followers} {
+		defer cleanupNote(t, n.ID)
+	}
+
+	has := func(f model.PublicNotesFilter, id string) bool {
+		rows, err := repo.ListPublicNotes(f, 50, "", "")
+		require.NoError(t, err)
+		for _, r := range rows {
+			if r.ID == id {
+				return true
+			}
+		}
+		return false
+	}
+	tr, fa := true, false
+
+	// no filter: public/非 localOnly のみ。localOnly / followers は除外。
+	assert.True(t, has(model.PublicNotesFilter{}, plain.ID))
+	assert.True(t, has(model.PublicNotesFilter{}, remote.ID))
+	assert.False(t, has(model.PublicNotesFilter{}, localonly.ID))
+	assert.False(t, has(model.PublicNotesFilter{}, followers.ID))
+	// local: userHost IS NULL のみ。
+	assert.True(t, has(model.PublicNotesFilter{Local: true}, plain.ID))
+	assert.False(t, has(model.PublicNotesFilter{Local: true}, remote.ID))
+	// reply true/false。
+	assert.True(t, has(model.PublicNotesFilter{Reply: &tr}, reply.ID))
+	assert.False(t, has(model.PublicNotesFilter{Reply: &tr}, plain.ID))
+	assert.True(t, has(model.PublicNotesFilter{Reply: &fa}, plain.ID))
+	assert.False(t, has(model.PublicNotesFilter{Reply: &fa}, reply.ID))
+	// renote true/false。
+	assert.True(t, has(model.PublicNotesFilter{Renote: &tr}, renote.ID))
+	assert.True(t, has(model.PublicNotesFilter{Renote: &fa}, plain.ID))
+	// withFiles true/false。
+	assert.True(t, has(model.PublicNotesFilter{WithFiles: &tr}, files.ID))
+	assert.True(t, has(model.PublicNotesFilter{WithFiles: &fa}, plain.ID))
+	// poll true/false。
+	assert.True(t, has(model.PublicNotesFilter{Poll: &tr}, poll.ID))
+	assert.True(t, has(model.PublicNotesFilter{Poll: &fa}, plain.ID))
+
+	// since/until 分岐。
+	_, err := repo.ListPublicNotes(model.PublicNotesFilter{}, 50, "nonexistent", "")
+	require.NoError(t, err)
+	_, err = repo.ListPublicNotes(model.PublicNotesFilter{}, 50, "", "nonexistent")
+	require.NoError(t, err)
+}

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -1460,6 +1460,30 @@ func (m *MockNoteRepository) ListGlobalTimeline(limit int, sinceID, untilID stri
 	}, untilID, sinceID, limit), nil
 }
 
+func (m *MockNoteRepository) ListPublicNotes(filter model.PublicNotesFilter, limit int, sinceID, untilID string) ([]*model.Note, error) {
+	return m.listFiltered(func(n *model.Note) bool {
+		if string(n.Visibility) != "public" || n.LocalOnly {
+			return false
+		}
+		if filter.Local && n.UserHost != nil {
+			return false
+		}
+		if filter.Reply != nil && (*filter.Reply) != (n.ReplyID != nil) {
+			return false
+		}
+		if filter.Renote != nil && (*filter.Renote) != (n.RenoteID != nil) {
+			return false
+		}
+		if filter.WithFiles != nil && (*filter.WithFiles) != (len(n.FileIDs) > 0) {
+			return false
+		}
+		if filter.Poll != nil && (*filter.Poll) != n.HasPoll {
+			return false
+		}
+		return true
+	}, untilID, sinceID, limit), nil
+}
+
 func (m *MockNoteRepository) DeleteExpiredRemoteNotes(_, _ int) (int64, error) {
 	return 0, nil
 }


### PR DESCRIPTION
#2106 L4 の follow-up (#2215)。POST /api/notes を hybrid 化: noteIds 指定時は従来の bulk lookup、不在時は upstream notes.ts 互換の public note 一覧 (visibility=public, localOnly=FALSE を local/reply/renote/withFiles/poll で filter + 時系列ページング) を返す。misskey-js SDK の {local:true,limit:30} 呼び出しと既存の {noteIds} 呼び出しが両立。NoteRepository に ListPublicNotes を追加。回帰テスト追加。Closes #2215