### PR TITLE
i/delete-account で cascade 削除と連合 Delete を enqueue する (Closes #2230)

### DIFF
--- a/internal/api/i/handler.go
+++ b/internal/api/i/handler.go
@@ -58,38 +58,41 @@ type AccountMover interface {
 
 // Handler handles account-related API endpoints.
 type Handler struct {
-	userService          *user.Service
-	idGen                id.Generator
-	roleProvider         RoleProvider
-	registryRepo         repository.RegistryRepository
-	favoriteRepo         repository.NoteFavoriteRepository
-	transferEnqueuer     TransferEnqueuer
-	webauthnSvc          *twofactor.WebAuthnService
-	securityKeyRepo      repository.UserSecurityKeyRepository
-	metaRepo             repository.MetaRepository
-	emailSender          EmailSender
-	serverURL            string
-	signinRepo           repository.SigninRepository
-	accessTokenRepo      repository.AccessTokenRepository
-	galleryRepo          GalleryRepository
-	pageLikeRepo         repository.PageLikeRepository
-	mover                AccountMover
-	notificationSvc      UnreadNotificationSource
-	achievementNotifier  AchievementNotifier
-	followRequestRepo    repository.FollowRequestRepository
-	announcementRepo     AnnouncementUnreadSource
-	chatRepo             ChatUnreadSource
-	antennaUnreadRepo    AntennaUnreadSource
-	channelUnreadRepo    ChannelUnreadSource
-	piningRepo           repository.UserNotePiningRepository
-	noteRepo             repository.NoteRepository
-	pageRepo             repository.PageRepository
-	instanceRepo         repository.InstanceRepository
-	emojiRepo            repository.EmojiRepository
-	bufReader            entity.BufferedReactionsReader
-	avatarDecorationRepo repository.AvatarDecorationRepository
-	mainStreamPublisher  MainStreamPublisher
-	fieldRes             *entity.NoteFieldResolver
+	userService      *user.Service
+	idGen            id.Generator
+	roleProvider     RoleProvider
+	registryRepo     repository.RegistryRepository
+	favoriteRepo     repository.NoteFavoriteRepository
+	transferEnqueuer TransferEnqueuer
+	// #2230: i/delete-account の cascade 削除と連合 Delete 配信 (admin/delete-account と同経路)。
+	deleteAccountEnqueuer DeleteAccountEnqueuer
+	accountDeletionFed    AccountDeletionFederationHook
+	webauthnSvc           *twofactor.WebAuthnService
+	securityKeyRepo       repository.UserSecurityKeyRepository
+	metaRepo              repository.MetaRepository
+	emailSender           EmailSender
+	serverURL             string
+	signinRepo            repository.SigninRepository
+	accessTokenRepo       repository.AccessTokenRepository
+	galleryRepo           GalleryRepository
+	pageLikeRepo          repository.PageLikeRepository
+	mover                 AccountMover
+	notificationSvc       UnreadNotificationSource
+	achievementNotifier   AchievementNotifier
+	followRequestRepo     repository.FollowRequestRepository
+	announcementRepo      AnnouncementUnreadSource
+	chatRepo              ChatUnreadSource
+	antennaUnreadRepo     AntennaUnreadSource
+	channelUnreadRepo     ChannelUnreadSource
+	piningRepo            repository.UserNotePiningRepository
+	noteRepo              repository.NoteRepository
+	pageRepo              repository.PageRepository
+	instanceRepo          repository.InstanceRepository
+	emojiRepo             repository.EmojiRepository
+	bufReader             entity.BufferedReactionsReader
+	avatarDecorationRepo  repository.AvatarDecorationRepository
+	mainStreamPublisher   MainStreamPublisher
+	fieldRes              *entity.NoteFieldResolver
 	// emailValidationClient は verifymail / truemail SaaS への outbound に
 	// 使う SSRF-safe HTTP client (#638)。nil ならデフォルトクライアント。
 	emailValidationClient *http.Client

--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -18,6 +19,7 @@ import (
 	"github.com/shiroha-a/mk/internal/misc/achievement"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -103,6 +105,13 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 		return c.JSON(http.StatusUnauthorized, apierr.Error("INCORRECT_PASSWORD", "Incorrect password.", "932c904e-9460-45b7-9ce6-7ed33be7eb2c"))
 	}
 
+	// #2230: root / system アカウントの自己削除は連合・instance を壊すため拒否する
+	// (admin/delete-account の isProtectedAccount と同じ guard、upstream DeleteAccountService の
+	// rootUserId / system account ガード相当)。cascade を走らせる前に弾く。
+	if isProtectedSelfDelete(u) {
+		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Cannot delete a root or system account.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
+	}
+
 	// isSuspended + isDeleted を true に設定 (論理削除)
 	if err := h.userService.UpdateUserFields(u.ID, map[string]any{
 		"isSuspended": true,
@@ -120,7 +129,60 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 	// 本 helper の O(N) cache scan cost は許容範囲。helper の詳細は
 	// handler.go の invalidateUserTokenCache を参照。
 	h.invalidateUserTokenCache(u.ID)
+
+	// #2230: 論理削除フラグを立てるだけでは notes / drive / following が purge されず、
+	// 連合先にも削除が伝わらない (= 「凍結止まりで削除が実行されない」)。admin/delete-account と
+	// 同様に (1) sharedInbox へ Delete(actor) を配信し、(2) cascade 削除 job を enqueue する。
+	// cascade は soft (user 行 / 署名鍵を残す) なので queue 経由配信でも鍵は生存する。
+	if h.accountDeletionFed != nil {
+		h.accountDeletionFed.OnUserDeleted(u)
+	}
+	if h.deleteAccountEnqueuer != nil {
+		if err := h.deleteAccountEnqueuer.EnqueueDeleteAccount(queue.DeleteAccountPayload{UserID: u.ID}); err != nil {
+			// enqueue 失敗は user 可視のエラーにしない (フラグは既に立っている)。
+			// 次回手動 retry / 再ログイン不可状態は維持されるため 204 を返す。
+			slog.Warn("i/delete-account: enqueue cascade failed", "userId", u.ID, "err", err)
+		}
+	}
 	return c.NoContent(http.StatusNoContent)
+}
+
+// DeleteAccountEnqueuer schedules the background cascade deletion of an account
+// (notes / drive / following purge), mirroring admin/delete-account (#2230).
+type DeleteAccountEnqueuer interface {
+	EnqueueDeleteAccount(payload queue.DeleteAccountPayload) error
+}
+
+// SetDeleteAccountEnqueuer wires the cascade-deletion enqueuer used by
+// i/delete-account (#2230). nil leaves the account logically deleted only.
+func (h *Handler) SetDeleteAccountEnqueuer(e DeleteAccountEnqueuer) {
+	h.deleteAccountEnqueuer = e
+}
+
+// AccountDeletionFederationHook delivers the AP Delete(actor) activity to the
+// account's followers' sharedInboxes on self-deletion (#2230).
+type AccountDeletionFederationHook interface {
+	OnUserDeleted(user *model.User)
+}
+
+// SetAccountDeletionFederationHook wires the federation Delete(actor) hook used
+// by i/delete-account (#2230). nil skips federation delivery.
+func (h *Handler) SetAccountDeletionFederationHook(hook AccountDeletionFederationHook) {
+	h.accountDeletionFed = hook
+}
+
+// isProtectedSelfDelete reports whether the self-deleting user is a root or local
+// system account that must never be deleted (#2230). Mirrors admin's
+// isProtectedAccount: IsRoot, or a local (host==nil) account whose username
+// contains '.' (systemaccount uses `<kind>.actor`).
+func isProtectedSelfDelete(u *model.User) bool {
+	if u == nil {
+		return false
+	}
+	if u.IsRoot {
+		return true
+	}
+	return u.Host == nil && strings.Contains(u.Username, ".")
 }
 
 // Favorites handles POST /api/i/favorites.

--- a/internal/api/i/handler_extra_test.go
+++ b/internal/api/i/handler_extra_test.go
@@ -3,6 +3,7 @@ package i
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"github.com/shiroha-a/mk/internal/entitycompat/shapetest"
 	"github.com/shiroha-a/mk/internal/misc/id"
 	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/queue"
 	"github.com/shiroha-a/mk/internal/server/middleware"
 	"github.com/shiroha-a/mk/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -596,4 +598,78 @@ func TestClaimAchievement_Duplicate_NoNotification(t *testing.T) {
 	rec := postExtra(h.ClaimAchievement, `{"name":"notes1"}`, &model.User{ID: "u1"})
 	require.Equal(t, http.StatusNoContent, rec.Code)
 	assert.Empty(t, notifier.calls)
+}
+
+// --- #2230: i/delete-account の cascade 削除 + 連合 Delete ---
+
+type fakeDeleteEnqueuer struct {
+	called []string
+	err    error
+}
+
+func (f *fakeDeleteEnqueuer) EnqueueDeleteAccount(p queue.DeleteAccountPayload) error {
+	f.called = append(f.called, p.UserID)
+	return f.err
+}
+
+type fakeAccountDeletionFed struct{ deleted []string }
+
+func (f *fakeAccountDeletionFed) OnUserDeleted(u *model.User) {
+	f.deleted = append(f.deleted, u.ID)
+}
+
+// #2230: noteIds/drive purge の cascade job enqueue と AP Delete(actor) 配信が
+// 走ることを検証する (論理削除フラグだけでなく実削除が triggered される)。
+func TestDeleteAccount_EnqueuesCascadeAndFederates(t *testing.T) {
+	h, repo := newExtraHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	enq := &fakeDeleteEnqueuer{}
+	fed := &fakeAccountDeletionFed{}
+	h.SetDeleteAccountEnqueuer(enq)
+	h.SetAccountDeletionFederationHook(fed)
+
+	rec := postExtra(h.DeleteAccount, `{"password":"pass"}`, user)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.True(t, repo.Users["u1"].IsDeleted)
+	assert.Equal(t, []string{"u1"}, enq.called, "cascade delete job must be enqueued")
+	assert.Equal(t, []string{"u1"}, fed.deleted, "AP Delete(actor) must be delivered")
+}
+
+// #2230: enqueue が失敗しても論理削除フラグは立ったままなので 204 を返す
+// (フラグが source of truth、cleanup は次回 retry に委ねる)。
+func TestDeleteAccount_EnqueueErrorStillReturns204(t *testing.T) {
+	h, repo := newExtraHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	h.SetDeleteAccountEnqueuer(&fakeDeleteEnqueuer{err: errors.New("boom")})
+
+	rec := postExtra(h.DeleteAccount, `{"password":"pass"}`, user)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.True(t, repo.Users["u1"].IsDeleted)
+}
+
+// #2230: root アカウントの自己削除は cascade 前に 403 で拒否し、削除も enqueue もしない。
+func TestDeleteAccount_ProtectedRootRejected(t *testing.T) {
+	h, repo := newExtraHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	user.IsRoot = true
+	enq := &fakeDeleteEnqueuer{}
+	h.SetDeleteAccountEnqueuer(enq)
+
+	rec := postExtra(h.DeleteAccount, `{"password":"pass"}`, user)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "ACCESS_DENIED")
+	assert.False(t, repo.Users["u1"].IsDeleted, "protected account must not be marked deleted")
+	assert.Empty(t, enq.called, "protected account must not enqueue cascade")
+}
+
+// #2230: ローカル system account (host=nil + username に '.') も自己削除を拒否する。
+func TestDeleteAccount_ProtectedSystemRejected(t *testing.T) {
+	h, repo := newExtraHandler(t)
+	user := setupUserWithPassword(repo, "u1", "pass")
+	user.Username = "relay.actor"
+	user.Host = nil
+
+	rec := postExtra(h.DeleteAccount, `{"password":"pass"}`, user)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.False(t, repo.Users["u1"].IsDeleted)
 }

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -1645,6 +1645,10 @@ func (s *Server) setupRoutes() {
 
 	// i/export-* and i/import-* (Phase 9.4)
 	iHandler.SetTransferEnqueuer(s.queueClient)
+	// #2230: i/delete-account の cascade 削除 (notes/drive/following purge) と AP Delete(actor)
+	// 配信を admin/delete-account と同経路で配線する。未配線だと論理削除フラグだけ立って実削除が走らない。
+	iHandler.SetDeleteAccountEnqueuer(s.queueClient)
+	iHandler.SetAccountDeletionFederationHook(corefederation.NewUserModerationDeliveryHook(deliverService, apRenderer, userRepo))
 	api.POST("/i/export-notes", iHandler.ExportNotes, middleware.RequireAuth(), middleware.RequireSecure())
 	api.POST("/i/export-following", iHandler.ExportFollowing, middleware.RequireAuth(), middleware.RequireSecure())
 	api.POST("/i/export-blocking", iHandler.ExportBlocking, middleware.RequireAuth(), middleware.RequireSecure())


### PR DESCRIPTION
## Summary
`i/delete-account` が `isSuspended`/`isDeleted` フラグを立てるだけで cascade 削除 job を enqueue せず、連合 Delete も配信していなかった。このため「凍結状態になりログイン不可だが削除は実行されない」(notes/drive/following が purge されず連合先にも伝わらない) 状態だった (#2230)。

## 主な変更点
- `i/delete-account` に admin/delete-account と同経路の処理を追加:
  1. **AP Delete(actor)** を sharedInbox へ配信 (`SetAccountDeletionFederationHook`)。
  2. **cascade 削除 job** (notes/drive/following purge) を enqueue (`SetDeleteAccountEnqueuer`)。
- cascade は soft (user 行/署名鍵を残す = upstream `DeleteAccountProcessorService` と同じ) なので queue 経由配信でも署名鍵は生存。
- 実削除が走るようになり blast radius が広がるため、**root / local system account の自己削除を 403 拒否** (upstream の rootUserId / system account ガード相当)。
- router で `iHandler` に enqueuer / federation hook を配線。

## テスト
- `TestDeleteAccount_EnqueuesCascadeAndFederates` — cascade enqueue + AP Delete 配信を検証
- `TestDeleteAccount_EnqueueErrorStillReturns204` — enqueue 失敗でもフラグは立つので 204
- `TestDeleteAccount_ProtectedRootRejected` / `_ProtectedSystemRejected` — 保護アカウントの自己削除 403
- `internal/api/i` coverage 90.7%、`go vet ./...` clean

Closes #2230