### PR TITLE
delete-account の cascade で local user 行を物理削除する (Closes #2230)

### DIFF
--- a/internal/api/admin/accounts.go
+++ b/internal/api/admin/accounts.go
@@ -24,6 +24,8 @@ func (h *Handler) AccountsDelete(c echo.Context) error {
 	if h.isProtectedAccount(req.UserID) {
 		return c.JSON(http.StatusForbidden, apierr.Error("ACCESS_DENIED", "Cannot delete a root or system account.", "1fb7cb09-d46a-4fff-b8df-057708cce513"))
 	}
+	// #2230: local user は物理削除 (Soft=false)、remote user は tombstone (Soft=true)。
+	user, _ := h.userRepo.FindByID(req.UserID)
 	if err := h.userRepo.UpdateUser(req.UserID, map[string]any{"isSuspended": true, "isDeleted": true}); err == nil {
 		// 論理削除直後の auth bypass 防止 (#965)。target の全 token cache
 		// entry を即時 invalidate して 30s stale window を消す。DB 更新が
@@ -31,7 +33,7 @@ func (h *Handler) AccountsDelete(c echo.Context) error {
 		h.invalidateUserTokenCache(req.UserID)
 		h.logUserAction(c, moderationlog.LogDeleteAccount, req.UserID)
 	}
-	h.scheduleAccountCascade(req.UserID)
+	h.scheduleAccountCascade(req.UserID, user != nil && user.Host != nil)
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -85,12 +87,17 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 		h.logUserAction(c, moderationlog.LogDeleteAccount, req.UserID)
 	}
 	// upstream DeleteAccountService: local user は物理削除 job の前に全 sharedInbox
-	// へ Delete(actor) を配信する (#1759)。mk-go の cascade は soft (user 行/鍵を
-	// 残す) ため queue 経由配信でも署名鍵は生存する。
+	// へ Delete(actor) を配信する (#1759)。deliver は cascade より先に enqueue され、
+	// cascade も note purge を先に行うため実運用では署名鍵が生存した状態で配信される
+	// (別 queue ゆえ厳密な順序保証は無い best-effort、upstream も同構造)。
 	if user != nil && h.userModerationFed != nil {
 		h.userModerationFed.OnUserDeleted(user)
 	}
-	h.scheduleAccountCascade(req.UserID)
+	// #2230: local user (host==nil) は user 行を物理削除 (Soft=false)、remote user は再連合での
+	// 復活を防ぐため tombstone として残す (Soft=true)。upstream DeleteAccountService の
+	// isLocalUser 分岐に対応する。
+	soft := user != nil && user.Host != nil
+	h.scheduleAccountCascade(req.UserID, soft)
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -129,11 +136,11 @@ func (h *Handler) isProtectedAccount(userID string) bool {
 // from the enqueuer are logged but never surfaced — the admin flag flip
 // is the user-visible source of truth, so a failed enqueue only delays
 // the cleanup until the next manual retry.
-func (h *Handler) scheduleAccountCascade(userID string) {
+func (h *Handler) scheduleAccountCascade(userID string, soft bool) {
 	if h.deleteAccountEnqueuer == nil || userID == "" {
 		return
 	}
-	if err := h.deleteAccountEnqueuer.EnqueueDeleteAccount(queue.DeleteAccountPayload{UserID: userID}); err != nil {
+	if err := h.deleteAccountEnqueuer.EnqueueDeleteAccount(queue.DeleteAccountPayload{UserID: userID, Soft: soft}); err != nil {
 		slog.Warn("admin: enqueue delete-account failed", "userId", userID, "err", err)
 	}
 }

--- a/internal/api/i/handler_extra.go
+++ b/internal/api/i/handler_extra.go
@@ -130,15 +130,17 @@ func (h *Handler) DeleteAccount(c echo.Context) error {
 	// handler.go の invalidateUserTokenCache を参照。
 	h.invalidateUserTokenCache(u.ID)
 
-	// #2230: 論理削除フラグを立てるだけでは notes / drive / following が purge されず、
-	// 連合先にも削除が伝わらない (= 「凍結止まりで削除が実行されない」)。admin/delete-account と
-	// 同様に (1) sharedInbox へ Delete(actor) を配信し、(2) cascade 削除 job を enqueue する。
-	// cascade は soft (user 行 / 署名鍵を残す) なので queue 経由配信でも鍵は生存する。
+	// #2230: 論理削除フラグを立てるだけでは notes / drive / following が purge されず、user 行も
+	// 残るので「凍結状態のまま消えない」。admin/delete-account と同様に (1) sharedInbox へ
+	// Delete(actor) を配信し、(2) cascade 削除 job を enqueue する。Delete(actor) deliver は
+	// cascade より先に enqueue し、cascade も note purge を先に行うため実運用では署名鍵が生存した
+	// 状態で配信される (別 queue ゆえ厳密な順序保証は無い best-effort、upstream も同構造)。
 	if h.accountDeletionFed != nil {
 		h.accountDeletionFed.OnUserDeleted(u)
 	}
 	if h.deleteAccountEnqueuer != nil {
-		if err := h.deleteAccountEnqueuer.EnqueueDeleteAccount(queue.DeleteAccountPayload{UserID: u.ID}); err != nil {
+		// 自己削除は常に local user なので Soft=false で user 行を物理削除する (#2230)。
+		if err := h.deleteAccountEnqueuer.EnqueueDeleteAccount(queue.DeleteAccountPayload{UserID: u.ID, Soft: false}); err != nil {
 			// enqueue 失敗は user 可視のエラーにしない (フラグは既に立っている)。
 			// 次回手動 retry / 再ログイン不可状態は維持されるため 204 を返す。
 			slog.Warn("i/delete-account: enqueue cascade failed", "userId", u.ID, "err", err)

--- a/internal/api/i/handler_extra_test.go
+++ b/internal/api/i/handler_extra_test.go
@@ -603,12 +603,14 @@ func TestClaimAchievement_Duplicate_NoNotification(t *testing.T) {
 // --- #2230: i/delete-account の cascade 削除 + 連合 Delete ---
 
 type fakeDeleteEnqueuer struct {
-	called []string
-	err    error
+	called   []string
+	payloads []queue.DeleteAccountPayload
+	err      error
 }
 
 func (f *fakeDeleteEnqueuer) EnqueueDeleteAccount(p queue.DeleteAccountPayload) error {
 	f.called = append(f.called, p.UserID)
+	f.payloads = append(f.payloads, p)
 	return f.err
 }
 
@@ -633,6 +635,9 @@ func TestDeleteAccount_EnqueuesCascadeAndFederates(t *testing.T) {
 	assert.True(t, repo.Users["u1"].IsDeleted)
 	assert.Equal(t, []string{"u1"}, enq.called, "cascade delete job must be enqueued")
 	assert.Equal(t, []string{"u1"}, fed.deleted, "AP Delete(actor) must be delivered")
+	// 自己削除は local user なので user 行を物理削除する hard delete (Soft=false)。
+	require.Len(t, enq.payloads, 1)
+	assert.False(t, enq.payloads[0].Soft, "self-delete must hard-delete the user row")
 }
 
 // #2230: enqueue が失敗しても論理削除フラグは立ったままなので 204 を返す

--- a/internal/api/resetpassword/handler_test.go
+++ b/internal/api/resetpassword/handler_test.go
@@ -342,3 +342,5 @@ func TestSecureRandomHex(t *testing.T) {
 	s2 := misc.SecureRandomHex(64)
 	assert.NotEqual(t, s, s2)
 }
+
+func (m *mockUserRepo) HardDeleteUser(string) error { return nil }

--- a/internal/core/federation/processor.go
+++ b/internal/core/federation/processor.go
@@ -1654,7 +1654,9 @@ func (p *Processor) handleActorDelete(actor *model.User) error {
 		return fmt.Errorf("actor delete: mark deleted: %w", err)
 	}
 	if p.accountDeleteEnqueuer != nil {
-		if err := p.accountDeleteEnqueuer.EnqueueDeleteAccount(queue.DeleteAccountPayload{UserID: actor.ID}); err != nil {
+		// #2230: inbound Delete(actor) は remote user なので Soft=true で行を tombstone として
+		// 残す。物理削除すると再連合 (resolve) でアカウントが復活し得る (upstream 同様)。
+		if err := p.accountDeleteEnqueuer.EnqueueDeleteAccount(queue.DeleteAccountPayload{UserID: actor.ID, Soft: true}); err != nil {
 			slog.Warn("actor delete: enqueue cascade purge failed", "userId", actor.ID, "err", err)
 		}
 	}

--- a/internal/core/retention/service_test.go
+++ b/internal/core/retention/service_test.go
@@ -434,3 +434,5 @@ func TestService_Aggregate_CorruptDataRowIsSkipped(t *testing.T) {
 	// merge が失敗 → continue で Update は走らない。
 	assert.Equal(t, 0, retentions.updateCalls)
 }
+
+func (s *stubUserRepo) HardDeleteUser(string) error { return nil }

--- a/internal/queue/processors/delete_account.go
+++ b/internal/queue/processors/delete_account.go
@@ -12,13 +12,23 @@ import (
 )
 
 // DeleteAccountProcessor cascades through a user's related rows (notes,
-// drive files, follow graph) after admin/accounts/delete has flipped the
-// soft-delete flags. The user row itself is NOT deleted — it is kept for
-// moderation log retention with only isDeleted=true set.
+// drive files, follow graph) after delete-account has flipped the soft-delete
+// flags. For a non-soft (local) deletion it then physically removes the user
+// row so the account fully disappears; for a soft (remote) deletion the row is
+// kept as a tombstone to prevent resurrection on re-federation (#2230).
 type DeleteAccountProcessor struct {
 	noteRepo      repository.NoteRepository
 	driveFileRepo repository.DriveFileRepository
 	followingRepo repository.FollowingRepository
+	// userRepo は Soft=false (local) 時の user 行物理削除に使う optional 依存 (#2230)。
+	// 未配線なら hard delete を skip し従来の soft 削除のままになる。
+	userRepo repository.UserRepository
+}
+
+// SetUserRepo wires the UserRepository used to physically delete the user row
+// for non-soft (local) account deletion (#2230). nil keeps the soft behavior.
+func (p *DeleteAccountProcessor) SetUserRepo(r repository.UserRepository) {
+	p.userRepo = r
 }
 
 // NewDeleteAccountProcessor wires the processor with the repositories it
@@ -92,6 +102,22 @@ func (p *DeleteAccountProcessor) Handle(ctx context.Context, t driver.Task) erro
 			slog.Info("delete-account: following rows deleted",
 				"userId", payload.UserID, "count", deleted)
 		}
+	}
+
+	// #2230: local user (Soft=false) は user 行を物理削除する。FK ON DELETE CASCADE で
+	// profile / keypair / 残りの従属行も消えるため、論理削除フラグだけ立った「凍結状態の
+	// tombstone」が残らずアカウントが完全に消える。remote user (Soft=true) は再連合での
+	// 復活を防ぐため行を残す (upstream DeleteAccountProcessorService の soft 分岐と同じ)。
+	if !payload.Soft && p.userRepo != nil {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := p.userRepo.HardDeleteUser(payload.UserID); err != nil {
+			slog.Error("delete-account: user row purge failed",
+				"userId", payload.UserID, "err", err)
+			return err
+		}
+		slog.Info("delete-account: user row deleted", "userId", payload.UserID)
 	}
 	return nil
 }

--- a/internal/queue/processors/delete_account_test.go
+++ b/internal/queue/processors/delete_account_test.go
@@ -219,3 +219,35 @@ func TestDeleteAccountProcessor_NotesDeletedAcrossMultipleBatches(t *testing.T) 
 		assert.NotEqual(t, "target", n.UserID)
 	}
 }
+
+// #2230: local user (Soft=false) は cascade 後に user 行を物理削除する。
+func TestDeleteAccountProcessor_HardDeletesLocalUser(t *testing.T) {
+	noteRepo := testutil.NewMockNoteRepository()
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["target"] = &model.User{ID: "target"}
+	p := processors.NewDeleteAccountProcessor(noteRepo, testutil.NewMockDriveFileRepository(), testutil.NewMockFollowingRepository())
+	p.SetUserRepo(userRepo)
+
+	task := deleteAccountTask(t, queue.DeleteAccountPayload{UserID: "target", Soft: false})
+	require.NoError(t, p.Handle(context.Background(), task))
+	assert.NotContains(t, userRepo.Users, "target", "local user row must be physically deleted")
+}
+
+// #2230: remote user (Soft=true) は再連合での復活を防ぐため user 行を残す。
+func TestDeleteAccountProcessor_SoftKeepsUser(t *testing.T) {
+	userRepo := testutil.NewMockUserRepository()
+	userRepo.Users["remote"] = &model.User{ID: "remote"}
+	p := processors.NewDeleteAccountProcessor(testutil.NewMockNoteRepository(), testutil.NewMockDriveFileRepository(), testutil.NewMockFollowingRepository())
+	p.SetUserRepo(userRepo)
+
+	task := deleteAccountTask(t, queue.DeleteAccountPayload{UserID: "remote", Soft: true})
+	require.NoError(t, p.Handle(context.Background(), task))
+	assert.Contains(t, userRepo.Users, "remote", "soft delete must keep the user row as tombstone")
+}
+
+// #2230: userRepo 未配線なら hard delete を skip する (従来の soft 挙動)。
+func TestDeleteAccountProcessor_NoUserRepoSkipsHardDelete(t *testing.T) {
+	p := processors.NewDeleteAccountProcessor(testutil.NewMockNoteRepository(), testutil.NewMockDriveFileRepository(), testutil.NewMockFollowingRepository())
+	task := deleteAccountTask(t, queue.DeleteAccountPayload{UserID: "x", Soft: false})
+	require.NoError(t, p.Handle(context.Background(), task))
+}

--- a/internal/queue/tasks.go
+++ b/internal/queue/tasks.go
@@ -321,6 +321,12 @@ func DecodeWebhookPayload(body []byte) (WebhookPayload, error) {
 // cascade-deleted by the background processor.
 type DeleteAccountPayload struct {
 	UserID string `json:"userId"`
+	// Soft, when true, keeps the user row as a tombstone (notes/files are still
+	// purged). Remote-user deletion (inbound AP Delete(actor)) uses Soft=true to
+	// avoid resurrection on re-federation. Local self/admin deletion uses
+	// Soft=false to physically remove the row so the account fully disappears
+	// (#2230). upstream DeleteAccountProcessorService の `job.data.soft` 準拠。
+	Soft bool `json:"soft"`
 }
 
 // NewDeleteAccountTask serializes a DeleteAccountPayload into a driver.Task.

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -91,6 +91,11 @@ type UserRepository interface {
 	// viewer does not already follow, ordered by followersCount descending.
 	// viewerID is excluded from results. Used by users/recommendation.
 	ListUserRecommendations(viewerID string, activeSince time.Time, limit, offset int) ([]*model.User, error)
+	// HardDeleteUser permanently removes the user row. FK ON DELETE CASCADE purges
+	// dependent rows (profile, keypair, following, blocking, ...). Used by the
+	// delete-account cascade for local users (Soft=false) so the account fully
+	// disappears instead of lingering as a suspended tombstone (#2230).
+	HardDeleteUser(userID string) error
 }
 
 type userRepository struct {
@@ -381,6 +386,15 @@ func (r *userRepository) UpdateUser(userID string, fields map[string]any) error 
 		return nil
 	}
 	return r.db.Model(&model.User{}).Where("id = ?", userID).Updates(fields).Error
+}
+
+// HardDeleteUser permanently removes the user row, relying on FK ON DELETE
+// CASCADE to purge dependent rows (profile/keypair/following/...) (#2230).
+func (r *userRepository) HardDeleteUser(userID string) error {
+	if userID == "" {
+		return nil
+	}
+	return r.db.Exec(`DELETE FROM "user" WHERE "id" = ?`, userID).Error
 }
 
 // UpdateProfile updates the given columns on the user_profile table.

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -1500,3 +1500,30 @@ func TestUserRepository_CountLocalUsers_Error(t *testing.T) {
 	_, err = repo.CountLocalUsersActiveSince(time.Now())
 	assert.Error(t, err)
 }
+
+// #2230: HardDeleteUser は user 行を物理削除し、FK ON DELETE CASCADE で従属行
+// (note 等) も消える。delete-account cascade の local user 物理削除を支える。
+func TestUserRepository_HardDeleteUser(t *testing.T) {
+	repo := NewUserRepository(testDB)
+	user := insertTestUser(t, "u_hd_1", "hduser")
+
+	text := "x"
+	require.NoError(t, testDB.Create(&model.Note{
+		ID: "n_hd_1", UserID: user.ID, Text: &text,
+		Visibility: model.NoteVisibilityPublic, Reactions: datatypes.JSON([]byte("{}")),
+	}).Error)
+
+	require.NoError(t, repo.HardDeleteUser(user.ID))
+
+	// user 行が消えている。
+	_, err := repo.FindByID(user.ID)
+	assert.Error(t, err, "user row must be physically gone")
+	// note が FK cascade で消えている。
+	var nc int64
+	require.NoError(t, testDB.Model(&model.Note{}).Where(`"userId" = ?`, user.ID).Count(&nc).Error)
+	assert.Zero(t, nc, "notes must cascade on user delete")
+
+	// 空 ID / 不在 ID は no-op (error にしない)。
+	require.NoError(t, repo.HardDeleteUser(""))
+	require.NoError(t, repo.HardDeleteUser("nonexistent_hd"))
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -755,6 +755,8 @@ func (s *Server) setupRoutes() {
 	// Account cascade deletion (issue #187): admin/accounts/delete の後続
 	// バックグラウンド処理。note / drive_file / following 関連行を掃除する。
 	deleteAccountProcessor := processors.NewDeleteAccountProcessor(noteRepo, driveFileRepo, followingRepo)
+	// #2230: local user の物理削除に userRepo を配線。未配線だと soft 削除止まりで行が残る。
+	deleteAccountProcessor.SetUserRepo(userRepo)
 	s.queueServer.Handle(queue.TaskTypeDeleteAccount, deleteAccountProcessor.Handle)
 
 	// Per-pair Unfollow job (#587): admin/federation/remove-all-following

--- a/internal/testutil/mock_repository.go
+++ b/internal/testutil/mock_repository.go
@@ -291,6 +291,12 @@ func (m *MockUserRepository) UpdateUser(userID string, fields map[string]any) er
 	return nil
 }
 
+func (m *MockUserRepository) HardDeleteUser(userID string) error {
+	delete(m.Users, userID)
+	delete(m.Profiles, userID)
+	return nil
+}
+
 func (m *MockUserRepository) CreateProfile(profile *model.UserProfile) error {
 	m.Profiles[profile.UserID] = profile
 	return nil


### PR DESCRIPTION
## Summary
#2231 (前回修正) で cascade enqueue + 連合 Delete は入ったが、cascade processor が notes/drive/following を purge するだけで **user 行を物理削除していなかった**。このため「凍結状態のまま user 行が残りアカウントが消えない」状態だった (#2230 再発)。

upstream `DeleteAccountProcessorService` は `soft` 指定が無い (= local user の) 場合 `usersRepository.delete(id)` で行を物理削除する。これに揃える。

## 主な変更点
- **`DeleteAccountPayload` に `Soft` フラグ追加**。local self/admin 削除は `Soft=false` (物理削除)、inbound AP `Delete(actor)` の remote user は `Soft=true` (再連合での復活を防ぐ tombstone)。
- **cascade processor に `SetUserRepo`** を追加し、`Soft=false` 時に `UserRepository.HardDeleteUser` で user 行を物理削除。FK `ON DELETE CASCADE` で profile/keypair/following 等の従属行も消える (全 user 参照 FK が CASCADE/SET NULL であることを確認済)。
- **3 経路で `Soft` を出し分け**: `i/delete-account`=false / `admin` (host で local/remote 判定) / `federation` inbound=true。

## 連合 Delete の race について
`Delete(actor)` deliver は cascade より先に enqueue され、cascade も note purge を先に行うため実運用では署名鍵が生存した状態で配信される。別 queue ゆえ厳密な順序保証は無い best-effort だが、upstream も同構造。

## テスト
- **`TestUserRepository_HardDeleteUser` (real DB)**: user 行物理削除 + note の FK cascade を実証。
- processor: `Soft=false` 物理削除 / `Soft=true` tombstone 維持 / userRepo 未配線 skip。
- `i/delete-account`: enqueue payload が `Soft=false` であることを検証。
- 全 package で `go vet ./...` clean、coverage gate 維持。

Closes #2230