### PR TITLE
Fix: HTTP署名のkey confusionによる連合認証バイパスを修正

### DIFF
--- a/internal/core/federation/resolver.go
+++ b/internal/core/federation/resolver.go
@@ -133,7 +133,11 @@ type PublickeyStore interface {
 // の rogue verify を許してしまう (#1070 follow-up)。
 type PublickeyExtraStore interface {
 	Upsert(pk *model.UserPublickeyExtra) error
-	FindByKeyID(keyID string) (*model.UserPublickeyExtra, error)
+	// FindByUserAndKeyID は (userID, keyID) で actor-scope に鍵を引く。keyID 単独の
+	// global lookup (FindByKeyID) は、攻撃者 actor が assertionMethod に victim の
+	// keyId を載せて鍵を植え込み victim を verify する key confusion を許すため、
+	// 意図的に interface へ公開しない (#security: HTTP-sig key confusion)。
+	FindByUserAndKeyID(userID, keyID string) (*model.UserPublickeyExtra, error)
 	ListByUserID(userID string) ([]model.UserPublickeyExtra, error)
 	DeleteByKeyID(userID, keyID string) error
 }
@@ -543,7 +547,7 @@ func (r *Resolver) resolveActorOnce(uri string, allowCrossHost bool) (*model.Use
 		slog.Warn("create remote user profile failed", "userId", user.ID, "err", err)
 	}
 	r.cachePublicKey(user.ID, actor.PublicKey.ID, actor.PublicKey.PublicKeyPEM)
-	r.cacheAssertionMethods(user.ID, actor.AssertionMethod)
+	r.cacheAssertionMethods(user.ID, actor.ID, actor.AssertionMethod)
 	r.notifyInstance(host)
 	if r.chartHook != nil {
 		r.chartHook.OnRemoteUserCreated(user)
@@ -730,7 +734,7 @@ func (r *Resolver) refreshActor(existing *model.User, uri string) {
 		_ = r.userRepo.UpdateProfile(existing.ID, map[string]any{"description": desc})
 	}
 	r.cachePublicKey(existing.ID, actor.PublicKey.ID, actor.PublicKey.PublicKeyPEM)
-	r.cacheAssertionMethods(existing.ID, actor.AssertionMethod)
+	r.cacheAssertionMethods(existing.ID, actor.ID, actor.AssertionMethod)
 	if existing.Host != nil {
 		r.notifyInstance(*existing.Host)
 	}
@@ -787,6 +791,18 @@ func (r *Resolver) fetchActor(uri string, allowCrossHost bool) (*activitypub.Per
 		slog.Warn("federation: rejecting non-actor type", "uri", uri, "type", actor.Type)
 		return nil, ErrInvalidActor
 	}
+	// publicKey.id (= HTTP Signature keyId) host を actor.ID host に縛る (Fix A、
+	// upstream validateActor の publicKey.id host check と同型、#1820 の object-host
+	// binding を鍵にも拡張)。これが無いと攻撃者 actor が publicKey.id に victim
+	// ドメインの keyId を載せて自分の RSA 鍵を植え込み、LD-Signature 経路の
+	// global FindByKeyID 解決で victim を名乗る活動を verify 通過させられる
+	// (key confusion / 連合認証バイパス)。allowCrossHost (ap/show) でも keyId は
+	// actor 自身の host に縛る (request host とは独立、upstream expectHost と同じ)。
+	if actor.PublicKey.ID != "" && !sameURIHost(actor.PublicKey.ID, actor.ID) {
+		slog.Warn("federation: actor publicKey.id host mismatch",
+			"uri", uri, "id", actor.ID, "publicKeyID", actor.PublicKey.ID)
+		return nil, ErrObjectHostMismatch
+	}
 	return &actor, nil
 }
 
@@ -799,7 +815,7 @@ func (r *Resolver) refreshPublicKey(userID, uri string) {
 		return
 	}
 	r.cachePublicKey(userID, actor.PublicKey.ID, actor.PublicKey.PublicKeyPEM)
-	r.cacheAssertionMethods(userID, actor.AssertionMethod)
+	r.cacheAssertionMethods(userID, actor.ID, actor.AssertionMethod)
 }
 
 // cachePublicKey stores a PEM in the in-memory cache and optionally persists
@@ -830,7 +846,7 @@ func (r *Resolver) cachePublicKey(userID, keyID, pem string) {
 // 上必須。publickeyExtraRepo 未配線 (= 旧 deployment) のときは何もしない。
 // 不正な entry (非 Multikey type / decode 失敗 / persist 失敗) は warn log
 // + skip して RSA only にフォールバックする (fail-soft)。
-func (r *Resolver) cacheAssertionMethods(userID string, ams []activitypub.Multikey) {
+func (r *Resolver) cacheAssertionMethods(userID, actorURI string, ams []activitypub.Multikey) {
 	if r.publickeyExtraRepo == nil {
 		return
 	}
@@ -838,6 +854,19 @@ func (r *Resolver) cacheAssertionMethods(userID string, ams []activitypub.Multik
 	receivedKeyIDs := make(map[string]bool, len(ams))
 	for _, am := range ams {
 		if am.Type != activitypub.MultikeyType || am.ID == "" || am.PublicKeyMultibase == "" {
+			continue
+		}
+		// keyId (am.ID) の host を actor の host に縛る (Fix B, upstream validateActor の
+		// publicKey.id host check と同型)。これが無いと攻撃者 actor が assertionMethod に
+		// victim ドメインの keyId を載せ、自分の Ed25519 鍵を victim の keyId で植え込んで
+		// victim を名乗る署名を verify 通過させられる (key confusion / 連合認証バイパス)。
+		// 検証鍵の lookup key は am.ID 自身 (PublicKeyForKeyID) なので、am.ID の host を
+		// actor に縛れば植え込み経路は塞がる (controller は lookup に使われないため追加検証
+		// は不要)。不正 entry は既存の decode 失敗時と同じく warn + skip (fail-soft、
+		// actor 自体は取り込む)。
+		if !sameURIHost(am.ID, actorURI) {
+			slog.Warn("assertionMethod keyId host mismatch",
+				"userID", userID, "actorURI", actorURI, "keyID", am.ID)
 			continue
 		}
 		pub, err := activitypub.DecodeEd25519Multikey(am.PublicKeyMultibase)
@@ -888,13 +917,19 @@ func (r *Resolver) cacheAssertionMethods(userID string, ams []activitypub.Multik
 // から正しい公開鍵を選ぶための path で、in-memory cache は介さない (= 永続層
 // の最新値で verify する)。
 //
+// 鍵は必ず actorID-scope で引く (FindByUserAndKeyID)。keyID 単独の global lookup に
+// すると、攻撃者 actor が assertionMethod に victim の keyId を載せて自分の鍵を
+// 植え込み、victim を名乗る署名を verify 通過させる key confusion (連合認証
+// バイパス) が成立する。actor (= keyId base から解決した signer) に紐づく鍵だけを
+// 許すことで、植え込まれた cross-actor 鍵を読取段でも排除する (Fix C, 二重防御)。
+//
 // `gorm.ErrRecordNotFound` (= keyId 一致なし = 通常状態) は silent fallback、
 // それ以外の DB error は診断のため slog.Warn を出す (= silent degradation を
 // 回避)。stale assertion key の削除は cacheAssertionMethods 側で actor fetch
 // 時に diff & delete するため、ここでは古い行が引っかかる可能性は最小化される。
 func (r *Resolver) PublicKeyForKeyID(actorID, keyID string) (string, error) {
 	if r.publickeyExtraRepo != nil && keyID != "" {
-		row, err := r.publickeyExtraRepo.FindByKeyID(keyID)
+		row, err := r.publickeyExtraRepo.FindByUserAndKeyID(actorID, keyID)
 		if err == nil {
 			return row.KeyPEM, nil
 		}
@@ -2224,6 +2259,19 @@ func normalizeMatchHost(u *url.URL) string {
 		return host + ":" + port
 	}
 	return host
+}
+
+// sameURIHost reports whether two absolute URIs share the same normalized host
+// (normalizeMatchHost: punycode + default-port + leading-www 正規化)。署名鍵の
+// keyId (publicKey.id / assertionMethod[].id) を actor URI の host に縛るために
+// 使う。どちらかが parse 不能 / host 欠落なら false (= 不一致扱い) を返す。
+func sameURIHost(a, b string) bool {
+	au, aerr := url.Parse(a)
+	bu, berr := url.Parse(b)
+	if aerr != nil || berr != nil || au.Hostname() == "" || bu.Hostname() == "" {
+		return false
+	}
+	return normalizeMatchHost(au) == normalizeMatchHost(bu)
 }
 
 // extractAttachments parses the AP `attachment` array (heterogeneous []any

--- a/internal/core/federation/resolver_test.go
+++ b/internal/core/federation/resolver_test.go
@@ -4351,18 +4351,6 @@ func (s *stubPublickeyExtraRepo) Upsert(pk *model.UserPublickeyExtra) error {
 	return nil
 }
 
-func (s *stubPublickeyExtraRepo) FindByKeyID(keyID string) (*model.UserPublickeyExtra, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	if pk, ok := s.entries[keyID]; ok {
-		return pk, nil
-	}
-	// production の gorm 経由 repository は ErrRecordNotFound を返すので、
-	// stub も同じ semantic を返して PublicKeyForKeyID の DB error と "行なし"
-	// の区別 path をテスト経由でも walk できるようにする (#1070 follow-up)。
-	return nil, gorm.ErrRecordNotFound
-}
-
 func (s *stubPublickeyExtraRepo) ListByUserID(userID string) ([]model.UserPublickeyExtra, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -4396,7 +4384,10 @@ func (s *stubPublickeyExtraRepo) FindByUserAndKeyID(userID, keyID string) (*mode
 	if pk, ok := s.entries[keyID]; ok && pk.UserID == userID {
 		return pk, nil
 	}
-	return nil, errors.New("not found")
+	// production の gorm repository は miss 時 ErrRecordNotFound を返す。
+	// PublicKeyForKeyID は ErrRecordNotFound を silent fallback、それ以外を warn と
+	// 区別するので、stub も同じ semantic を返して fallback path を正確に再現する。
+	return nil, gorm.ErrRecordNotFound
 }
 
 func (s *stubPublickeyExtraRepo) DeleteByUserID(userID string) error {
@@ -4469,7 +4460,7 @@ func TestResolveActor_PersistsAssertionMethod(t *testing.T) {
 	user, err := r.ResolveActor("https://remote.example/users/alice")
 	require.NoError(t, err)
 
-	row, err := extra.FindByKeyID("https://remote.example/users/alice#ed25519-key")
+	row, err := extra.FindByUserAndKeyID(user.ID, "https://remote.example/users/alice#ed25519-key")
 	require.NoError(t, err)
 	assert.Equal(t, user.ID, row.UserID)
 	assert.Equal(t, model.AlgEd25519, row.Alg)
@@ -4550,6 +4541,97 @@ func TestPublicKeyForKeyID_DualLookup(t *testing.T) {
 	pem, err = r.PublicKeyForKeyID("alice", "https://remote.example/users/alice#main-key")
 	require.NoError(t, err)
 	assert.Contains(t, pem, "RSA-FAKE")
+}
+
+// Fix A (security): cross-host な publicKey.id を持つ actor は fetchActor で
+// reject される。これが無いと攻撃者 actor が publicKey.id に victim の keyId を
+// 載せて自分の RSA 鍵を植え込み、LD-Signature 経路の global FindByKeyID 解決で
+// victim を名乗る活動を verify 通過させられる (key confusion / 連合認証バイパス)。
+func TestResolveActor_RejectsCrossHostPublicKeyID(t *testing.T) {
+	body := `{ "@context": "https://www.w3.org/ns/activitystreams",
+		"id": "https://evil.example/users/mal",
+		"type": "Person",
+		"preferredUsername": "mal",
+		"inbox": "https://evil.example/users/mal/inbox",
+		"publicKey": {
+			"id": "https://victim.example/users/alice#main-key",
+			"owner": "https://victim.example/users/alice",
+			"publicKeyPem": "-----BEGIN PUBLIC KEY-----\nATTACKER\n-----END PUBLIC KEY-----"
+		}
+	}`
+	r, repo := newResolver(t, body, nil)
+	_, err := r.ResolveActor("https://evil.example/users/mal")
+	require.Error(t, err, "cross-host publicKey.id を持つ actor は拒否されるべき")
+	assert.ErrorIs(t, err, federation.ErrObjectHostMismatch)
+	assert.Empty(t, repo.Users, "拒否された actor を DB に作ってはいけない")
+}
+
+// Fix B (security): assertionMethod の keyId (am.ID) host が actor host と一致
+// しない entry は保存されない。攻撃者 actor (evil.example) が victim ドメインの
+// keyId を載せても user_publickey_extra に入らず、key confusion を成立させない。
+// 同一 host の正規 entry は従来どおり保存される。
+func TestResolveActor_SkipsCrossHostAssertionMethodKeyID(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	mb, err := activitypub.EncodeEd25519Multikey(pub)
+	require.NoError(t, err)
+
+	body := `{ "@context": "https://www.w3.org/ns/activitystreams",
+		"id": "https://evil.example/users/mal",
+		"type": "Person",
+		"preferredUsername": "mal",
+		"inbox": "https://evil.example/users/mal/inbox",
+		"publicKey": {"id": "https://evil.example/users/mal#main-key", "owner": "https://evil.example/users/mal", "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nFAKE\n-----END PUBLIC KEY-----"},
+		"assertionMethod": [
+			{"id": "https://evil.example/users/mal#ed25519-key", "type": "Multikey", "controller": "https://evil.example/users/mal", "publicKeyMultibase": "` + mb + `"},
+			{"id": "https://victim.example/users/alice#x9z", "type": "Multikey", "controller": "https://victim.example/users/alice", "publicKeyMultibase": "` + mb + `"}
+		]
+	}`
+	r, _ := newResolver(t, body, nil)
+	extra := &stubPublickeyExtraRepo{}
+	r.SetPublickeyExtraRepo(extra)
+
+	user, err := r.ResolveActor("https://evil.example/users/mal")
+	require.NoError(t, err)
+
+	// 同一 host の entry のみ保存され、cross-host の victim keyId は drop される
+	rows, err := extra.ListByUserID(user.ID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "https://evil.example/users/mal#ed25519-key", rows[0].KeyID)
+
+	// 植え込もうとした victim の keyId は user_publickey_extra に存在しない
+	_, err = extra.FindByUserAndKeyID(user.ID, "https://victim.example/users/alice#x9z")
+	require.Error(t, err, "cross-host keyId は保存されていないはず")
+}
+
+// Fix C (security, defense-in-depth): PublicKeyForKeyID は actorID-scope で鍵を
+// 引く。万一 cross-host keyId が別 actor (mal) 配下に存在しても、victim を actorID
+// に指定した lookup ではヒットせず、攻撃者鍵を返さない。RSA primary に fallback する。
+func TestPublicKeyForKeyID_ActorScopedRejectsPlantedKey(t *testing.T) {
+	r, _ := newResolver(t, sampleActor, nil)
+	pkRepo := &stubPublickeyRepo{entries: map[string]*model.UserPublickey{}}
+	r.SetPublickeyRepo(pkRepo)
+	extra := &stubPublickeyExtraRepo{}
+	r.SetPublickeyExtraRepo(extra)
+
+	// victim alice の正規 RSA primary
+	require.NoError(t, pkRepo.Upsert(&model.UserPublickey{
+		UserID: "alice", KeyID: "https://victim.example/users/alice#main-key",
+		KeyPEM: "-----BEGIN PUBLIC KEY-----\nALICE-RSA\n-----END PUBLIC KEY-----",
+	}))
+	// 攻撃者が mal 配下に alice の keyId で植え込んだ Ed25519 鍵 (Fix B を擦り抜けたと仮定)
+	require.NoError(t, extra.Upsert(&model.UserPublickeyExtra{
+		UserID: "mal", KeyID: "https://victim.example/users/alice#x9z",
+		KeyPEM: "-----BEGIN PUBLIC KEY-----\nATTACKER\n-----END PUBLIC KEY-----",
+		Alg:    model.AlgEd25519,
+	}))
+
+	// alice を actorID にした lookup は植え込み鍵を返さず、alice の RSA primary に fallback
+	pem, err := r.PublicKeyForKeyID("alice", "https://victim.example/users/alice#x9z")
+	require.NoError(t, err)
+	assert.NotContains(t, pem, "ATTACKER", "他 actor 配下の植え込み鍵を返してはいけない")
+	assert.Contains(t, pem, "ALICE-RSA")
 }
 
 // 同じ actor を refresh する経路で stale keyId が削除されることを検証する。

--- a/internal/repository/user_publickey.go
+++ b/internal/repository/user_publickey.go
@@ -38,6 +38,13 @@ func (r *userPublickeyRepository) FindByUserID(userID string) (*model.UserPublic
 	return &pk, nil
 }
 
+// FindByKeyID looks up an RSA primary key by keyId alone (global). This is safe
+// ONLY because the resolver enforces a write-time invariant that a row's keyId
+// host always equals its owning actor's host (fetchActor の publicKey.id host
+// binding, Fix A)。この不変条件が崩れると、攻撃者が victim の keyId で自分の鍵を
+// 植え込んで LD-Signature 経路の verify をすり抜ける key confusion が再発する。
+// 新たに keyId を保存する経路を足すときは必ず host binding を通すこと
+// (#security: HTTP-sig key confusion)。
 func (r *userPublickeyRepository) FindByKeyID(keyID string) (*model.UserPublickey, error) {
 	var pk model.UserPublickey
 	if err := r.db.Where(`"keyId" = ?`, keyID).First(&pk).Error; err != nil {

--- a/internal/repository/user_publickey_extra.go
+++ b/internal/repository/user_publickey_extra.go
@@ -12,8 +12,12 @@ import (
 // publish multiple keys (e.g. RSA + Ed25519).
 type UserPublickeyExtraRepository interface {
 	Upsert(pk *model.UserPublickeyExtra) error
+	// FindByUserAndKeyID looks up a key scoped to its owning actor. 鍵検索は必ず
+	// (userID, keyID) で行うこと。keyID 単独の global lookup は、攻撃者 actor が
+	// assertionMethod に victim の keyId を載せて鍵を植え込み、victim を名乗る署名を
+	// verify 通過させる key confusion (連合認証バイパス) を許すため、本 interface
+	// には意図的に用意しない (#security: HTTP-sig key confusion)。
 	FindByUserAndKeyID(userID, keyID string) (*model.UserPublickeyExtra, error)
-	FindByKeyID(keyID string) (*model.UserPublickeyExtra, error)
 	ListByUserID(userID string) ([]model.UserPublickeyExtra, error)
 	// DeleteByKeyID deletes a single (userID, keyID) row. resolver が actor
 	// fetch 時に assertionMethod[] から消えた keyId を purge する用途 (key
@@ -41,14 +45,6 @@ func (r *userPublickeyExtraRepository) Upsert(pk *model.UserPublickeyExtra) erro
 func (r *userPublickeyExtraRepository) FindByUserAndKeyID(userID, keyID string) (*model.UserPublickeyExtra, error) {
 	var pk model.UserPublickeyExtra
 	if err := r.db.Where(`"userId" = ? AND "keyId" = ?`, userID, keyID).First(&pk).Error; err != nil {
-		return nil, err
-	}
-	return &pk, nil
-}
-
-func (r *userPublickeyExtraRepository) FindByKeyID(keyID string) (*model.UserPublickeyExtra, error) {
-	var pk model.UserPublickeyExtra
-	if err := r.db.Where(`"keyId" = ?`, keyID).First(&pk).Error; err != nil {
 		return nil, err
 	}
 	return &pk, nil

--- a/internal/repository/user_publickey_extra_test.go
+++ b/internal/repository/user_publickey_extra_test.go
@@ -32,9 +32,6 @@ func TestUserPublickeyExtraRepository_UpsertAndFind(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, pk1.KeyPEM, got.KeyPEM)
 	assert.Equal(t, model.AlgEd25519, got.Alg)
-
-	got, err = repo.FindByKeyID(pk1.KeyID)
-	require.NoError(t, err)
 	assert.Equal(t, user.ID, got.UserID)
 
 	// 同一 (userId, keyId) で再 Upsert すると更新される
@@ -108,8 +105,6 @@ func TestUserPublickeyExtraRepository_NotFound(t *testing.T) {
 	repo := NewUserPublickeyExtraRepository(testDB)
 	_, err := repo.FindByUserAndKeyID("nope_user", "nope_key")
 	assert.Error(t, err)
-	_, err = repo.FindByKeyID("nope_key")
-	assert.Error(t, err)
 }
 
 func TestUserPublickeyExtraRepository_QueryErrors(t *testing.T) {
@@ -120,8 +115,6 @@ func TestUserPublickeyExtraRepository_QueryErrors(t *testing.T) {
 	err := repo.Upsert(&model.UserPublickeyExtra{UserID: "x", KeyID: "k", KeyPEM: "p", Alg: model.AlgEd25519})
 	assert.Error(t, err)
 	_, err = repo.FindByUserAndKeyID("x", "k")
-	assert.Error(t, err)
-	_, err = repo.FindByKeyID("k")
 	assert.Error(t, err)
 	_, err = repo.ListByUserID("x")
 	assert.Error(t, err)


### PR DESCRIPTION
## Summary

インバウンドHTTP署名検証における **key confusion** 脆弱性(連合認証バイパス / 任意リモートユーザーなりすまし)を修正する。セキュリティ案件のため対応issueは作成していない。

## 背景

mk-go はリモート actor の `assertionMethod[]`(FEP-521a Ed25519 Multikey)および `publicKey`(RSA)を **host 検証なし** でキャッシュし、署名鍵を keyId のみで **global 解決**(`FindByKeyID`)していた。このため攻撃者は以下で任意のリモートユーザーになりすませた:

1. 自分の actor(`evil.example/users/mal`)の `assertionMethod` / `publicKey` に `id: https://victim.example/users/alice#x9z` + 攻撃者鍵を載せて植え込む
2. mk-go に自 actor を fetch させ、host 検証なしで攻撃者鍵が `victim` の keyId で保存される
3. `victim` を名乗る署名付き activity を inbox へ送ると、global 解決が攻撃者鍵を返し署名検証成功 → `signer == bodyActor == victim` で受理

影響範囲は Ed25519 HTTP-sig 経路と RSA / LD-Signature 経路の双方。

## 主な変更点

- **Fix A** (`fetchActor`): `publicKey.id` の host を `actor.ID` の host に縛り、cross-host な actor を reject。RSA / LD-Signature 経路の鍵植え込みを書込段で遮断。
- **Fix B** (`cacheAssertionMethods`): `assertionMethod[].id` の host を actor host に縛り、不一致 entry を skip。Ed25519 経路の植え込みを遮断。
- **Fix C** (`PublicKeyForKeyID`): `FindByUserAndKeyID(actorID, keyID)` による actor-scope 読取に変更。unsafe な global `FindByKeyID` を `UserPublickeyExtraRepository` から除去し、型システムレベルで再導入を防止(二重防御の読取段)。
- RSA repo に残る global `FindByKeyID` は LD-Signature 検証の現役 caller があるため維持し、Fix A の write-time 不変条件で安全であることをコメントで明文化。
- ヘルパー `sameURIHost`(`normalizeMatchHost` 利用、fail-closed)を追加。

## upstream との整合

upstream Misskey TS は `validateActor()` で `publicKey.id` host == actor host を必須化(`ApPersonService.ts`)、`InboxProcessorService` で鍵 owner == activity.actor を必須化している。本修正はこの2層防御を mk-go 独自拡張の assertionMethod 経路にも移植したもので、設計が整合する(upstream は Ed25519 assertionMethod 自体を未サポート)。

## テスト

- 回帰テスト3本を追加:
  - `TestResolveActor_RejectsCrossHostPublicKeyID`(Fix A: cross-host publicKey.id の actor を reject)
  - `TestResolveActor_SkipsCrossHostAssertionMethodKeyID`(Fix B: cross-host keyId entry を保存しない)
  - `TestPublicKeyForKeyID_ActorScopedRejectsPlantedKey`(Fix C: 別 actor 配下の植込み鍵を返さない)
- `make fmt && make lint` クリーン。関連パッケージ(`federation` / `repository` / `queue` / `api/inbox`)テスト green。
- カバレッジ: `federation` 90.2% / `repository` 90.1%(いずれも CI gate 90% 以上)。
- 敵対的レビュー2ラウンドで指摘ゼロに収束。

## その他

- `third_party/misskey` サブモジュールの変更は本PRに含まない。