### PR TITLE
Fix: SSRFガードでIPv6 unspecified :: を遮断する

### DIFF
--- a/internal/safehttp/ssrf.go
+++ b/internal/safehttp/ssrf.go
@@ -36,6 +36,11 @@ func init() {
 		"224.0.0.0/4",
 		"240.0.0.0/4",
 		// IPv6 private / reserved
+		// IPv4 の 0.0.0.0/8 と対称に IPv6 unspecified も遮断する。これが無いと
+		// `http://[::]:PORT/` が isPrivateIP をすり抜け、Linux の connect(::) が
+		// loopback (::1) にルートされて SSRF 保護を回避できる (upstream ipaddr.js
+		// も :: を unspecified range として遮断する)。
+		"::/128",
 		"::1/128",
 		"fe80::/10",
 		"fc00::/7",

--- a/internal/safehttp/ssrf_test.go
+++ b/internal/safehttp/ssrf_test.go
@@ -25,6 +25,7 @@ func TestIsPrivateIP_IPv4Private(t *testing.T) {
 		{"172.31.x", "172.31.255.255"},
 		{"192.168.x", "192.168.1.1"},
 		{"link-local", "169.254.1.1"},
+		{"unspecified", "0.0.0.0"},
 		{"zero network", "0.0.0.1"},
 		{"CGN", "100.64.0.1"},
 		{"documentation 192.0.2.x", "192.0.2.1"},
@@ -46,6 +47,7 @@ func TestIsPrivateIP_IPv6Private(t *testing.T) {
 		name string
 		ip   string
 	}{
+		{"unspecified", "::"},
 		{"loopback", "::1"},
 		{"link-local", "fe80::1"},
 		{"unique-local fd", "fd00::1"},
@@ -125,6 +127,20 @@ func TestNewSSRFSafeTransport_BlocksLoopback(t *testing.T) {
 	client := &http.Client{Transport: tr}
 
 	_, err := client.Get(ts.URL + "/test")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "private IP blocked")
+}
+
+// IPv6 unspecified `::` 宛は SSRF block される。Linux では connect(::) が
+// loopback (::1) にルートされるため、`http://0.0.0.0:PORT/` を弾く保護を
+// `http://[::]:PORT/` で回避できてはならない (`::/128` を privateRanges に
+// 追加して 0.0.0.0/8 と対称化した)。
+func TestNewSSRFSafeTransport_BlocksIPv6Unspecified(t *testing.T) {
+	tr := NewSSRFSafeTransport(nil)
+	client := &http.Client{Transport: tr}
+
+	// dial 前の isPrivateIP(::) 判定で弾かれるため実際の接続は発生しない。
+	_, err := client.Get("http://[::]:80/test")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "private IP blocked")
 }


### PR DESCRIPTION
## Summary

SSRF 保護(`internal/safehttp/ssrf.go`)の **IPv6 unspecified `::` 遮断欠落** を修正する。セキュリティ案件のため対応issueは作成していない。

## 背景

`privateRanges`(SSRF遮断CIDR)は IPv4 unspecified `0.0.0.0/8` を遮断する一方、**IPv6 unspecified `::/128` を含まなかった**(IPv6側は `::1/128` / `fe80::/10` / `fc00::/7` のみ)。`isPrivateIP` はCIDR包含チェックのみで `net.IP.IsUnspecified()` を呼ばないため `isPrivateIP(::)` が false を返していた。

Linux では `connect(::)` が IPv6 loopback `::1` にルートされるため、`http://0.0.0.0:PORT/` を弾く保護を `http://[::]:PORT/` で回避でき、host 制御可能な outbound 経路(特に**未認証の `/api/fetch-rss`**、url-preview / fetch-external / drive url-upload 等)から内部サービスへ到達できた。

## 主な変更点

- `privateRanges` の IPv6 セクションに `"::/128"` を追加し、`0.0.0.0/8`(IPv4 unspecified)と対称化。`isPrivateIP(::)` が true を返し dial 段で遮断される。

## upstream との整合

upstream Misskey TS は `HttpRequestService.isPrivateIp` で ipaddr.js の `range() !== 'unicast'` 判定を用い、`::` を `unspecified`(`::/128`)として遮断する。本修正はこの挙動と整合する。

## テスト

- `TestIsPrivateIP_IPv6Private` に `::`、`TestIsPrivateIP_IPv4Private` に `0.0.0.0` を追加(回帰固定)。
- transport 層の `TestNewSSRFSafeTransport_BlocksIPv6Unspecified`(`http://[::]:80/` が "private IP blocked" になる)を追加。修正が無ければ fail する(false-green でない)。
- `make fmt && make lint` クリーン。`safehttp` パッケージ green、カバレッジ 94.9%(CI gate 90% 以上)。
- 敵対的レビューで `::` の別表現(`::0` / `0:0:0:0:0:0:0:0` / `::0.0.0.0` / `::ffff:0.0.0.0`)も全て遮断されること、public IPv6 を誤遮断しないこと、`allowedPrivateNetworks` の opt-out が効くことを確認(指摘ゼロ)。

## その他

- `third_party/misskey` サブモジュールの変更は本PRに含まない。
- 参考(本PR対象外): NAT64 `64:ff9b::/96` は mk-go の allowlist 方式では未遮断という別系統の divergence があるが、NAT64 GW 経由が前提で本件とは別。将来 mk-go の遮断方式を upstream の non-unicast denylist へ寄せるかは別途検討。