### PR TITLE
safehttp の SSRF guard を non-unicast 特殊用途レンジまで強化

### DIFF
--- a/internal/safehttp/ssrf.go
+++ b/internal/safehttp/ssrf.go
@@ -19,31 +19,57 @@ import (
 var privateRanges []*net.IPNet
 
 func init() {
+	// privateRanges は upstream Misskey TS (HttpRequestService.isPrivateIp) が
+	// ipaddr.js の `range() !== 'unicast'` で遮断する「非 unicast」集合に揃える。
+	// 単なる RFC1918/loopback だけでなく、embedded/relay で内部 IPv4 へ到達しうる
+	// NAT64 / 6to4 / rfc6145 や、multicast / documentation / tunneling 等の特殊用途
+	// レンジも遮断する。operator が正当に使うレンジは config.allowedPrivateNetworks
+	// で opt-out できる (isPrivateIP は allowedNets を privateRanges より先に評価)。
 	cidrs := []string{
-		// IPv4 private / reserved
-		"0.0.0.0/8",
-		"10.0.0.0/8",
-		"100.64.0.0/10",
-		"127.0.0.0/8",
-		"169.254.0.0/16",
-		"172.16.0.0/12",
-		"192.0.0.0/24",
-		"192.0.2.0/24",
-		"192.168.0.0/16",
-		"198.18.0.0/15",
-		"198.51.100.0/24",
-		"203.0.113.0/24",
-		"224.0.0.0/4",
-		"240.0.0.0/4",
-		// IPv6 private / reserved
-		// IPv4 の 0.0.0.0/8 と対称に IPv6 unspecified も遮断する。これが無いと
+		// === IPv4 private / reserved (RFC5735 / RFC6890 系) ===
+		"0.0.0.0/8",       // unspecified / this-host
+		"10.0.0.0/8",      // private (RFC1918)
+		"100.64.0.0/10",   // carrier-grade NAT (RFC6598)
+		"127.0.0.0/8",     // loopback
+		"169.254.0.0/16",  // link-local
+		"172.16.0.0/12",   // private (RFC1918)
+		"192.0.0.0/24",    // IETF protocol assignments
+		"192.0.2.0/24",    // documentation TEST-NET-1
+		"192.31.196.0/24", // AS112-v4 (RFC7535)
+		"192.52.193.0/24", // AMT anycast (RFC7450)
+		"192.88.99.0/24",  // 6to4 relay anycast, deprecated (RFC7526)
+		"192.168.0.0/16",  // private (RFC1918)
+		"192.175.48.0/24", // AS112 direct delegation (RFC7534)
+		"198.18.0.0/15",   // benchmarking (RFC2544)
+		"198.51.100.0/24", // documentation TEST-NET-2
+		"203.0.113.0/24",  // documentation TEST-NET-3
+		"224.0.0.0/4",     // multicast
+		"240.0.0.0/4",     // reserved (255.255.255.255 broadcast を内包)
+		// === IPv6 private / reserved (ipaddr.js の non-unicast 集合に対応) ===
+		// IPv4 の 0.0.0.0/8 と対称に IPv6 unspecified (::) も遮断する。これが無いと
 		// `http://[::]:PORT/` が isPrivateIP をすり抜け、Linux の connect(::) が
-		// loopback (::1) にルートされて SSRF 保護を回避できる (upstream ipaddr.js
-		// も :: を unspecified range として遮断する)。
-		"::/128",
-		"::1/128",
-		"fe80::/10",
-		"fc00::/7",
+		// loopback (::1) にルートされて SSRF 保護を回避できる。
+		"::/128",    // unspecified
+		"::1/128",   // loopback
+		"fc00::/7",  // unique-local (RFC4193)
+		"fe80::/10", // link-local
+		"fec0::/10", // deprecated site-local (RFC3879)
+		"ff00::/8",  // multicast (IPv4 224.0.0.0/4 と対称)
+		"100::/64",  // discard-only (RFC6666)
+		// embedded/relay で内部 IPv4 へ到達しうる SSRF 直結レンジ。To4() は
+		// ::ffff:x.x.x.x (ipv4-mapped) しか展開しないため、下記は CIDR で明示遮断する。
+		"0:0:0:0:ffff:0:0:0/96", // IPv4-translatable (RFC6145), embeds v4
+		"64:ff9b::/96",          // NAT64 well-known prefix (RFC6052), embeds v4
+		"64:ff9b:1::/48",        // NAT64 local-use (RFC8215), embeds v4
+		"2002::/16",             // 6to4 (RFC3056), embeds v4
+		// 2001::/23 は teredo (2001::/32, v4 を埋め込む) を含み、benchmarking /
+		// amt / orchid / drone / as112v6(2001:4:112) も 1 本に集約する。本番 unicast
+		// (例 Google 2001:4860) は第2 hextet > 0x01ff なので含まれない。
+		"2001::/23",
+		"2001:db8::/32",     // documentation (RFC3849)
+		"2620:4f:8000::/48", // AS112 (RFC7534)
+		"3fff::/20",         // documentation (RFC9637)
+		"5f00::/16",         // SRv6 SID (RFC9602)
 	}
 	for _, cidr := range cidrs {
 		_, ipNet, err := net.ParseCIDR(cidr)
@@ -276,7 +302,14 @@ func matchFamily(ip net.IP, family string) bool {
 // isPrivateIP returns true if ip falls within a private/reserved range
 // and is NOT covered by any of the allowedNets exceptions.
 func isPrivateIP(ip net.IP, allowedNets []*net.IPNet) bool {
-	// IPv4-mapped IPv6 (::ffff:x.x.x.x) の中身を取り出してIPv4として判定
+	// IPv4-mapped IPv6 (::ffff:x.x.x.x) の中身を取り出してIPv4として判定する。
+	// upstream Misskey (ipaddr.js range='ipv4Mapped') は public 埋め込みも含め
+	// ::ffff:0:0/96 を一律遮断するが、mk-go は埋め込み v4 を IPv4 レンジで評価する
+	// ため private 埋め込み (::ffff:127.0.0.1 等) は遮断しつつ public 埋め込み
+	// (::ffff:8.8.8.8) は許可する。dial 先 IP は public で内部到達しないため SSRF 的
+	// には完全かつ upstream の over-block より精密、という意図的な divergence。
+	// なお RFC6145 (0:0:0:0:ffff:0:0:0/96) や NAT64 (64:ff9b::/96) は To4() では
+	// 展開されないため privateRanges 側で明示遮断している。
 	if v4 := ip.To4(); v4 != nil {
 		ip = v4
 	}

--- a/internal/safehttp/ssrf_test.go
+++ b/internal/safehttp/ssrf_test.go
@@ -32,8 +32,13 @@ func TestIsPrivateIP_IPv4Private(t *testing.T) {
 		{"documentation 198.51.100.x", "198.51.100.1"},
 		{"documentation 203.0.113.x", "203.0.113.1"},
 		{"benchmark 198.18.x", "198.18.0.1"},
+		{"6to4 relay anycast", "192.88.99.1"},
+		{"AS112 direct", "192.175.48.1"},
+		{"AS112 v4", "192.31.196.1"},
+		{"AMT anycast", "192.52.193.1"},
 		{"multicast", "224.0.0.1"},
 		{"reserved 240.x", "240.0.0.1"},
+		{"broadcast", "255.255.255.255"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -52,6 +57,27 @@ func TestIsPrivateIP_IPv6Private(t *testing.T) {
 		{"link-local", "fe80::1"},
 		{"unique-local fd", "fd00::1"},
 		{"unique-local fc", "fc00::1"},
+		{"deprecated site-local", "fec0::1"},
+		{"multicast", "ff00::1"},
+		{"multicast all-nodes", "ff02::1"},
+		{"discard", "100::1"},
+		// embedded-v4 系 (NAT64 / 6to4 / rfc6145): 内部 IPv4 を埋め込んで NAT64/6to4
+		// gateway 経由で到達しうるため遮断する。To4() では展開されない。
+		{"rfc6145 ipv4-translatable", "0:0:0:0:ffff:0:7f00:1"},
+		{"NAT64 well-known", "64:ff9b::1"},
+		{"NAT64 well-known embeds loopback", "64:ff9b::7f00:1"},
+		{"NAT64 local-use", "64:ff9b:1::1"},
+		{"6to4", "2002::1"},
+		{"6to4 embeds private v4", "2002:c0a8:1::1"},
+		// 2001::/23 集約レンジ
+		{"teredo", "2001::1"},
+		{"benchmarking", "2001:2::1"},
+		{"orchid2", "2001:20::1"},
+		// documentation / special-use
+		{"documentation db8", "2001:db8::1"},
+		{"documentation 3fff", "3fff::1"},
+		{"AS112 v6", "2620:4f:8000::1"},
+		{"SRv6 SID", "5f00::1"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -77,13 +103,31 @@ func TestIsPrivateIP_PublicIP(t *testing.T) {
 		{"Google DNS", "8.8.8.8"},
 		{"Cloudflare DNS", "1.1.1.1"},
 		{"random public", "203.104.209.7"},
-		{"IPv6 public", "2001:4860:4860::8888"},
+		{"IPv6 public Google", "2001:4860:4860::8888"},
+		// over-block 回帰: special-use レンジ拡張で正規 public IPv6 を誤遮断しない。
+		// いずれも 2001::/23 等の拡張レンジの外 (第2 hextet > 0x01ff)。
+		{"IPv6 public Cloudflare", "2606:4700:4700::1111"},
+		{"IPv6 public HE tunnelbroker", "2001:470::1"},
+		{"IPv6 public Quad9", "2620:fe::fe"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.False(t, isPrivateIP(net.ParseIP(tt.ip), nil), "%s should be public", tt.ip)
 		})
 	}
+}
+
+// ipv4-mapped IPv6 の意図的 divergence を lock する: mk-go は To4() で埋め込み v4 を
+// 評価するため public 埋め込み (::ffff:8.8.8.8) は許可、private 埋め込み
+// (::ffff:127.0.0.1) は遮断する。upstream は ipv4-mapped を一律遮断するが、mk-go の
+// 方が精密 (内部到達しうるものだけ遮断) という divergence を回帰で固定する。
+func TestIsPrivateIP_IPv4MappedDivergence(t *testing.T) {
+	assert.False(t, isPrivateIP(net.ParseIP("::ffff:8.8.8.8"), nil),
+		"public ipv4-mapped は許可される (upstream との意図的乖離)")
+	assert.True(t, isPrivateIP(net.ParseIP("::ffff:127.0.0.1"), nil),
+		"private ipv4-mapped は遮断される")
+	assert.True(t, isPrivateIP(net.ParseIP("::ffff:169.254.169.254"), nil),
+		"link-local (cloud metadata) の ipv4-mapped は遮断される")
 }
 
 func TestIsPrivateIP_AllowedCIDR(t *testing.T) {
@@ -141,6 +185,18 @@ func TestNewSSRFSafeTransport_BlocksIPv6Unspecified(t *testing.T) {
 
 	// dial 前の isPrivateIP(::) 判定で弾かれるため実際の接続は発生しない。
 	_, err := client.Get("http://[::]:80/test")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "private IP blocked")
+}
+
+// NAT64 well-known prefix (64:ff9b::/96) 宛は SSRF block される。末尾 32bit に
+// 内部 IPv4 を埋め込めるため、NAT64 gateway 経由の内部到達を dial 前に遮断する。
+func TestNewSSRFSafeTransport_BlocksNAT64(t *testing.T) {
+	tr := NewSSRFSafeTransport(nil)
+	client := &http.Client{Transport: tr}
+
+	// 64:ff9b::7f00:1 = NAT64 representation of 127.0.0.1
+	_, err := client.Get("http://[64:ff9b::7f00:1]:80/test")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "private IP blocked")
 }


### PR DESCRIPTION
## Summary

先の IPv6 `::` 修正(#2234)に続く SSRF hardening。`internal/safehttp/ssrf.go` の `privateRanges` を、upstream Misskey TS が ipaddr.js の `range() !== 'unicast'` で遮断する「**非 unicast**」集合に揃える。NAT64 / 6to4 / rfc6145 のように embedded/relay で内部 IPv4 へ到達しうるレンジを含む、特殊用途アドレスの取りこぼしを塞ぐ。

## 背景

mk-go は明示 CIDR denylist 方式。従来は RFC1918/loopback/link-local 等の基本レンジのみで、NAT64(`64:ff9b::/96`)・6to4(`2002::/16`)・rfc6145(`0:0:0:0:ffff:0:0:0/96`)等の embedded-v4 レンジが抜けており、NAT64/6to4 gateway を備える環境では内部 IPv4 への SSRF 余地があった。

## 主な変更点

- **IPv4 追加(4)**: `192.31.196.0/24`・`192.175.48.0/24`(AS112)、`192.52.193.0/24`(AMT)、`192.88.99.0/24`(6to4 relay anycast, deprecated)
- **IPv6 追加(12)**: `fec0::/10`(site-local)、`ff00::/8`(multicast)、`100::/64`(discard)、`0:0:0:0:ffff:0:0:0/96`(rfc6145)、`64:ff9b::/96`+`64:ff9b:1::/48`(NAT64)、`2002::/16`(6to4)、`2001::/23`(teredo 等を集約)、`2001:db8::/32`、`2620:4f:8000::/48`、`3fff::/20`、`5f00::/16`
- **ipv4-mapped(`::ffff:0:0/96`)は意図的に従来の `To4()` 方式を維持**: public 埋め込み(`::ffff:8.8.8.8`)は許可、private 埋め込み(`::ffff:127.0.0.1`)は遮断。upstream は ipv4-mapped を一律遮断するが、mk-go は内部到達しうるものだけを遮断する**より精密な**挙動。コメントで意図的 divergence を明記。
- `allowedPrivateNetworks` による operator opt-out は先行評価で維持(NAT64 等を正当利用する環境は whitelist 可能)。

## upstream との整合

ipaddr.js 2.4.0 の SpecialRanges(非 unicast)と突き合わせ済み: IPv4 は完全一致、IPv6 は non-unicast を網羅(`2001::/23` は upstream 自身の reserved 定義と同値で teredo 等を集約)。唯一 ipv4-mapped のみ精密化のため divergence。

## テスト

- 新遮断レンジ(NAT64/6to4/rfc6145/teredo/multicast/site-local/discard/documentation/AS112/SRv6)を `TestIsPrivateIP_IPv6Private` / `TestIsPrivateIP_IPv4Private` に追加。
- `TestIsPrivateIP_PublicIP` に over-block 回帰(Google/Cloudflare/HE tunnelbroker/Quad9 の public IPv6 が誤遮断されないこと)。
- `TestIsPrivateIP_IPv4MappedDivergence`(public 許可 / private・metadata 遮断を lock)。
- `TestNewSSRFSafeTransport_BlocksNAT64`(transport 層で NAT64 dial が block)。
- `make fmt && make lint` クリーン。`safehttp` green、カバレッジ 94.9%。
- 敵対的レビューで over-block(実 public アドレス多数)/ under-block(embedded-v4 全種)/ CIDR 計算 / opt-out を検証し指摘ゼロ。

## その他

- `third_party/misskey` サブモジュールの変更は本PRに含まない。