### PR TITLE
Fix: リノートされた引用投稿の引用先がTLで「削除されたノート」になる問題を修正

### DIFF
--- a/internal/api/notehide/notehide.go
+++ b/internal/api/notehide/notehide.go
@@ -4,9 +4,11 @@
 //
 // Two layers, both blanking content in place (entity.HideNoteEntity), never
 // filtering rows:
-//   - Embedded renote/reply: the FULL decision (corenote.HideEmbedDecision),
-//     including intrinsic followers/specified — depth-2 embeds have no upstream
-//     visibility gate of their own (#1536).
+//   - Embedded renote/reply (depth-1) と引用先 (renote.renote, depth-2): the FULL
+//     decision (corenote.HideEmbedDecision), including intrinsic
+//     followers/specified — embeds have no upstream visibility gate of their own
+//     (#1536)。packer が pure renote → quote の引用先 (renote.renote) を depth-2 で
+//     出すようになったため、その引用先も同じ embed gate で blank する。
 //   - Top-level note: the author-PREFERENCE subset only
 //     (corenote.HideNoteByPrefsDecision): treatVisibility downgrade
 //     (makeNotesFollowersOnlyBefore), makeNotesHiddenBefore and
@@ -98,11 +100,20 @@ func hideEmbedsAt(viewer *model.User, packed []entity.NoteEntity, repo repositor
 		hideTopLevelIfNeeded(viewer, &packed[i], follows, nowMs)
 		hideEmbedIfNeeded(viewer, packed[i].Renote, follows, nowMs)
 		hideEmbedIfNeeded(viewer, packed[i].Reply, follows, nowMs)
+		// pure renote → quote の引用先 (renote.renote, depth-2) も embed gate を適用する。
+		// packer がこの depth-2 を出すようになった (#timeline nested quote) ため、
+		// 非公開の引用先が renote 経由で leak しないようここで blank する。
+		if packed[i].Renote != nil {
+			hideEmbedIfNeeded(viewer, packed[i].Renote.Renote, follows, nowMs)
+		}
 		// #2106 L5: treatVisibility downgrade を packed entity の visibility field にも反映する
 		// (hide 判定が元の visibility を読み終えた後に書き換える、viewer 非依存)。
 		downgradeVisibilityIfNeeded(&packed[i], nowMs)
 		downgradeVisibilityIfNeeded(packed[i].Renote, nowMs)
 		downgradeVisibilityIfNeeded(packed[i].Reply, nowMs)
+		if packed[i].Renote != nil {
+			downgradeVisibilityIfNeeded(packed[i].Renote.Renote, nowMs)
+		}
 	}
 }
 
@@ -153,6 +164,10 @@ func buildFollowSet(viewer *model.User, packed []entity.NoteEntity, repo reposit
 		collectTopLevelAuthor(&packed[i], viewer.ID, seen)
 		collectEmbedAuthor(packed[i].Renote, viewer.ID, seen)
 		collectEmbedAuthor(packed[i].Reply, viewer.ID, seen)
+		// depth-2 引用先 (renote.renote) の著者も follow 判定対象に含める。
+		if packed[i].Renote != nil {
+			collectEmbedAuthor(packed[i].Renote.Renote, viewer.ID, seen)
+		}
 	}
 	if len(seen) == 0 {
 		return never

--- a/internal/api/notehide/notehide_test.go
+++ b/internal/api/notehide/notehide_test.go
@@ -67,6 +67,30 @@ func TestHideEmbedsAt_SingleQueryForMixedAuthors(t *testing.T) {
 	}
 }
 
+// depth-2 引用先 (renote.renote) が followers-only の場合、非フォロワー viewer には
+// blank される (#timeline nested quote の embed leak 防止)。renote (quote) 自体は
+// public なので残る。
+func TestHideEmbedsAt_DepthTwoQuoteTargetHidden(t *testing.T) {
+	viewer := &model.User{ID: "viewer"}
+	repo := followsRepo() // viewer は誰もフォローしていない
+	quoteTarget := followersEmbed("qt", "secret-author")
+	quote := &entity.NoteEntity{
+		ID: "quote", UserID: "qa", CreatedAt: "2026-01-02T03:04:05.000Z",
+		User: entity.UserLite{ID: "qa"}, Visibility: "public", Text: heStr("quoting"),
+		FileIDs: []string{}, Files: []any{}, VisibleUserIDs: []string{}, Mentions: []string{},
+		Renote: quoteTarget,
+	}
+	packed := []entity.NoteEntity{noteWithRenote("boost", quote)}
+	hideEmbedsAt(viewer, packed, repo, heNowMs)
+
+	if packed[0].Renote.IsHidden || packed[0].Renote.Text == nil {
+		t.Error("public quote embed must stay visible")
+	}
+	if !packed[0].Renote.Renote.IsHidden || packed[0].Renote.Renote.Text != nil {
+		t.Error("depth-2 followers-only quote target must be hidden for non-follower")
+	}
+}
+
 func TestHideEmbedsAt_PublicBatchZeroQuery(t *testing.T) {
 	viewer := &model.User{ID: "viewer"}
 	repo := followsRepo()

--- a/internal/core/webpush/packers.go
+++ b/internal/core/webpush/packers.go
@@ -73,6 +73,12 @@ func (p *NoteRepoPacker) hideEmbeds(viewer *model.User, packed *entity.NoteEntit
 	follows := p.buildFollowSet(viewer, packed)
 	hideEmbedIfNeeded(viewer, packed.Renote, follows, nowMs)
 	hideEmbedIfNeeded(viewer, packed.Reply, follows, nowMs)
+	// depth-2 引用先 (renote.renote): packer が pure renote → quote の引用先を出す
+	// ようになったため、非公開の引用先が push payload に leak しないよう gate する
+	// (notehide / stream note_filter と整合)。
+	if packed.Renote != nil {
+		hideEmbedIfNeeded(viewer, packed.Renote.Renote, follows, nowMs)
+	}
 }
 
 // buildFollowSet resolves, in ONE query, which embed authors `viewer` follows.
@@ -90,6 +96,10 @@ func (p *NoteRepoPacker) buildFollowSet(viewer *model.User, packed *entity.NoteE
 	seen := make(map[string]struct{})
 	collectEmbedAuthor(packed.Renote, viewer.ID, seen)
 	collectEmbedAuthor(packed.Reply, viewer.ID, seen)
+	// depth-2 引用先 (renote.renote) の著者も follow 判定対象に含める。
+	if packed.Renote != nil {
+		collectEmbedAuthor(packed.Renote.Renote, viewer.ID, seen)
+	}
 	if len(seen) == 0 {
 		return never
 	}

--- a/internal/core/webpush/packers_test.go
+++ b/internal/core/webpush/packers_test.go
@@ -331,6 +331,46 @@ func TestNoteRepoPacker_EmbedPublicNotHidden(t *testing.T) {
 	assert.Equal(t, "secret", embed["text"])
 }
 
+// depth-2 引用先 (renote.renote): public renote(boost) → public quote → followers
+// 引用先。引用先が非フォロワー受信者の push payload で blank されること。packer が
+// depth-2 を emit するようになったため、depth-1 と同じ embed gate を depth-2 にも
+// 適用する必要がある (これが無いと followers 引用先が leak する IDOR)。
+func TestNoteRepoPacker_EmbedRenoteRenoteHiddenFromNonFollower(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	repo := testutil.NewMockNoteRepository()
+	follow := testutil.NewMockFollowingRepository()
+	target := seedNoteWithUser(repo, idGen, "author", model.NoteVisibilityFollowers, nil) // depth-2 引用先
+	quote := seedRenoteOf(repo, idGen, target)                                            // depth-1 public quote (quote.Renote=target)
+	top := seedRenoteOf(repo, idGen, quote)                                               // depth-0 public boost (top.Renote=quote)
+
+	p := webpush.NewNoteRepoPacker(repo, idGen, follow)
+	out, ok := p.PackNoteByID(top.ID, "stranger") // public top, not author, not follower
+	assert.True(t, ok, "public top-level note must be delivered")
+	renote := embedOf(out, "renote")
+	assert.NotEqual(t, true, renote["isHidden"], "depth-1 public quote stays visible")
+	rr := embedOf(renote, "renote")
+	assert.Equal(t, true, rr["isHidden"], "depth-2 followers quote target must be blanked for a non-follower recipient")
+	assert.Nil(t, rr["text"], "blanked depth-2 embed must drop text")
+}
+
+// depth-2 引用先がフォロワー受信者には見える (gate が過剰 blank しない回帰)。
+func TestNoteRepoPacker_EmbedRenoteRenoteVisibleToFollower(t *testing.T) {
+	idGen, _ := id.NewGenerator("aidx")
+	repo := testutil.NewMockNoteRepository()
+	follow := testutil.NewMockFollowingRepository()
+	target := seedNoteWithUser(repo, idGen, "author", model.NoteVisibilityFollowers, nil)
+	quote := seedRenoteOf(repo, idGen, target)
+	top := seedRenoteOf(repo, idGen, quote)
+	seedFollow(follow, "viewer", "author")
+
+	p := webpush.NewNoteRepoPacker(repo, idGen, follow)
+	out, ok := p.PackNoteByID(top.ID, "viewer")
+	assert.True(t, ok)
+	rr := embedOf(embedOf(out, "renote"), "renote")
+	assert.NotEqual(t, true, rr["isHidden"], "depth-2 quote target visible to a follower recipient")
+	assert.Equal(t, "secret", rr["text"])
+}
+
 func TestNoteRepoPacker_EmbedFollowersOnlyBeforeDowngrade(t *testing.T) {
 	idGen, _ := id.NewGenerator("aidx")
 	repo := testutil.NewMockNoteRepository()

--- a/internal/entity/note.go
+++ b/internal/entity/note.go
@@ -122,12 +122,16 @@ type PollChoice struct {
 	IsVoted bool   `json:"isVoted"`
 }
 
-// maxNoteEmbedDepth caps how many levels of Renote / Reply are expanded when
-// packing. repository 側の preloadNoteRelations は 1 段しか preload しない
-// ので通常 1 で十分だが、テストや将来の preload 変更で n.Renote.Renote などが
-// 意図せず非 nil になった場合でも応答を bounded に保つためのガード (#416
-// Devin review)。
-const maxNoteEmbedDepth = 1
+// maxNoteEmbedDepth caps how many levels of Renote chain are expanded when
+// packing. 純粋リノート (boost) が引用投稿 (quote) を包む場合、TL の最上位は
+// pure renote で、その renote (= quote) の renote (= 引用先) まで出さないと
+// frontend が引用先を「削除されたノート」として描画してしまう。upstream
+// NoteEntityService は renote 埋め込みを detail:true で再帰 pack するため
+// renote チェーンは実質無制限だが、frontend の quote box (MkNoteSimple) は
+// 再帰しないので表示には 2 段で足りる。reply 埋め込みは detail:false (子を
+// 持たない) なので depth ではなく detail gate で 1 段に止める (下記 packNoteAtDepth)。
+// 2 にすることで preload / batch loader 側も renote ブランチを 2 段供給する。
+const maxNoteEmbedDepth = 2
 
 // PackNote converts a model.Note to a NoteEntity. Renote / Reply の embed は
 // maxNoteEmbedDepth で制限する。
@@ -293,19 +297,29 @@ func packNoteAtDepth(n *model.Note, idGen id.Generator, depth int, detail bool) 
 		entity.User = PackUserLite(n.User)
 	}
 
-	// Renote / Reply の target は repository 層で Preload("Renote.User") /
-	// Preload("Reply.User") されている前提で 1 段だけ展開する。preload が
+	// Renote / Reply の target は repository 層で preload (Renote.User /
+	// Renote.Renote.User / Reply.User …) されている前提で展開する。preload が
 	// 無ければ n.Renote == nil になり、フロントエンドはこれを「削除された投稿」
 	// として描画する (renoteId だけが入ってる状態と区別するため #416)。
-	// renote embed は upstream で detail:true、reply embed は detail:false
-	// (NoteEntityService.ts:445 / :437)。reply embed では clippedCount/poll/
-	// myReaction を省く (#1816)。
-	if depth < maxNoteEmbedDepth {
+	//
+	// 展開は detail==true のときだけ行う。upstream NoteEntityService は renote
+	// embed を detail:true (NoteEntityService.ts:445)、reply embed を detail:false
+	// (:437) で pack し、detail:false の note は renote/reply を一切持たない。
+	// renote チェーンは detail:true のまま maxNoteEmbedDepth まで再帰させ、
+	// 「pure renote → quote → 引用先」の引用先 (renote.renote) を出す。これが
+	// 無いと frontend が引用先を「削除されたノート」として描画する。
+	//
+	// reply embed は top-level (depth 0) のみ展開する。renote 埋め込み内の reply
+	// (depth 2) は frontend の表示要件が無く、かつ depth-2 embed には可視性ゲート
+	// (notehide / streaming note_filter) を別途用意する必要があるため、不要な leak
+	// 面を増やさないよう展開しない (renote.renote だけを depth-2 で出す)。reply
+	// embed では clippedCount/poll/myReaction を省く (#1816)。
+	if detail && depth < maxNoteEmbedDepth {
 		if n.Renote != nil {
 			r := packNoteAtDepth(n.Renote, idGen, depth+1, true)
 			entity.Renote = &r
 		}
-		if n.Reply != nil {
+		if depth == 0 && n.Reply != nil {
 			r := packNoteAtDepth(n.Reply, idGen, depth+1, false)
 			entity.Reply = &r
 		}

--- a/internal/entity/note_test.go
+++ b/internal/entity/note_test.go
@@ -329,6 +329,79 @@ func TestPackNote_WithRenoteAndReply(t *testing.T) {
 	assert.Equal(t, &replyText, e.Reply.Text)
 }
 
+// 純粋リノート (boost) が引用投稿 (quote) を包む場合、引用先 (renote.renote) まで
+// pack されること。これが無いと frontend は引用先を「削除されたノート」として
+// 描画する (timeline bug)。併せて (1) reply embed は detail:false leaf、(2) renote
+// embed 内の reply (renote.reply, depth-2) は展開しない (top-level reply のみ)、
+// (3) renote chain は maxNoteEmbedDepth=2 で止まる、ことを検証する。
+func TestPackNote_NestedRenoteEmbedPacksQuoteTarget(t *testing.T) {
+	idGen := newTestIDGen(t)
+	deepID := idGen.Generate(time.Now())       // LV3 (cap で出ないはず)
+	targetID := idGen.Generate(time.Now())     // LV2 引用先
+	quoteReplyID := idGen.Generate(time.Now()) // quote の reply (depth-2、出ないはず)
+	replyChildID := idGen.Generate(time.Now()) // top.reply の renote (leaf、出ないはず)
+	quoteID := idGen.Generate(time.Now())      // LV1 引用投稿
+	replyID := idGen.Generate(time.Now())      // top の reply
+	topID := idGen.Generate(time.Now())        // LV0 pure renote
+
+	targetText := "quote target body"
+	quoteText := "quoting"
+
+	mk := func(id, uid string) *model.Note {
+		return &model.Note{
+			ID: id, UserID: uid, Visibility: model.NoteVisibilityPublic,
+			Reactions: datatypes.JSON([]byte("{}")),
+		}
+	}
+
+	// LV2 引用先。さらに自分の renote (LV3) を持たせて cap=2 の打ち切りを検証。
+	target := mk(targetID, "u3")
+	target.Text = &targetText
+	target.User = &model.User{ID: "u3", Username: "target_author", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	target.RenoteID = &deepID
+	target.Renote = mk(deepID, "u4")
+
+	// LV1 引用投稿 (text 付き renote = quote)。reply も持たせ、renote.reply が depth-2 で
+	// 展開されないこと (top-level reply のみ展開) を検証する。
+	quote := mk(quoteID, "u2")
+	quote.Text = &quoteText
+	quote.RenoteID = &targetID
+	quote.ReplyID = &quoteReplyID
+	quote.Reply = mk(quoteReplyID, "u7")
+	quote.User = &model.User{ID: "u2", Username: "quote_author", AvatarDecorations: datatypes.JSON([]byte("[]"))}
+	quote.Renote = target
+
+	// top の reply target。自分の renote を持たせ、reply embed が leaf であることを検証。
+	reply := mk(replyID, "u5")
+	reply.RenoteID = &replyChildID
+	reply.Renote = mk(replyChildID, "u6")
+
+	// LV0 pure renote (text 無し) が quote を包む。
+	top := mk(topID, "u1")
+	top.RenoteID = &quoteID
+	top.ReplyID = &replyID
+	top.Renote = quote
+	top.Reply = reply
+
+	e := PackNote(top, idGen)
+
+	// LV1: 引用投稿
+	require.NotNil(t, e.Renote, "top.renote (quote) should pack")
+	assert.Equal(t, quoteID, e.Renote.ID)
+	// LV2: 引用先 — 本バグの修正点。depth 2 まで展開される。
+	require.NotNil(t, e.Renote.Renote, "renote.renote (quote target) must pack, else frontend shows deleted note")
+	assert.Equal(t, targetID, e.Renote.Renote.ID)
+	assert.Equal(t, &targetText, e.Renote.Renote.Text)
+	// LV3: maxNoteEmbedDepth=2 で打ち切られる。
+	assert.Nil(t, e.Renote.Renote.Renote, "renote chain must stop at maxNoteEmbedDepth=2")
+	// renote embed 内の reply (depth-2) は展開しない (top-level reply のみ)。
+	assert.Nil(t, e.Renote.Reply, "renote.reply (depth-2) must not be packed")
+
+	// reply embed は detail:false leaf なので自分の renote を展開しない (upstream 一致)。
+	require.NotNil(t, e.Reply, "top.reply should pack")
+	assert.Nil(t, e.Reply.Renote, "reply embed is detail:false leaf and must not expand its renote")
+}
+
 // #1816: reply embed は upstream で detail:false なので clippedCount / poll を
 // 出力しない。renote embed は detail:true なので両方とも出す。
 func TestPackNote_ReplyEmbedDetailFalse(t *testing.T) {

--- a/internal/repository/note.go
+++ b/internal/repository/note.go
@@ -229,10 +229,17 @@ func NewNoteRepository(db *gorm.DB) NoteRepository {
 	return &noteRepository{db: db}
 }
 
-// preloadNoteRelations applies Preload for the author plus 1 level of
-// reply/renote targets (with their authors). NoteEntity の packer は
-// renote/reply の target note を埋めるためこれらの preload が必須。
+// preloadNoteRelations applies Preload for the author plus the reply/renote
+// targets (with their authors) needed by the NoteEntity packer. NoteEntity の
+// packer は renote/reply の target note を埋めるためこれらの preload が必須。
 // GORM の preload は明示した relation しか辿らないので N+1 には成らない。
+//
+// renote ブランチだけ 2 段展開する: 純粋リノート (boost) が引用投稿 (quote) を
+// 包む場合、renote (= quote) のさらに renote (= 引用先) まで preload しないと
+// frontend が引用先を「削除されたノート」として描画してしまう (packer の
+// maxNoteEmbedDepth=2 と一致)。packer は renote.renote のみ depth-2 で出す
+// (renote.reply / reply.* の depth-2 は出さない) ので、preload も Renote.Renote
+// のみ 2 段にする。
 //
 // Poll は note.hasPoll==true のとき 1:1 で attach する (#690)。Preload は
 // 自動的に hasPoll=false の note では何も読まないので overhead は小さい
@@ -242,6 +249,9 @@ func preloadNoteRelations(db *gorm.DB) *gorm.DB {
 		Preload("Renote").
 		Preload("Renote.User").
 		Preload("Renote.Poll").
+		Preload("Renote.Renote").
+		Preload("Renote.Renote.User").
+		Preload("Renote.Renote.Poll").
 		Preload("Reply").
 		Preload("Reply.User").
 		Preload("Reply.Poll").
@@ -597,12 +607,17 @@ func (r *noteRepository) FindManyByIDsWithUser(ids []string) ([]*model.Note, err
 		return nil, nil
 	}
 	// timeline read hot path。GORM の Preload は relation ごとに別クエリを発行する
-	// ため preloadNoteRelations (8 relation) は 1 ページ ~9 往復になる (#1368 計測)。
-	// ここでは relation を種類ごとに batch IN で引いて Go 側で配線し、往復を 4 query
-	// (notes / sub-notes / users / polls) に畳む。出力 shape は preload 版と同一
-	// (TestNoteRepository_FindManyByIDsWithUser_HydratesRelations が回帰を捕捉)。
-	// preload は Renote/Reply を 1 段しか展開しない (maxNoteEmbedDepth=1) ので
-	// sub-note の renote/reply は辿らない。
+	// ため preloadNoteRelations は 1 ページ多数往復になる (#1368 計測)。ここでは
+	// relation を種類ごとに batch IN で引いて Go 側で配線し、往復を ~5 query
+	// (notes / sub-notes / sub-sub-notes / users / polls) に畳む。出力 shape は
+	// preload 版と同一 (TestNoteRepository_FindManyByIDsWithUser_HydratesRelations
+	// が回帰を捕捉)。
+	//
+	// renote ブランチは 2 段展開する: 純粋リノート (boost) が引用投稿 (quote) を
+	// 包む場合、renote (= quote) のさらに renote/reply (= 引用先) まで配線しないと
+	// frontend が引用先を「削除されたノート」として描画する (packer の
+	// maxNoteEmbedDepth=2 / detail gate と一致)。reply embed は detail:false で
+	// 子を持たないため、reply target の子は辿らない。
 	var notes []*model.Note
 	if err := r.db.Where("id IN ?", ids).Find(&notes).Error; err != nil {
 		return nil, err
@@ -637,6 +652,46 @@ func (r *noteRepository) FindManyByIDsWithUser(ids []string) ([]*model.Note, err
 			if n.ReplyID != nil {
 				n.Reply = subByID[*n.ReplyID]
 			}
+		}
+	}
+
+	// (2.5) 2 段目: 1 段目 renote target (= quote 候補) の renote (= 引用先) を
+	// さらに 1 query で取得し配線する。pure renote → quote → 引用先 の 3 段目を
+	// 埋めるため。packer は renote.renote のみ depth-2 で出す (renote.reply /
+	// reply.* は出さない) ので、ここも renote ブランチのみ辿る。
+	var renoteTargetSubs []*model.Note
+	for _, n := range notes {
+		if n.RenoteID != nil {
+			if s := subByID[*n.RenoteID]; s != nil {
+				renoteTargetSubs = append(renoteTargetSubs, s)
+			}
+		}
+	}
+	lvl2IDSet := make(map[string]struct{})
+	for _, s := range renoteTargetSubs {
+		if s.RenoteID != nil {
+			if _, ok := subByID[*s.RenoteID]; !ok {
+				lvl2IDSet[*s.RenoteID] = struct{}{}
+			}
+		}
+	}
+	if len(lvl2IDSet) > 0 {
+		var lvl2 []*model.Note
+		if err := r.db.Where("id IN ?", mapKeys(lvl2IDSet)).Find(&lvl2).Error; err != nil {
+			return nil, err
+		}
+		for _, s := range lvl2 {
+			subByID[s.ID] = s
+		}
+	}
+	// 1 段目 renote target に 2 段目 renote を配線する。配線は lvl2IDSet が空でも
+	// 必ず実行する: 同ページの別ノートが既に depth-2 ターゲットを depth-1 sub として
+	// 読み込んでいる (aliasing) と lvl2IDSet が空になるが、その場合でも subByID には
+	// ターゲットが入っているので配線が必要 (これを skip すると quote-of-quote が
+	// 「削除されたノート」表示で再発する)。
+	for _, s := range renoteTargetSubs {
+		if s.RenoteID != nil {
+			s.Renote = subByID[*s.RenoteID]
 		}
 	}
 

--- a/internal/repository/note_test.go
+++ b/internal/repository/note_test.go
@@ -932,6 +932,112 @@ func TestNoteRepository_FindManyByIDsWithUser_HydratesRelations(t *testing.T) {
 	assert.Equal(t, np.ID, got.Reply.Poll.NoteID)
 }
 
+// 純粋リノート (boost) が引用投稿 (quote) を包む場合、timeline batch loader が
+// renote embed の renote (= 引用先) を 2 段 hydrate すること。これが無いと frontend
+// で引用先が「削除されたノート」になる (timeline bug)。packer は renote.renote のみ
+// depth-2 で出す (renote.reply は出さない) ので、reply は 2 段目を hydrate しない
+// ことも併せて検証する。バッチに renote を持たない note (引用先自身) も混ぜ、
+// level-2 の RenoteID==nil 分岐も網羅する。
+func TestNoteRepository_FindManyByIDsWithUser_HydratesNestedRenote(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+
+	ut := insertTestUser(t, "u_nr_t", "nr_target")
+	uq := insertTestUser(t, "u_nr_q", "nr_quoter")
+	ub := insertTestUser(t, "u_nr_b", "nr_booster")
+	urp := insertTestUser(t, "u_nr_rp", "nr_replytgt")
+	defer cleanupUser(t, ut.ID)
+	defer cleanupUser(t, uq.ID)
+	defer cleanupUser(t, ub.ID)
+	defer cleanupUser(t, urp.ID)
+
+	mkNote := func(id, uid string, renoteID, replyID, text *string) *model.Note {
+		n := &model.Note{ID: id, UserID: uid, Text: text, Visibility: model.NoteVisibilityPublic, RenoteID: renoteID, ReplyID: replyID, Reactions: datatypes.JSON([]byte("{}"))}
+		require.NoError(t, repo.Create(n))
+		t.Cleanup(func() { cleanupNote(t, id) })
+		return n
+	}
+
+	qtext := "quoting"
+	target := mkNote("n_nr_t", ut.ID, nil, nil, nil) // LV2 引用先
+	rtgt := mkNote("n_nr_rp", urp.ID, nil, nil, nil) // quote の reply 先 (depth-2 では hydrate されない)
+	// LV1 引用投稿 = renote(target) + reply(rtgt) + text。
+	quote := mkNote("n_nr_q", uq.ID, &target.ID, &rtgt.ID, &qtext)
+	boost := mkNote("n_nr_b", ub.ID, &quote.ID, nil, nil) // LV0 pure renote
+
+	// boost に加え、renote を持たない target も問い合わせて RenoteID==nil 経路を通す。
+	out, err := repo.FindManyByIDsWithUser([]string{boost.ID, target.ID})
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	byID := map[string]*model.Note{}
+	for _, n := range out {
+		byID[n.ID] = n
+	}
+	got := byID[boost.ID]
+	require.NotNil(t, got)
+
+	// LV1: 引用投稿
+	require.NotNil(t, got.Renote, "renote (quote) must be hydrated")
+	assert.Equal(t, quote.ID, got.Renote.ID)
+	require.NotNil(t, got.Renote.User, "renote.user must be hydrated")
+	assert.Equal(t, uq.ID, got.Renote.User.ID)
+	// LV2 renote: 引用先 — 本バグの修正点
+	require.NotNil(t, got.Renote.Renote, "renote.renote (quote target) must be hydrated")
+	assert.Equal(t, target.ID, got.Renote.Renote.ID)
+	require.NotNil(t, got.Renote.Renote.User, "quote target user must be hydrated")
+	assert.Equal(t, ut.ID, got.Renote.Renote.User.ID)
+	// renote.reply (depth-2) は hydrate しない (packer が出さないため)。
+	assert.Nil(t, got.Renote.Reply, "renote.reply (depth-2) must not be hydrated")
+}
+
+// aliasing 回帰: 同ページの別ノートが depth-2 ターゲットを既に depth-1 sub として
+// 読み込んでいる場合でも、quote の引用先 (renote.renote) が配線されること。
+// level-2 の配線が lvl2IDSet の有無に依存していると、このケースで配線が skip され
+// quote-of-quote が「削除されたノート」表示で再発する。
+func TestNoteRepository_FindManyByIDsWithUser_NestedRenoteAliasing(t *testing.T) {
+	repo := NewNoteRepository(testDB)
+
+	ut := insertTestUser(t, "u_al_t", "al_target")
+	uq := insertTestUser(t, "u_al_q", "al_quoter")
+	ua := insertTestUser(t, "u_al_a", "al_booster")
+	urb := insertTestUser(t, "u_al_b", "al_replier")
+	defer cleanupUser(t, ut.ID)
+	defer cleanupUser(t, uq.ID)
+	defer cleanupUser(t, ua.ID)
+	defer cleanupUser(t, urb.ID)
+
+	mkNote := func(id, uid string, renoteID, replyID, text *string) *model.Note {
+		n := &model.Note{ID: id, UserID: uid, Text: text, Visibility: model.NoteVisibilityPublic, RenoteID: renoteID, ReplyID: replyID, Reactions: datatypes.JSON([]byte("{}"))}
+		require.NoError(t, repo.Create(n))
+		t.Cleanup(func() { cleanupNote(t, id) })
+		return n
+	}
+
+	qtext := "quoting"
+	btext := "replying"
+	target := mkNote("n_al_t", ut.ID, nil, nil, nil)           // T = 引用先
+	quote := mkNote("n_al_q", uq.ID, &target.ID, nil, &qtext)  // Q = T の引用 (ページに直接は無い)
+	boost := mkNote("n_al_a", ua.ID, &quote.ID, nil, nil)      // A = Q の pure renote
+	reply := mkNote("n_al_b", urb.ID, nil, &target.ID, &btext) // B = T への reply
+
+	// A と B を同ページで取得する。B の reply target として T が depth-1 sub に入るため、
+	// Q の renote(T) は lvl2IDSet に乗らない (aliasing) が、配線は必須。
+	out, err := repo.FindManyByIDsWithUser([]string{boost.ID, reply.ID})
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	byID := map[string]*model.Note{}
+	for _, n := range out {
+		byID[n.ID] = n
+	}
+	got := byID[boost.ID]
+	require.NotNil(t, got)
+
+	require.NotNil(t, got.Renote, "renote (quote) must be hydrated")
+	assert.Equal(t, quote.ID, got.Renote.ID)
+	// aliasing でも引用先が配線されること (本回帰の核心)。
+	require.NotNil(t, got.Renote.Renote, "renote.renote must be wired even when target was loaded as another note's depth-1 sub")
+	assert.Equal(t, target.ID, got.Renote.Renote.ID)
+}
+
 func TestNoteRepository_QueryErrors(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/stream/channels/note_filter.go
+++ b/internal/stream/channels/note_filter.go
@@ -313,7 +313,20 @@ func hideNoteRawForViewer(payload []byte, viewer *model.User, snap map[string]bo
 	hideTop := topNoteHideable(probe.embedProbe, probe.Reply, viewer, snap, nowMs)
 	hideRenote := embedRawHideable(probe.Renote, viewer, snap, nowMs)
 	hideReply := embedRawHideable(probe.Reply, viewer, snap, nowMs)
-	if !hideTop && !hideRenote && !hideReply {
+	// depth-2 引用先 (renote.renote): packer が pure renote → quote の引用先を出す
+	// ようになったため、非公開の引用先が renote 経由で leak しないよう embed gate を
+	// 適用する (#timeline nested quote)。renote raw から nested renote を取り出す。
+	var renoteRenoteRaw json.RawMessage
+	if len(probe.Renote) > 0 {
+		var rp struct {
+			Renote json.RawMessage `json:"renote"`
+		}
+		if json.Unmarshal(probe.Renote, &rp) == nil {
+			renoteRenoteRaw = rp.Renote
+		}
+	}
+	hideRenoteRenote := embedRawHideable(renoteRenoteRaw, viewer, snap, nowMs)
+	if !hideTop && !hideRenote && !hideReply && !hideRenoteRenote {
 		// 隠すものが無い (= no-embed / public / own / follower) → verbatim。
 		return payload, false
 	}
@@ -326,6 +339,9 @@ func hideNoteRawForViewer(payload []byte, viewer *model.User, snap map[string]bo
 	}
 	if hideRenote && full.Renote != nil {
 		entity.HideNoteEntity(full.Renote)
+	}
+	if hideRenoteRenote && full.Renote != nil && full.Renote.Renote != nil {
+		entity.HideNoteEntity(full.Renote.Renote)
 	}
 	if hideReply && full.Reply != nil {
 		entity.HideNoteEntity(full.Reply)

--- a/internal/stream/channels/note_hide_test.go
+++ b/internal/stream/channels/note_hide_test.go
@@ -91,6 +91,33 @@ func TestHideEmbedsForViewer_FollowersEmbed(t *testing.T) {
 	})
 }
 
+// depth-2 引用先 (renote.renote) が followers-only のとき、非フォロワー viewer 向け
+// streaming payload で blank される (#timeline nested quote の embed leak 防止)。
+// renote (quote) 自体は public なので残る。
+func TestHideEmbedsForViewer_DepthTwoQuoteTarget(t *testing.T) {
+	viewer := &model.User{ID: "viewer"}
+	target := embed("followers", "secret-author", nil) // depth-2 引用先
+	quote := entity.NoteEntity{
+		ID: "quote", UserID: "qa", CreatedAt: "2026-01-02T03:04:05.000Z",
+		User: entity.UserLite{ID: "qa"}, Visibility: "public", Text: sptr("quoting"),
+		FileIDs: []string{}, Files: []any{}, VisibleUserIDs: []string{}, Mentions: []string{},
+		Renote: &target,
+	}
+	payload := parentJSON(t, quote)
+	out := hideEmbedsForViewer(payload, viewer, map[string]bool{}, hideNowMs)
+
+	var n entity.NoteEntity
+	if err := json.Unmarshal(out, &n); err != nil {
+		t.Fatal(err)
+	}
+	if n.Renote == nil || n.Renote.IsHidden || n.Renote.Text == nil {
+		t.Error("public quote embed must stay visible")
+	}
+	if n.Renote.Renote == nil || !n.Renote.Renote.IsHidden || n.Renote.Renote.Text != nil {
+		t.Error("depth-2 followers-only quote target must be blanked for non-follower")
+	}
+}
+
 func TestHideEmbedsForViewer_PublicVerbatim(t *testing.T) {
 	payload := parentJSON(t, embed("public", "author", nil))
 	out := hideEmbedsForViewer(payload, nil, nil, hideNowMs)


### PR DESCRIPTION
## Summary

純粋リノート(boost)が引用投稿(quote)を包んでタイムラインに流れてくると、その**引用先(renote.renote)が「削除されたノート」として表示される**バグを修正する。詳細画面(引用投稿が最上位)では正常表示されていた。

実例の連鎖: `リノート(p1.a9z.dev)` → `引用投稿(jiskey.dev)` → `引用先(ローカルに存在)`。引用先はDBに存在するが、TL のpacking で出ていなかった。

## 根本原因

packer と repository が renote/reply 埋め込みを **1 段しか**展開・hydrate しなかった(`maxNoteEmbedDepth=1`、`preloadNoteRelations` / `FindManyByIDsWithUser` が 1 段)。TL の最上位は pure renote なので、`renote(quote)` の `renote(引用先)` = 3 段目が欠落し、frontend が `renote==null` を「削除されたノート」として描画していた。詳細画面は引用投稿が最上位(1 段で引用先に届く)なので正常だった。

## upstream との整合

upstream Misskey `NoteEntityService` は renote 埋め込みを `detail:true`(自身の renote を再帰 pack)、reply 埋め込みを `detail:false`(子を持たない leaf)で pack する。frontend の quote box(`MkNoteSimple`)は再帰しないため、表示には renote チェーン 2 段で十分。

## 主な変更点

- **packer** (`internal/entity/note.go`): `maxNoteEmbedDepth=2`、sub-embed 展開を `detail==true` で gate。renote チェーンのみ depth-2 まで展開し引用先を出す。reply 埋め込みは top-level のみ(`renote.reply` / `reply.*` の depth-2 は出さない)。
- **repository** (`internal/repository/note.go`): `preloadNoteRelations` に `Renote.Renote(.User/.Poll)` を追加。timeline hot-path `FindManyByIDsWithUser` に renote ブランチの level-2 batch(+1 query)を追加。配線は aliasing(同ページの別ノートが depth-2 を先読み)でも skip しないよう常時実行。
- **可視性ゲート(IDOR 防止)**: packer が depth-2 を出すようになったため、REST(`notehide`)/ streaming(`stream/channels/note_filter`)/ Web Push(`core/webpush`)の hideNote gate を `renote.renote` まで拡張。非公開の引用先が embed 経由で leak しないようにした。

## テスト

- entity packer: depth-2 引用先が pack される / cap=2 で打ち切り / `renote.reply` 非展開 / reply leaf。
- repository: 非 aliasing + **aliasing 回帰**(別ノートが depth-2 を先読みしても配線される)。
- 可視性ゲート: notehide / streaming / webpush それぞれで「非フォロワーには depth-2 followers 引用先が blank」「フォロワーには可視」。
- `make fmt && make lint` クリーン。関連パッケージ green、カバレッジは entity 95.5% / repository 90.1% / notehide 94.9% / webpush 95.0% / stream/channels 92.0%。
- 敵対的レビュー 2 ラウンドで収束(初回で webpush の depth-2 IDOR と batch loader の aliasing 配線漏れを検出 → 修正 → 再レビューで確認)。

## 既知の follow-up(本PR対象外)

webhook 配信経路(`core/webhook`)は embed の可視性 gate を持たない(depth-1 から pre-existing)。本変更で depth-2 引用先も webhook payload に流入しうる(opt-in + 連合ネスト引用が前提の Low)。webhook の embed gate は owner-viewer 適用の別設計が必要なため、depth-1/depth-2 両対応で別途修正する。

## その他

- `third_party/misskey` サブモジュールの変更は本PRに含まない。