### PR TITLE
Fix: webhook の note payload で embed 可視性を受信者ごとに gate する

### DIFF
--- a/internal/core/webhook/embedgate.go
+++ b/internal/core/webhook/embedgate.go
@@ -1,0 +1,135 @@
+package webhook
+
+import (
+	"time"
+
+	corenote "github.com/shiroha-a/mk/internal/core/note"
+	"github.com/shiroha-a/mk/internal/entity"
+	"github.com/shiroha-a/mk/internal/model"
+	"github.com/shiroha-a/mk/internal/repository"
+)
+
+// gateNoteEmbeds blanks the renote / reply / 引用先 (renote.renote) embeds of n
+// that the webhook recipient (viewer) is not allowed to see, using ONE batched
+// FilterFollowingsFromAnchor. webhook の note payload は受信者ごとに pack して
+// recipient を viewer として gate する (upstream の mention webhook が
+// `pack(note, recipient)` で per-recipient gate するのに倣う; note/reply/renote は
+// upstream では skipHide=true だが、mk-go は安全側に倒して全イベントで gate する)。
+//
+// 可視性ゲートの本体は REST (api/notehide) / streaming (stream/channels/note_filter)
+// / Web Push (core/webpush) と同型のコピーで、いずれかを変更したら全箇所を同じ
+// depth (renote/reply の depth-1 + 引用先 renote.renote の depth-2) で同期させること
+// (core は api/notehide を import できないため共有できず、各 boundary に複製している)。
+// viewer / repo が nil の場合は fail-closed (followers/specified embed を隠す)。
+func gateNoteEmbeds(viewer *model.User, n *entity.NoteEntity, repo repository.FollowingRepository, nowMs int64) {
+	if n == nil {
+		return
+	}
+	follows := buildEmbedFollowSet(viewer, n, repo)
+	hideEmbedIfNeeded(viewer, n.Renote, follows, nowMs)
+	hideEmbedIfNeeded(viewer, n.Reply, follows, nowMs)
+	// depth-2 引用先 (renote.renote)。packer が pure renote → quote の引用先を出す
+	// ため、非公開の引用先が webhook payload に leak しないよう gate する。
+	if n.Renote != nil {
+		hideEmbedIfNeeded(viewer, n.Renote.Renote, follows, nowMs)
+	}
+}
+
+// buildEmbedFollowSet resolves, in ONE query, which embed authors viewer follows.
+// embed 著者のうち follow 判定が要るもの (followers、または makeNotesFollowersOnlyBefore
+// で降格しうる public/home) だけを集めて FilterFollowingsFromAnchor を 1 回発行する。
+// viewer nil / repo nil / query 失敗は「誰もフォローしていない」(fail-closed)。
+func buildEmbedFollowSet(viewer *model.User, n *entity.NoteEntity, repo repository.FollowingRepository) func(string) bool {
+	never := func(string) bool { return false }
+	if viewer == nil || repo == nil {
+		return never
+	}
+	seen := make(map[string]struct{})
+	collectEmbedAuthor(n.Renote, viewer.ID, seen)
+	collectEmbedAuthor(n.Reply, viewer.ID, seen)
+	if n.Renote != nil {
+		collectEmbedAuthor(n.Renote.Renote, viewer.ID, seen)
+	}
+	if len(seen) == 0 {
+		return never
+	}
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	followed, err := repo.FilterFollowingsFromAnchor(viewer.ID, ids)
+	if err != nil {
+		return never
+	}
+	set := make(map[string]struct{}, len(followed))
+	for _, id := range followed {
+		set[id] = struct{}{}
+	}
+	return func(id string) bool {
+		_, ok := set[id]
+		return ok
+	}
+}
+
+// collectEmbedAuthor adds an embed author to seen only when a follow check is
+// actually needed (followers, or public/home that could downgrade via the
+// author's makeNotesFollowersOnlyBefore). specified/unknown need no follow query.
+// notehide.collectEmbedAuthor / webpush.collectEmbedAuthor と同一。
+func collectEmbedAuthor(embed *entity.NoteEntity, viewerID string, seen map[string]struct{}) {
+	if embed == nil || embed.UserID == "" || embed.UserID == viewerID {
+		return
+	}
+	switch embed.Visibility {
+	case string(model.NoteVisibilityFollowers):
+		// followers は必ず follow 判定が要る。
+	case string(model.NoteVisibilityPublic), string(model.NoteVisibilityHome):
+		if embed.User.MakeNotesFollowersOnlyBefore == nil {
+			return
+		}
+	default:
+		return
+	}
+	seen[embed.UserID] = struct{}{}
+}
+
+// hideEmbedIfNeeded blanks an embed in place when corenote.HideEmbedDecision says
+// viewer cannot see it. notehide / webpush と同一。
+func hideEmbedIfNeeded(viewer *model.User, embed *entity.NoteEntity, follows func(string) bool, nowMs int64) {
+	if embed == nil {
+		return
+	}
+	if corenote.HideEmbedDecision(viewer, embedFactsFromEntity(embed), follows, nowMs) {
+		entity.HideNoteEntity(embed)
+	}
+}
+
+// embedFactsFromEntity translates a packed embed NoteEntity into core/note
+// EmbedFacts. notehide / webpush の同名関数と同一。
+func embedFactsFromEntity(embed *entity.NoteEntity) corenote.EmbedFacts {
+	f := corenote.EmbedFacts{
+		AuthorID:       embed.UserID,
+		Visibility:     embed.Visibility,
+		VisibleUserIDs: embed.VisibleUserIDs,
+		Mentions:       embed.Mentions,
+		CreatedAtMs:    parseCreatedAtMs(embed.CreatedAt),
+	}
+	if embed.User.ID != "" {
+		f.AuthorPrefsKnown = true
+		if embed.User.RequireSigninToViewContents != nil {
+			f.RequireSigninToViewContents = *embed.User.RequireSigninToViewContents
+		}
+		f.MakeNotesHiddenBefore = embed.User.MakeNotesHiddenBefore
+		f.MakeNotesFollowersOnlyBefore = embed.User.MakeNotesFollowersOnlyBefore
+	}
+	return f
+}
+
+// parseCreatedAtMs parses the packed RFC3339-ms createdAt back to unix-ms. On
+// failure returns 0 (fail-closed on the time-window gates). notehide / webpush と同一。
+func parseCreatedAtMs(s string) int64 {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return 0
+	}
+	return t.UnixMilli()
+}

--- a/internal/core/webhook/hooks.go
+++ b/internal/core/webhook/hooks.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/shiroha-a/mk/internal/entity"
 	"github.com/shiroha-a/mk/internal/misc/id"
@@ -24,6 +25,10 @@ type NoteCreateHook struct {
 	// threadMuteRepo は reply/mention webhook のスレッドミュート gate に使う
 	// optional 依存 (#1965)。未配線なら gate は素通り。
 	threadMuteRepo repository.NoteThreadMutingRepository
+	// followingRepo は note payload の embed (renote/reply/引用先) を受信者の
+	// 可視性で gate するために使う。未配線なら fail-closed (followers/specified
+	// embed を隠す)。
+	followingRepo repository.FollowingRepository
 }
 
 // NewNoteCreateHook constructs a NoteCreateHook.
@@ -36,6 +41,13 @@ func NewNoteCreateHook(svc *Service, idGen id.Generator) *NoteCreateHook {
 // matching upstream NoteCreateService (#1965). nil disables the gate.
 func (h *NoteCreateHook) SetThreadMutingRepo(r repository.NoteThreadMutingRepository) {
 	h.threadMuteRepo = r
+}
+
+// SetFollowingRepo attaches a FollowingRepository used to gate the embed
+// (renote/reply/引用先) visibility of the note payload per recipient. nil keeps
+// the gate fail-closed (followers/specified embeds hidden).
+func (h *NoteCreateHook) SetFollowingRepo(r repository.FollowingRepository) {
+	h.followingRepo = r
 }
 
 // isThreadMuted reports whether userID has muted the thread that threadNote
@@ -59,19 +71,25 @@ func (h *NoteCreateHook) OnNoteCreated(note *model.Note, author *model.User, rep
 	if h == nil || h.svc == nil || note == nil || author == nil {
 		return
 	}
-	body := map[string]any{"note": packNote(note, author, h.idGen)}
+	// note payload は受信者ごとに pack + embed gate する。同一 body を共有すると、
+	// ある受信者が見られない embed (第三者の followers 引用先など) が別受信者に
+	// leak する。upstream の mention webhook と同じ per-recipient gate。
+	emit := func(recipientID, event string) {
+		body := map[string]any{"note": h.packNoteFor(note, author, recipientID)}
+		h.svc.DispatchUser(recipientID, event, body)
+	}
 
 	// 作者本人のwebhook
-	h.svc.DispatchUser(author.ID, EventNote, body)
+	emit(author.ID, EventNote)
 
 	// reply: 親ノート投稿者。upstream はスレッドミュート中の reply 先には reply
 	// webhook を出さない (#1965)。thread は reply 先ノートの threadId。
 	if replyTarget != nil && replyTarget.UserID != author.ID && !h.isThreadMuted(replyTarget.UserID, replyTarget) {
-		h.svc.DispatchUser(replyTarget.UserID, EventReply, body)
+		emit(replyTarget.UserID, EventReply)
 	}
 	// renote: 対象ノート投稿者 (renote はスレッドミュートで gate しない、upstream 同様)。
 	if renoteTarget != nil && renoteTarget.UserID != author.ID {
-		h.svc.DispatchUser(renoteTarget.UserID, EventRenote, body)
+		emit(renoteTarget.UserID, EventRenote)
 	}
 	// mention: 本文から抽出されたユーザー ID ごとに配信。スレッドミュート中の
 	// mention 先には mention webhook を出さない (#1965)。thread は新規ノートの threadId。
@@ -82,19 +100,42 @@ func (h *NoteCreateHook) OnNoteCreated(note *model.Note, author *model.User, rep
 		if h.isThreadMuted(mentionID, note) {
 			continue
 		}
-		h.svc.DispatchUser(mentionID, EventMention, body)
+		emit(mentionID, EventMention)
 	}
+}
+
+// packNoteFor packs note for a single webhook recipient and applies the
+// per-recipient embed visibility gate (renote/reply/引用先) with recipientID as
+// the viewer. entity.PackNote produces fresh embed pointers each call, so the
+// per-recipient blank never mutates another recipient's payload.
+func (h *NoteCreateHook) packNoteFor(note *model.Note, author *model.User, recipientID string) map[string]any {
+	if note.User == nil && author != nil {
+		clone := *note
+		clone.User = author
+		note = &clone
+	}
+	packed := entity.PackNote(note, h.idGen)
+	gateNoteEmbeds(&model.User{ID: recipientID}, &packed, h.followingRepo, time.Now().UnixMilli())
+	return noteEntityToMap(packed)
 }
 
 // ReactionCreateHook implements the reaction WebhookHook interface.
 type ReactionCreateHook struct {
-	svc   *Service
-	idGen id.Generator
+	svc           *Service
+	idGen         id.Generator
+	followingRepo repository.FollowingRepository
 }
 
 // NewReactionCreateHook constructs a ReactionCreateHook.
 func NewReactionCreateHook(svc *Service, idGen id.Generator) *ReactionCreateHook {
 	return &ReactionCreateHook{svc: svc, idGen: idGen}
+}
+
+// SetFollowingRepo attaches a FollowingRepository used to gate the embed
+// visibility of the reaction note payload for the recipient (= note author).
+// nil keeps the gate fail-closed.
+func (h *ReactionCreateHook) SetFollowingRepo(r repository.FollowingRepository) {
+	h.followingRepo = r
 }
 
 // OnReactionCreated fires the `reaction` webhook event on the note author.
@@ -108,8 +149,18 @@ func (h *ReactionCreateHook) OnReactionCreated(note *model.Note, reactor *model.
 	if h == nil || h.svc == nil || note == nil || reactor == nil {
 		return
 	}
+	// reaction webhook の受信者は note 著者 (note.UserID)。embed は受信者 (= 著者)
+	// の可視性で gate する。著者本人が見られない第三者ネスト引用先が leak しないように。
+	noteForPack := note
+	if note.User == nil {
+		clone := *note
+		clone.User = &model.User{ID: note.UserID}
+		noteForPack = &clone
+	}
+	packed := entity.PackNote(noteForPack, h.idGen)
+	gateNoteEmbeds(&model.User{ID: note.UserID}, &packed, h.followingRepo, time.Now().UnixMilli())
 	body := map[string]any{
-		"note":     packNote(note, note.User, h.idGen),
+		"note":     noteEntityToMap(packed),
 		"userId":   reactor.ID,
 		"reaction": reaction,
 	}
@@ -169,17 +220,10 @@ func (h *SignupHook) OnUserCreated(user *model.User) {
 	h.svc.DispatchSystem(SystemEventUserCreated, packUser(user))
 }
 
-// packNote turns a model.Note into a generic map matching entity.NoteEntity.
-// 既存の entity.PackNote を JSON 経由で map[string]any に変換する。
-// Note/User/IDGen は呼び出し元でnil-check済みの前提。json.Marshal/Unmarshal は
-// 正常値に対して失敗しないため戻り値は常に非nil。
-func packNote(note *model.Note, author *model.User, idGen id.Generator) map[string]any {
-	if note.User == nil && author != nil {
-		clone := *note
-		clone.User = author
-		note = &clone
-	}
-	packed := entity.PackNote(note, idGen)
+// noteEntityToMap converts a packed NoteEntity into the generic map[string]any
+// shape the webhook envelope carries. json.Marshal/Unmarshal は正常値に対して
+// 失敗しないため戻り値は常に非 nil。
+func noteEntityToMap(packed entity.NoteEntity) map[string]any {
 	raw, _ := json.Marshal(packed)
 	out := map[string]any{}
 	_ = json.Unmarshal(raw, &out)

--- a/internal/core/webhook/hooks_test.go
+++ b/internal/core/webhook/hooks_test.go
@@ -1,6 +1,7 @@
 package webhook_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/lib/pq"
@@ -223,6 +224,114 @@ func TestReactionCreateHook_NilSafe(t *testing.T) {
 	idGen, _ := id.NewGenerator("aidx")
 	h = webhook.NewReactionCreateHook(nil, idGen)
 	h.OnReactionCreated(nil, nil, "")
+}
+
+// --- per-recipient embed visibility gate on the note payload ---
+
+// nestedQuoteNote builds: top (public, by topAuthor) → renote = quote (public, by
+// midAuthor) → renote.renote = target (targetVis, by targetAuthor). embed 著者には
+// User を attach して AuthorPrefsKnown を立てる。
+func nestedQuoteNote(topAuthor, midAuthor, targetAuthor string, targetVis model.NoteVisibility) *model.Note {
+	tText, qText, topText := "secret target", "quoting", "top body"
+	targetID, quoteID := "t_nested", "q_nested"
+	target := &model.Note{
+		ID: targetID, UserID: targetAuthor, Visibility: targetVis, Text: &tText,
+		User: &model.User{ID: targetAuthor, Username: targetAuthor, UsernameLower: targetAuthor},
+	}
+	quote := &model.Note{
+		ID: quoteID, UserID: midAuthor, Visibility: model.NoteVisibilityPublic, Text: &qText,
+		RenoteID: &targetID, Renote: target,
+		User: &model.User{ID: midAuthor, Username: midAuthor, UsernameLower: midAuthor},
+	}
+	return &model.Note{
+		ID: "top_nested", UserID: topAuthor, Visibility: model.NoteVisibilityPublic, Text: &topText,
+		RenoteID: &quoteID, Renote: quote,
+	}
+}
+
+// renoteRenoteOf extracts body.note.renote.renote (depth-2 引用先) from an
+// enqueued webhook Envelope body.
+func renoteRenoteOf(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var env struct {
+		Body struct {
+			Note map[string]any `json:"note"`
+		} `json:"body"`
+	}
+	require.NoError(t, json.Unmarshal(body, &env))
+	require.NotNil(t, env.Body.Note, "note must be present")
+	renote, _ := env.Body.Note["renote"].(map[string]any)
+	require.NotNil(t, renote, "depth-1 renote (quote) must be present")
+	rr, _ := renote["renote"].(map[string]any)
+	require.NotNil(t, rr, "depth-2 renote.renote (quote target) must be present")
+	return rr
+}
+
+// 引用先 (renote.renote) が followers-only のとき、非フォロワー受信者の webhook
+// payload で blank される (#timeline nested quote の embed leak を webhook でも防ぐ)。
+func TestNoteCreateHook_GatesDepthTwoFollowersQuoteTarget(t *testing.T) {
+	svc, enq, userRepo, _ := newTestService(t)
+	userRepo.hooks["h1"] = &model.Webhook{ID: "h1", UserID: "alice", Active: true, On: pq.StringArray{"note"}}
+	idGen, _ := id.NewGenerator("aidx")
+	follow := testutil.NewMockFollowingRepository() // alice follows nobody
+	h := webhook.NewNoteCreateHook(svc, idGen)
+	h.SetFollowingRepo(follow)
+
+	top := nestedQuoteNote("alice", "host", "carol", model.NoteVisibilityFollowers)
+	h.OnNoteCreated(top, &model.User{ID: "alice", Username: "alice", UsernameLower: "alice"}, nil, nil)
+
+	require.Len(t, enq.userCalls, 1)
+	rr := renoteRenoteOf(t, enq.userCalls[0].Body)
+	assert.Equal(t, true, rr["isHidden"], "depth-2 followers quote target must be blanked for non-follower recipient")
+	assert.Nil(t, rr["text"], "blanked embed drops text")
+}
+
+// 引用先がフォロワー受信者には見える (過剰 blank しない回帰)。
+func TestNoteCreateHook_DepthTwoQuoteTargetVisibleToFollower(t *testing.T) {
+	svc, enq, userRepo, _ := newTestService(t)
+	userRepo.hooks["h1"] = &model.Webhook{ID: "h1", UserID: "alice", Active: true, On: pq.StringArray{"note"}}
+	idGen, _ := id.NewGenerator("aidx")
+	follow := testutil.NewMockFollowingRepository()
+	follow.Followings["f"] = &model.Following{ID: "f", FollowerID: "alice", FolloweeID: "carol"}
+	h := webhook.NewNoteCreateHook(svc, idGen)
+	h.SetFollowingRepo(follow)
+
+	top := nestedQuoteNote("alice", "host", "carol", model.NoteVisibilityFollowers)
+	h.OnNoteCreated(top, &model.User{ID: "alice", Username: "alice", UsernameLower: "alice"}, nil, nil)
+
+	require.Len(t, enq.userCalls, 1)
+	rr := renoteRenoteOf(t, enq.userCalls[0].Body)
+	assert.NotEqual(t, true, rr["isHidden"], "follower recipient sees the depth-2 quote target")
+	assert.Equal(t, "secret target", rr["text"])
+}
+
+// per-recipient: 同じノートでも受信者ごとに別 body を pack/gate するため、引用先が
+// 見える受信者 (follower) と見えない受信者 (non-follower) が混在しても leak しない。
+// 共有 body だとこのテストは fail する。
+func TestNoteCreateHook_PerRecipientEmbedGate(t *testing.T) {
+	svc, enq, userRepo, _ := newTestService(t)
+	userRepo.hooks["hd"] = &model.Webhook{ID: "hd", UserID: "dave", Active: true, On: pq.StringArray{"mention"}}
+	userRepo.hooks["he"] = &model.Webhook{ID: "he", UserID: "eve", Active: true, On: pq.StringArray{"mention"}}
+	idGen, _ := id.NewGenerator("aidx")
+	follow := testutil.NewMockFollowingRepository()
+	follow.Followings["f"] = &model.Following{ID: "f", FollowerID: "dave", FolloweeID: "carol"} // dave follows carol, eve does not
+	h := webhook.NewNoteCreateHook(svc, idGen)
+	h.SetFollowingRepo(follow)
+
+	top := nestedQuoteNote("alice", "host", "carol", model.NoteVisibilityFollowers)
+	top.Mentions = pq.StringArray{"dave", "eve"}
+	h.OnNoteCreated(top, &model.User{ID: "alice", Username: "alice", UsernameLower: "alice"}, nil, nil)
+
+	require.Len(t, enq.userCalls, 2) // alice (note) は webhook 未登録 → call 無し
+	byUser := map[string]map[string]any{}
+	for _, c := range enq.userCalls {
+		byUser[c.UserID] = renoteRenoteOf(t, c.Body)
+	}
+	require.NotNil(t, byUser["dave"])
+	require.NotNil(t, byUser["eve"])
+	assert.NotEqual(t, true, byUser["dave"]["isHidden"], "follower dave sees the depth-2 quote target")
+	assert.Equal(t, "secret target", byUser["dave"]["text"])
+	assert.Equal(t, true, byUser["eve"]["isHidden"], "non-follower eve has the depth-2 quote target blanked")
 }
 
 func TestFollowingHook_FiresFollowAndFollowed(t *testing.T) {

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -374,8 +374,12 @@ func (s *Server) setupRoutes() {
 	webhookNoteHook := corewebhook.NewNoteCreateHook(webhookService, idGen)
 	// reply/mention webhook をスレッドミュート済 recipient に出さない (#1965)。
 	webhookNoteHook.SetThreadMutingRepo(noteThreadMutingRepo)
+	// note payload の embed (renote/reply/引用先) を受信者の可視性で gate する。
+	webhookNoteHook.SetFollowingRepo(followingRepo)
 	noteCreateService.SetWebhookHook(webhookNoteHook)
-	reactionService.SetWebhookHook(corewebhook.NewReactionCreateHook(webhookService, idGen))
+	webhookReactionHook := corewebhook.NewReactionCreateHook(webhookService, idGen)
+	webhookReactionHook.SetFollowingRepo(followingRepo)
+	reactionService.SetWebhookHook(webhookReactionHook)
 	followingService.SetWebhookHook(corewebhook.NewFollowingHook(webhookService))
 	signupService.SetWebhookHook(corewebhook.NewSignupHook(webhookService))
 	// Webhook delivery: SSRF-safe transport + forward proxy 経由で user-supplied


### PR DESCRIPTION
## Summary

webhook 配信経路(`internal/core/webhook`)が note payload の embed(renote/reply/引用先)の可視性 gate を持たず、1 つの body を全受信者で共有していた問題を修正する。直前の #2237 で packer が depth-2 引用先(`renote.renote`)を emit するようになり、この未 gate 経路に**第三者の followers 引用先まで流入しうる**状態になっていた(depth-1 embed の未 gate 自体は pre-existing)。

## upstream との整合

upstream Misskey の user webhook は:
- `note` / `reply` / `renote`: `me=null, skipHide=true` で **gate しない**(1 回 pack を共有)。
- `mention`: `me=受信者, skipHide=false` で **per-recipient gate**(top + 全 embed + 引用先まで)。

mk-go は安全側に倒し、**全 webhook note イベントで per-recipient の embed gate** を適用する(upstream の mention webhook と同モデル。`feedback_parity` の「mk-go が upstream より strict/安全なら維持」方針)。受信者=embed 著者の通常ケース(reply 先 = reply embed 著者、renote 先 = renote embed 著者、note = 自分)は own-embed として可視のまま、第三者のネスト引用先のみ非フォロワー受信者に blank する。top note 自体は event-directed(受信者に向けられたイベント)なので配信する(embed のみ gate)。

## 主な変更点

- **`core/webhook/embedgate.go`(新規)**: REST(notehide)/ streaming(note_filter)/ Web Push(webpush)と同型の embed gate helper。`corenote.HideEmbedDecision` + `entity.HideNoteEntity` で depth-1(renote/reply)+ depth-2(renote.renote)を gate。viewer/repo nil は fail-closed。
- **`core/webhook/hooks.go`**: `NoteCreateHook` / `ReactionCreateHook` に `followingRepo` + `SetFollowingRepo` を追加。`OnNoteCreated` を **per-recipient pack+gate**(各受信者を viewer に `entity.PackNote` し直し→gate→dispatch)に変更。`OnReactionCreated` も note 著者を viewer に gate。
- **`router.go`**: 両 hook に `followingRepo` を配線。

## テスト

- depth-2 followers 引用先が非フォロワー受信者で blank される / フォロワー受信者には可視(過剰 blank なし)。
- **per-recipient 分離**: 同一ノートを follower(dave)と non-follower(eve)に配信した際、dave は引用先可視・eve は blank(共有 body だと fail するテスト=旧挙動の回帰を捕捉)。
- `make fmt && make lint` クリーン。`webhook` green、カバレッジ 91.4%。dispatch ルール(self-skip / thread mute #1965 / renote 非 mute)の既存テストも維持。
- 敵対的レビューで per-recipient 独立性・nil-safety・depth-2 leak 閉鎖・regression 無しを確認(変異テストで false-green でないことも実証)、指摘ゼロ。

## 補足

可視性ゲートは REST / streaming / Web Push / webhook の 4 箇所に同型コピーがある(core は `api/notehide` を import できないため共有不可)。embed 深さを変える際は全てを同じ深さで同期させること。

`third_party/misskey` サブモジュールの変更は本PRに含まない。